### PR TITLE
Remove unused kernel generators and clean up voltage solver code

### DIFF
--- a/braincell/__init__.py
+++ b/braincell/__init__.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 
-__version__ = "0.0.7"
+__version__ = "0.0.8"
 __version_info__ = tuple(map(int, __version__.split(".")))
 
 from . import channel

--- a/braincell/quad/_integrator_voltage_solver.py
+++ b/braincell/quad/_integrator_voltage_solver.py
@@ -25,8 +25,6 @@ import brainunit as u
 import jax
 import jax.numpy as jnp
 import numpy as np
-from brainevent._compatible_import import pallas as pl
-from brainevent._misc import generate_block_dim
 
 from braincell._misc import set_module_as
 from ._integrator_protocol import DiffEqModule
@@ -115,68 +113,6 @@ def dhs_voltage_step(target, t, dt, *args):
     target.V.value = solves[:, internal_node_inds].reshape(target.V.value.shape) * u.mV
 
 
-def _comp_triang_numba_kernel_generator(**kwargs):
-    def kernel(diags, solves, lowers, uppers, children, parents, out_diags_ref, out_solves_ref):
-        for i_edge in range(children.shape[0]):
-            child = children[i_edge]
-            parent = parents[i_edge]
-            lower_val = lowers[child]
-            upper_val = uppers[child]
-            child_diag = diags[:, child]
-            child_solve = solves[:, child]
-            multiplier = upper_val / child_diag
-            out_diags_ref[:, parent] = out_diags_ref[:, parent] - lower_val * multiplier
-            out_solves_ref[:, parent] = out_solves_ref[:, parent] - child_solve * multiplier
-
-    return brainevent.numba_kernel(kernel, input_output_aliases={0: 0, 1: 1})
-
-
-def _comp_triang_pallas_kernel_generator(diags_info: jax.ShapeDtypeStruct, **kwargs):
-    block_size = generate_block_dim(diags_info.shape[0], maximum=128)
-    n_neuron_loop = pl.cdiv(diags_info.shape[0], block_size)
-
-    def kernel(
-        diags_ref,  # [n_neuron, n_nodes]
-        solves_ref,  # [n_neuron, n_nodes]
-        lowers_ref,  # [ n_nodes]
-        uppers_ref,  # [ n_nodes]
-        children_ref,  # [ n_nodes-1]
-        parent_ref,  # [ n_nodes-1]
-        # outs
-        out_diags_ref,  # [n_neuron, n_nodes]
-        out_solves_ref,  # [n_neuron, n_nodes]
-    ):
-        i_neuron_block = pl.program_id(0)
-        i_neuron = i_neuron_block * block_size
-        mask = jnp.arange(block_size) + i_neuron < diags_info.shape[0]
-
-        def edge_loop_fn(i_edge, _):
-            child = children_ref[i_edge]
-            parent = parent_ref[i_edge]
-            lower_val = lowers_ref[child]
-            upper_val = uppers_ref[child]
-            child_diag = pl.load(diags_ref, (pl.dslice(i_neuron, block_size), child), mask=mask)
-            child_solve = pl.load(solves_ref, (pl.dslice(i_neuron, block_size), child), mask=mask)
-            multiplier = upper_val / child_diag
-            index = (pl.dslice(i_neuron, block_size), parent)
-            old_diag = pl.load(out_diags_ref, index, mask=mask)
-            old_solve = pl.load(out_solves_ref, index, mask=mask)
-            pl.store(out_diags_ref, index, old_diag - lower_val * multiplier, mask=mask)
-            pl.store(out_solves_ref, index, old_solve - child_solve * multiplier, mask=mask)
-
-        jax.lax.fori_loop(0, children_ref.shape[0], edge_loop_fn, None)
-
-    return brainevent.pallas_kernel(
-        kernel, tile=(n_neuron_loop,), input_output_aliases={0: 0, 1: 1}, outs=kwargs['outs']
-    )
-
-
-_comp_triang = brainevent.XLACustomKernel('comp_triang')
-_comp_triang.def_cpu_kernel(_comp_triang_numba_kernel_generator)
-_comp_triang.def_gpu_kernel(pallas=_comp_triang_pallas_kernel_generator)
-_comp_triang.def_tpu_kernel(_comp_triang_pallas_kernel_generator)
-
-
 def _check_comp_triang(diags, solves, lowers, uppers, edges):
     assert not isinstance(diags, u.Quantity)
     assert not isinstance(solves, u.Quantity)
