### PR TITLE
docs: document missing public APIs in docs/apis/

### DIFF
--- a/docs/apis/braincell.mech.rst
+++ b/docs/apis/braincell.mech.rst
@@ -1,0 +1,75 @@
+``braincell.mech`` module
+=========================
+
+.. currentmodule:: braincell.mech
+.. automodule:: braincell.mech
+
+``braincell.mech`` is the purely declarative mechanism layer for
+:class:`braincell.Cell`. It describes *what* to install on a cell without
+touching runtime state, JAX, or ``brainstate``. Every declaration inherits
+from the :class:`Mechanism` marker base class and splits into two families:
+
+- **Density mechanisms** are distributed over a region of a cell
+  (:class:`Density` and its concrete subclasses :class:`Channel` for ion
+  channels and :class:`Ion` for ion species).
+- **Point mechanisms** are attached to a single location (:class:`Point` and
+  its subclasses, including :class:`Synapse`, :class:`Junction`, and the probe
+  declarations).
+
+The passive cable property and the stimulus clamps
+(:class:`~braincell.CableProperty`, :class:`~braincell.CurrentClamp`,
+:class:`~braincell.SineClamp`, :class:`~braincell.FunctionClamp`) are also
+declared here but are re-exported at the top level; see
+:doc:`braincell` for their reference entries.
+
+
+Base
+----
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+    Mechanism
+    Params
+
+
+Density Mechanisms
+------------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+    Density
+    Channel
+    Ion
+
+
+Point Mechanisms
+----------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+    Point
+    Junction
+    Synapse
+
+
+Probes
+------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+    StateProbe
+    MechanismProbe
+    CurrentProbe
+    ProbeMechanism

--- a/docs/apis/braincell.rst
+++ b/docs/apis/braincell.rst
@@ -26,6 +26,7 @@ Base Class for Cell Modeling
     HHTypedNeuron
     SingleCompartment
     Cell
+    RunResult
 
 
 
@@ -42,3 +43,75 @@ Base Class for Ion Channels
     IonInfo
     MixIons
     Channel
+
+
+Ion Helpers
+-----------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+    mix_ions
+
+
+Discretization: Control Volumes and Policies
+---------------------------------------------
+
+Static, declaration-time representation of how a multi-compartment cell is
+divided into control volumes (CVs), plus the policies that decide how many
+CVs each branch receives.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+    CV
+    CVTree
+    Node
+    NodeTree
+    CVPolicy
+    CVPerBranch
+    CVPolicyByTypeRule
+    CompositeByTypePolicy
+    DLambda
+    MaxCVLen
+
+
+Morphology
+----------
+
+Neuronal morphology container and the branch types used to label sections of
+a reconstruction.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+    Morphology
+    Branch
+    Soma
+    Dendrite
+    Axon
+    BasalDendrite
+    ApicalDendrite
+    CustomBranch
+
+
+Stimulus and Cable Mechanisms
+-----------------------------
+
+Passive cable properties and stimulus clamps attachable to a cell. See
+:doc:`braincell.mech` for the full declarative mechanism layer.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+    CableProperty
+    CurrentClamp
+    SineClamp
+    FunctionClamp

--- a/docs/apis/vis.rst
+++ b/docs/apis/vis.rst
@@ -45,6 +45,7 @@ Morphometry and topology plots
 
     plot_dendrogram
     plot_topology
+    plot_point_topology
     plot_sholl
     plot_branch_order_histogram
 
@@ -118,3 +119,19 @@ Layout engine
 
     LayoutConfig
     LayoutCache
+
+
+Publication constants
+----------------------
+
+.. py:data:: PUBLICATION_BRANCH_TYPE_COLORS
+
+   Publication-ready branch-type colour palette (RGB tuples keyed by branch
+   type). High-contrast, print-friendly, and colour-blind safe; mirrors the
+   keys of the default palette so the two presets can be diffed side by side.
+
+.. py:data:: PUBLICATION_RC_PARAMS
+
+   Matplotlib ``rcParams`` applied when the publication theme is active.
+   Tuned for LaTeX-style output (serif font, thicker lines, no grid, tight
+   margins) and 300 dpi raster export.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -110,8 +110,8 @@ Here is an example to model a **single-compartment** thalamus neuron model:
 
    apis/braincell.rst
    apis/morphology.rst
-   apis/braincell.neuron.rst
    apis/braincell.synapse.rst
+   apis/braincell.mech.rst
    apis/braincell.ion.rst
    apis/braincell.channel.rst
    apis/integration.rst


### PR DESCRIPTION
## Summary
Audited each module's effective public surface (`__all__`, including star-imported submodule lists) against the rendered Sphinx API reference and filled the gaps. `channel`, `ion`, `synapse`, `quad`, and `morph` were already complete; the gaps were in the top-level namespace, an entirely missing `mech` page, `vis`, and a broken toctree reference.

- **`apis/braincell.rst`** — document the undocumented top-level re-exports: `RunResult`, discretization control volumes & policies (`CV`, `CVTree`, `Node`, `NodeTree`, `CVPolicy`, `CVPerBranch`, `CVPolicyByTypeRule`, `CompositeByTypePolicy`, `DLambda`, `MaxCVLen`), morphology (`Morphology` + `Branch`/`Soma`/`Dendrite`/`Axon`/`BasalDendrite`/`ApicalDendrite`/`CustomBranch`), the cable/stimulus clamps, and `mix_ions`.
- **`apis/braincell.mech.rst`** — new page covering the user-facing declarative mechanism types (base, density, point, and probe declarations). Internal registry plumbing (`MechanismRegistry`, `register_*`, `get_registry`) is intentionally omitted.
- **`apis/vis.rst`** — add the missing `plot_point_topology` plus a publication-constants section.
- **`index.rst`** — remove the broken `apis/braincell.neuron.rst` toctree reference (no such module) and wire in the new mech page.

## Test plan
- [x] Every newly documented symbol resolves at import time (`getattr` check on `braincell`, `braincell.mech`, `braincell.vis`).
- [x] Full `sphinx-build` succeeds and generates `generated/` stubs for all new entries.
- [x] Before/after warning diff: this change **removes** 2 warnings (the broken `braincell.neuron` toctree ref and the orphaned mech page) and introduces no new RST warnings. The only newly-surfaced warnings are pre-existing source-code docstring/annotation defects exposed by documenting those symbols (`FunctionClamp` docstring style — a codebase-wide pattern; `Morphology.from_swc` unresolved `SwcReadOptions` forward-ref) and are left out of scope.

## Summary by Sourcery

Document previously undocumented public APIs in the braincell module and fix related Sphinx reference issues.

Documentation:
- Expand braincell API docs to cover top-level public re-exports including simulation results, discretization controls, morphology types, clamps, and mix_ions.
- Add a new braincell.mech API page describing user-facing declarative mechanism types while omitting internal registry details.
- Update vis API docs to include plot_point_topology and publication constants.
- Adjust the main docs index to remove a broken braincell.neuron entry and link the new braincell.mech page.