### PR TITLE
Add independent exp euler solver; refactor and update examples

### DIFF
--- a/braincell/_integrator.py
+++ b/braincell/_integrator.py
@@ -24,6 +24,7 @@ __all__ = [
 
     # exponential Euler
     'exp_euler_step',
+    'ind_exp_euler_step',
 
     # runge-kutta methods
     'euler_step',

--- a/braincell/_integrator_diffrax.py
+++ b/braincell/_integrator_diffrax.py
@@ -16,11 +16,12 @@
 import functools
 import importlib.util
 
-import jax.numpy as jnp
 import brainunit as u
+import jax.numpy as jnp
 
-from ._integrator_util import apply_standard_solver_step, VectorFiled, Y0, T, DT
+from ._integrator_util import apply_standard_solver_step
 from ._protocol import DiffEqModule
+from ._typing import VectorFiled, Y0, T, DT
 
 __all__ = [
     # runge-kutta methods
@@ -381,6 +382,7 @@ def diffrax_bwd_euler_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
         target, t, dt, *args
     )
 
+
 def diffrax_kvaerno3_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
     """
     Advances the state of a differential equation module by one integration step using the Kvaerno3 method
@@ -452,6 +454,7 @@ def diffrax_kvaerno4_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
         target, t, dt, *args
     )
 
+
 def diffrax_kvaerno5_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
     """
     Advances the state of a differential equation module by one integration step using the Kvaerno5 method
@@ -486,4 +489,3 @@ def diffrax_kvaerno5_step(target: DiffEqModule, t: T, dt: DT, *args, tol=1e-5):
         diffrax.Kvaerno5(root_finder=diffrax.VeryChord(rtol=tol, atol=tol)),
         target, t, dt, *args
     )
-

--- a/braincell/_integrator_runge_kutta.py
+++ b/braincell/_integrator_runge_kutta.py
@@ -20,9 +20,9 @@ import brainstate
 import brainunit as u
 import jax
 
-from ._integrator_util import T, DT
 from ._misc import set_module_as
 from ._protocol import DiffEqState, DiffEqModule
+from ._typing import T, DT
 
 __all__ = [
     'euler_step',

--- a/braincell/_integrator_util.py
+++ b/braincell/_integrator_util.py
@@ -21,15 +21,7 @@ import jax
 import jax.numpy as jnp
 
 from ._protocol import DiffEqState, DiffEqModule
-
-T = u.Quantity[u.second]
-DT = u.Quantity[u.second]
-VectorFiled = Callable
-Y0 = jax.Array
-Y1 = jax.Array
-Jacobian = jax.Array
-Args = Tuple
-Aux = Dict
+from ._typing import T, DT, Y0, Y1, Aux, Jacobian, VectorFiled, Args
 
 
 def _check_diffeq_state_derivative(state: DiffEqState, dt: u.Quantity):

--- a/braincell/_misc.py
+++ b/braincell/_misc.py
@@ -67,6 +67,7 @@ def set_module_as(name: str):
     Returns:
         Callable: A decorator that modifies the `__name__` attribute of the module.
     """
+
     def decorator(module):
         """
         Decorator to set the `__name__` attribute of the given module.

--- a/braincell/_morphology_utils_test.py
+++ b/braincell/_morphology_utils_test.py
@@ -380,7 +380,7 @@ class TestGenerateInterpolatedNodes(unittest.TestCase):
         node_pre = u.Quantity(np.array([
             [0, 0, 0, 1],
             [10, 0, 0, 2]
-        ]), unit = u.um)
+        ]), unit=u.um)
         nseg = 2
         result = generate_interpolated_nodes(node_pre, nseg)
         self.assertEqual(result.shape, (5, 4))