@@ -193,46 +129,8 @@ def _check_comp_triang(diags, solves, lowers, uppers, edges):
     assert edges.ndim == 2 and edges.shape[1] == 2
 
 
-def comp_triang_call(diags, solves, lowers, uppers, edges):
-    # diags: [n_neuron, n_nodes]
-    # solves: [n_neuron, n_nodes]
-    # lowers: [n_nodes]
-    # uppers: [n_nodes]
-    # edges: [n_nodes-1, 2]
-    _check_comp_triang(diags, solves, lowers, uppers, edges)
-    return _comp_triang(
-        diags, solves, lowers, uppers, edges[:, 0], edges[:, 1],
-        diags_info=jax.ShapeDtypeStruct(diags.shape, diags.dtype),
-        outs=(
-            jax.ShapeDtypeStruct(diags.shape, diags.dtype),
-            jax.ShapeDtypeStruct(solves.shape, solves.dtype),
-        )
-    )
-
-
 def comp_triang_raw(diags, solves, lowers, uppers, edges, level_sizes):
     _check_comp_triang(diags, solves, lowers, uppers, edges)
-
-    def version1():
-        def loop_fn(val, edge):
-            diags_, solves_ = val
-            child, parent = edge
-            lower_val = lowers[child]
-            upper_val = uppers[child]
-            child_diag = diags_[:, child]
-            child_solve = solves_[:, child]
-
-            # Factor that the child row has to be multiplied by.
-            multiplier = upper_val / child_diag
-
-            # Updates to diagonal and solve
-            diags_ = diags_.at[:, parent].add(-lower_val * multiplier)
-            solves_ = solves_.at[:, parent].add(-child_solve * multiplier)
-            return (diags_, solves_), None
-
-        return jax.lax.scan(loop_fn, (diags, solves), edges)[0]
-
-    # return version1()
 
     with jax.ensure_compile_time_eval():
         level_sizes = np.cumsum(np.insert(level_sizes, 0, 0))
@@ -251,217 +149,6 @@ def comp_triang_raw(diags, solves, lowers, uppers, edges, level_sizes):
         diags = diags.at[:, parent].add(-lower_val * multiplier)
         solves = solves.at[:, parent].add(-child_solve * multiplier)
     return diags, solves
