### PR TITLE
Standardize Units, Refactor Current Handling, and Enhance Examples

### DIFF
--- a/braincell/_base.py
+++ b/braincell/_base.py
@@ -81,7 +81,7 @@ The actual implementations of some classes (e.g., SingleCompartment, specific Io
 may be defined in other files within the BrainCell library.
 """
 
-from typing import Optional, Dict, Sequence, Callable, NamedTuple, Tuple, Type
+from typing import Optional, Dict, Sequence, Callable, NamedTuple, Tuple, Type, Hashable
 
 import numpy as np
 
@@ -884,18 +884,18 @@ class Ion(IonChannel, Container):
             node: Channel
             node.reset_state(V, ion_info, batch_size)
 
-    def register_external_current(self, key: str, fun: Callable):
+    def register_external_current(self, key: Hashable, fun: Callable):
         """
         Register an external current function.
 
         This method adds a new external current function to the ion channel.
 
         Parameters:
-            key (str): A unique identifier for the external current.
+            key (Hashable): A unique identifier for the external current.
             fun (Callable): The function that computes the external current.
 
         Raises:
-            ValueError: If the key already exists in the external currents dictionary.
+            ValueError: If the key already exists in the external currents' dictionary.
         """
         if key in self._external_currents:
             raise ValueError
@@ -1280,7 +1280,7 @@ class MixIons(IonChannel, Container):
             elem: Channel
             for ion_root in elem.root_type.__args__:
                 ion = self._get_ion(ion_root)
-                ion.register_external_current(elem.name, self._get_ion_fun(ion, elem))
+                ion.register_external_current(id(elem), self._get_ion_fun(ion, elem))
 
     def _get_ion_fun(self, ion: 'Ion', node: 'Channel'):
         def fun(V, ion_info):

--- a/braincell/_single_compartment.py
+++ b/braincell/_single_compartment.py
@@ -225,12 +225,16 @@ class SingleCompartment(HHTypedNeuron):
             External current input. Default is 0 nA/cm^2.
         """
         I_ext = self.sum_current_inputs(I_ext, self.V.value)
-
         for key, ch in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
-            I_ext = I_ext + ch.current(self.V.value)
-
+            try:
+                I_ext = I_ext + ch.current(self.V.value)
+            except Exception as e:
+                raise ValueError(
+                    f"Error in computing current for ion channel '{key}': \n"
+                    f"{ch}\n"
+                    f"Error: {e}"
+                )
         self.V.derivative = I_ext / self.C
-
         for key, node in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
             node.compute_derivative(self.V.value)
 
@@ -303,4 +307,3 @@ class SingleCompartment(HHTypedNeuron):
     def soma_spike(self):
         denom = 20.0 * u.mV
         return self.spk_fun((self.V.value - self.V_th) / denom)
-


### PR DESCRIPTION
## Summary by Sourcery

Improve unit consistency and debugging in neuron and network models, refine external current registration, and enhance example scripts with better plotting and progress reporting.

Bug Fixes:
- Add try/except around ion channel current computation to raise informative errors with channel context

Enhancements:
- Refactor register_external_current to accept Hashable keys and use element id to prevent collisions
- Consolidate current summation and area scaling in ThalamusNeuron.compute_derivative
- Standardize units for conductances and synaptic parameters in the unified thalamus example
- Update raster_plot to use set_xlabel/set_ylabel and reformat its signature
- Remove redundant dt setting, add progress bar to for_loop, and add suptitle in example simulations