### PR TITLE
Refactor integration functions to use `exprel` for improved numerical…

### DIFF
--- a/braincell/channel/potassium.py
+++ b/braincell/channel/potassium.py
@@ -261,7 +261,7 @@ class IKDR_Ba2002(_IK_p4_markov):
     def f_p_alpha(self, V):
         V = (V - self.V_sh).to_decimal(u.mV)
         tmp = V - 15.
-        return 0.032 * tmp / (1. - u.math.exp(-tmp / 5.))
+        return 0.032 * 5. / u.math.exprel(-tmp / 5.)
 
     def f_p_beta(self, V):
         V = (V - self.V_sh).to_decimal(u.mV)
@@ -323,7 +323,7 @@ class IK_TM1991(_IK_p4_markov):
 
     def f_p_alpha(self, V):
         c = 15 + (- V + self.V_sh).to_decimal(u.mV)
-        return 0.032 * c / (u.math.exp(c / 5) - 1.)
+        return 0.032 * 5 / u.math.exprel(c / 5)
 
     def f_p_beta(self, V):
         V = (self.V_sh - V).to_decimal(u.mV)
@@ -386,8 +386,8 @@ class IK_HH1952(_IK_p4_markov):
 
     def f_p_alpha(self, V):
         V = (V - self.V_sh).to_decimal(u.mV)
-        temp = V + 10
-        return 0.01 * temp / (1 - u.math.exp(-temp / 10))
+        temp = -(V + 10) / 10
+        return 0.1 / u.math.exprel(temp)
 
     def f_p_beta(self, V):
         V = (V - self.V_sh).to_decimal(u.mV)

--- a/braincell/channel/sodium.py
+++ b/braincell/channel/sodium.py
@@ -415,7 +415,7 @@ class INa_HH1952(INa_p3q_markov):
 
     def f_p_alpha(self, V):
         temp = (V - self.V_sh).to_decimal(u.mV) - 5
-        return 0.1 * temp / (1 - u.math.exp(-temp / 10))
+        return 1. / u.math.exprel(-temp / 10)
 
     def f_p_beta(self, V):
         V = (V - self.V_sh).to_decimal(u.mV)

--- a/docs/apis/braincell.rst
+++ b/docs/apis/braincell.rst
@@ -15,7 +15,6 @@ Base Classes
    :template: classtemplate.rst
 
     HHTypedNeuron
-    State4Integral
     IonChannel
     Ion
     IonInfo


### PR DESCRIPTION
This pull request includes several changes to the `braincell/channel/potassium.py` and `braincell/channel/sodium.py` files to improve mathematical expressions and a minor documentation update in `docs/apis/braincell.rst`.

Mathematical expression improvements:

* [`braincell/channel/potassium.py`](diffhunk://#diff-c502c32b9a8ac3022e1b5a577a2112c540e5a3bf80b84ef2e6484a9cec28d30fL264-R264): Modified the `f_p_alpha` method to use `u.math.exprel` for more accurate calculations in three instances. [[1]](diffhunk://#diff-c502c32b9a8ac3022e1b5a577a2112c540e5a3bf80b84ef2e6484a9cec28d30fL264-R264) [[2]](diffhunk://#diff-c502c32b9a8ac3022e1b5a577a2112c540e5a3bf80b84ef2e6484a9cec28d30fL326-R326) [[3]](diffhunk://#diff-c502c32b9a8ac3022e1b5a577a2112c540e5a3bf80b84ef2e6484a9cec28d30fL389-R390)
* [`braincell/channel/sodium.py`](diffhunk://#diff-203ec9ad124c2f7741ea89b4d1406705563dfe8b7e4901c28b4315151fc83187L418-R418): Updated the `f_p_alpha` method to use `u.math.exprel` for more accurate calculations.

Documentation update:

* [`docs/apis/braincell.rst`](diffhunk://#diff-a13bec3a2cd0cc34e6552cca04cf5f7d03363c361a86dc47bf7b1ba9ee42eb79L18): Removed the `State4Integral` class from the list of base classes.

## Summary by Sourcery

Refactor the `f_p_alpha` methods in the potassium and sodium channel models to use `u.math.exprel` for improved numerical accuracy. Also, update the `braincell` API documentation to remove the `State4Integral` class from the list of base classes.

Enhancements:
- Improve the numerical accuracy of `f_p_alpha` calculations in potassium and sodium channel models by using `u.math.exprel`.

Documentation:
- Remove the `State4Integral` class from the list of base classes in the `braincell` API documentation.