### PR TITLE
Refactor integrators and morphology; add implicit diffrax

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,8 @@
 # Security Policy
 
-## Reporting a bug in ``dendritex``
+## Reporting a bug in ``BrainCell``
 
-Report security bugs in ``dendritex`` via [Github Issue](https://github.com/chaoming0625/dendritex/issues).
+Report security bugs in ``BrainCell`` via [Github Issue](https://github.com/chaobrain/braincell/issues).
 
 Normally your report will be acknowledged within 5 days, and you'll receive a more detailed response 
 to your report within 10 days indicating the next steps in handling your submission. These timelines 

--- a/braincell/_integrator.py
+++ b/braincell/_integrator.py
@@ -50,6 +50,9 @@ __all__ = [
 
     # diffrax implicit methods
     'diffrax_bwd_euler_step',
+    'diffrax_kvaerno3_step',
+    'diffrax_kvaerno4_step',
+    'diffrax_kvaerno5_step',
 ]
 
 all_integrators = {k.replace('_step', ''): v for k, v in locals().items() if k.endswith('_step')}

--- a/braincell/_integrator.py
+++ b/braincell/_integrator.py
@@ -38,7 +38,7 @@ __all__ = [
     'rk4_step',
     'ralston4_step',
 
-    # diffrax methods
+    # diffrax explicit methods
     'diffrax_euler_step',
     'diffrax_heun_step',
     'diffrax_midpoint_step',
@@ -47,6 +47,9 @@ __all__ = [
     'diffrax_tsit5_step',
     'diffrax_dopri5_step',
     'diffrax_dopri8_step',
+
+    # diffrax implicit methods
+    'diffrax_bwd_euler_step',
 ]
 
 all_integrators = {k.replace('_step', ''): v for k, v in locals().items() if k.endswith('_step')}

--- a/braincell/_integrator_diffrax.py
+++ b/braincell/_integrator_diffrax.py
@@ -16,6 +16,7 @@
 import functools
 import importlib.util
 
+import jax.numpy as jnp
 import brainunit as u
 
 from ._integrator_util import apply_standard_solver_step, VectorFiled, Y0, T, DT
@@ -34,6 +35,9 @@ __all__ = [
 
     # implicit methods
     'diffrax_bwd_euler_step',
+    'diffrax_kvaerno3_step',
+    'diffrax_kvaerno4_step',
+    'diffrax_kvaerno5_step',
 ]
 
 diffrax_installed = importlib.util.find_spec('diffrax') is not None
@@ -54,6 +58,9 @@ else:
 def _explicit_solver(solver, fn: VectorFiled, y0: Y0, t0: T, dt: DT, args=()):
     dt = u.Quantity(dt)
     t0 = u.get_magnitude(u.Quantity(t0).to_decimal(dt.unit))
+    dt = dt.mantissa
+    dt = jnp.asarray(dt)
+    t0 = jnp.asarray(t0)
     y1, _, _, state, _ = solver.step(
         diffrax.ODETerm(lambda t, y, args_: fn(t, y, *args_)[0]),
         t0,
@@ -369,7 +376,114 @@ def diffrax_bwd_euler_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
         - It is part of a suite of step functions that provide different integration methods.
         - The function is designed to be compatible with the braincell integration framework.
     """
-    _diffrax_implicit_solver(
+    _diffrax_explicit_solver(
         diffrax.ImplicitEuler(root_finder=diffrax.VeryChord(rtol=tol, atol=tol)),
         target, t, dt, *args
     )
+
+def diffrax_kvaerno3_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
+    """
+    Advances the state of a differential equation module by one integration step using the Kvaerno3 method
+    from the diffrax library: `diffrax.Kvaerno3 <https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Kvaerno3>`_.
+
+    This function serves as a wrapper that applies the implicit Kvaerno3 solver (a third-order method)
+    to the given target module. It is intended for use in time-stepping routines where the state of the system
+    is updated in-place. The root-finding tolerance for the implicit step can be controlled via the `tol` parameter.
+
+    Args:
+        target (DiffEqModule): The differential equation module whose state will be advanced.
+        t (T): The current simulation time.
+        dt (DT): The numerical time step of the integration step.
+        *args: Additional arguments to be passed to the solver.
+        tol (float, optional): Tolerance for the root-finding algorithm used in the implicit step.
+            Defaults to 1e-5.
+
+    Returns:
+        None: The function updates the state of the target module in place.
+
+    Raises:
+        ModuleNotFoundError: If the diffrax library is not installed.
+
+    Notes:
+        - This function relies on the diffrax.Kvaerno3 solver for numerical integration.
+        - The root-finding algorithm used is diffrax.VeryChord, with both relative and absolute
+          tolerances set to `tol`.
+        - It is part of a suite of step functions that provide different integration methods.
+        - The function is designed to be compatible with the braincell integration framework.
+    """
+    _diffrax_explicit_solver(
+        diffrax.Kvaerno3(root_finder=diffrax.VeryChord(rtol=tol, atol=tol)),
+        target, t, dt, *args
+    )
+
+
+def diffrax_kvaerno4_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
+    """
+    Advances the state of a differential equation module by one integration step using the Kvaerno4 method
+    from the diffrax library: `diffrax.Kvaerno4 <https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Kvaerno4>`_.
+
+    This function serves as a wrapper that applies the implicit Kvaerno4 solver (a fourth-order method)
+    to the given target module. It is intended for use in time-stepping routines where the state of the system
+    is updated in-place. The root-finding tolerance for the implicit step can be controlled via the `tol` parameter.
+
+    Args:
+        target (DiffEqModule): The differential equation module whose state will be advanced.
+        t (T): The current simulation time.
+        dt (DT): The numerical time step of the integration step.
+        *args: Additional arguments to be passed to the solver.
+        tol (float, optional): Tolerance for the root-finding algorithm used in the implicit step.
+            Defaults to 1e-5.
+
+    Returns:
+        None: The function updates the state of the target module in place.
+
+    Raises:
+        ModuleNotFoundError: If the diffrax library is not installed.
+
+    Notes:
+        - This function relies on the diffrax.Kvaerno4 solver for numerical integration.
+        - The root-finding algorithm used is diffrax.VeryChord, with both relative and absolute
+          tolerances set to `tol`.
+        - It is part of a suite of step functions that provide different integration methods.
+        - The function is designed to be compatible with the braincell integration framework.
+    """
+    _diffrax_explicit_solver(
+        diffrax.Kvaerno4(root_finder=diffrax.VeryChord(rtol=tol, atol=tol)),
+        target, t, dt, *args
+    )
+
+def diffrax_kvaerno5_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
+    """
+    Advances the state of a differential equation module by one integration step using the Kvaerno5 method
+    from the diffrax library: `diffrax.Kvaerno5 <https://docs.kidger.site/diffrax/api/solvers/ode_solvers/#diffrax.Kvaerno5>`_.
+
+    This function serves as a wrapper that applies the implicit Kvaerno5 solver (a fifth-order method)
+    to the given target module. It is intended for use in time-stepping routines where the state of the system
+    is updated in-place. The root-finding tolerance for the implicit step can be controlled via the `tol` parameter.
+
+    Args:
+        target (DiffEqModule): The differential equation module whose state will be advanced.
+        t (T): The current simulation time.
+        dt (DT): The numerical time step of the integration step.
+        *args: Additional arguments to be passed to the solver.
+        tol (float, optional): Tolerance for the root-finding algorithm used in the implicit step.
+            Defaults to 1e-5.
+
+    Returns:
+        None: The function updates the state of the target module in place.
+
+    Raises:
+        ModuleNotFoundError: If the diffrax library is not installed.
+
+    Notes:
+        - This function relies on the diffrax.Kvaerno5 solver for numerical integration.
+        - The root-finding algorithm used is diffrax.VeryChord, with both relative and absolute
+          tolerances set to `tol`.
+        - It is part of a suite of step functions that provide different integration methods.
+        - The function is designed to be compatible with the braincell integration framework.
+    """
+    _diffrax_explicit_solver(
+        diffrax.Kvaerno5(root_finder=diffrax.VeryChord(rtol=tol, atol=tol)),
+        target, t, dt, *args
+    )
+

--- a/braincell/_integrator_exp_euler.py
+++ b/braincell/_integrator_exp_euler.py
@@ -19,7 +19,7 @@ import jax.numpy as jnp
 from jax.scipy.linalg import expm
 
 from ._base import HHTypedNeuron
-from ._integrator_util import apply_standard_solver_step, jacrev_last_dim
+from ._integrator_util import apply_standard_solver_step, jacrev_last_dim, T, DT
 from ._misc import set_module_as
 from ._protocol import DiffEqModule
 
@@ -61,11 +61,7 @@ def _exponential_euler(f, y0, t, dt, args=()):
 
 
 @set_module_as('braincell')
-def exp_euler_step(
-    target: DiffEqModule,
-    t: u.Quantity[u.second],
-    *args
-):
+def exp_euler_step(target: DiffEqModule, t: T, dt: DT, *args):
     r"""
     Perform an exponential Euler step for solving differential equations.
 
@@ -104,6 +100,8 @@ def exp_euler_step(
         Must be an instance of HHTypedNeuron.
     t : u.Quantity[u.second]
         The current time point in the simulation.
+    dt : u.Quantity[u.second]
+        The numerical time step of the integration step.
     *args : 
         Additional arguments to be passed to the underlying implementation.
 
@@ -131,6 +129,7 @@ def exp_euler_step(
             _exponential_euler,
             target,
             t,
+            dt,
             *args,
             merging_method='stack'
         )
@@ -140,6 +139,7 @@ def exp_euler_step(
             _exponential_euler,
             target,
             t,
+            dt,
             *args,
             merging_method='concat'
         )

--- a/braincell/_morphology_test.py
+++ b/braincell/_morphology_test.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
-import braincell
 import brainunit as u
+
+import braincell
 
 
 class TestMorphologyConstruction:
@@ -25,7 +26,12 @@ class TestMorphologyConstruction:
         # Create individual sections using `create_section`
         morphology.add_cylinder_section('soma', length=20 * u.um, diam=10 * u.um, nseg=1)  # Soma section
         morphology.add_cylinder_section('axon', length=100 * u.um, diam=1 * u.um, nseg=2)  # Axon section
-        morphology.add_point_section('dendrite', [[0, 0, 0, 2], [100, 0, 0, 3], [200, 0, 0, 2]] * u.um, nseg=3)  # Dendrite
+        morphology.add_point_section(
+            'dendrite',
+            position=[[0, 0, 0], [100, 0, 0], [200, 0, 0]] * u.um,
+            diam=[2, 3, 2] * u.um,
+            nseg=3
+        )  # Dendrite
 
         # Connect the sections (e.g., dendrite and axon connected to soma)
         morphology.connect('axon', 'soma', parent_loc=1.0)  # Axon connected at the end of soma
@@ -55,7 +61,9 @@ class TestMorphologyConstruction:
         section_dicts = {
             'soma': {'length': 20 * u.um, 'diam': 10 * u.um, 'nseg': 1},
             'axon': {'length': 100 * u.um, 'diam': 1 * u.um, 'nseg': 2},
-            'dendrite': {'points': [[0, 0, 0, 2], [100, 0, 0, 3], [200, 0, 0, 2]] * u.um, 'nseg': 3}
+            'dendrite': {'position': [[0, 0, 0], [100, 0, 0], [200, 0, 0]] * u.um,
+                         'diam': [2, 3, 2] * u.um,
+                         'nseg': 3}
         }
         morphology.add_multiple_sections(section_dicts)
 
@@ -78,4 +86,3 @@ class TestMorphologyConstruction:
         # Construct conductance matrix for the model
         print(morphology.conductance_matrix)
         print(morphology.area)
-

--- a/braincell/_morphology_utils.py
+++ b/braincell/_morphology_utils.py
@@ -26,7 +26,7 @@ import numpy as np
 @jax.jit
 def calculate_total_resistance_and_area(
     points: brainstate.typing.Array,
-    resistivity: u.Quantity = 100.0 * u.ohm * u.cm  # TODO
+    resistivity: u.Quantity = 100.0 * u.ohm * u.cm
 ):
     r"""
     Calculate the total axial resistance and surface area of a neurite represented as N-1 frustums 

--- a/braincell/_multi_compartment.py
+++ b/braincell/_multi_compartment.py
@@ -22,9 +22,7 @@ import numpy as np
 from ._base import HHTypedNeuron, IonChannel
 from ._integrator import get_integrator
 from ._morphology import Morphology
-from ._morphology_utils import (
-    diffusive_coupling,
-)
+from ._morphology_utils import diffusive_coupling
 from ._protocol import DiffEqState
 from ._typing import Initializer
 
@@ -329,7 +327,8 @@ class MultiCompartment(HHTypedNeuron):
         """
         last_V = self.V.value
         t = brainstate.environ.get('t')
-        self.solver(self, t, I_ext)
+        dt = brainstate.environ.get('dt')
+        self.solver(self, t, dt, I_ext)
         return self.get_spike(last_V, self.V.value)
 
     def get_spike(self, last_V, next_V):

--- a/braincell/_multi_compartment.py
+++ b/braincell/_multi_compartment.py
@@ -175,10 +175,27 @@ class MultiCompartment(HHTypedNeuron):
 
     @property
     def pop_size(self) -> Tuple[int, ...]:
+        """
+        Returns the shape of the neuron population, excluding the compartment dimension.
+
+        Returns
+        -------
+        Tuple[int, ...]
+            The shape of the neuron population (all dimensions except the last, which
+            corresponds to the number of compartments).
+        """
         return self.varshape[:-1]
 
     @property
     def n_compartment(self) -> int:
+        """
+        Returns the number of compartments in the neuron model.
+
+        Returns
+        -------
+        int
+            The number of compartments, corresponding to the last dimension of the neuron's variable shape.
+        """
         return self.varshape[-1]
 
     def init_state(self, batch_size=None):

--- a/braincell/_single_compartment.py
+++ b/braincell/_single_compartment.py
@@ -261,7 +261,8 @@ class SingleCompartment(HHTypedNeuron):
         """
         last_V = self.V.value
         t = brainstate.environ.get('t')
-        self.solver(self, t, I_ext)
+        dt = brainstate.environ.get('dt')
+        self.solver(self, t, dt, I_ext)
         return self.get_spike(last_V, self.V.value)
 
     def get_spike(self, last_V, next_V):

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -388,7 +388,7 @@ class ICaT_HM1992(_ICa_p2q_ss):
     def __init__(
         self,
         size: brainstate.typing.Size,
-        T: brainstate.typing.ArrayLike = 36.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(36.),
         T_base_p: brainstate.typing.ArrayLike = 3.55,
         T_base_q: brainstate.typing.ArrayLike = 3.,
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 2. * (u.mS / u.cm ** 2),
@@ -397,6 +397,7 @@ class ICaT_HM1992(_ICa_p2q_ss):
         phi_q: Union[brainstate.typing.ArrayLike, Callable] = None,
         name: Optional[str] = None,
     ):
+        T = u.kelvin2celsius(T)
         phi_p = T_base_p ** ((T - 24) / 10) if phi_p is None else phi_p
         phi_q = T_base_q ** ((T - 24) / 10) if phi_q is None else phi_q
         super().__init__(
@@ -489,7 +490,7 @@ class ICaT_HP1992(_ICa_p2q_ss):
     def __init__(
         self,
         size: brainstate.typing.Size,
-        T: brainstate.typing.ArrayLike = 36.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(36.),
         T_base_p: brainstate.typing.ArrayLike = 5.,
         T_base_q: brainstate.typing.ArrayLike = 3.,
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 1.75 * (u.mS / u.cm ** 2),
@@ -498,6 +499,7 @@ class ICaT_HP1992(_ICa_p2q_ss):
         phi_q: Union[brainstate.typing.ArrayLike, Callable] = None,
         name: Optional[str] = None,
     ):
+        T = u.kelvin2celsius(T)
         phi_p = T_base_p ** ((T - 24) / 10) if phi_p is None else phi_p
         phi_q = T_base_q ** ((T - 24) / 10) if phi_q is None else phi_q
         super().__init__(
@@ -587,13 +589,14 @@ class ICaHT_HM1992(_ICa_p2q_ss):
     def __init__(
         self,
         size: brainstate.typing.Size,
-        T: brainstate.typing.ArrayLike = 36.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(36.),
         T_base_p: brainstate.typing.ArrayLike = 3.55,
         T_base_q: brainstate.typing.ArrayLike = 3.,
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 2. * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 25. * u.mV,
         name: Optional[str] = None,
     ):
+        T = u.kelvin2celsius(T)
         super().__init__(
             size,
             name=name,
@@ -684,7 +687,7 @@ class ICaHT_Re1993(_ICa_p2q_markov):
     def __init__(
         self,
         size: brainstate.typing.Size,
-        T: brainstate.typing.ArrayLike = 36.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(36.),
         T_base_p: brainstate.typing.ArrayLike = 2.3,
         T_base_q: brainstate.typing.ArrayLike = 2.3,
         phi_p: Union[brainstate.typing.ArrayLike, Callable] = None,
@@ -693,6 +696,7 @@ class ICaHT_Re1993(_ICa_p2q_markov):
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0. * u.mV,
         name: Optional[str] = None,
     ):
+        T = u.kelvin2celsius(T)
         phi_p = T_base_p ** ((T - 23.) / 10.) if phi_p is None else phi_p
         phi_q = T_base_q ** ((T - 23.) / 10.) if phi_q is None else phi_q
         super().__init__(
@@ -776,13 +780,14 @@ class ICaL_IS2008(_ICa_p2q_ss):
     def __init__(
         self,
         size: brainstate.typing.Size,
-        T: Union[brainstate.typing.ArrayLike, Callable] = 36.,
+        T: Union[brainstate.typing.ArrayLike, Callable] = u.celsius2kelvin(36.),
         T_base_p: Union[brainstate.typing.ArrayLike, Callable] = 3.55,
         T_base_q: Union[brainstate.typing.ArrayLike, Callable] = 3.,
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 1. * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0. * u.mV,
         name: Optional[str] = None,
     ):
+        T = u.kelvin2celsius(T)
         super().__init__(
             size,
             name=name,
@@ -830,12 +835,13 @@ class ICav12_Ma2020(CalciumChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 0 * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0 * u.mV,
         T_base: brainstate.typing.ArrayLike = 3,
-        T: brainstate.typing.ArrayLike = 22.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22.),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
@@ -903,12 +909,13 @@ class ICav13_Ma2020(CalciumChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 0 * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0 * u.mV,
         T_base: brainstate.typing.ArrayLike = 3,
-        T: brainstate.typing.ArrayLike = 22.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22.),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
@@ -983,12 +990,13 @@ class ICav23_Ma2020(CalciumChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 0 * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0 * u.mV,
         T_base: brainstate.typing.ArrayLike = 3,
-        T: brainstate.typing.ArrayLike = 22.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22.),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
@@ -1052,12 +1060,13 @@ class ICav31_Ma2020(CalciumChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 2.5e-4 * (u.cm / u.second),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0 * u.mV,
         T_base: brainstate.typing.ArrayLike = 3,
-        T: brainstate.typing.ArrayLike = 22.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22.),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
@@ -1143,12 +1152,13 @@ class ICaGrc_Ma2020(CalciumChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 0.46 * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0 * u.mV,
         T_base: brainstate.typing.ArrayLike = 3,
-        T: brainstate.typing.ArrayLike = 22.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22.),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)

--- a/braincell/channel/hyperpolarization_activated.py
+++ b/braincell/channel/hyperpolarization_activated.py
@@ -261,11 +261,13 @@ class Ih1_Ma2020(Channel):
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0. * u.mV,
         T_base_g: brainstate.typing.ArrayLike = 1.5,
         T_base_channel: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 22,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22),
         name: Optional[str] = None,
     ):
-        super().__init__(size=size, name=name, )
+        super().__init__(size=size, name=name)
+
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.E = brainstate.init.param(E, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
@@ -344,11 +346,13 @@ class Ih2_Ma2020(Channel):
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0. * u.mV,
         T_base_g: brainstate.typing.ArrayLike = 1.5,
         T_base_channel: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 22,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22),
         name: Optional[str] = None,
     ):
-        super().__init__(size=size, name=name, )
+        super().__init__(size=size, name=name)
+
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.E = brainstate.init.param(E, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)

--- a/braincell/channel/potassium.py
+++ b/braincell/channel/potassium.py
@@ -239,10 +239,11 @@ class IKDR_Ba2002(_IK_p4_markov):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 10. * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = -50. * u.mV,
         T_base: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 36.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(36.),
         phi: Optional[Union[brainstate.typing.ArrayLike, Callable]] = None,
         name: Optional[str] = None,
     ):
+        T = u.kelvin2celsius(T)
         phi = T_base ** ((T - 36) / 10) if phi is None else phi
         super().__init__(
             size,
@@ -1074,13 +1075,14 @@ class IKv11_Ak2007(PotassiumChannel):
         gunit: Union[brainstate.typing.ArrayLike, Callable] = 16. * 1e-9 * u.mS,
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0. * u.mV,
         T_base: brainstate.typing.ArrayLike = 2.7,
-        T: brainstate.typing.ArrayLike = 22,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22),
         name: Optional[str] = None,
     ):
 
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.gateCurrent = brainstate.init.param(gateCurrent, self.varshape, allow_none=False)
         self.gunit = brainstate.init.param(gunit, self.varshape, allow_none=False)
@@ -1146,13 +1148,14 @@ class IKv34_Ma2020(PotassiumChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 4. * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = -11. * u.mV,
         T_base: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 22,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
-        # parameters
-        self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
 
+        # parameters
+        T = u.kelvin2celsius(T)
+        self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
         self.phi = brainstate.init.param(T_base ** ((T - 37) / 10), self.varshape, allow_none=False)
@@ -1235,14 +1238,14 @@ class IKv43_Ma2020(PotassiumChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 3.2 * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0. * u.mV,
         T_base: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 22,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
-
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
         self.phi = brainstate.init.param(T_base ** ((T - 25.5) / 10), self.varshape, allow_none=False)
@@ -1338,14 +1341,14 @@ class IKM_Grc_Ma2020(PotassiumChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 0.25 * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = 0. * u.mV,
         T_base: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 22,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
-
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
         self.phi = brainstate.init.param(T_base ** ((T - 22) / 10), self.varshape, allow_none=False)

--- a/braincell/channel/potassium_calcium.py
+++ b/braincell/channel/potassium_calcium.py
@@ -250,12 +250,13 @@ class IKca3_1_Ma2020(KCaChannel):
         size: brainstate.typing.Size,
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 120. * (u.mS / u.cm ** 2),
         T_base: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 22,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
         self.phi = brainstate.init.param(T_base ** ((T - 37) / 10), self.varshape, allow_none=False)
@@ -324,12 +325,13 @@ class IKca2_2_Ma2020(KCaChannel):
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 38. * (u.mS / u.cm ** 2),
         T_base: brainstate.typing.ArrayLike = 3.,
         diff: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 22,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)
         self.phi = brainstate.init.param(T_base ** ((T - 23) / 10), self.varshape, allow_none=False)
@@ -431,12 +433,13 @@ class IKca1_1_Ma2020(KCaChannel):
         size: brainstate.typing.Size,
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 10. * (u.mS / u.cm ** 2),
         T_base: brainstate.typing.ArrayLike = 3.,
-        T: brainstate.typing.ArrayLike = 22.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22.),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
         # parameters
+        T = u.kelvin2celsius(T)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
         self.T = brainstate.init.param(T, self.varshape, allow_none=False)
         self.T_base = brainstate.init.param(T_base, self.varshape, allow_none=False)

--- a/braincell/channel/sodium.py
+++ b/braincell/channel/sodium.py
@@ -242,11 +242,12 @@ class INa_Ba2002(INa_p3q_markov):
     def __init__(
         self,
         size: brainstate.typing.Size,
-        T: brainstate.typing.ArrayLike = 36.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(36.),
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 90. * (u.mS / u.cm ** 2),
         V_sh: Union[brainstate.typing.ArrayLike, Callable] = -50. * u.mV,
         name: Optional[str] = None,
     ):
+        T = u.kelvin2celsius(T)
         super().__init__(
             size,
             name=name,
@@ -440,12 +441,13 @@ class INa_Rsg(SodiumChannel):
     def __init__(
         self,
         size: brainstate.typing.Size,
-        T: brainstate.typing.ArrayLike = 22.,
+        T: brainstate.typing.ArrayLike = u.celsius2kelvin(22.),
         g_max: Union[brainstate.typing.ArrayLike, Callable] = 15. * (u.mS / u.cm ** 2),
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name, )
 
+        T = u.kelvin2celsius(T)
         self.phi = brainstate.init.param(3 ** ((T - 22) / 10), self.varshape, allow_none=False)
         self.g_max = brainstate.init.param(g_max, self.varshape, allow_none=False)
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor integrators to uniformly accept explicit time-step arguments, improve unit handling, and add new implicit diffrax methods; update Runge-Kutta and exponential Euler integrators to pass dt explicitly; enhance morphology API to separate position and diameter arrays with stricter typing; convert channel temperature parameters to use Kelvin quantities internally; update compartment solvers and tests to match new signatures; rename project references in SECURITY policy.

New Features:
- Introduce implicit diffrax integration methods: backward Euler, Kvaerno3, Kvaerno4, and Kvaerno5.

Enhancements:
- Unify all integrators to accept explicit dt arguments and convert units appropriately in explicit and RK solvers.
- Refactor _integrator_util with type aliases, improved unit checks, and dt propagation.
- Update morphology API to use separate position and diam arrays with enhanced type checking and assertions.
- Modify channel constructors to default temperature parameters in Kelvin and convert to Celsius internally.
- Pass dt from environment to single- and multi-compartment solvers.

Documentation:
- Update SECURITY.md to rename project to BrainCell and correct GitHub issue link for security reports.

Tests:
- Adjust morphology tests to use new position and diam parameters for point sections.