### PR TITLE
Update project tagline from JAX to BrainX

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # BrainCell – Developer Guide
 
-Biologically detailed brain cell modeling in JAX.
+Biologically detailed brain cell modeling in BrainX.
 
 ## Working agreement
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
 
-# Biologically Detailed Brain Cell Modeling in JAX
+# Biologically Detailed Brain Cell Modeling in BrainX
 
 <p align="center">
   	<img alt="Header image of BrainCell." src="https://brainx.chaobrain.com/images/braincell.webp" width=50%>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [ "setuptools>=77.0.3" ]
 
 [project]
 name = "braincell"
-description = "Biologically Detailed Brain Cell Modeling in JAX"
+description = "Biologically Detailed Brain Cell Modeling in BrainX"
 readme = "README.md"
 keywords = [
   "brain modeling",


### PR DESCRIPTION
Changes the project tagline from "Biologically Detailed Brain Cell Modeling in JAX" to "... in BrainX" in all three places it appears:

- `README.md` — H1 heading
- `pyproject.toml` — package `description` (shown on PyPI)
- `AGENTS.md` — sentence-case variant of the same tagline

No other occurrences exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the project tagline to reference BrainX instead of JAX across user-facing materials.

Build:
- Update pyproject package description to use the BrainX-branded tagline for distribution metadata.

Documentation:
- Refresh README and developer guide tagline to use BrainX branding instead of JAX.