-
-
-def comp_triang_call_v2(diags, solves, lowers, uppers, edges, level_sizes):
-    _check_comp_triang(diags, solves, lowers, uppers, edges)
-    block_size = generate_block_dim(diags.shape[0], maximum=128)
-    n_neuron_loop = pl.cdiv(diags.shape[0], block_size)
-
-    with jax.ensure_compile_time_eval():
-        level_sizes = np.cumsum(np.insert(level_sizes, 0, 0))
-
-    def kernel(
-        diags_ref,  # [n_neuron, n_nodes]
-        solves_ref,  # [n_neuron, n_nodes]
-        lowers_ref,  # [ n_nodes]
-        uppers_ref,  # [ n_nodes]
-        children_ref,  # [ n_nodes-1]
-        parent_ref,  # [ n_nodes-1]
-        # outs
-        out_diags_ref,  # [n_neuron, n_nodes]
-        out_solves_ref,  # [n_neuron, n_nodes]
-    ):
-        i_neuron_block = pl.program_id(0)
-        i_neuron = i_neuron_block * block_size
-        mask = jnp.arange(block_size) + i_neuron < diags_ref.shape[0]
-        mask = mask[:, np.newaxis]
-
-        for i in range(level_sizes.shape[0] - 1):
-            child = children_ref[level_sizes[i]:level_sizes[i + 1]]
-            parent = parent_ref[level_sizes[i]:level_sizes[i + 1]]
-            lower_val = lowers_ref[child]
-            upper_val = uppers_ref[child]
-            child_diag = pl.load(diags_ref, (pl.dslice(i_neuron, block_size), child), mask=mask)
-            child_solve = pl.load(solves_ref, (pl.dslice(i_neuron, block_size), child), mask=mask)
-            multiplier = upper_val / child_diag
-            index = (pl.dslice(i_neuron, block_size), parent)
-            old_diag = pl.load(out_diags_ref, index, mask=mask)
-            old_solve = pl.load(out_solves_ref, index, mask=mask)
-            pl.store(out_diags_ref, index, old_diag - lower_val * multiplier, mask=mask)
-            pl.store(out_solves_ref, index, old_solve - child_solve * multiplier, mask=mask)
-
-    return pl.pallas_call(
-        kernel,
-        grid=(n_neuron_loop,),
-        out_shape=(
-            jax.ShapeDtypeStruct(diags.shape, diags.dtype),
-            jax.ShapeDtypeStruct(solves.shape, solves.dtype)
-        ),
-    )(diags, solves, lowers, uppers, edges[:, 0], edges[:, 1])
-
-
-def _comp_backsub_numba_kernel_generator(n_nodes: int, n_steps: int, **kwargs):
-    def kernel(diags_ref, solves_ref, lowers_ref, parent_lookup_ref, out_solve_ref):
-        # Set lowers[0]=0.0 because the zero-eth compartment does not have a `lower`.
-        lowers_ref[0] = 0.0
-
-        # Rephrase the equations as a recursion.
-        # x[n] = solve[n]/diag[n] - lower[n]/diag[n] * x[parent].
-        # x[n] = solve_effect[n] + lower_effect[n] * x[parent].
-        lower_effect = -lowers_ref / diags_ref
-        solve_effect = solves_ref / diags_ref
-
-        step = 1
-        while step <= n_steps:
-            # For each node, get its k-step parent, where k=`step`.
-            k_step_parent = np.arange(n_nodes + 1)
-            for _ in range(step):
-                k_step_parent = parent_lookup_ref[k_step_parent]
-
-            # Update
-            solve_effect = solve_effect + lower_effect * solve_effect[:, k_step_parent]
-            lower_effect = lower_effect * lower_effect[:, k_step_parent]
-            step *= 2
-
-        # We have to return a `diags` because the final solution is computed as
-        # `solves/diags` (see `step_voltage_implicit_with_dhs_solve`). For recursive
-        # doubling, the solution should just be `solve_effect`, so we define diags as
-        # 1.0 so the division has no effect.
-        out_solve_ref[:] = solve_effect
-
-    return brainevent.numba_kernel(kernel)
-
-
-def _comp_backsub_warp_kernel_generator(
-    diags_info: jax.ShapeDtypeStruct,
-    solves_info: jax.ShapeDtypeStruct,
-    lowers_info: jax.ShapeDtypeStruct,
-    indices_info: jax.ShapeDtypeStruct,
-    **kwargs
-):
-    import warp
-    TILE_SIZE = warp.constant(solves_info.shape[1])
-
-    def kernel(
-        diags_ref: brainevent.jaxinfo_to_warpinfo(diags_info),
-        solves_ref: brainevent.jaxinfo_to_warpinfo(solves_info),
-        lowers_ref: brainevent.jaxinfo_to_warpinfo(lowers_info),
-        indices_ref: brainevent.jaxinfo_to_warpinfo(indices_info),
-        out_solve_ref: brainevent.jaxinfo_to_warpinfo(solves_info),
-    ):
-        i_neuron = warp.tid()
-
-        diags = warp.tile_load(diags_ref[i_neuron], TILE_SIZE, storage='shared')
-        solves = warp.tile_load(solves_ref[i_neuron], TILE_SIZE, storage='shared')
-        lowers = warp.tile_load(lowers_ref, TILE_SIZE, storage='shared')
-
-        lowers[0] = 0.0
-        lowers2 = warp.untile(lowers)
-        diags2 = warp.untile(diags)
-        solves2 = warp.untile(solves)
-        lower_effect1 = -lowers2 / diags2
-        solve_effect1 = solves2 / diags2
-        lower_effect = warp.tile(lower_effect1)
-        solve_effect = warp.tile(solve_effect1)
-
-        for i in range(indices_ref.shape[0]):
-            k_step_parent = warp.untile(warp.tile_load(indices_ref[i], TILE_SIZE))
-            solve2 = warp.tile(solve_effect[k_step_parent])
-            lower2 = warp.tile(lower_effect[k_step_parent])
-            solve_effect = lower_effect * solve2 + solve_effect
-            lower_effect = lower_effect * lower2
-
-        warp.tile_store(out_solve_ref[i_neuron], solve_effect, TILE_SIZE)
-
-    return brainevent.warp_kernel(kernel, tile=(solves_info.shape[0],), block_dim=TILE_SIZE)
-
-
-def _comp_backsub_warp_kernel_generator_v1(
-    diags_info: jax.ShapeDtypeStruct,
-    solves_info: jax.ShapeDtypeStruct,
-    lowers_info: jax.ShapeDtypeStruct,
-    indices_info: jax.ShapeDtypeStruct,
-    **kwargs
-):
-    import warp
-    TILE_SIZE = warp.constant(solves_info.shape[1])
-
-    @warp.func
-    def ke1(x: float, y: float) -> float:
-        return -x / y
-
-    @warp.func
-    def ke2(x: float, y: float) -> float:
-        return x / y
-
-    def kernel(
-        diags_ref: brainevent.jaxinfo_to_warpinfo(diags_info),
-        solves_ref: brainevent.jaxinfo_to_warpinfo(solves_info),
-        lowers_ref: brainevent.jaxinfo_to_warpinfo(lowers_info),
-        indices_ref: brainevent.jaxinfo_to_warpinfo(indices_info),
-        out_solve_ref: brainevent.jaxinfo_to_warpinfo(solves_info),
-    ):
-        i_neuron = warp.tid()
-
-        diags = warp.tile_load(diags_ref[i_neuron], TILE_SIZE, storage='shared')
-        solves = warp.tile_load(solves_ref[i_neuron], TILE_SIZE, storage='shared')
-        lowers = warp.tile_load(lowers_ref, TILE_SIZE, storage='shared')
-
-        lowers[0] = 0.0
-        lower_effect = warp.tile_map(ke1, lowers, diags)
-        solve_effect = warp.tile_map(ke2, solves, diags)
-
-        for i in range(indices_ref.shape[0]):
-            k_step_parent = warp.tile_load(indices_ref[i], TILE_SIZE)
-            solve_effect = lower_effect * solve_effect[k_step_parent] + solve_effect
-            lower_effect = lower_effect * lower_effect[k_step_parent]
-
-        warp.tile_store(out_solve_ref[i_neuron], solve_effect, TILE_SIZE)
-
-    return brainevent.warp_kernel(kernel, tile=(solves_info.shape[0],), block_dim=TILE_SIZE)
-
-
-def _comp_backsub_pallas_kernel_generator_v1(
-    solves_info: jax.ShapeDtypeStruct,
-    n_nodes: int,
-    **kwargs
-):
-    def kernel(
-        diags_ref,
-        solves_ref,
-        lowers_ref,
-        indices_ref,
-        out_solve_ref,
-    ):
-        i_neuron = pl.program_id(0)
-
-        mask = jnp.arange(lowers_ref.shape[0]) < n_nodes + 1
-        diags = pl.load(diags_ref, i_neuron)
-        solves = pl.load(solves_ref, i_neuron)
-        lowers = pl.load(lowers_ref, pl.dslice(None))
-
-        lowers = lowers.at[0].set(0.0)
-        lower_effect = -lowers / diags
-        solve_effect = solves / diags
-        for i in range(indices_ref.shape[0]):
-            index = pl.load(indices_ref, i)
-            solve_effect = lower_effect * solve_effect[index] + solve_effect
-            lower_effect = lower_effect * lower_effect[index]
-
-        pl.store(out_solve_ref, i_neuron, solve_effect)
-
-    return brainevent.pallas_kernel(kernel, tile=(solves_info.shape[0],), outs=kwargs['outs'])
-
-
-_comp_backsub = brainevent.XLACustomKernel('comp_backsub')
-_comp_backsub.def_cpu_kernel(_comp_backsub_numba_kernel_generator)
-_comp_backsub.def_gpu_kernel(
-    warp=_comp_backsub_warp_kernel_generator_v1,
-    pallas=_comp_backsub_pallas_kernel_generator_v1,
-    default='warp'
-)
-_comp_backsub.def_tpu_kernel(_comp_backsub_pallas_kernel_generator_v1)
 
 
 def _check_comp_backsub(diags, solves, lowers, parent_lookup):