--- a/braincell/_single_compartment.py
+++ b/braincell/_single_compartment.py
@@ -168,6 +168,7 @@ class SingleCompartment(HHTypedNeuron):
         None
         """
         self.V = DiffEqState(brainstate.init.param(self.V_initializer, self.varshape, batch_size))
+        self.spike = brainstate.ShortTermState(self.get_spike(self.V.value, self.V.value))
         super().init_state(batch_size)
 
     def reset_state(self, batch_size=None):
@@ -187,6 +188,7 @@ class SingleCompartment(HHTypedNeuron):
         None
         """
         self.V.value = brainstate.init.param(self.V_initializer, self.varshape, batch_size)
+        self.spike = self.get_spike(self.V.value, self.V.value)
         super().init_state(batch_size)
 
     def pre_integral(self, I_ext=0. * u.nA / u.cm ** 2):
@@ -263,7 +265,9 @@ class SingleCompartment(HHTypedNeuron):
         t = brainstate.environ.get('t')
         dt = brainstate.environ.get('dt')
         self.solver(self, t, dt, I_ext)
-        return self.get_spike(last_V, self.V.value)
+        spk = self.get_spike(last_V, self.V.value)
+        self.spike.value = spk
+        return spk
 
     def get_spike(self, last_V, next_V):
         """

--- a/braincell/_typing.py
+++ b/braincell/_typing.py
@@ -13,10 +13,20 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Union, Callable, Hashable
+from typing import Union, Callable, Hashable, Tuple, Dict
 
 import brainstate
+import brainunit as u
+import jax
 
 Initializer = Union[brainstate.typing.ArrayLike, Callable]
 SectionName = Hashable
-
+T = u.Quantity[u.second]
+DT = u.Quantity[u.second]
+VectorFiled = Callable
+Y0 = jax.Array
+Y1 = jax.Array
+Jacobian = jax.Array
+Args = Tuple
+Aux = Dict
+Path = Tuple[str, ...]

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -166,17 +166,17 @@ class ICaN_IS2008(CalciumChannel):
     def init_state(self, V, Ca: IonInfo, batch_size: int = None):
         self.p = DiffEqState(brainstate.init.param(u.math.zeros, self.varshape, batch_size))
 
-    def reset_state(self, V, Ca, batch_size=None):
+    def reset_state(self, V, Ca: IonInfo, batch_size=None):
         V = V.to_decimal(u.mV)
         self.p.value = 1.0 / (1 + u.math.exp(-(V + 43.) / 5.2))
 
-    def compute_derivative(self, V, Ca):
+    def compute_derivative(self, V, Ca: IonInfo):
         V = V.to_decimal(u.mV)
         phi_p = 1.0 / (1 + u.math.exp(-(V + 43.) / 5.2))
         p_inf = 2.7 / (u.math.exp(-(V + 55.) / 15.) + u.math.exp((V + 55.) / 15.)) + 1.6
         self.p.derivative = self.phi * (phi_p - self.p.value) / p_inf / u.ms
 
-    def current(self, V, Ca):
+    def current(self, V, Ca: IonInfo):
         M = Ca.C / (Ca.C + 0.2 * u.mM)
         g = self.g_max * M * self.p.value
         return g * (self.E - V)
@@ -237,11 +237,11 @@ class _ICa_p2q_ss(CalciumChannel):
             assert self.p.value.shape[0] == batch_size
             assert self.q.value.shape[0] == batch_size
 
-    def compute_derivative(self, V, Ca):
+    def compute_derivative(self, V, Ca: IonInfo):
         self.p.derivative = self.phi_p * (self.f_p_inf(V) - self.p.value) / self.f_p_tau(V) / u.ms
         self.q.derivative = self.phi_q * (self.f_q_inf(V) - self.q.value) / self.f_q_tau(V) / u.ms
 
-    def current(self, V, Ca):
+    def current(self, V, Ca: IonInfo):
         return self.g_max * self.p.value * self.p.value * self.q.value * (Ca.E - V)
 
     def f_p_inf(self, V):
@@ -317,7 +317,7 @@ class _ICa_p2q_markov(CalciumChannel):
         self.p.derivative = self.phi_p * (self.f_p_alpha(V) * (1 - p) - self.f_p_beta(V) * p) / u.ms
         self.q.derivative = self.phi_q * (self.f_q_alpha(V) * (1 - q) - self.f_q_beta(V) * q) / u.ms
 
-    def current(self, V, Ca):
+    def current(self, V, Ca: IonInfo):
         return self.g_max * self.p.value * self.p.value * self.q.value * (Ca.E - V)
 
     def f_p_alpha(self, V):

--- a/docs/apis/integration.rst
+++ b/docs/apis/integration.rst
@@ -22,6 +22,7 @@ Exponential Integrators
    :toctree: generated/
 
    exp_euler_step
+   ind_exp_euler_step
 
 
 Runge-Kutta Integrators

--- a/examples/COBA_HH_2007_braincell.py
+++ b/examples/COBA_HH_2007_braincell.py
@@ -1,0 +1,96 @@
+# Copyright 2024 BDP Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+#
+# Implementation of the paper:
+#
+# - Brette, R., Rudolph, M., Carnevale, T., Hines, M., Beeman, D., Bower, J. M., et al. (2007),
+#   Simulation of networks of spiking neurons: a review of tools and strategies., J. Comput. Neurosci., 23, 3, 349–98
+#
+
+import brainunit as u
+import matplotlib.pyplot as plt
+
+import braincell
+import brainstate
+
+
+V_th = -20. * u.mV
+area = 20000 * u.um ** 2
+area = area.in_unit(u.cm ** 2)
+Cm = (1 * u.uF * u.cm ** -2) * area  # Membrane Capacitance [pF]
+
+
+class HH(braincell.SingleCompartment):
+    def __init__(self, in_size):
+        super().__init__(in_size, C=Cm, solver='ind_exp_euler')
+        self.na = braincell.ion.SodiumFixed(in_size, E=50. * u.mV)
+        self.na.add_elem(
+            INa=braincell.channel.INa_TM1991(in_size, g_max=(100. * u.mS * u.cm ** -2) * area, V_sh=-63. * u.mV)
+        )
+
+        self.k = braincell.ion.PotassiumFixed(in_size, E=-90 * u.mV)
+        self.k.add_elem(
+            IK=braincell.channel.IK_TM1991(in_size, g_max=(30. * u.mS * u.cm ** -2) * area, V_sh=-63. * u.mV)
+        )
+
+        self.IL = braincell.channel.IL(in_size, E=-60. * u.mV, g_max=(5. * u.nS * u.cm ** -2) * area)
+
+
+class EINet(brainstate.nn.DynamicsGroup):
+    def __init__(self):
+        super().__init__()
+        self.n_exc = 3200
+        self.n_inh = 800
+        self.num = self.n_exc + self.n_inh
+        self.N = HH(self.num)
+
+        self.E = brainstate.nn.AlignPostProj(
+            comm=brainstate.nn.EventFixedProb(self.n_exc, self.num, conn_num=0.02, conn_weight=6. * u.nS),
+            syn=brainstate.nn.Expon(self.num, tau=5. * u.ms),
+            out=brainstate.nn.COBA(E=0. * u.mV),
+            post=self.N
+        )
+        self.I = brainstate.nn.AlignPostProj(
+            comm=brainstate.nn.EventFixedProb(self.n_inh, self.num, conn_num=0.02, conn_weight=67. * u.nS),
+            syn=brainstate.nn.Expon(self.num, tau=10. * u.ms),
+            out=brainstate.nn.COBA(E=-80. * u.mV),
+            post=self.N
+        )
+
+    def update(self, t):
+        with brainstate.environ.context(t=t):
+            spk = self.N.spike.value
+            self.E(spk[:self.n_exc])
+            self.I(spk[self.n_exc:])
+            spk = self.N(0. * u.nA)
+            return spk
+
+
+# network
+net = EINet()
+brainstate.nn.init_all_states(net)
+
+# simulation
+with brainstate.environ.context(dt=0.1 * u.ms):
+    times = u.math.arange(0. * u.ms, 100. * u.ms, brainstate.environ.get_dt())
+    spikes = brainstate.compile.for_loop(net.update, times, pbar=brainstate.compile.ProgressBar(10))
+
+# visualization
+t_indices, n_indices = u.math.where(spikes)
+plt.scatter(times[t_indices], n_indices, s=1)
+plt.xlabel('Time (ms)')
+plt.ylabel('Neuron index')
+plt.show()

--- a/examples/thalamus_single_compartment_neurons.py
+++ b/examples/thalamus_single_compartment_neurons.py
@@ -47,7 +47,7 @@ class HTC(ThalamusNeuron):
         size,
         gKL=0.01 * (u.mS / u.cm ** 2),
         V_initializer=brainstate.init.Constant(-65. * u.mV),
-        solver: str = 'exp_euler'
+        solver: str = 'ind_exp_euler'
     ):
         super().__init__(size, V_initializer=V_initializer, V_th=20. * u.mV, solver=solver)
 
@@ -79,7 +79,7 @@ class RTC(ThalamusNeuron):
         size,
         gKL=0.01 * (u.mS / u.cm ** 2),
         V_initializer=brainstate.init.Constant(-65. * u.mV),
-        solver: str = 'exp_euler'
+        solver: str = 'ind_exp_euler'
     ):
         super().__init__(size, V_initializer=V_initializer, V_th=20 * u.mV, solver=solver)
 
@@ -110,7 +110,7 @@ class IN(ThalamusNeuron):
         self,
         size,
         V_initializer=brainstate.init.Constant(-70. * u.mV),
-        solver: str = 'exp_euler'
+        solver: str = 'ind_exp_euler'
     ):
         super().__init__(size, V_initializer=V_initializer, V_th=20. * u.mV, solver=solver)
 
@@ -139,7 +139,7 @@ class TRN(ThalamusNeuron):
         self,
         size,
         V_initializer=brainstate.init.Constant(-70. * u.mV), gl=0.0075,
-        solver: str = 'exp_euler'
+        solver: str = 'ind_exp_euler'
     ):
         super().__init__(size, V_initializer=V_initializer, V_th=20. * u.mV, solver=solver)
 
@@ -174,7 +174,7 @@ def try_trn_neuron():
     # neu = HTC(1)  # [n_neuron, ]
     # neu = IN(1)  # [n_neuron, ]
     # neu = RTC(1)  # [n_neuron, ]
-    neu = HTC(1, solver='exp_euler')  # [n_neuron,]
+    neu = HTC(1, solver='ind_exp_euler')  # [n_neuron,]
     neu.init_state()
 
     t0 = time.time()


### PR DESCRIPTION
## Summary by Sourcery

Introduce an independent exponential Euler integrator alongside typing and API improvements, update examples to use it, and enrich channel type annotations.

New Features:
- Add `ind_exp_euler_step` for per‐state exponential Euler integration.
- Introduce `power_iteration_expm` for matrix exponential via power series or SciPy.
- Record and return spike output via `ShortTermState` in `SingleCompartment`.
- Provide a new `examples/COBA_HH_2007_braincell.py` demo using the independent solver.

Enhancements:
- Refactor `exp_euler_step` to delegate its matrix exponential to `power_iteration_expm`.
- Switch default solver in existing example scripts from `exp_euler` to `ind_exp_euler`.
- Centralize and extend physical type definitions in `_typing.py` and apply them throughout integrators.
- Add `IonInfo` type annotations to channel `compute_derivative` and `current` methods.
- Expose `ind_exp_euler_step` in the package `__all__` lists.

Documentation:
- Add a standalone COBA HH example script under `examples/` for user guidance.

Tests:
- Fix argument formatting in `_morphology_utils_test`.