### PR TITLE
Render PyVista html backend as static iframe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,20 @@ python -m pip install -r requirements-doc.txt
 python -m pip install -e .
 ```
 
+If you regenerate notebooks that contain interactive `vis3d(...)` output,
+also install the PyVista HTML export dependencies before running and saving
+those notebooks:
+
+```bash
+python -m pip install "braincell[vis]" ipywidgets trame trame-vtk trame-vuetify
+```
+
+For interactive authoring inside JupyterLab, install JupyterLab as well:
+
+```bash
+python -m pip install "jupyterlab>=3"
+```
+
 Then build the HTML docs:
 
 ```bash
@@ -84,7 +98,7 @@ cd docs
 .\make.bat html
 ```
 
-Documentation includes Markdown, reStructuredText, and notebooks. Notebook execution is disabled in the Sphinx configuration, so documentation changes should focus on content correctness and importability.
+Documentation includes Markdown, reStructuredText, and notebooks. Notebook execution is disabled in the Sphinx configuration, so documentation changes should focus on content correctness and importability. For static interactive PyVista output, use `vis3d(notebook=True, jupyter_backend="html")`; the PyVista backend exports raw iframe HTML for this backend so the published docs page does not need to load the Jupyter widget manager.
 
 ## Code style and contribution expectations
 

--- a/braincell/morph/branch.py
+++ b/braincell/morph/branch.py
@@ -842,9 +842,15 @@ class Branch:
         chooser : BackendChooser or None
             Explicit backend chooser; overrides *backend* when given.
         notebook : bool or None
-            Enable notebook-specific rendering when *True*.
+            Enable notebook-specific rendering when *True*. Use this in
+            Jupyter notebooks or notebook-based docs so the 3-D scene is
+            embedded in the cell output; leave it false/omitted when you
+            want the raw backend plotter in a script.
         jupyter_backend : str or None
-            Jupyter backend name for notebook rendering.
+            Jupyter backend name for notebook rendering. Use ``"html"``
+            for static HTML docs and headless builds; use interactive
+            server/client backends only in a live Jupyter session
+            configured for them.
         return_plotter : bool
             If *True*, return the backend plotter object instead of
             displaying the figure.

--- a/braincell/morph/morphology.py
+++ b/braincell/morph/morphology.py
@@ -1095,10 +1095,15 @@ class Morphology:
         chooser : BackendChooser or None
             Explicit backend chooser; overrides *backend* when given.
         notebook : bool or None
-            Enable notebook-specific rendering when *True*.
+            Enable notebook-specific rendering when *True*. Use this in
+            Jupyter notebooks or notebook-based docs so the 3-D scene is
+            embedded in the cell output; leave it false/omitted when you
+            want the raw PyVista plotter in a script.
         jupyter_backend : str or None
-            Jupyter backend name for notebook rendering (e.g.,
-            ``"trame"``, ``"static"``).
+            Jupyter backend name for notebook rendering. Use ``"html"``
+            for static HTML docs and headless builds; use interactive
+            server/client backends such as ``"trame"`` only in a live
+            Jupyter session configured for them.
         return_plotter : bool
             If *True*, return the PyVista plotter object instead of
             displaying the figure.
@@ -1185,11 +1190,11 @@ class Morphology:
             >>> plotter.add_text("My neuron", font_size=12)  # doctest: +SKIP
             >>> plotter.show()  # doctest: +SKIP
 
-        **Notebook rendering** with the Trame backend:
+        **Static notebook/doc rendering** for headless builds:
 
         .. code-block:: python
 
-            >>> morph.vis3d(notebook=True, jupyter_backend="trame")  # doctest: +SKIP
+            >>> morph.vis3d(notebook=True, jupyter_backend="html")  # doctest: +SKIP
         """
         from braincell.vis.plot3d import plot3d
 

--- a/braincell/vis/backend_pyvista.py
+++ b/braincell/vis/backend_pyvista.py
@@ -18,7 +18,9 @@
 import importlib.util
 import os
 import sys
+from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
+from html import escape
 from typing import Any
 
 import numpy as np
@@ -31,6 +33,24 @@ from .scene import RenderRequest, RenderScene3D, ValueBatch3D, ValueSpec
 # lookup table to a plotter. Downstream picking callbacks read it via
 # ``getattr(plotter, _BC_POINT_BRANCH_MAP, None)``.
 _BC_POINT_BRANCH_MAP = "_bc_point_branch_map"
+
+
+class PyVistaHTML:
+    """Notebook display wrapper for exported PyVista HTML."""
+
+    def __init__(self, html: str, *, height: int = 600) -> None:
+        srcdoc = escape(html, quote=True)
+        self.html = (
+            f'<iframe srcdoc="{srcdoc}" class="pyvista" '
+            f'style="width: 100%; height: {int(height)}px; border: 1px solid #ddd;" '
+            'loading="lazy"></iframe>'
+        )
+
+    def _repr_html_(self) -> str:
+        return self.html
+
+    def __repr__(self) -> str:
+        return "<interactive PyVista scene>"
 
 
 @dataclass(frozen=True)
@@ -64,7 +84,10 @@ class PyVistaBackend:
         jupyter_backend = backend_options.get("jupyter_backend")
         return_plotter = bool(backend_options.get("return_plotter", False))
 
-        plotter = pv.Plotter(**self.plotter_kwargs)
+        suppress_stderr = jupyter_backend == "html"
+        plotter_context = _suppress_stderr_fd() if suppress_stderr else nullcontext()
+        with plotter_context:
+            plotter = pv.Plotter(**self.plotter_kwargs)
         plotter.set_background(self.background)
         if self.show_axes:
             plotter.show_axes()
@@ -170,6 +193,14 @@ class PyVistaBackend:
         for candidate in _notebook_backends(jupyter_backend):
             _prepare_plotter_for_notebook(plotter)
             attempted.append(candidate)
+            if candidate == "html":
+                if return_plotter:
+                    return plotter
+                try:
+                    return _export_plotter_html(plotter)
+                except Exception as exc:
+                    failures.append((candidate, f"{type(exc).__name__}: {exc}"))
+                    continue
             try:
                 viewer = plotter.show(
                     jupyter_backend=candidate,
@@ -198,6 +229,30 @@ class PyVistaBackend:
             "Server/trame modes may also require a virtual framebuffer. "
             "You can still pass return_plotter=True to receive the raw Plotter."
         )
+
+
+def _export_plotter_html(plotter: Any) -> PyVistaHTML:
+    """Export a plotter as self-contained iframe HTML for static notebooks."""
+    with _suppress_stderr_fd():
+        exported = plotter.export_html(filename=None)
+    html = exported.getvalue() if hasattr(exported, "getvalue") else str(exported)
+    if hasattr(plotter, "close"):
+        plotter.close()
+    return PyVistaHTML(html)
+
+
+@contextmanager
+def _suppress_stderr_fd():
+    """Suppress native-library stderr while PyVista creates static HTML."""
+    stderr_fd = 2
+    saved_fd = os.dup(stderr_fd)
+    try:
+        with open(os.devnull, "w") as devnull:
+            os.dup2(devnull.fileno(), stderr_fd)
+            yield
+    finally:
+        os.dup2(saved_fd, stderr_fd)
+        os.close(saved_fd)
 
 
 def _rgb_to_float(rgb: tuple[int, int, int]) -> tuple[float, float, float]:

--- a/braincell/vis/backend_pyvista_test.py
+++ b/braincell/vis/backend_pyvista_test.py
@@ -62,6 +62,7 @@ class _FakePlotter:
         self._rendered = False
         self.pick_callback = None
         self.pick_enabled = False
+        self.export_html_calls = []
 
     def set_background(self, color) -> None:
         self.background = color
@@ -85,6 +86,10 @@ class _FakePlotter:
 
     def close(self) -> None:
         self.closed = True
+
+    def export_html(self, filename=None):
+        self.export_html_calls.append(filename)
+        return "<html><body>OfflineLocalView</body></html>"
 
     def enable_point_picking(self, *, callback, show_message=True, use_picker=True):
         self.pick_callback = callback
@@ -126,6 +131,12 @@ class _AlwaysFailPlotter(_FakePlotter):
     def show(self, **kwargs):
         self.show_calls.append(kwargs)
         raise RuntimeError(f"{kwargs['jupyter_backend']} boom")
+
+
+class _AlwaysFailIncludingExportPlotter(_AlwaysFailPlotter):
+    def export_html(self, filename=None):
+        self.export_html_calls.append(filename)
+        raise RuntimeError("html boom")
 
 
 def _request(*, notebook: bool | None = None, jupyter_backend: str | None = None, return_plotter: bool = False):
@@ -234,6 +245,17 @@ class PyVistaBackendTest(unittest.TestCase):
 
         self.assertEqual(viewer["viewer"]["jupyter_backend"], "client")
 
+    def test_render_exports_raw_iframe_for_html_backend(self) -> None:
+        fake_pv = _fake_pyvista(_FakePlotter)
+        backend = PyVistaBackend()
+
+        with mock.patch.dict("sys.modules", {"pyvista": fake_pv}):
+            viewer = backend.render(_request(notebook=True, jupyter_backend="html"))
+
+        self.assertIn("<iframe", viewer._repr_html_())
+        self.assertIn("OfflineLocalView", viewer._repr_html_())
+        self.assertEqual(repr(viewer), "<interactive PyVista scene>")
+
     def test_render_falls_back_from_client_to_html(self) -> None:
         fake_pv = _fake_pyvista(_ClientFailsPlotter)
         backend = PyVistaBackend()
@@ -242,7 +264,8 @@ class PyVistaBackendTest(unittest.TestCase):
             with mock.patch.dict(os.environ, {}, clear=True):
                 viewer = backend.render(_request(notebook=True))
 
-        self.assertEqual(viewer["viewer"]["jupyter_backend"], "html")
+        self.assertIn("<iframe", viewer._repr_html_())
+        self.assertIn("OfflineLocalView", viewer._repr_html_())
 
     def test_render_uses_trame_first_when_display_exists(self) -> None:
         fake_pv = _fake_pyvista(_FakePlotter)
@@ -276,7 +299,7 @@ class PyVistaBackendTest(unittest.TestCase):
         self.assertEqual(viewer["viewer"]["jupyter_backend"], "client")
 
     def test_render_reports_attempted_backends_on_failure(self) -> None:
-        fake_pv = _fake_pyvista(_AlwaysFailPlotter)
+        fake_pv = _fake_pyvista(_AlwaysFailIncludingExportPlotter)
         backend = PyVistaBackend()
 
         with mock.patch.dict("sys.modules", {"pyvista": fake_pv}):
@@ -298,7 +321,7 @@ class PyVistaBackendTest(unittest.TestCase):
 
         with mock.patch.dict("sys.modules", {"pyvista": fake_pv}):
             with self.assertRaisesRegex(RuntimeError, "PyVista returned no notebook viewer"):
-                backend.render(_request(notebook=True, jupyter_backend="html"))
+                backend.render(_request(notebook=True, jupyter_backend="trame"))
 
 
 class PyVistaPickMetadataTest(unittest.TestCase):


### PR DESCRIPTION
## Description

  This PR updates the PyVista notebook HTML path used by `vis3d(...)` so static documentation can render interactive 3D scenes without
  depending on the Jupyter widget manager.

  Changes:
  - Export `jupyter_backend="html"` PyVista scenes with `plotter.export_html(...)`
  - Wrap the exported HTML in a raw iframe display object
  - Keep the external docs/user API as `vis3d(notebook=True, jupyter_backend="html")`
  - Suppress native VTK `DISPLAY` warnings during static HTML export on headless servers
  - Update morphology docs and parameter documentation for `notebook` / `jupyter_backend`
  - Add tests for explicit HTML backend rendering and fallback to HTML

  ## How Has This Been Tested

  Tested locally in the `braincell_311` conda environment with Python 3.11.

  Test command:

      python -m unittest braincell.vis.backend_pyvista_test

  Result:

      Ran 14 tests in 0.172s
      OK

  Docs build command:

      cd docs
      make html SPHINXBUILD=/home/swl/anaconda3/envs/braincell_311/bin/sphinx-build

  Result:

      build succeeded, 77 warnings

  The warnings are existing docs warnings unrelated to this change.

  Verified the generated morphology page:
  - `@jupyter-widgets`: 0
  - `embed-amd.js`: 0
  - iframe outputs: 3
  - `OfflineLocalView`: 12
  - `bad X server connection`: 0

  ## Types of changes

  - Bug fix (non-breaking change which fixes an issue)
  - Documentation (non-breaking change which updates documentation)

  ## Checklist

  - [x] Code follows the code style of this project.
  - [x] Changes follow the **CONTRIBUTING** guidelines.
  - [x] Update necessary documentation accordingly.
  - [x] Lint and tests pass locally with the changes.
  - [x] Check issues and pull requests first. You don't want to duplicate effort.

  ## Other information

  This keeps the public usage in notebooks/docs as:

      tree.vis3d(notebook=True, jupyter_backend="html")

  For static docs and headless builds, the HTML backend now embeds a self-contained iframe instead of requiring the Jupyter widget
  manager.