@@ -493,39 +180,6 @@ def _get_index_comp_backsub(parent_lookup, n_steps, n_nodes):
             indices.append(k_step_parent)
         indices = np.asarray(indices)
     return indices
-
-
-def comp_backsub_call(
-    diags,
-    solves,
-    lowers,
-    parent_lookup,
-    *,
-    n_nodes: int,
-    n_steps: int,
-):
-    # diags: [n_neuron, n_nodes]
-    # solves: [n_neuron, n_nodes]
-    # lowers: [n_nodes]
-    # parent_lookup: [n_nodes]
-
-    # size_power2 = pl.next_power_of_2(n_nodes + 1)
-    # diags = jnp.pad(diags, ((0, 0), (0, size_power2 - (n_nodes + 1))), mode='constant')
-    # solves = jnp.pad(solves, ((0, 0), (0, size_power2 - (n_nodes + 1))), mode='constant')
-    # lowers = jnp.pad(lowers, (0, size_power2 - (n_nodes + 1)), mode='constant')
-    # parent_lookup = jnp.pad(parent_lookup, (0, size_power2 - (n_nodes + 1)), mode='edge')
-    _check_comp_backsub(diags, solves, lowers, parent_lookup)
-    indices = _get_index_comp_backsub(parent_lookup, n_steps, n_nodes)
-    return _comp_backsub(
-        diags, solves, lowers, indices,
-        n_nodes=n_nodes,
-        n_steps=n_steps,
-        diags_info=jax.ShapeDtypeStruct(diags.shape, diags.dtype),
-        solves_info=jax.ShapeDtypeStruct(solves.shape, solves.dtype),
-        lowers_info=jax.ShapeDtypeStruct(lowers.shape, lowers.dtype),
-        indices_info=jax.ShapeDtypeStruct(indices.shape, indices.dtype),
-        outs=(jax.ShapeDtypeStruct(solves.shape, solves.dtype),)
-    )[0]
 
 
 def comp_backsub_raw(
@@ -744,7 +398,7 @@ def _laplacian_matrix(target: DiffEqModule) -> brainevent.CSR:
           off-diagonal elements to ensure conservation of current.
         - The normalization by (area*cm) accounts for compartment geometry and membrane properties.
     """
-    from ._multi_compartment import MultiCompartment
+    from braincell._multi_compartment import MultiCompartment
     target: MultiCompartment
 
     with jax.ensure_compile_time_eval():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ version = { attr = "braincell.__version__" }
 name = "braincell"
 description = "Biologically Detailed Brain Cell Modeling in JAX"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 authors = [{ name = "BrainCell Developers", email = "chao.brain@qq.com" }]
 keywords = [
     "dendritic computation",
@@ -39,7 +39,6 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -54,7 +53,7 @@ dependencies = [
     "numpy>=1.15",
     "brainunit>=0.0.8",
     "brainstate>=0.2.0",
-    "brainevent>=0.0.2",
+    "brainevent>=0.0.7",
     "scipy",
     "brainpy>=2.7.5",
     "braintools>=0.1.0",
@@ -70,8 +69,8 @@ Documentation = "https://braincell.readthedocs.io/"
 
 
 [project.optional-dependencies]
-cpu = ["jax[cpu]", "brainstate", "brainunit", "brainevent", "brainpy", "braintools"]
-cuda12 = ["jax[cuda12]", "brainstate", "brainunit", "brainevent", "brainpy", "braintools"]
-cuda13 = ["jax[cuda13]", "brainstate", "brainunit", "brainevent", "brainpy", "braintools"]
-tpu = ["jax[tpu]", "brainstate", "brainunit", "brainevent", "brainpy", "braintools"]
-testing = ["pytest", "jax", "brainstate", "brainunit", "brainevent", "brainpy", "braintools"]
+cpu = ["jax[cpu]"]
+cuda12 = ["jax[cuda12]"]
+cuda13 = ["jax[cuda13]"]
+tpu = ["jax[tpu]"]
+testing = ["pytest", "jax"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ scipy
 jax
 brainunit>=0.0.4
 brainstate>=0.2.9
-brainevent>=0.0.2
+brainevent>=0.0.7
 brainpy>=2.7.5


### PR DESCRIPTION
## Summary by Sourcery

Simplify voltage solver implementation by removing unused custom kernel pathways and using the raw JAX-based routines, while cleaning up internal imports.

Enhancements:
- Remove unused custom XLA/Numba/Pallas/Warp kernel generators and call wrappers for DHS forward (comp_triang) and backward substitution (comp_backsub), relying instead on the raw implementations.
- Update the Laplacian construction helper to use an absolute import for the multi-compartment module to improve clarity and module structure.