### PR TITLE
ci: revert PyPI publish to API token auth

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -69,13 +69,6 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
 
-    environment:
-      name: pypi
-      url: https://pypi.org/p/braincell
-
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
     steps:
       - name: Download distribution packages
         uses: actions/download-artifact@v8
@@ -85,3 +78,5 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Why

The `Publish to PyPI` job failed for the **v0.1.0** release ([run 27735433497](https://github.com/chaobrain/braincell/actions/runs/27735433497/job/82051229735)):

```
Trusted publishing exchange failure:
* invalid-publisher: valid token, but no corresponding publisher
  (Publisher with matching claims was not found)
```

### Root cause

`Publish.yml` was switched from API-token auth to **PyPI Trusted Publishing** in #55 (added `id-token: write` + `environment: pypi`, removed `password: ${{ secrets.PYPI_API_TOKEN }}`), but a matching **trusted publisher was never registered on PyPI**. Every prior release (`0.0.1`–`0.0.8`) had shipped via the API token, so this gap only surfaced when v0.1.0 first exercised the new path. `0.1.0` is not on PyPI (HTTP 404) — it genuinely failed to publish.

## What

Restore the password-based publishing that worked for `0.0.1`–`0.0.8`:

- Drop the `environment: pypi` block and `id-token: write` permission
- Pass `password: ${{ secrets.PYPI_API_TOKEN }}` to `gh-action-pypi-publish`

Diff is limited to the `publish-to-pypi` job; pre-existing line endings are preserved.

## ⚠️ Required before this works

- **`PYPI_API_TOKEN` secret must exist.** It is currently **absent** at the repo and `pypi`-environment level (only `DEPLOY_*` secrets exist). Confirm it exists as a `chaobrain` org secret, or create a PyPI API token scoped to `braincell` and add it as a repo secret.

## Publishing v0.1.0 after merge

A `release: published` run uses the workflow file **at the tag ref**, so this fix won't retroactively repair the existing v0.1.0 release. After merge, trigger the **`workflow_dispatch`** button from `main` — it builds the current `0.1.0` code and skips the tag/version guard (which only runs on `release` events).

## Summary by Sourcery

CI:
- Update the Publish workflow to remove the PyPI environment and OIDC id-token permissions and pass the PYPI_API_TOKEN secret to the PyPI publish action.