### PR TITLE
Upgrade braincell.ion and braincell.channel docstrings with verified references

### DIFF
--- a/braincell/_testing.py
+++ b/braincell/_testing.py
@@ -1,0 +1,97 @@
+"""Test-only helpers for the docstring conformance guards.
+
+Not a test module: the leading underscore keeps pytest from collecting it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from types import ModuleType
+from typing import Iterator
+
+_SECTION = re.compile(r"^(?P<title>[A-Z][A-Za-z ]{2,})\n(?P<rule>-{3,})[ \t]*$", re.MULTILINE)
+_CITATION = re.compile(r"^\s*\.\.\s+\[\d+\]\s+\S", re.MULTILINE)
+
+
+def public_symbols(module: ModuleType) -> Iterator[tuple[str, object]]:
+    """Yield ``(name, obj)`` for every entry in ``module.__all__``."""
+    for name in getattr(module, "__all__", ()):
+        yield name, getattr(module, name)
+
+
+def own_docstring(obj) -> str | None:
+    """Return the docstring defined on ``obj`` itself, never an inherited one."""
+    doc = obj.__dict__.get("__doc__") if inspect.isclass(obj) else getattr(obj, "__doc__", None)
+    if isinstance(doc, str) and doc.strip():
+        return inspect.cleandoc(doc)
+    return None
+
+
+def sections(doc: str) -> dict[str, str]:
+    """Split a NumPy-doc docstring into ``{section title: section body}``."""
+    found = {}
+    matches = list(_SECTION.finditer(doc))
+    for i, match in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(doc)
+        found[match.group("title").rstrip()] = doc[match.end():end]
+    return found
+
+
+def has_citation(doc: str) -> bool:
+    """True when ``doc`` has a References section holding a ``.. [n]`` entry."""
+    body = sections(doc).get("References")
+    return bool(body) and bool(_CITATION.search(body))
+
+
+class DocstringConformanceTests:
+    """Assertions shared by the per-package docstring guards.
+
+    Mix into a :class:`unittest.TestCase` subclass that sets
+    ``covered_modules`` and ``no_primary_source``. This class is deliberately
+    not a ``TestCase`` itself, so it is never collected on its own.
+    """
+
+    covered_modules: tuple[ModuleType, ...] = ()
+    no_primary_source: frozenset[str] = frozenset()
+
+    def _symbols(self):
+        for module in self.covered_modules:
+            for name, obj in public_symbols(module):
+                yield module.__name__, name, obj
+
+    def test_every_public_symbol_defines_its_own_docstring(self):
+        missing = [
+            f"{mod}.{name}"
+            for mod, name, obj in self._symbols()
+            if own_docstring(obj) is None
+        ]
+        self.assertEqual(missing, [], f"undocumented public symbols: {missing}")
+
+    def test_summary_is_a_single_sentence_line(self):
+        bad = []
+        for mod, name, obj in self._symbols():
+            doc = own_docstring(obj)
+            if doc is None:
+                continue
+            summary = doc.splitlines()[0].strip()
+            if not summary.endswith("."):
+                bad.append(f"{mod}.{name}: {summary!r}")
+        self.assertEqual(bad, [], f"summary must be one sentence ending in '.': {bad}")
+
+    def test_every_public_symbol_cites_a_reference(self):
+        uncited = []
+        for mod, name, obj in self._symbols():
+            if name in self.no_primary_source:
+                continue
+            doc = own_docstring(obj)
+            if doc is None or not has_citation(doc):
+                uncited.append(f"{mod}.{name}")
+        self.assertEqual(uncited, [], f"missing References with '.. [n]': {uncited}")
+
+    def test_no_primary_source_allowlist_has_no_dead_entries(self):
+        if not self.covered_modules:
+            self.skipTest("no modules covered yet")
+        live = {name for _, name, _ in self._symbols()}
+        dead = sorted(n for n in self.no_primary_source if n not in live)
+        self.assertEqual(dead, [], f"allowlist names no longer public: {dead}")

--- a/braincell/_testing.py
+++ b/braincell/_testing.py
@@ -34,7 +34,7 @@ def sections(doc: str) -> dict[str, str]:
     matches = list(_SECTION.finditer(doc))
     for i, match in enumerate(matches):
         end = matches[i + 1].start() if i + 1 < len(matches) else len(doc)
-        found[match.group("title").rstrip()] = doc[match.end():end]
+        found[match.group("title").rstrip()] = doc[match.end() : end]
     return found
 
 
@@ -61,11 +61,7 @@ class DocstringConformanceTests:
                 yield module.__name__, name, obj
 
     def test_every_public_symbol_defines_its_own_docstring(self):
-        missing = [
-            f"{mod}.{name}"
-            for mod, name, obj in self._symbols()
-            if own_docstring(obj) is None
-        ]
+        missing = [f"{mod}.{name}" for mod, name, obj in self._symbols() if own_docstring(obj) is None]
         self.assertEqual(missing, [], f"undocumented public symbols: {missing}")
 
     def test_summary_is_a_single_sentence_line(self):

--- a/braincell/channel/_base.py
+++ b/braincell/channel/_base.py
@@ -85,6 +85,13 @@ def ghk_flux(V, ci, co, z, temp):
     ``abs(1 - exp(-zeta)) <= 1e-6``, which both avoids the division and
     stays numerically well conditioned near that singularity.
 
+    Goldman (1943) and Hodgkin & Katz (1949) are together the origin of
+    the name "GHK", but they are the primary sources for two different
+    equations. This function computes the constant-field flux/current
+    equation, whose primary source is Goldman (1943) -- hence ``.. [1]``
+    first. It does not compute the constant-field voltage equation, for
+    which Hodgkin & Katz (1949) is the primary source.
+
     References
     ----------
     .. [1] Goldman, D. E. (1943). Potential, impedance, and
@@ -94,13 +101,6 @@ def ghk_flux(V, ci, co, z, temp):
            on the electrical activity of the giant axon of the squid.
            The Journal of Physiology, 108(1), 37-77.
            doi:10.1113/jphysiol.1949.sp004310
-
-    Goldman (1943) and Hodgkin & Katz (1949) are together the origin of
-    the name "GHK", but they are the primary sources for two different
-    equations. This function computes the constant-field flux/current
-    equation, whose primary source is Goldman (1943) -- hence ``.. [1]``
-    first. It does not compute the constant-field voltage equation, for
-    which Hodgkin & Katz (1949) is the primary source.
     """
     zeta = (z * u.faraday_constant * V) / (u.gas_constant * temp)
     exp_term = u.math.exp(-zeta)
@@ -411,6 +411,12 @@ class HH(Channel):
     (GHK flux, permeability-scaled calcium channels) subclass ``HH``
     directly and implement :meth:`current` themselves.
 
+    See Also
+    --------
+    OhmicHH : Adds an ohmic driving force on top of this gating template.
+    Gate : Per-gate metadata consumed by ``gates``.
+    Markov : Sibling template for probability-state (non-HH) kinetics.
+
     Notes
     -----
     ``__init_subclass__`` resolves and validates ``gates`` once, when the
@@ -418,12 +424,6 @@ class HH(Channel):
     subclass that declares no gates -- ``HH`` itself, ``OhmicHH``, or any
     other abstract intermediate -- is skipped by this validation, so such
     classes stay definable without a concrete gate set.
-
-    See Also
-    --------
-    OhmicHH : Adds an ohmic driving force on top of this gating template.
-    Gate : Per-gate metadata consumed by ``gates``.
-    Markov : Sibling template for probability-state (non-HH) kinetics.
 
     Attributes
     ----------
@@ -705,7 +705,7 @@ class Markov(Channel, IndependentIntegration):
     default_substeps : int, default 1
         Number of solver substeps per outer integration step, used when
         the constructor's ``substeps`` argument is not supplied.
-    clip_states : bool
+    clip_states : bool, default True
         Project each independent state into ``[0, 1]`` before evaluating
         the transition graph, so a probability pool that has drifted off
         the simplex still yields meaningful kinetics; the stored states

--- a/braincell/channel/_base.py
+++ b/braincell/channel/_base.py
@@ -85,12 +85,13 @@ def ghk_flux(V, ci, co, z, temp):
     ``abs(1 - exp(-zeta)) <= 1e-6``, which both avoids the division and
     stays numerically well conditioned near that singularity.
 
-    Goldman (1943) and Hodgkin & Katz (1949) are together the origin of
-    the name "GHK", but they are the primary sources for two different
-    equations. This function computes the constant-field flux/current
-    equation, whose primary source is Goldman (1943) -- hence ``.. [1]``
-    first. It does not compute the constant-field voltage equation, for
-    which Hodgkin & Katz (1949) is the primary source.
+    Goldman (1943) [1]_ and Hodgkin & Katz (1949) [2]_ are together the
+    origin of the name "GHK", but they are the primary sources for two
+    different equations. This function computes the constant-field
+    flux/current equation, whose primary source is Goldman (1943) --
+    hence ``.. [1]`` first. It does not compute the constant-field
+    voltage equation, for which Hodgkin & Katz (1949) is the primary
+    source.
 
     References
     ----------

--- a/braincell/channel/_base.py
+++ b/braincell/channel/_base.py
@@ -31,7 +31,77 @@ __all__ = [
 
 
 def ghk_flux(V, ci, co, z, temp):
-    """Unit-aware GHK flux helper with a small-zeta stable branch."""
+    r"""Compute the Goldman-Hodgkin-Katz constant-field flux, per permeability.
+
+    Evaluates the constant-field (GHK) electrodiffusion equation for a
+    single permeant ion species, returning the flux divided through by the
+    membrane permeability. Channels in the catalogue that use GHK-style
+    currents (calcium channels, most notably) multiply this result by
+    their own ``g_max``, which occupies the permeability slot ``P_s``
+    that a textbook GHK flux equation would otherwise carry explicitly.
+
+    Parameters
+    ----------
+    V : ArrayLike
+        Membrane potential, as a voltage (for example ``u.mV``).
+    ci : ArrayLike
+        Intracellular concentration of the permeant ion, as a molar
+        concentration (for example ``u.mM``).
+    co : ArrayLike
+        Extracellular concentration of the permeant ion, as a molar
+        concentration (for example ``u.mM``).
+    z : ArrayLike
+        Valence of the permeant ion. Dimensionless.
+    temp : ArrayLike
+        Absolute temperature, as a temperature (for example ``u.kelvin``).
+
+    Returns
+    -------
+    ArrayLike
+        The constant-field flux, divided through by the permeability
+        ``P_s`` that a caller is expected to supply separately (typically
+        as ``g_max``). Not yet a current or a conductance on its own.
+
+    Notes
+    -----
+    Let ``zeta = z * F * V / (R * T)``, with ``F`` the Faraday constant and
+    ``R`` the gas constant. The function evaluates
+
+    .. math::
+
+        \text{regular\_branch} = \frac{z \zeta F
+        (c_i - c_o e^{-\zeta})}{1 - e^{-\zeta}}
+
+    which is undefined at ``zeta = 0`` because ``1 - exp(-zeta)`` vanishes
+    there and the branch divides by it. To keep the function stable as
+    ``zeta -> 0``, a second, algebraically equivalent branch
+
+    .. math::
+
+        \text{small\_branch} = z F (c_i - c_o e^{-\zeta})
+        \left(1 + \frac{\zeta}{2}\right)
+
+    is selected instead via ``u.math.where`` whenever
+    ``abs(1 - exp(-zeta)) <= 1e-6``, which both avoids the division and
+    stays numerically well conditioned near that singularity.
+
+    References
+    ----------
+    .. [1] Goldman, D. E. (1943). Potential, impedance, and
+           rectification in membranes. The Journal of General
+           Physiology, 27(1), 37-60. doi:10.1085/jgp.27.1.37
+    .. [2] Hodgkin, A. L., & Katz, B. (1949). The effect of sodium ions
+           on the electrical activity of the giant axon of the squid.
+           The Journal of Physiology, 108(1), 37-77.
+           doi:10.1113/jphysiol.1949.sp004310
+
+    Goldman (1943) and Hodgkin & Katz (1949) are together the origin of
+    the name "GHK", but they are the primary sources for two different
+    equations. This function computes the constant-field flux/current
+    equation, whose primary source is Goldman (1943) -- hence ``.. [1]``
+    first. It does not compute the constant-field voltage equation, for
+    which Hodgkin & Katz (1949) is the primary source.
+    """
     zeta = (z * u.faraday_constant * V) / (u.gas_constant * temp)
     exp_term = u.math.exp(-zeta)
     numerator = ci - co * exp_term
@@ -182,6 +252,13 @@ class Gate:
         when a solver is expected to overshoot and an odd ``power`` would
         otherwise yield a negative conductance. The stored state is never
         rewritten -- only the value used for the conductance product.
+
+    Raises
+    ------
+    ValueError
+        If ``phi`` is provided together with ``q10`` or ``temp_ref``, if
+        ``q10`` and ``temp_ref`` are not both provided together, or if
+        ``time_unit`` does not have a time dimension.
     """
 
     name: str
@@ -281,7 +358,35 @@ def _check_derivative(value, label: str):
 
 @dataclass(frozen=True)
 class Transition:
-    """One directed/reversible transition used by Markov channels."""
+    """One directed or reversible transition used by Markov channels.
+
+    A ``Transition`` names two states and the rate method(s) that move
+    probability between them; it does not itself hold rates or values.
+    :class:`Markov` consumes a tuple of these under ``pairs`` and builds
+    the generator matrix for the whole state graph from them.
+
+    Parameters
+    ----------
+    src : str
+        Name of the source state.
+    dst : str
+        Name of the destination state.
+    forward : str
+        Name of the rate method that governs the ``src -> dst`` direction.
+        Looked up on the owning channel and called the same way as any
+        other rate method.
+    backward : str or None, default None
+        Name of the rate method that governs the ``dst -> src`` direction.
+        When ``None``, the transition is directed: probability only flows
+        ``src -> dst`` and no reverse rate is looked up or evaluated, so
+        the pair contributes nothing to the ``dst -> src`` entry of the
+        generator matrix. Supplying a name makes the transition
+        reversible, with independent forward and backward rates.
+
+    See Also
+    --------
+    Markov : Consumes a tuple of ``Transition`` under ``pairs``.
+    """
 
     src: str
     dst: str
@@ -296,6 +401,44 @@ class HH(Channel):
 
     - ``f_<g>_inf`` and ``f_<g>_tau``
     - ``f_<g>_alpha`` and ``f_<g>_beta``
+
+    ``HH`` is the gating-only half of the template layer: it declares
+    ``gates``, resolves and validates them once at subclass-creation time,
+    and implements state initialisation, the conductance product, and the
+    Hodgkin-Huxley derivative from whichever form each gate declares. It
+    does not implement a current -- :class:`OhmicHH` adds the ohmic driving
+    force for the common case, while channels with a non-ohmic current
+    (GHK flux, permeability-scaled calcium channels) subclass ``HH``
+    directly and implement :meth:`current` themselves.
+
+    Notes
+    -----
+    ``__init_subclass__`` resolves and validates ``gates`` once, when the
+    subclass is created, rather than lazily at ``reset_state`` time. A
+    subclass that declares no gates -- ``HH`` itself, ``OhmicHH``, or any
+    other abstract intermediate -- is skipped by this validation, so such
+    classes stay definable without a concrete gate set.
+
+    See Also
+    --------
+    OhmicHH : Adds an ohmic driving force on top of this gating template.
+    Gate : Per-gate metadata consumed by ``gates``.
+    Markov : Sibling template for probability-state (non-HH) kinetics.
+
+    Attributes
+    ----------
+    gates : tuple of Gate or tuple
+        Class-level declaration of the gates a subclass defines. Each
+        entry is either a :class:`Gate` or the plain tuple of its fields.
+        Set by the subclass; read by ``__init_subclass__``.
+    _resolved_gates : tuple of Gate
+        ``gates`` normalised to :class:`Gate` instances. Derived by
+        ``__init_subclass__``; a subclass never sets this directly, but
+        :meth:`_iter_gates` and every gate-driven method read it.
+    _gate_forms : dict of str to str
+        Maps each gate name to ``"inf_tau"`` or ``"alpha_beta"``, the form
+        detected for it. Derived alongside ``_resolved_gates`` and read by
+        :meth:`_gate_form` to route state init, reset, and the derivative.
     """
 
     gates: ClassVar[tuple[Gate | tuple[Any, ...], ...]] = ()
@@ -538,6 +681,38 @@ class Markov(Channel, IndependentIntegration):
     :attr:`Gate.time_unit` on the HH side, except that the unit is fixed at
     ``u.ms`` rather than declared per transition -- the catalogue's Markov
     channels all come from NEURON ``.mod`` sources written in milliseconds.
+
+    Attributes
+    ----------
+    pairs : tuple of Transition or tuple
+        Class-level declaration of the transition graph. Each entry is
+        either a :class:`Transition` or the plain tuple of its fields;
+        both forms are normalised by ``__init_subclass__``.
+    conserve : Any, default 1.0
+        Total probability mass the declared states must sum to. Resolved
+        per instance the same way as :class:`Gate` metadata -- a ``str``
+        names an instance attribute, a callable is applied to the
+        instance, anything else is a literal.
+    dependent_state : str or None, default None
+        Name of the state eliminated from the independent set and
+        reconstructed as ``conserve`` minus the others. Declaring it
+        explicitly is effectively required: the ``None`` fallback resolves
+        to "the last state discovered while scanning ``pairs``", which is
+        order-dependent, and doing so emits a ``DeprecationWarning``.
+    default_solver : str, default "backward_euler"
+        Solver name used by :class:`IndependentIntegration` when the
+        constructor's ``solver`` argument is not supplied.
+    default_substeps : int, default 1
+        Number of solver substeps per outer integration step, used when
+        the constructor's ``substeps`` argument is not supplied.
+    clip_states : bool
+        Project each independent state into ``[0, 1]`` before evaluating
+        the transition graph, so a probability pool that has drifted off
+        the simplex still yields meaningful kinetics; the stored states
+        themselves are left untouched. On by default, unlike
+        :attr:`Gate.clip` on the HH side, because an out-of-simplex
+        probability pool corrupts the kinetics, whereas an unclipped HH
+        gate is merely inaccurate.
     """
 
     pairs: ClassVar[tuple[Transition | tuple[Any, ...], ...]] = ()

--- a/braincell/channel/_base.py
+++ b/braincell/channel/_base.py
@@ -96,7 +96,8 @@ def ghk_flux(V, ci, co, z, temp):
     ----------
     .. [1] Goldman, D. E. (1943). Potential, impedance, and
            rectification in membranes. The Journal of General
-           Physiology, 27(1), 37-60. doi:10.1085/jgp.27.1.37
+           Physiology, 27(1), 37-60.
+           doi:10.1085/jgp.27.1.37
     .. [2] Hodgkin, A. L., & Katz, B. (1949). The effect of sodium ions
            on the electrical activity of the giant axon of the squid.
            The Journal of Physiology, 108(1), 37-77.

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -3,11 +3,11 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
-from braincell.channel import leaky
+from braincell.channel import leaky, potassium_sodium
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = (leaky,)
+_COVERED_MODULES = (leaky, potassium_sodium)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new channel that lands undocumented fails instead of

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -3,11 +3,11 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
-from braincell.channel import _base, leaky, potassium_sodium
+from braincell.channel import _base, hyperpolarization_activated, leaky, potassium_sodium
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = (_base, leaky, potassium_sodium)
+_COVERED_MODULES = (_base, hyperpolarization_activated, leaky, potassium_sodium)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new channel that lands undocumented fails instead of

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -3,15 +3,19 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
+from braincell.channel import leaky
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = ()
+_COVERED_MODULES = (leaky,)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new channel that lands undocumented fails instead of
 # silently inheriting an exemption.
-_NO_PRIMARY_SOURCE = frozenset()
+_NO_PRIMARY_SOURCE = frozenset({
+    "LeakageChannel",
+    "IL",
+})
 
 
 class ChannelDocstringTest(DocstringConformanceTests, unittest.TestCase):

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -7,6 +7,7 @@ from braincell.channel import (
     _base,
     hyperpolarization_activated,
     leaky,
+    potassium_calcium,
     potassium_sodium,
     sodium,
 )
@@ -17,6 +18,7 @@ _COVERED_MODULES = (
     _base,
     hyperpolarization_activated,
     leaky,
+    potassium_calcium,
     potassium_sodium,
     sodium,
 )

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -8,6 +8,7 @@ from braincell.channel import (
     calcium,
     hyperpolarization_activated,
     leaky,
+    potassium,
     potassium_calcium,
     potassium_sodium,
     sodium,
@@ -20,6 +21,7 @@ _COVERED_MODULES = (
     calcium,
     hyperpolarization_activated,
     leaky,
+    potassium,
     potassium_calcium,
     potassium_sodium,
     sodium,
@@ -38,6 +40,8 @@ _NO_PRIMARY_SOURCE = frozenset({
     "Markov",
     "CaN_IS2008",
     "CaL_IS2008",
+    "K_Leak",
+    "K_Kv_test",
 })
 
 

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -3,11 +3,11 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
-from braincell.channel import leaky, potassium_sodium
+from braincell.channel import _base, leaky, potassium_sodium
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = (leaky, potassium_sodium)
+_COVERED_MODULES = (_base, leaky, potassium_sodium)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new channel that lands undocumented fails instead of
@@ -15,6 +15,11 @@ _COVERED_MODULES = (leaky, potassium_sodium)
 _NO_PRIMARY_SOURCE = frozenset({
     "LeakageChannel",
     "IL",
+    "Gate",
+    "Transition",
+    "HH",
+    "OhmicHH",
+    "Markov",
 })
 
 

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -3,11 +3,23 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
-from braincell.channel import _base, hyperpolarization_activated, leaky, potassium_sodium
+from braincell.channel import (
+    _base,
+    hyperpolarization_activated,
+    leaky,
+    potassium_sodium,
+    sodium,
+)
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = (_base, hyperpolarization_activated, leaky, potassium_sodium)
+_COVERED_MODULES = (
+    _base,
+    hyperpolarization_activated,
+    leaky,
+    potassium_sodium,
+    sodium,
+)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new channel that lands undocumented fails instead of

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -30,19 +30,21 @@ _COVERED_MODULES = (
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new channel that lands undocumented fails instead of
 # silently inheriting an exemption.
-_NO_PRIMARY_SOURCE = frozenset({
-    "LeakageChannel",
-    "IL",
-    "Gate",
-    "Transition",
-    "HH",
-    "OhmicHH",
-    "Markov",
-    "CaN_IS2008",
-    "CaL_IS2008",
-    "K_Leak",
-    "K_Kv_test",
-})
+_NO_PRIMARY_SOURCE = frozenset(
+    {
+        "LeakageChannel",
+        "IL",
+        "Gate",
+        "Transition",
+        "HH",
+        "OhmicHH",
+        "Markov",
+        "CaN_IS2008",
+        "CaL_IS2008",
+        "K_Leak",
+        "K_Kv_test",
+    }
+)
 
 
 class ChannelDocstringTest(DocstringConformanceTests, unittest.TestCase):

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -1,0 +1,23 @@
+"""Docstring conformance guard for :mod:`braincell.channel`."""
+
+import unittest
+
+from braincell._testing import DocstringConformanceTests
+
+# Extended by one module per docstring task. A module is listed only once
+# every one of its public symbols satisfies the shared assertions.
+_COVERED_MODULES = ()
+
+# Public symbols with no primary literature source. Membership must be a
+# deliberate decision: a new channel that lands undocumented fails instead of
+# silently inheriting an exemption.
+_NO_PRIMARY_SOURCE = frozenset()
+
+
+class ChannelDocstringTest(DocstringConformanceTests, unittest.TestCase):
+    covered_modules = _COVERED_MODULES
+    no_primary_source = _NO_PRIMARY_SOURCE
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/braincell/channel/_docstring_test.py
+++ b/braincell/channel/_docstring_test.py
@@ -5,6 +5,7 @@ import unittest
 from braincell._testing import DocstringConformanceTests
 from braincell.channel import (
     _base,
+    calcium,
     hyperpolarization_activated,
     leaky,
     potassium_calcium,
@@ -16,6 +17,7 @@ from braincell.channel import (
 # every one of its public symbols satisfies the shared assertions.
 _COVERED_MODULES = (
     _base,
+    calcium,
     hyperpolarization_activated,
     leaky,
     potassium_calcium,
@@ -34,6 +36,8 @@ _NO_PRIMARY_SOURCE = frozenset({
     "HH",
     "OhmicHH",
     "Markov",
+    "CaN_IS2008",
+    "CaL_IS2008",
 })
 
 

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -575,7 +575,7 @@ class CaHT_HM1992(OhmicHH):
     Notes
     -----
     **This class does not implement a current described in
-    (Huguenard & McCormick, 1992) [1]_.** That paper models exactly
+    (Huguenard & McCormick, 1992).** That paper [1]_ models exactly
     four currents -- a *low*-threshold T-type calcium current, two
     potassium currents and a hyperpolarization-activated current --
     and contains no high-threshold or high-voltage-activated calcium
@@ -5024,7 +5024,9 @@ class Ca_ZH2019_IO_Frozen(Ca_ZH2019_IO):
     class's Notes. Per the bibliography's attribution scan, this
     subclass contributes no rate-function code of its own -- it
     inherits every kinetic equation unchanged from
-    :class:`Ca_ZH2019_IO`.
+    :class:`Ca_ZH2019_IO`, that is from Manor, Rinzel, Segev &
+    Yarom (1997) [1]_ as imported by Zhang & Santaniello
+    (2019) [2]_.
 
     References
     ----------

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -106,7 +106,83 @@ def _freeze_quantity_gradient(value):
 
 @register_channel("CaN_IS2008")
 class CaN_IS2008(HH):
-    r"""Inoue & Strowbridge 2008 calcium-activated non-selective cation current."""
+    r"""Inoue & Strowbridge 2008 calcium-activated non-selective cation current.
+
+    A calcium- and voltage-dependent non-selective cation current
+    (:math:`I_{CAN}`) gated by a single activation variable and scaled
+    by a saturating calcium-modulation factor:
+
+    .. math::
+
+        \begin{aligned}
+        I_{CAN} &= \bar g \cdot M([Ca]_i) \cdot p \cdot (E - V) \\
+        M([Ca]_i) &= \frac{[Ca]_i}{[Ca]_i + 0.2\ \mathrm{mM}} \\
+        p_\infty &= \frac{1}{1 + \exp(-(V + 43) / 5.2)} \\
+        \tau_p &= \frac{2.7}{\exp(-(V + 55) / 15) + \exp((V + 55) / 15)}
+                  + 1.6
+        \end{aligned}
+
+    where :math:`V` is read in millivolts, :math:`[Ca]_i` is the
+    intracellular calcium concentration, and :math:`p` relaxes toward
+    :math:`p_\infty` with time constant :math:`\tau_p` (in
+    milliseconds) scaled by
+    :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    E : array-like or callable, optional
+        Reversal potential. Defaults to ``10.0 mV``.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``1.0 mS/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``1.0``
+        (no temperature scaling at the reference temperature).
+    temp_ref : array-like, optional
+        Reference temperature for the Q10 formula, default 36
+        degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaL_IS2008 : Sibling channel from the same source paper, whose
+        L-type attribution is contradicted by the paper's own text
+        (see its Notes).
+
+    Notes
+    -----
+    Ported verbatim from BrainPy's ``ICaN_IS2008``
+    (``brainpy/dyn/channels/calcium.py``): every rate constant and
+    the ``M([Ca]_i)`` modulation term match exactly. BrainPy in turn
+    attributes the current to two sources, only one of which is
+    Inoue & Strowbridge (2008): the
+    ``M([Ca]_i) = [Ca]_i / ([Ca]_i + 0.2 mM)`` modulation is the
+    calcium-activated non-selective cation form used by Destexhe,
+    Contreras, Steriade, Sejnowski & Huguenard (1994), while the
+    voltage dependence of ``p`` is attributed to Inoue & Strowbridge
+    (2008).
+
+    Inoue, T., & Strowbridge, B. W. (2008) models a calcium- and
+    voltage-dependent nonselective cation current
+    (:math:`I_{CAN}`) in an olfactory bulb granule-cell model, where
+    it generates the calcium-dependent afterdepolarization central to
+    the paper's thesis about persistent activity -- this substantially
+    supports the attribution of this class to that paper. However,
+    the paper's Methods defer the gating constants to supplementary
+    materials that are not included with the PMC-deposited author
+    manuscript and were not otherwise obtainable, and no ModelDB
+    deposit exists for this paper. **No published source has been
+    read that prints the** ``p_inf``/``tau_p`` **constants above**, so
+    this docstring ships no ``References`` section: the current is
+    documented as a ported implementation of substantially supported
+    but not fully confirmed provenance, not as a transcription of a
+    specific paper's printed equations.
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -144,7 +220,109 @@ class CaN_IS2008(HH):
 
 @register_channel("CaT_HM1992")
 class CaT_HM1992(OhmicHH):
-    r"""Huguenard & McCormick 1992 low-threshold T-type calcium current."""
+    r"""Huguenard & McCormick 1992 low-threshold T-type calcium current.
+
+    The thalamic relay-neuron low-threshold (T-type) calcium current
+    :math:`I_T` of (Huguenard & McCormick, 1992) [1]_, with
+    :math:`p^2 q` HH gating and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 59) / 6.2)} \\
+        \tau_p &= \frac{1}
+                  {\exp(-(V' + 132) / 16.7) + \exp((V' + 16.8) / 18.2)}
+                  + 0.612 \\
+        q_\infty &= \frac{1}{1 + \exp((V' + 83) / 4)} \\
+        \tau_q &= \begin{cases}
+                  \exp((V' + 467) / 66.6) & V' < -80 \\
+                  \exp(-(V' + 22) / 10.5) + 28 & V' \geq -80
+                  \end{cases}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and
+    :math:`\tau_p`/:math:`\tau_q` (in milliseconds) are further scaled
+    by :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``2.0 mS/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default
+        ``3.55``. This value could not be traced to the paper or to
+        any reference NEURON implementation; treat it as a
+        BrainCell/BrainPy default (see Notes).
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 24 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default
+        ``3.0``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 24 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``-3.0 mV`` (see Notes).
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaHT_HM1992 : Same gating functions with ``V_sh`` moved to
+        ``+25.0 mV``, relabelled as a high-threshold current; that
+        relabelling has no source in this paper (see its Notes).
+    CaT_HP1992 : Independently sourced T-type current for reticular
+        nucleus neurons, with the same ``p^2 q`` gating shape but a
+        different Boltzmann parameterisation.
+
+    Notes
+    -----
+    Compared against ``ITGHK.mod`` (ModelDB accession 279),
+    Destexhe's NEURON implementation of this paper, headed "Model of
+    Huguenard & McCormick, J Neurophysiol 68: 1373-1383, 1992". The
+    mod file's own ``shift = 2 mV`` (screening charge at 2 mM
+    external calcium) is folded into this class's Boltzmann
+    midpoints only -- 57 to 59 in ``p_inf``, 81 to 83 in ``q_inf`` --
+    **not** into the time-constant expressions: ``tau_p`` carries the
+    mod file's bare 132/16.8 and ``tau_q`` its bare 467/22 with the
+    branch at :math:`V' = -80`, i.e. exactly ``ITGHK.mod``'s numbers
+    read at ``shift = 0``, not at its own shipped ``shift = 2 mV``.
+    So the equations above match ``ITGHK.mod``'s ``tau_p``, piecewise
+    ``tau_q`` and ``p^2 q`` gating exactly against a ``shift = 0``
+    reading, while the steady-state midpoints match the mod file
+    *with* the 2 mV shift folded in. Do not describe this class as
+    reproducing the mod file "with the 2 mV screening-charge shift
+    folded in" everywhere -- that is true of the midpoints and false
+    of the time constants.
+
+    A second, unrelated mod file, ``IT.mod`` (ModelDB accession
+    3817), is *not* a source for any constant here despite modelling
+    the same paper's data: its header reads "Model **based on the
+    data of** Huguenard & McCormick... **and** Huguenard & Prince...",
+    it shares only ``m_inf``/``h_inf`` with ``ITGHK.mod``, has no
+    real ``tau_m`` (activation is taken at steady state), and its
+    piecewise ``tau_h`` is commented out in favour of a different
+    bi-exponential fit.
+
+    This class applies a further ``V_sh = -3.0 mV`` on top of the
+    already-folded 2 mV shift, so the shipped defaults sit 3 mV from
+    ``ITGHK.mod``'s own defaults. This is a documented free
+    parameter, not a citation error.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -197,7 +375,92 @@ class CaT_HM1992(OhmicHH):
 
 @register_channel("CaT_HP1992")
 class CaT_HP1992(OhmicHH):
-    r"""Huguenard & Prince 1992 T-type calcium current for reticular nucleus."""
+    r"""Huguenard & Prince 1992 T-type calcium current for reticular nucleus.
+
+    The slowly inactivating transient (T-type) calcium current
+    :math:`I_{Ts}` recorded in rat thalamic reticular nucleus (nRt)
+    neurons by (Huguenard & Prince, 1992) [1]_, with :math:`p^2 q` HH
+    gating and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 52) / 7.4)} \\
+        \tau_p &= 3 + \frac{1}
+                  {\exp((V' + 27) / 10) + \exp(-(V' + 102) / 15)} \\
+        q_\infty &= \frac{1}{1 + \exp((V' + 80) / 5)} \\
+        \tau_q &= 85 + \frac{1}
+                  {\exp((V' + 48) / 4) + \exp(-(V' + 407) / 50)}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and
+    :math:`\tau_p`/:math:`\tau_q` (in milliseconds) are further scaled
+    by :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``1.75 mS/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``5.0``.
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 24 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default
+        ``3.0``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 24 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``-3.0 mV`` (see Notes).
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaT_HM1992 : Independently sourced low-threshold T-type current
+        for thalamic relay neurons, with the same ``p^2 q`` gating
+        shape but a different Boltzmann parameterisation.
+
+    Notes
+    -----
+    Compared against ``IT2.mod`` (ModelDB accession 3670), whose
+    header reads: "The kinetics is described by standard equations
+    (NOT GHK) using a m2h format, according to the voltage-clamp data
+    (whole cell patch clamp) of Huguenard & Prince, J Neurosci. 12:
+    3804-3817, 1992", with "Q10 changed to 5 and 3". Unlike
+    :class:`CaT_HM1992`, the mod file's ``shift = 2 mV`` (screening
+    charge for external calcium = 2 mM) is folded into **every**
+    constant here -- both the Boltzmann midpoints and the
+    time-constant offsets -- so all six mod-file numbers (50, 78, 25,
+    100, 46, 405) shift uniformly to the 52, 80, 27, 102, 48, 407
+    used above. ``q10_p = 5.0`` and ``q10_q = 3.0`` at
+    ``temp_ref = 24 degC`` match the mod file's
+    ``phi_m = 5^((celsius-24)/10)`` and ``phi_h = 3^((celsius-24)/10)``
+    exactly.
+
+    This class applies a further ``V_sh = -3.0 mV`` on top of the
+    already-folded 2 mV shift, so the shipped defaults sit 3 mV
+    depolarized relative to ``IT2.mod``'s own defaults. This is a
+    documented free parameter, not a citation error.
+    ``g_max = 1.75 mS/cm2`` matches ``IT2.mod``'s
+    ``gcabar = 0.00175 mho/cm2``.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & Prince, D. A. (1992). A novel T-type
+           current underlies prolonged Ca2+-dependent burst firing in
+           GABAergic neurons of rat thalamic reticular nucleus. The
+           Journal of Neuroscience, 12(10), 3804-3817.
+           doi:10.1523/JNEUROSCI.12-10-03804.1992
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -246,7 +509,110 @@ class CaT_HP1992(OhmicHH):
 
 @register_channel("CaHT_HM1992")
 class CaHT_HM1992(OhmicHH):
-    r"""Huguenard & McCormick 1992 high-threshold calcium current."""
+    r"""Depolarized-shift variant of the Huguenard & McCormick 1992 T current.
+
+    :math:`p^2 q` HH gating with an ohmic driving force, using the
+    same rate functions as :class:`CaT_HM1992` but with the threshold
+    shift moved from ``-3.0 mV`` to ``+25.0 mV`` (see Notes for why
+    this is not a citation for a genuine high-threshold current):
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 59) / 6.2)} \\
+        \tau_p &= \frac{1}
+                  {\exp(-(V' + 132) / 16.7) + \exp((V' + 16.8) / 18.2)}
+                  + 0.612 \\
+        q_\infty &= \frac{1}{1 + \exp((V' + 83) / 4)} \\
+        \tau_q &= \begin{cases}
+                  \exp((V' + 467) / 66.6) & V' < -80 \\
+                  \exp(-(V' + 22) / 10.5) + 28 & V' \geq -80
+                  \end{cases}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and
+    :math:`\tau_p`/:math:`\tau_q` (in milliseconds) are further scaled
+    by :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``2.0 mS/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default
+        ``3.55``, inherited unchanged from :class:`CaT_HM1992` (see
+        that class's Notes on this value's provenance).
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 24 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default
+        ``3.0``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 24 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``+25.0 mV`` -- see Notes; this is the only numeric
+        difference from :class:`CaT_HM1992`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaT_HM1992 : The unshifted low-threshold T current this class is
+        character-for-character derived from (``V_sh = -3.0 mV``);
+        see its Notes for how the source paper's 2 mV screening
+        shift is folded into these same rate functions.
+    CaHT_Re1993 : Independently sourced high-threshold calcium
+        current with a genuine high-voltage-activated attribution.
+
+    Notes
+    -----
+    **This class does not implement a current described in
+    (Huguenard & McCormick, 1992) [1]_.** That paper models exactly
+    four currents -- a *low*-threshold T-type calcium current, two
+    potassium currents and a hyperpolarization-activated current --
+    and contains no high-threshold or high-voltage-activated calcium
+    current at all. Reading the code confirms this class's rate
+    functions are character-for-character identical to
+    :class:`CaT_HM1992`'s (same 59, 6.2, 0.612, 132, 16.7, 16.8,
+    18.2, 83, 4.0, 467, 66.6, 22, 10.5, 28 constants, the same
+    :math:`V' = -80` branch point, the same ``p^2 q`` gating and the
+    same ``q10_p = 3.55`` / ``q10_q = 3.0`` at 24 degC defaults). The
+    only difference is ``V_sh``: ``+25.0 mV`` here versus ``-3.0 mV``
+    in :class:`CaT_HM1992`. This class is the paper's low-threshold T
+    current translated 28 mV depolarized and relabelled
+    "high-threshold" -- a BrainCell/BrainPy-derived variant, not a
+    current the cited paper reports. The ``+25 mV`` shift itself has
+    no traceable source in the paper.
+
+    The citation below is included because it correctly identifies
+    the origin of the *gating kinetics* (they are exactly Huguenard &
+    McCormick's T-current rate functions -- see :class:`CaT_HM1992`
+    for the full derivation and the 2 mV screening-shift caveat that
+    also applies here), not because the paper describes a
+    high-threshold current under this name. A genuine high-threshold
+    thalamic calcium current, :math:`I_L`, is described in the
+    companion paper McCormick, D. A., & Huguenard, J. R. (1992), "A
+    model of the electrophysiological properties of thalamocortical
+    relay neurons", Journal of Neurophysiology, 68(4), 1384-1400,
+    doi:10.1152/jn.1992.68.4.1384 -- but this class's gating functions
+    do not match that current's kinetics either, so that paper is
+    named here only as a lead for future re-derivation, not cited.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -299,7 +665,80 @@ class CaHT_HM1992(OhmicHH):
 
 @register_channel("CaHT_Re1993")
 class CaHT_Re1993(OhmicHH):
-    r"""Reuveni 1993 high-threshold calcium current."""
+    r"""Reuveni 1993 high-threshold calcium current.
+
+    The high-voltage-activated (HVA) calcium current underlying the
+    calcium plateau spike in neocortical pyramidal cells, from
+    (Reuveni et al., 1993) [1]_, with :math:`p^2 q` HH gating (an
+    :math:`m^2 h` scheme in the source mod file's naming) and an
+    ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_p &= \frac{0.055 (V'' - 27)}{\exp((V'' - 27) / 3.8) - 1} \\
+        \beta_p &= 0.94 \exp((V'' - 75) / 17) \\
+        \alpha_q &= 0.000457 \exp((V'' - 13) / 50) \\
+        \beta_q &= \frac{0.0065}{\exp((V'' - 15) / 28) + 1}
+        \end{aligned}
+
+    where :math:`V'' = (V_{sh} - V) / \mathrm{mV}` is the negated-
+    voltage form the source mod file uses inline, so with the default
+    ``V_sh = 0.0 mV`` this reduces to :math:`V'' = -V / \mathrm{mV}`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``1.0 mS/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``2.3``.
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 23 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default
+        ``2.3``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 23 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift entering the negated-voltage form above,
+        default ``0.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaHT_HM1992 : Nominally also a high-threshold current, but
+        actually a relabelled low-threshold T current with no
+        genuine high-threshold attribution (see its Notes).
+
+    Notes
+    -----
+    Compared against ``ca.mod`` (ModelDB accession 2488), headed "HVA
+    Ca current / Based on Reuveni, Friedman, Amitai and Gutnick
+    (1993) / J. Neurosci. 13:4609-4621" (implementation by Zach
+    Mainen, Salk Institute, 1994). Every rate constant above matches
+    the mod file's ``alpha_m``/``beta_m``/``alpha_h``/``beta_h``
+    term for term, and the temperature parameters match exactly:
+    ``ca.mod`` uses ``temp = 23 degC, q10 = 2.3``; this class
+    defaults to ``q10_p = q10_q = 2.3`` at ``temp_ref = 23 degC``.
+    Gating is :math:`m^2 h` in both.
+
+    References
+    ----------
+    .. [1] Reuveni, I., Friedman, A., Amitai, Y., & Gutnick, M. J.
+           (1993). Stepwise repolarization from Ca2+ plateaus in
+           neocortical pyramidal cells: evidence for nonhomogeneous
+           distribution of HVA Ca2+ channels in dendrites. The
+           Journal of Neuroscience, 13(11), 4609-4621.
+           doi:10.1523/JNEUROSCI.13-11-04609.1993
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -349,7 +788,92 @@ class CaHT_Re1993(OhmicHH):
 
 @register_channel("CaL_IS2008")
 class CaL_IS2008(OhmicHH):
-    r"""Inoue & Strowbridge 2008 L-type calcium current."""
+    r"""Inoue & Strowbridge 2008 L-type calcium current.
+
+    A voltage-gated calcium current with :math:`p^2 q` HH gating and
+    an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 10) / 4)} \\
+        \tau_p &= 0.4 + \frac{0.7}
+                  {\exp(-(V' + 5) / 15) + \exp((V' + 5) / 15)} \\
+        q_\infty &= \frac{1}{1 + \exp((V' + 25) / 2)} \\
+        \tau_q &= 300 + \frac{100}
+                  {\exp((V' + 40) / 9.5) + \exp(-(V' + 40) / 9.5)}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}`, gating is
+    :math:`p^2 q`, and :math:`\tau_p`/:math:`\tau_q` (in milliseconds)
+    are further scaled by
+    :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``1.0 mS/cm2``.
+    temp : array-like or callable, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``3.55``.
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 24 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default
+        ``3.0``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 24 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``0.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaN_IS2008 : Sibling channel from the same source paper, whose
+        calcium-activated non-selective cation attribution is
+        substantially, though not fully, supported (see its Notes).
+
+    Notes
+    -----
+    Ported verbatim from BrainPy's ``ICaL_IS2008``
+    (``brainpy/dyn/channels/calcium.py``): every rate constant and
+    the ``p^2 q`` gating scheme match exactly, and BrainPy attributes
+    this current to Inoue & Strowbridge (2008) alone.
+
+    **This attribution is contradicted by the cited paper's own
+    text.** Inoue, T., & Strowbridge, B. W. (2008) models exactly two
+    voltage-gated calcium currents in its olfactory bulb granule-cell
+    simulations: "a low-threshold (T-type) Ca current, and a
+    high-threshold (P/N-type) Ca current." The strings "L-type",
+    "L type" and "ICaL" do not occur anywhere in the article text --
+    the paper has **no L-type calcium current** for this class to be
+    a port of. Two further, independent signs point the same way:
+    this class's ``q10_p = 3.55`` / ``q10_q = 3.0`` at 24 degrees
+    Celsius defaults are byte-identical to :class:`CaT_HM1992`'s
+    temperature defaults (24 degC is the Huguenard & McCormick
+    reference temperature, not an olfactory-bulb one), and no ModelDB
+    deposit exists for this paper to compare constants against. The
+    paper's Methods also defer whatever gating constants it does
+    report to supplementary materials not included with the
+    PMC-deposited author manuscript, so even the P/N-type or T-type
+    currents it does contain cannot be checked against this class
+    from the text alone.
+
+    Because of this, either this class implements the paper's
+    high-threshold P/N-type current under the wrong name, or its true
+    source is a different paper entirely; both possibilities remain
+    open. This docstring ships no ``References`` section: printing a
+    confident citation to Inoue & Strowbridge (2008) for an *L-type*
+    current would misattribute a current that paper does not contain.
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -398,7 +922,102 @@ class CaL_IS2008(OhmicHH):
 
 @register_channel("CaHVA_SU2015_DCN")
 class CaHVA_SU2015_DCN(HH):
-    """Template-based import of ``CaHVA_SU15_DCN.mod``."""
+    r"""High-voltage-activated calcium current of the DCN model (Sudhakar et al., 2015).
+
+    A GHK-driven calcium current with a single :math:`m^3` activation
+    gate, used for the deep cerebellar nucleus (DCN) neuron model of
+    (Sudhakar et al., 2015) [2]_:
+
+    .. math::
+
+        \begin{aligned}
+        I_{CaHVA} &= -P \cdot m^3 \cdot \Phi(V, [Ca]_i, [Ca]_o, T) \\
+        m_\infty &= \frac{1}{1 + \exp(-(V + 34.5) / -9.0)} \\
+        \tau_m &= \frac{1}{\dfrac{31.746}{\exp((V - 5) / -13.89) + 1}
+                  + \dfrac{3.97 \times 10^{-4} (V + 8.9)}
+                  {\exp((V + 8.9) / 5) - 1}} \Big/ q_{\Delta t}
+        \end{aligned}
+
+    where :math:`\Phi` is the constant-field GHK flux (see
+    :func:`~braincell.channel._base.ghk_flux`) evaluated with this
+    class's own inline Faraday/gas-constant literals rather than the
+    shared helper (see Notes), and :math:`P` is the permeability
+    parameter.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    perm : array-like or callable, optional
+        Permeability entering the GHK flux term. Defaults to
+        ``7.5e-6 cm/s``.
+    temp : array-like, optional
+        Absolute temperature entering the GHK flux term and the
+        activation time constant. Defaults to 36 degrees Celsius.
+    qdeltat : array-like or callable, optional
+        Divisor applied to :math:`\tau_m`; a NEURON-style ``Q10``-free
+        rate scale, not a :class:`~braincell.channel._base.Gate`
+        ``phi`` factor. Defaults to ``1.0``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaLVA_SU2015_DCN : Sibling DCN calcium current using the same
+        inline GHK constants and permeability parameterisation, with
+        low-voltage-activated (:math:`m^2 h`) gating instead.
+    CaL_SU2015_DCN : Sibling DCN calcium current with the same
+        low-voltage-activated gating shape as
+        :class:`CaLVA_SU2015_DCN`, but driven ohmically against a
+        fixed reversal potential rather than through GHK.
+    braincell.channel._base.ghk_flux : Shared GHK flux helper; this
+        class does not call it directly (see Notes).
+
+    Notes
+    -----
+    Ported from ``DCN/channel/CaHVA_SU15_DCN.mod``, whose ``TITLE``
+    reads "High voltage activated calcium current (CaHVA) of deep
+    cerebellar nucleus (DCN) neuron". The origin of the DCN kinetics
+    is the GENESIS model of Steuber, Schultheiss, Silver, De Schutter
+    & Jaeger (2011) [1]_, translated from GENESIS to NEURON by
+    Luthman, Hoebeek, Maex, Davey, Adams, De Zeeuw & Steuber (2011)
+    and reused, without modification credit, in Sudhakar et al.
+    (2015) [2]_. The string "CaHVA" does not occur in the Sudhakar et
+    al. (2015) article text; this docstring records only that the
+    mechanism is part of the model published as [2]_, not that the
+    paper names or describes it, and it does not claim that either
+    paper prints the ``m_inf``/``tau_m`` constants above.
+
+    ``current()`` evaluates the GHK constant-field equation inline
+    with the mod file's own hard-coded literals
+    (``4.47814e6``, ``-23.20764929``) rather than calling
+    :func:`~braincell.channel._base.ghk_flux`, matching the pattern
+    used by the module-level ``_cav3p1_nmodl_ghk_flux`` /
+    ``_cav3p3_nmodl_ghk_flux`` helpers elsewhere in this file.
+    NEURON's raw ``ica`` for this mechanism is outward-positive; the
+    sign is flipped in ``current()`` to match BrainCell's repo-wide
+    inward-positive convention.
+
+    The original mechanism's ``TABLE`` directive tabulated ``minf``
+    and ``taum`` over ``[-150, 100] mV`` (plus a ``DEPEND T`` table);
+    BrainCell removes the table and evaluates both expressions
+    per-call instead.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -445,7 +1064,106 @@ class CaHVA_SU2015_DCN(HH):
 
 @register_channel("CaL_SU2015_DCN")
 class CaL_SU2015_DCN(OhmicHH):
-    """Template-based import of ``CaL_SU15_DCN.mod``."""
+    r"""Low-voltage-activated calcium current of the DCN model (Sudhakar et al., 2015).
+
+    An ohmically-driven calcium current with :math:`m^2 h` HH gating
+    against a fixed reversal potential, used for the deep cerebellar
+    nucleus (DCN) neuron model of (Sudhakar et al., 2015) [2]_:
+
+    .. math::
+
+        \begin{aligned}
+        I_{CaL} &= g_{\mathrm{max}} \, m^2 h \, (E - V) \\
+        m_\infty &= \frac{1}{1 + \exp(-(V + 56) / -6.2)} \\
+        \tau_m &= \left(\frac{0.333}
+                  {\exp((V + 131) / -16.7) + \exp((V + 15.8) / 18.2)}
+                  + 0.204\right) \Big/ q_{\Delta t} \\
+        h_\infty &= \frac{1}{1 + \exp((V + 80) / 4)} \\
+        \tau_h &= \frac{1}{q_{\Delta t}} \times \begin{cases}
+                  0.333 \exp((V + 466) / 66) & V < -81 \\
+                  0.333 \exp((V + 21) / -10.5) + 9.32 & V \geq -81
+                  \end{cases}
+        \end{aligned}
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.01 mS/cm2``.
+    E : array-like or callable, optional
+        Fixed reversal potential used in place of an ion-derived
+        value (see Notes). Defaults to ``139.0 mV``.
+    qdeltat : array-like or callable, optional
+        Divisor applied to :math:`\tau_m` and :math:`\tau_h`; a
+        NEURON-style ``Q10``-free rate scale, not a
+        :class:`~braincell.channel._base.Gate` ``phi`` factor.
+        Defaults to ``1.0``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaLVA_SU2015_DCN : Sibling DCN calcium current with the same
+        :math:`m^2 h` gating shape and identical rate constants (see
+        Notes), driven through GHK against ion concentrations rather
+        than ohmically against a fixed ``E``.
+    CaHVA_SU2015_DCN : Sibling DCN calcium current with
+        high-voltage-activated (:math:`m^3`) gating instead.
+
+    Notes
+    -----
+    Ported from ``DCN/channel/CaL_SU15_DCN.mod``. **Its own ``TITLE``
+    reads "LVA calcium current (CaLVA) of deep cerebellar nucleus
+    (DCN) neuron"** -- i.e. the mod file named ``CaL_SU15_DCN.mod``
+    describes itself as an LVA / "CaLVA" current, not an L-type
+    current, despite the ``CaL`` symbol name. This class's rate
+    functions are in fact algebraically identical to
+    :class:`CaLVA_SU2015_DCN`'s: both use
+    ``m_inf = 1/(1 + exp((V+56)/-6.2))`` and the same
+    :math:`\tau_m`/:math:`h_\infty`/:math:`\tau_h` expressions above.
+    The only structural difference between the two classes is the
+    current law -- this class overrides
+    :meth:`~braincell.channel._base.OhmicHH.reversal_potential` to
+    return the fixed ``E`` parameter and derives its driving force
+    ohmically, while :class:`CaLVA_SU2015_DCN` derives its driving
+    force from a GHK flux against explicit ion concentrations. The
+    default ``E = 139.0 mV`` was not independently verified against
+    the mod file's own ``PARAMETER`` block for this task; it is
+    documented here as a shipped BrainCell default, not attributed to
+    a specific value printed in Sudhakar et al. (2015) [2]_.
+
+    The origin of the DCN kinetics is the GENESIS model of Steuber,
+    Schultheiss, Silver, De Schutter & Jaeger (2011) [1]_, translated
+    from GENESIS to NEURON by Luthman, Hoebeek, Maex, Davey, Adams,
+    De Zeeuw & Steuber (2011) and reused, without modification
+    credit, in Sudhakar et al. (2015) [2]_. The string "CaL" does not
+    occur in the Sudhakar et al. (2015) article text; this docstring
+    records only that the mechanism is part of the model published as
+    [2]_, not that the paper names or describes it, and it does not
+    claim that either paper prints the constants above.
+
+    The original mechanism's ``TABLE`` directive tabulated ``minf``,
+    ``taum``, ``hinf`` and ``tauh`` over ``[-150, 100] mV`` (with no
+    ``DEPEND T`` table, unlike :class:`CaHVA_SU2015_DCN` and
+    :class:`CaLVA_SU2015_DCN`); BrainCell removes the table and
+    evaluates all four expressions per-call instead.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = HHTypedNeuron
@@ -501,7 +1219,131 @@ class CaL_SU2015_DCN(OhmicHH):
 
 @register_channel("CaLVA_SU2015_DCN")
 class CaLVA_SU2015_DCN(HH):
-    """Template-based import of ``CaLVA_SU15_DCN.mod``."""
+    r"""Low-voltage-activated calcium current of the DCN model (Sudhakar et al., 2015).
+
+    A GHK-driven calcium current with :math:`m^2 h` gating, used for
+    the deep cerebellar nucleus (DCN) neuron model of (Sudhakar et
+    al., 2015) [2]_:
+
+    .. math::
+
+        \begin{aligned}
+        I_{CaLVA} &= -P \cdot m^2 h \cdot \Phi(V, [Ca]_i, [Ca]_o, T) \\
+        m_\infty &= \frac{1}{1 + \exp(-(V + 56) / -6.2)} \\
+        \tau_m &= \left(\frac{0.333}
+                  {\exp((V + 131) / -16.7) + \exp((V + 15.8) / 18.2)}
+                  + 0.204\right) \Big/ q_{\Delta t} \\
+        h_\infty &= \frac{1}{1 + \exp((V + 80) / 4)} \\
+        \tau_h &= \frac{1}{q_{\Delta t}} \times \begin{cases}
+                  0.333 \exp((V + 466) / 66) & V < -81 \\
+                  0.333 \exp((V + 21) / -10.5) + 9.32 & V \geq -81
+                  \end{cases}
+        \end{aligned}
+
+    where :math:`\Phi` is the constant-field GHK flux (see
+    :func:`~braincell.channel._base.ghk_flux`) evaluated with this
+    class's own inline Faraday/gas-constant literals rather than the
+    shared helper (see Notes), and :math:`P` is the permeability
+    parameter.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    perm : array-like or callable, optional
+        Permeability entering the GHK flux term. Defaults to
+        ``1.0 cm/s``.
+    temp : array-like, optional
+        Absolute temperature entering the GHK flux term and the
+        activation/inactivation time constants. Defaults to 36
+        degrees Celsius.
+    qdeltat : array-like or callable, optional
+        Divisor applied to :math:`\tau_m` and :math:`\tau_h`; a
+        NEURON-style ``Q10``-free rate scale, not a
+        :class:`~braincell.channel._base.Gate` ``phi`` factor.
+        Defaults to ``1.0``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaL_SU2015_DCN : Sibling DCN calcium current with the same
+        :math:`m^2 h` gating shape and identical rate constants (see
+        Notes), driven ohmically against a fixed reversal potential
+        rather than through GHK.
+    CaHVA_SU2015_DCN : Sibling DCN calcium current with
+        high-voltage-activated (:math:`m^3`) gating instead.
+    braincell.ion.CdpLVA_SU2015_DCN : Dedicated LVA-current-driven
+        calcium pool BrainCell ships for this current; see Notes for
+        how it relates to :attr:`root_type`.
+    braincell.channel._base.ghk_flux : Shared GHK flux helper; this
+        class does not call it directly (see Notes).
+
+    Notes
+    -----
+    Ported from ``DCN/channel/CaLVA_SU15_DCN.mod``, whose ``TITLE``
+    reads "Low voltage activated calcium current (CaLVA) of deep
+    cerebellar nucleus (DCN) neuron". This class's rate functions are
+    algebraically identical to :class:`CaL_SU2015_DCN`'s, whose own
+    mod file (``CaL_SU15_DCN.mod``) is *also* titled "LVA calcium
+    current (CaLVA) of deep cerebellar nucleus (DCN) neuron" despite
+    its different ``CaL`` symbol name -- the two BrainCell classes
+    are the same LVA current family exposed through two different
+    current laws (see :class:`CaL_SU2015_DCN`'s Notes).
+
+    ``root_type`` here is the generic :class:`~braincell.ion.Calcium`
+    base, identical to :class:`CaHVA_SU2015_DCN`'s -- nothing in this
+    channel class itself restricts it to a particular ion pool.
+    BrainCell separately ships
+    :class:`~braincell.ion.CdpLVA_SU2015_DCN`, a dedicated
+    LVA-current-driven calcium pool mirroring the imported NMODL's
+    separate ``cali``/``cal`` pool (as opposed to
+    ``CdpHVA_SU2015_DCN``'s ``cai``, which the original NEURON
+    mechanism used to let the LVA and HVA currents drive
+    independently trackable calcium pools). Preserving that
+    separation in a BrainCell model is a compositional choice made
+    when attaching this channel to a specific ion instance, not a
+    guarantee enforced by this class's ``root_type``.
+
+    ``current()`` evaluates the GHK constant-field equation inline
+    with the mod file's own hard-coded literals
+    (``4.47814e6``, ``-23.20764929``) rather than calling
+    :func:`~braincell.channel._base.ghk_flux`, matching the pattern
+    used by the module-level ``_cav3p1_nmodl_ghk_flux`` /
+    ``_cav3p3_nmodl_ghk_flux`` helpers elsewhere in this file.
+    NEURON's raw ``ical`` for this mechanism is outward-positive; the
+    sign is flipped in ``current()`` to match BrainCell's repo-wide
+    inward-positive convention.
+
+    The origin of the DCN kinetics is the GENESIS model of Steuber,
+    Schultheiss, Silver, De Schutter & Jaeger (2011) [1]_, translated
+    from GENESIS to NEURON by Luthman, Hoebeek, Maex, Davey, Adams,
+    De Zeeuw & Steuber (2011) and reused, without modification
+    credit, in Sudhakar et al. (2015) [2]_. The string "CaLVA" does
+    occur in the Sudhakar et al. (2015) article text, but this
+    docstring does not claim that either paper prints the
+    ``m_inf``/``tau_m``/``h_inf``/``tau_h`` constants above.
+
+    The original mechanism's ``TABLE`` directive tabulated ``minf``,
+    ``taum``, ``hinf`` and ``tauh`` over ``[-150, 100] mV`` (plus a
+    ``DEPEND T`` table); BrainCell removes the table and evaluates
+    all four expressions per-call instead.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -1482,31 +2324,106 @@ class Cav2p3_MA2020_GoC(OhmicHH):
 
 @register_channel("Ca_ZH2019_IO")
 class Ca_ZH2019_IO(HH):
-    """Template-based import of ``Ca_ZH2019_IO.mod``.
+    r"""Somatic calcium current of the inferior-olive model (Zhang & Santaniello, 2019).
+
+    A fixed-reversal-potential calcium current with an instantaneous,
+    non-stateful cubic activation and one dynamic inactivation gate,
+    used for the single-compartment inferior-olive neuron model of
+    (Zhang & Santaniello, 2019) [2]_:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= g_{max} \cdot m_\infty \cdot h \cdot (E - V) \\
+        m_\infty &= \left(\frac{1}{1 + \exp((V_{mid} - V) / 4.2)}\right)^3 \\
+        h_\infty &= \frac{1}{1 + \exp((V + 85.5) / 8.6)} \\
+        \tau_h &= 40 + 30 \cdot \frac{1}{1 + \exp((V + 84) / 7.3)}
+                  \cdot \exp\!\left(\frac{V + 160}{30}\right)
+        \end{aligned}
+
+    Only :math:`h` is an integrated :class:`~braincell.channel._base.Gate`
+    state (``gates = (Gate("h"),)``); :math:`m_\infty` is recomputed
+    from :math:`V` on every call to :meth:`current` rather than tracked
+    as a channel state (see Notes).
 
     Parameters
     ----------
     size : brainstate.typing.Size
         Channel state shape.
     g_max : array-like or callable, optional
-        Maximum conductance density.
+        Maximum conductance density. Defaults to ``0.4 mS/cm**2``.
     E : array-like or callable, optional
-        Calcium current reversal potential.
+        Fixed calcium current reversal potential (this class does not
+        derive :math:`E` from an ion concentration). Defaults to
+        ``120.0 mV``.
     mMidV : array-like or callable, optional
-        Midpoint parameter used by the instantaneous activation curve.
+        Midpoint voltage of the instantaneous activation curve.
+        Defaults to ``-61.0 mV``.
     freeze_m_inf : bool, optional
-        Whether to stop autodiff through the instantaneous activation
-        factor while preserving the forward current value.
+        If ``True`` (the default), block autodiff through the
+        instantaneous activation factor with
+        :func:`jax.lax.stop_gradient` while leaving the forward
+        current value unchanged; see Notes.
     name : str, optional
-        Optional module name.
+        Optional channel name.
+
+    See Also
+    --------
+    Ca_ZH2019_IO_Frozen : Registry alias that forces
+        ``freeze_m_inf=True`` unconditionally.
+    braincell.channel.hyperpolarization_activated.HCN_ZH2019_IO :
+        Sibling inferior-olive current from the same import family
+        (different bibliography origin; see Notes).
 
     Notes
     -----
-    The source IO mechanism uses instantaneous activation and one
-    dynamic inactivation gate. Freezing ``m_inf`` is useful for
-    NEURON-style no-concentration channel comparisons where the forward
-    current should match while the local voltage Jacobian only includes
-    the driving-force term.
+    Ported from ``IO/channel/Ca_ZH19_IO.mod``, whose header credits
+    "Ca channel from Manor (Rinzel, Segev, Yarom) 1997" and porter
+    "B. Torben-Nielsen @ HUJI, 7-10-2010" -- i.e. the kinetics
+    originate with Manor, Rinzel, Segev & Yarom (1997) [1]_ and were
+    ported to NEURON by Torben-Nielsen, Segev & Yarom (2012), whose
+    inferior-olive model in turn was reused, without further
+    modification credit, by Zhang & Santaniello (2019) [2]_. The 2012
+    port paper is cited here only in this prose, per house style, not
+    as a numbered reference.
+
+    The inferior-olive neurons in both the Torben-Nielsen et al.
+    (2012) and Zhang & Santaniello (2019) models are
+    single-compartment (``nseg = 1``); the multi-compartment part of
+    that lineage is a separate Purkinje-cell population, not the
+    inferior olive. This docstring does not describe this mechanism
+    as multi-compartment.
+
+    In the imported ``.mod`` file, the shared ``rates(v)`` helper that
+    recomputes ``minf``/``hinf``/``htau`` was called from
+    ``BREAKPOINT`` in the original NEURON mechanism; BrainCell's port
+    (like the rest of this ``ZH19``/``IO`` import family) evaluates
+    the equivalent expressions from ``DERIVATIVE``-time state updates
+    instead, so ``m_inf``/``h_inf``/``tau_h`` are refreshed before,
+    rather than after, the state integration step within a given call.
+
+    ``m`` carries no persistent state and is not part of ``gates``:
+    :meth:`current` calls :meth:`f_m_inf` fresh on every evaluation,
+    so nothing "evolves" over time for the activation term -- it is a
+    purely algebraic function of the instantaneous voltage. Setting
+    ``freeze_m_inf=True`` (the default) wraps that same forward value
+    in :func:`jax.lax.stop_gradient`; it changes only which terms
+    appear in gradients taken through this channel, never the forward
+    current or the value of ``m_inf`` itself.
+
+    References
+    ----------
+    .. [1] Manor, Y., Rinzel, J., Segev, I., & Yarom, Y. (1997).
+           Low-amplitude oscillations in the inferior olive: A model
+           based on electrical coupling of neurons with heterogeneous
+           channel densities. Journal of Neurophysiology, 77(5),
+           2736-2752.
+           doi:10.1152/jn.1997.77.5.2736
+    .. [2] Zhang, X., & Santaniello, S. (2019). Role of cerebellar
+           GABAergic dysfunctions in the origins of essential tremor.
+           Proceedings of the National Academy of Sciences of the
+           United States of America, 116(27), 13592-13601.
+           doi:10.1073/pnas.1817689116
     """
 
     __module__ = "braincell.channel"
@@ -1551,21 +2468,66 @@ class Ca_ZH2019_IO(HH):
 
 @register_channel("Ca_ZH2019_IO_Frozen")
 class Ca_ZH2019_IO_Frozen(Ca_ZH2019_IO):
-    """IO calcium variant with frozen instantaneous activation.
+    r""":class:`Ca_ZH2019_IO` with ``freeze_m_inf`` pinned unconditionally to ``True``.
+
+    A registry-only subclass of :class:`Ca_ZH2019_IO` that always
+    stops autodiff through the instantaneous activation factor,
+    regardless of what a caller passes for ``freeze_m_inf``.
 
     Parameters
     ----------
     *args
         Positional arguments forwarded to :class:`Ca_ZH2019_IO`.
     **kwargs
-        Keyword arguments forwarded to :class:`Ca_ZH2019_IO`.
+        Keyword arguments forwarded to :class:`Ca_ZH2019_IO`; any
+        ``freeze_m_inf`` entry is overwritten with ``True`` before the
+        parent constructor runs (see Notes).
+
+    See Also
+    --------
+    Ca_ZH2019_IO : Base class; already defaults to
+        ``freeze_m_inf=True`` (see Notes for what this subclass adds
+        on top of that default).
 
     Notes
     -----
-    This registry alias always sets ``freeze_m_inf=True``. It keeps the
-    same forward current as :class:`Ca_ZH2019_IO` while forcing autodiff
-    to ignore the voltage derivative of the instantaneous activation
-    term.
+    "Frozen" describes the gradient path through the instantaneous
+    activation term, not the forward numerics: :class:`Ca_ZH2019_IO`
+    already defaults to ``freeze_m_inf=True``, so this subclass does
+    not change the default forward current or default gradient
+    behaviour by itself. What it changes is *configurability* --
+    ``__init__`` here unconditionally sets
+    ``kwargs["freeze_m_inf"] = True`` before delegating to
+    :class:`Ca_ZH2019_IO`, so a caller cannot recover the unfrozen
+    (full-gradient) behaviour by passing ``freeze_m_inf=False`` to
+    this class, whereas it can to the base class. No channel state
+    stops evolving: ``m`` was never a stateful
+    :class:`~braincell.channel._base.Gate` in the base class either
+    (only ``h`` is), and :func:`jax.lax.stop_gradient` affects only
+    backward-mode differentiation, never the forward value computed
+    by :meth:`~Ca_ZH2019_IO.f_m_inf`.
+
+    Provenance, the single-compartment caveat, and the
+    ``rates``-relocation import deviation are identical to
+    :class:`Ca_ZH2019_IO`'s and are not repeated here; see that
+    class's Notes. Per the bibliography's attribution scan, this
+    subclass contributes no rate-function code of its own -- it
+    inherits every kinetic equation unchanged from
+    :class:`Ca_ZH2019_IO`.
+
+    References
+    ----------
+    .. [1] Manor, Y., Rinzel, J., Segev, I., & Yarom, Y. (1997).
+           Low-amplitude oscillations in the inferior olive: A model
+           based on electrical coupling of neurons with heterogeneous
+           channel densities. Journal of Neurophysiology, 77(5),
+           2736-2752.
+           doi:10.1152/jn.1997.77.5.2736
+    .. [2] Zhang, X., & Santaniello, S. (2019). Role of cerebellar
+           GABAergic dysfunctions in the origins of essential tremor.
+           Proceedings of the National Academy of Sciences of the
+           United States of America, 116(27), 13592-13601.
+           doi:10.1073/pnas.1817689116
     """
 
     __module__ = "braincell.channel"

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -1406,7 +1406,145 @@ class CaLVA_SU2015_DCN(HH):
 
 @register_channel("Cav1p2_MA2020_GoC")
 class Cav1p2_MA2020_GoC(OhmicHH):
-    r"""Evans/Beining Cav1.2 calcium current with calcium-dependent inactivation."""
+    r"""Golgi cell Cav1.2 L-type calcium current with Ca inactivation.
+
+    The Cav1.2 (L-type) calcium current of the cerebellar Golgi cell
+    model of (Masoli et al., 2020) [3]_. Its kinetics are the GENESIS
+    Cav1.2 model of (Evans, Maniar & Blackwell, 2013) [1]_, transferred
+    from GENESIS to NEURON by (Beining et al., 2017) [2]_. Gating is
+    :math:`m\,h\,n` with an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= g_{max} \, m \, h \, n \, (E_{Ca} - V) \\
+        m_\infty &= \frac{1}{1 + \exp(-(V' + 8.9) / 6.7)} \\
+        \tau_m &= \frac{1}{\alpha_m + \beta_m} \\
+        \alpha_m &= \frac{39800 \, (V' + 8.124)}
+                    {\exp((V' + 8.124) / 9.005) - 1} \\
+        \beta_m &= 990 \exp(V' / 31.4) \\
+        h_\infty &= \frac{\mathrm{VDI}}{1 + \exp((V' + 55) / 8)}
+                    + (1 - \mathrm{VDI}) \\
+        \tau_h &= 44.3 \\
+        n_\infty &= \frac{k_f}{k_f + [Ca]_i / \mathrm{mM}} \\
+        \tau_n &= 0.5
+        \end{aligned}
+
+    where :math:`V' = V / \mathrm{mV}`, the time constants are in
+    milliseconds, :math:`\mathrm{VDI} = 0.17` and
+    :math:`k_f = 0.0005`. The :math:`n` gate is the imported
+    mechanism's ``h2`` state: a calcium-dependent inactivation whose
+    steady state depends on the internal calcium concentration alone
+    and which relaxes with a fixed 0.5 ms time constant. Because
+    :math:`\mathrm{VDI} = 0.17`, the voltage-dependent inactivation
+    :math:`h_\infty` never falls below 0.83.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.0002 S/cm2``,
+        i.e. ``0.2 mS/cm2`` (see Notes).
+    V_sh : array-like or callable, optional
+        Threshold shift. Accepted and stored, but read by no rate
+        method of this class (see Notes). Defaults to ``0.0 mV``.
+    temp : array-like, optional
+        Absolute temperature driving the gate Q10 factors. Defaults
+        to 22 degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 factor shared by all three gates. Defaults to ``1.0``,
+        which makes the temperature scaling a no-op (see Notes).
+    temp_ref : array-like, optional
+        Reference temperature for ``q10``. Defaults to 22 degrees
+        Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav1p3_MA2020_GoC : Sibling Cav1.3 current from the same import
+        family and the same two origin papers, with its own
+        Boltzmann parameters and an ``exprel``-guarded ``tau_m``.
+    Cav1p2_MA2025_BC : The same mechanism re-imported for the basket
+        cell model; identical kinetics, different model citation.
+    braincell.channel._base.OhmicHH : Template supplying the ohmic
+        driving force used above.
+
+    Notes
+    -----
+    Ported from ``GoC/channel/Cav1p2_MA20_GoC.mod``. That file has no
+    ``TITLE``; its whole header is the comment "model from Evans et al
+    2013, transferred from GENESIS to NEURON by Beining et al (2016),
+    'A novel comprehensive and consistent electrophysiologcal model of
+    dentate granule cells'" (typo in the original). Both fields that
+    header gives are wrong: the transfer paper appeared in 2017, and
+    the quoted title corresponds to no published paper or preprint --
+    it reads as a pre-publication working title. The citable record is
+    the 2017 eLife paper [2]_. Note also that Evans et al. (2013) is a
+    striatal medium spiny neuron paper, not a dentate granule cell
+    paper, despite what the header's phrasing invites.
+
+    The mod file's second header line, "also added Calcium dependent
+    inactivation", and an inline comment crediting the ``h2`` state to
+    "santhakumar 05" are recorded here as prose only. The verified
+    bibliography resolves this mechanism to the two origin papers
+    cited above and does not resolve that third credit, so no
+    reference entry is written for it.
+
+    ``V_sh`` is accepted, stored and never read: no rate method of
+    this class uses it. That reproduces the mod file, whose
+    ``PARAMETER`` block likewise declares ``vshift = 0 (mV)`` and
+    never uses it. In the same spirit, the three gates are wired for
+    Q10 scaling through ``Gate(q10="q10", temp_ref="temp_ref")``, but
+    the shipped defaults (``q10 = 1.0`` and
+    ``temp = temp_ref = 22 degC``) make ``phi`` exactly 1, matching
+    the mod file, which applies no temperature scaling at all.
+
+    **Import deviation -- rate-refresh relocation.** The ``rates()``
+    call moved from ``BREAKPOINT`` into ``DERIVATIVE state``, so
+    ``inf``/``tau`` are refreshed before the ``cnexp`` state update
+    rather than after it.
+
+    **Open question -- a possible unit-scale defect inherited from
+    upstream.** The GENESIS originals (``CaL12CDI.g``,
+    ``CaL13CDI.g``) evaluate the ``mTau`` linoid in volts and return
+    seconds, whereas the NEURON ports apply the same numeric
+    coefficients in mV and declare ``mTau (ms)``. The worked
+    comparison is given in :class:`Cav1p3_MA2020_GoC`'s Notes, and
+    Cav1.2 shows the same pattern. That comparison is derived
+    arithmetic, not a fetched claim, and it was not confirmed against
+    a NEURON run, so it is recorded as an open question rather than
+    as a defect: BrainCell reproduces the mod file faithfully under
+    either reading, and this docstring asserts neither.
+
+    NEURON's raw ``ica`` here is ``g * (v - eca)``, i.e.
+    outward-positive; :class:`~braincell.channel._base.OhmicHH`
+    computes ``g_max * m h n * (E - V)``, the same current under
+    BrainCell's repo-wide inward-positive convention.
+
+    ``g_max``'s default is the ``gbar`` of the cell-model deposit this
+    mechanism was imported from -- a value tuned for that model, not a
+    conductance reported by either origin paper.
+
+    References
+    ----------
+    .. [1] Evans, R. C., Maniar, Y. M., & Blackwell, K. T. (2013).
+           Dynamic modulation of spike timing-dependent calcium
+           influx during corticostriatal upstates. Journal of
+           Neurophysiology, 110(7), 1631-1645.
+           doi:10.1152/jn.00232.2013
+    .. [2] Beining, M., Mongiat, L. A., Schwarzacher, S. W., Cuntz,
+           H., & Jedlicka, P. (2017). T2N as a new tool for robust
+           electrophysiological modeling demonstrated for mature and
+           adult-born dentate granule cells. eLife, 6, e26517.
+           doi:10.7554/eLife.26517
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -1461,14 +1599,239 @@ class Cav1p2_MA2020_GoC(OhmicHH):
 
 @register_channel("Cav1p2_MA2025_BC")
 class Cav1p2_MA2025_BC(Cav1p2_MA2020_GoC):
-    r"""Template-based import of ``Cav1p2_MA25_BC.mod``."""
+    r"""Cav1.2 L-type calcium current, basket-cell parameterisation.
+
+    The same :math:`m\,h\,n` Cav1.2 kinetics documented in
+    :class:`Cav1p2_MA2020_GoC`, reused unchanged for the cerebellar
+    basket cell model of (Masoli et al., 2025) [3]_. The kinetics
+    remain those of (Evans, Maniar & Blackwell, 2013) [1]_ as
+    transferred from GENESIS to NEURON by (Beining et al., 2017) [2]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.0002 S/cm2``
+        (``0.2 mS/cm2``). Inherited from :class:`Cav1p2_MA2020_GoC`.
+    V_sh : array-like or callable, optional
+        Accepted but not read by any rate method (see
+        :class:`Cav1p2_MA2020_GoC` Notes). Default ``0.0 mV``.
+        Inherited from :class:`Cav1p2_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature driving the gate Q10 factors, default 22
+        degrees Celsius. Inherited from :class:`Cav1p2_MA2020_GoC`.
+    q10 : array-like or callable, optional
+        Q10 factor shared by all three gates, default ``1.0``.
+        Inherited from :class:`Cav1p2_MA2020_GoC`.
+    temp_ref : array-like, optional
+        Reference temperature for ``q10``, default 22 degrees
+        Celsius. Inherited from :class:`Cav1p2_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav1p2_MA2020_GoC : The base class; the full equation set, the
+        header corrections, the inert ``V_sh`` and the ``mTau``
+        unit-scale open question are all documented there.
+    Cav1p3_MA2025_BC : Sibling Cav1.3 current of the same basket cell
+        model, from the same two origin papers.
+
+    Notes
+    -----
+    Ported from ``BC/channel/Cav1p2_MA25_BC.mod``, which is identical
+    to ``GoC/channel/Cav1p2_MA20_GoC.mod`` except for its ``SUFFIX``
+    line. Accordingly this class overrides nothing: the constructor,
+    the gate declarations, the rate methods and the ``kf``/``VDI``
+    constants are all inherited from :class:`Cav1p2_MA2020_GoC`. Only
+    the ``register_channel`` key and this docstring's model citation
+    differ.
+
+    The ``MA2025`` import-deviations table records the same
+    rate-refresh relocation already documented on
+    :class:`Cav1p2_MA2020_GoC`: ``rates()`` moved from ``BREAKPOINT``
+    into ``DERIVATIVE state``, so ``inf``/``tau`` are refreshed before
+    the ``cnexp`` state update. The ``mTau`` unit-scale open question
+    recorded for the ``MA2020`` Cav1.2/Cav1.3 pair applies identically
+    here.
+
+    References
+    ----------
+    .. [1] Evans, R. C., Maniar, Y. M., & Blackwell, K. T. (2013).
+           Dynamic modulation of spike timing-dependent calcium
+           influx during corticostriatal upstates. Journal of
+           Neurophysiology, 110(7), 1631-1645.
+           doi:10.1152/jn.00232.2013
+    .. [2] Beining, M., Mongiat, L. A., Schwarzacher, S. W., Cuntz,
+           H., & Jedlicka, P. (2017). T2N as a new tool for robust
+           electrophysiological modeling demonstrated for mature and
+           adult-born dentate granule cells. eLife, 6, e26517.
+           doi:10.7554/eLife.26517
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav1p3_MA2020_GoC")
 class Cav1p3_MA2020_GoC(OhmicHH):
-    r"""Evans/Beining Cav1.3 calcium current with calcium-dependent inactivation."""
+    r"""Golgi cell Cav1.3 L-type calcium current with Ca inactivation.
+
+    The Cav1.3 (L-type) calcium current of the cerebellar Golgi cell
+    model of (Masoli et al., 2020) [3]_. Its kinetics are the GENESIS
+    Cav1.3 model of (Evans, Maniar & Blackwell, 2013) [1]_, transferred
+    from GENESIS to NEURON by (Beining et al., 2017) [2]_. Gating is
+    :math:`m\,h\,n` with an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= g_{max} \, m \, h \, n \, (E_{Ca} - V) \\
+        m_\infty &= \frac{1}{\exp(-(V' + 40) / 5) + 1} \\
+        \tau_m &= \frac{1}{\alpha_m + \beta_m} \\
+        \alpha_m &= \frac{39800 \times 15.005}
+                    {\mathrm{exprel}((V' + 67.24) / 15.005)} \\
+        \beta_m &= 3500 \exp(V' / 31.4) \\
+        h_\infty &= \frac{\mathrm{VDI}}{\exp((V' + 37) / 5) + 1}
+                    + (1 - \mathrm{VDI}) \\
+        \tau_h &= 44.3 \\
+        n_\infty &= \frac{k_f}{k_f + [Ca]_i / \mathrm{mM}} \\
+        \tau_n &= 0.5
+        \end{aligned}
+
+    where :math:`V' = V / \mathrm{mV}`, the time constants are in
+    milliseconds, :math:`\mathrm{VDI} = 1.0` and
+    :math:`k_f = 0.0005`. Unlike :class:`Cav1p2_MA2020_GoC`
+    (:math:`\mathrm{VDI} = 0.17`), :math:`\mathrm{VDI} = 1.0` here
+    leaves no non-inactivating floor, so :math:`h_\infty` reduces to
+    the plain Boltzmann :math:`1 / (1 + \exp((V' + 37) / 5))`. The
+    :math:`n` gate is the imported mechanism's ``h2`` state, a
+    calcium-dependent inactivation with a fixed 0.5 ms time constant.
+
+    :math:`\mathrm{exprel}(x) = (\exp(x) - 1) / x`, so
+    :math:`\alpha_m` equals the mod file's literal
+    :math:`39800 (V' + 67.24) / (\exp((V' + 67.24) / 15.005) - 1)`
+    while remaining finite at :math:`V' = -67.24` mV, where the
+    literal form is an indeterminate :math:`0/0`. At that voltage
+    :math:`\mathrm{exprel}(0) = 1` and
+    :math:`\alpha_m = 39800 \times 15.005`, the limit of the mod
+    file's expression.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.000005 S/cm2``,
+        i.e. ``0.005 mS/cm2`` (see Notes).
+    V_sh : array-like or callable, optional
+        Threshold shift. Accepted and stored, but read by no rate
+        method of this class (see Notes). Defaults to ``0.0 mV``.
+    temp : array-like, optional
+        Absolute temperature driving the gate Q10 factors. Defaults
+        to 22 degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 factor shared by all three gates. Defaults to ``1.0``,
+        which makes the temperature scaling a no-op (see Notes).
+    temp_ref : array-like, optional
+        Reference temperature for ``q10``. Defaults to 22 degrees
+        Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav1p2_MA2020_GoC : Sibling Cav1.2 current from the same import
+        family and the same two origin papers; its ``alpha_m`` keeps
+        the mod file's literal, unguarded quotient.
+    Cav1p3_MA2025_BC : The same mechanism re-imported for the basket
+        cell model; identical kinetics, different model citation.
+    braincell.channel._base.OhmicHH : Template supplying the ohmic
+        driving force used above.
+
+    Notes
+    -----
+    Ported from ``GoC/channel/Cav1p3_MA20_GoC.mod``. That file has no
+    ``TITLE``; its whole header is the comment "model from Evans et al
+    2013, transferred from GENESIS to NEURON by Beining et al (2016),
+    'A novel comprehensive and consistent electrophysiologcal model of
+    dentate granule cells'" (typo in the original). Both fields that
+    header gives are wrong: the transfer paper appeared in 2017, and
+    the quoted title corresponds to no published paper or preprint --
+    it reads as a pre-publication working title. The citable record is
+    the 2017 eLife paper [2]_. Evans et al. (2013) is a striatal
+    medium spiny neuron paper, not a dentate granule cell paper,
+    despite what the header's phrasing invites.
+
+    The mod file's second header line, "also added Calcium dependent
+    inactivation", and an inline comment crediting the ``h2`` state to
+    "santhakumar 05" are recorded here as prose only. The verified
+    bibliography resolves this mechanism to the two origin papers
+    cited above and does not resolve that third credit, so no
+    reference entry is written for it.
+
+    ``V_sh`` is accepted, stored and never read: no rate method of
+    this class uses it. That reproduces the mod file, whose
+    ``PARAMETER`` block likewise declares ``vshift = 0 (mV)`` and
+    never uses it. In the same spirit, the three gates are wired for
+    Q10 scaling through ``Gate(q10="q10", temp_ref="temp_ref")``, but
+    the shipped defaults (``q10 = 1.0`` and
+    ``temp = temp_ref = 22 degC``) make ``phi`` exactly 1, matching
+    the mod file, which applies no temperature scaling at all.
+
+    **Import deviation -- rate-refresh relocation.** The ``rates()``
+    call moved from ``BREAKPOINT`` into ``DERIVATIVE state``, so
+    ``inf``/``tau`` are refreshed before the ``cnexp`` state update
+    rather than after it.
+
+    **Open question -- a possible unit-scale defect inherited from
+    upstream.** The GENESIS original ``CaL13CDI.g`` evaluates the
+    ``mTau`` linoid in volts and returns seconds, whereas the NEURON
+    port applies the same numeric coefficients in mV and declares
+    ``mTau (ms)``. Worked at :math:`V = 0` mV, the GENESIS reading
+    gives ``tau_m`` about 0.283 ms while the mod file -- and hence
+    this class -- gives about 2.9e-5 ms, roughly 1e4 times smaller,
+    i.e. effectively instantaneous activation. Cav1.2 shows the same
+    pattern, and the transfer paper's Methods mention no intentional
+    rescaling. This is derived arithmetic, not a fetched claim, and
+    it was not confirmed against a NEURON run, so it is recorded as
+    an open question rather than as a defect: BrainCell reproduces
+    the mod file faithfully under either reading, and this docstring
+    asserts neither.
+
+    NEURON's raw ``ica`` here is ``g * (v - eca)``, i.e.
+    outward-positive; :class:`~braincell.channel._base.OhmicHH`
+    computes ``g_max * m h n * (E - V)``, the same current under
+    BrainCell's repo-wide inward-positive convention.
+
+    ``g_max``'s default is the ``gbar`` of the cell-model deposit this
+    mechanism was imported from -- a value tuned for that model, not a
+    conductance reported by either origin paper.
+
+    References
+    ----------
+    .. [1] Evans, R. C., Maniar, Y. M., & Blackwell, K. T. (2013).
+           Dynamic modulation of spike timing-dependent calcium
+           influx during corticostriatal upstates. Journal of
+           Neurophysiology, 110(7), 1631-1645.
+           doi:10.1152/jn.00232.2013
+    .. [2] Beining, M., Mongiat, L. A., Schwarzacher, S. W., Cuntz,
+           H., & Jedlicka, P. (2017). T2N as a new tool for robust
+           electrophysiological modeling demonstrated for mature and
+           adult-born dentate granule cells. eLife, 6, e26517.
+           doi:10.7554/eLife.26517
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -1523,32 +1886,246 @@ class Cav1p3_MA2020_GoC(OhmicHH):
 
 @register_channel("Cav1p3_MA2025_BC")
 class Cav1p3_MA2025_BC(Cav1p3_MA2020_GoC):
-    r"""Template-based import of ``Cav1p3_MA25_BC.mod``."""
+    r"""Cav1.3 L-type calcium current, basket-cell parameterisation.
+
+    The same :math:`m\,h\,n` Cav1.3 kinetics documented in
+    :class:`Cav1p3_MA2020_GoC`, reused unchanged for the cerebellar
+    basket cell model of (Masoli et al., 2025) [3]_. The kinetics
+    remain those of (Evans, Maniar & Blackwell, 2013) [1]_ as
+    transferred from GENESIS to NEURON by (Beining et al., 2017) [2]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.000005 S/cm2``
+        (``0.005 mS/cm2``). Inherited from
+        :class:`Cav1p3_MA2020_GoC`.
+    V_sh : array-like or callable, optional
+        Accepted but not read by any rate method (see
+        :class:`Cav1p3_MA2020_GoC` Notes). Default ``0.0 mV``.
+        Inherited from :class:`Cav1p3_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature driving the gate Q10 factors, default 22
+        degrees Celsius. Inherited from :class:`Cav1p3_MA2020_GoC`.
+    q10 : array-like or callable, optional
+        Q10 factor shared by all three gates, default ``1.0``.
+        Inherited from :class:`Cav1p3_MA2020_GoC`.
+    temp_ref : array-like, optional
+        Reference temperature for ``q10``, default 22 degrees
+        Celsius. Inherited from :class:`Cav1p3_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav1p3_MA2020_GoC : The base class; the full equation set, the
+        ``exprel`` guard, the header corrections, the inert ``V_sh``
+        and the ``mTau`` unit-scale open question are documented
+        there.
+    Cav1p2_MA2025_BC : Sibling Cav1.2 current of the same basket cell
+        model, from the same two origin papers.
+
+    Notes
+    -----
+    Ported from ``BC/channel/Cav1p3_MA25_BC.mod``, which is identical
+    to ``GoC/channel/Cav1p3_MA20_GoC.mod`` except for its ``SUFFIX``
+    line. Accordingly this class overrides nothing: the constructor,
+    the gate declarations, the rate methods and the ``kf``/``VDI``
+    constants are all inherited from :class:`Cav1p3_MA2020_GoC`. Only
+    the ``register_channel`` key and this docstring's model citation
+    differ.
+
+    The ``MA2025`` import-deviations table records the same
+    rate-refresh relocation already documented on
+    :class:`Cav1p3_MA2020_GoC`: ``rates()`` moved from ``BREAKPOINT``
+    into ``DERIVATIVE state``, so ``inf``/``tau`` are refreshed before
+    the ``cnexp`` state update. The ``mTau`` unit-scale open question
+    recorded for the ``MA2020`` Cav1.2/Cav1.3 pair applies identically
+    here.
+
+    References
+    ----------
+    .. [1] Evans, R. C., Maniar, Y. M., & Blackwell, K. T. (2013).
+           Dynamic modulation of spike timing-dependent calcium
+           influx during corticostriatal upstates. Journal of
+           Neurophysiology, 110(7), 1631-1645.
+           doi:10.1152/jn.00232.2013
+    .. [2] Beining, M., Mongiat, L. A., Schwarzacher, S. W., Cuntz,
+           H., & Jedlicka, P. (2017). T2N as a new tool for robust
+           electrophysiological modeling demonstrated for mature and
+           adult-born dentate granule cells. eLife, 6, e26517.
+           doi:10.7554/eLife.26517
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav3p1_MA2020_GoC")
 class Cav3p1_MA2020_GoC(HH):
-    r"""Purkinje cell Cav3.1 low-threshold calcium current with GHK drive.
+    r"""Golgi cell Cav3.1 low-threshold calcium current with GHK drive.
+
+    The Cav3.1 (T-type) low-threshold calcium current of the
+    cerebellar Golgi cell model of (Masoli et al., 2020) [3]_. Its
+    kinetics were fitted to the Cav3.1 temperature-dependence
+    recordings of (Iftinca et al., 2006) [1]_ and published in the
+    Purkinje-cell calcium-buffering model of (Anwar, Hong & De
+    Schutter, 2012) [2]_. Gating is :math:`p^2 q`, driven by a
+    constant-field (GHK) calcium flux rather than an ohmic term:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= -P \, p^2 q \, \Phi(V, [Ca]_i, [Ca]_o, z{=}2, T) \\
+        p_\infty &= \frac{1}{1 + \exp((V - v_{0,m}) / k_m)} \\
+        q_\infty &= \frac{1}{1 + \exp((V - v_{0,h}) / k_h)} \\
+        \tau_p &= \begin{cases}
+                  1 & V \leq -90\ \mathrm{mV} \\
+                  \dfrac{1}{q_t}\left(C_{\tau m} + \dfrac{A_{\tau m}}
+                  {e^{(V - v_{\tau m1})/k_{\tau m1}}
+                   + e^{(V - v_{\tau m2})/k_{\tau m2}}}\right)
+                  & V > -90\ \mathrm{mV}
+                  \end{cases} \\
+        \tau_q &= \frac{1}{q_t}\left(C_{\tau h}
+                  + \frac{A_{\tau h}}
+                  {e^{(V - v_{\tau h1})/k_{\tau h1}}}\right) \\
+        q_t &= Q_{10}^{(T - T_{ref}) / 10}
+        \end{aligned}
+
+    with :math:`v_{0,m} = -52` mV, :math:`k_m = -5` mV,
+    :math:`v_{0,h} = -72` mV, :math:`k_h = 7` mV,
+    :math:`C_{\tau m} = A_{\tau m} = A_{\tau h} = 1`,
+    :math:`C_{\tau h} = 15`, :math:`v_{\tau m1} = -40` mV,
+    :math:`v_{\tau m2} = -102` mV, :math:`k_{\tau m1} = 9` mV,
+    :math:`k_{\tau m2} = -18` mV, :math:`v_{\tau h1} = -32` mV and
+    :math:`k_{\tau h1} = 7` mV; the time constants are in
+    milliseconds and :math:`P` is the calcium permeability. The
+    :math:`\tau_p` branch point is inclusive at exactly
+    :math:`-90` mV, and its constant branch is **not** divided by
+    :math:`q_t` (see Notes).
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability :math:`P` entering the GHK flux -- the
+        mod file's ``pcabar`` -- despite the ``g_max`` name and
+        conductance-like spelling. Defaults to ``2.5e-4 cm/s`` (see
+        Notes).
+    V_sh : array-like or callable, optional
+        Threshold shift. Accepted and stored, but read by no method
+        of this class (see Notes). Defaults to ``0.0 mV``.
+    temp : array-like, optional
+        Absolute temperature. Enters both :math:`q_t` and the GHK
+        flux. Defaults to 22 degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 factor for :math:`q_t`. Defaults to ``3.0``.
+    temp_ref : array-like, optional
+        Reference temperature for :math:`q_t`. Defaults to 37 degrees
+        Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p1_MA2024_PC : The same mechanism re-imported for the human
+        Purkinje cell model; identical kinetics, different model
+        citation.
+    Cav3p1_MA2020_GoC_Frozen : This class with the GHK term's
+        voltage dependence removed from the autodiff graph.
+    Cav3p1Test_PC24 : Anonymous test variant that replaces the GHK
+        drive with a direct conductance-density current law.
+    braincell.channel._base.ghk_flux : Shared GHK flux helper; this
+        class does not call it directly (see Notes).
 
     Notes
     -----
-    The source NMODL applies temperature scaling directly inside the tau
-    formulas instead of through a uniform gate-level ``phi`` factor:
+    Ported from ``GoC/channel/Cav3p1_MA20_GoC.mod``. That file's
+    ``TITLE`` reads "Low threshold calcium current Cerebellum Purkinje
+    Cell Model" and its ``COMMENT`` records the rename "Suffix from
+    CaT3_1 to CaV3_1" -- both inherited verbatim from Anwar's original
+    Purkinje-cell mechanism (ModelDB 138382). This class is
+    nonetheless the **Golgi cell** port (``SUFFIX Cav3p1_MA20_GoC``),
+    used in the Golgi cell model cited as [3]_; the ``TITLE``'s
+    "Purkinje" is upstream provenance, not a description of this
+    class. An earlier revision of this docstring's summary line
+    repeated it as though it were, and that is corrected here.
 
-    - for ``p``/``m`` the ``v <= -90`` branch is hard-coded to ``1 ms`` and is
-      **not** divided by ``qt``;
-    - in the other branch the full ``C_tau_m + A_tau_m / (...)`` expression is
-      divided by ``qt``;
-    - for ``q``/``h`` the full ``C_tau_h + A_tau_h / exp(...)`` expression is
-      also divided by ``qt``.
+    Two corrections to the mod header's own reference line, "Anwar H,
+    Hong S, De Schutter E (2010) ... in Purkinje cell": the citable
+    record is 2012 -- 2010 is the online-first date, which is also why
+    the DOI carries ``-010-`` -- and the published title ends
+    "Purkinje **cells**", plural. Entry [2]_ below is the corrected
+    form. The header's "Written by Haroon Anwar" line names the
+    mechanism's author and is deliberately not turned into a citation.
 
-    That behavior does not match the generic ``HH`` gate temperature path,
-    where ``Gate(q10=..., temp_ref=...)`` would multiply the full derivative by
-    ``phi`` and therefore divide the whole tau by ``qt``. We intentionally keep
-    gate ``phi=1`` here and encode the source-mod temperature handling directly
-    in :meth:`f_p_tau` and :meth:`f_q_tau`.
+    **Temperature handling is encoded in the tau expressions, not in
+    the gate declaration.** The source NMODL applies :math:`q_t`
+    directly inside the tau formulas instead of through a uniform
+    gate-level ``phi``:
+
+    - for ``p``/``m`` the ``v <= -90`` branch is hard-coded to
+      ``1 ms`` and is **not** divided by ``qt``;
+    - in the other branch the full ``C_tau_m + A_tau_m / (...)``
+      expression is divided by ``qt``;
+    - for ``q``/``h`` the full ``C_tau_h + A_tau_h / exp(...)``
+      expression is also divided by ``qt``.
+
+    That does not match the generic ``HH`` gate temperature path,
+    where ``Gate(q10=..., temp_ref=...)`` multiplies the whole
+    derivative by ``phi`` and therefore divides the whole tau by
+    ``qt``. Gate ``phi`` is intentionally left at 1 here and the
+    source-mod temperature handling is encoded directly in
+    :meth:`f_p_tau` and :meth:`f_q_tau`.
+
+    ``current()`` evaluates the GHK constant-field equation through
+    the module-level ``_cav3p1_nmodl_ghk_flux`` helper rather than
+    :func:`~braincell.channel._base.ghk_flux`, so that it reproduces
+    the mod file's own constants exactly: ``F = 9.6485e4 C/mol``,
+    ``R = 8.3145 J/(K mol)`` and the mod file's ``kelvinfkt``
+    conversion ``273.19 + celsius``, whose 0.04 K offset from
+    :func:`brainunit.celsius2kelvin` is carried as
+    ``_CAV3P1_NMODL_TEMP_OFFSET``. The helper also keeps the mod
+    file's small-``zeta`` series branch, taken when
+    ``|1 - exp(-zeta)| < 1e-6``. NEURON's raw ``ica`` for this
+    mechanism is outward-positive; ``current()`` negates it to match
+    BrainCell's repo-wide inward-positive convention.
+
+    ``g_max`` is a permeability in ``cm/s``, not a conductance
+    density: the name is BrainCell's uniform parameter name for the
+    scale factor in front of the gating product, and this mechanism's
+    current law is a permeability-scaled GHK flux. ``V_sh`` is
+    accepted, stored and never read; the mod file declares no
+    corresponding parameter at all.
+
+    ``g_max``'s default is the ``pcabar`` of the cell-model deposit
+    this mechanism was imported from -- a value tuned for that model,
+    not a permeability reported by either origin paper.
+
+    References
+    ----------
+    .. [1] Iftinca, M., McKay, B. E., Snutch, T. P., McRory, J. E.,
+           Turner, R. W., & Zamponi, G. W. (2006). Temperature
+           dependence of T-type calcium channel gating.
+           Neuroscience, 142(4), 1031-1042.
+           doi:10.1016/j.neuroscience.2006.07.010
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
     """
 
     __module__ = "braincell.channel"
@@ -1625,14 +2202,183 @@ class Cav3p1_MA2020_GoC(HH):
 
 @register_channel("Cav3p1_MA2024_PC")
 class Cav3p1_MA2024_PC(Cav3p1_MA2020_GoC):
-    """Template-based import of ``Cav3p1_MA2024_PC.mod``."""
+    r"""Purkinje cell Cav3.1 low-threshold calcium current, GHK drive.
+
+    The same :math:`p^2 q` Cav3.1 kinetics and GHK current law
+    documented in :class:`Cav3p1_MA2020_GoC`, reused unchanged for the
+    human Purkinje cell model of (Masoli et al., 2024) [3]_. The
+    kinetics remain the fit to (Iftinca et al., 2006) [1]_ published
+    in (Anwar, Hong & De Schutter, 2012) [2]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), default ``2.5e-4 cm/s``. Inherited from
+        :class:`Cav3p1_MA2020_GoC`.
+    V_sh : array-like or callable, optional
+        Accepted but read by no method of this class (see
+        :class:`Cav3p1_MA2020_GoC` Notes). Default ``0.0 mV``.
+        Inherited from :class:`Cav3p1_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature entering both the ``qt`` factor and the
+        GHK flux, default 22 degrees Celsius. Inherited from
+        :class:`Cav3p1_MA2020_GoC`.
+    q10 : array-like or callable, optional
+        Q10 factor for ``qt``, default ``3.0``. Inherited from
+        :class:`Cav3p1_MA2020_GoC`.
+    temp_ref : array-like, optional
+        Reference temperature for ``qt``, default 37 degrees Celsius.
+        Inherited from :class:`Cav3p1_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p1_MA2020_GoC : The base class; the full equation set, the
+        GHK helper's constants, the tau-embedded temperature handling
+        and the header corrections are documented there.
+    Cav3p1_MA2024_PC_Frozen : Purkinje-cell variant with the GHK
+        term's voltage dependence removed from the autodiff graph.
+        It is **not** a subclass of this class (see its Notes).
+    Cav3p1Test_PC24 : Anonymous test variant of the same mechanism
+        with the GHK drive replaced by a direct conductance-density
+        current law.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Cav3p1_MA24_PC.mod``. An earlier revision
+    of this docstring named the source file ``Cav3p1_MA2024_PC.mod``,
+    which does not exist; the shipped file uses the two-digit year
+    code, and that is corrected here. That file is identical to
+    ``GoC/channel/Cav3p1_MA20_GoC.mod`` except for its ``SUFFIX`` line
+    and a dropped ``INDEPENDENT`` statement, neither of which affects
+    the kinetics. Accordingly this class overrides nothing: the
+    constructor, the gate declarations, the named Boltzmann/tau
+    parameter block and the ``current`` method are all inherited from
+    :class:`Cav3p1_MA2020_GoC`. Only the ``register_channel`` key and
+    this docstring's model citation differ.
+
+    The ``MA2024`` import-deviations tables list no ``TABLE`` removal,
+    no integration-method substitution and no rate-refresh relocation
+    for ``Cav3p1``.
+
+    References
+    ----------
+    .. [1] Iftinca, M., McKay, B. E., Snutch, T. P., McRory, J. E.,
+           Turner, R. W., & Zamponi, G. W. (2006). Temperature
+           dependence of T-type calcium channel gating.
+           Neuroscience, 142(4), 1031-1042.
+           doi:10.1016/j.neuroscience.2006.07.010
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav3p1_MA2020_GoC_Frozen")
 class Cav3p1_MA2020_GoC_Frozen(Cav3p1_MA2020_GoC):
-    """GoC Cav3.1 variant that freezes GHK voltage dependence in autodiff."""
+    r"""Golgi cell Cav3.1 with the GHK drive frozen for autodiff.
+
+    A subclass of :class:`Cav3p1_MA2020_GoC` that overrides
+    :meth:`current` alone, stopping the gradient through the membrane
+    potential where it enters the constant-field (GHK) flux term. The
+    forward current is bit-for-bit that of the base class; only
+    reverse-mode derivatives differ. Every kinetic equation, the whole
+    parameter block and the Golgi cell model attribution of (Masoli et
+    al., 2020) [3]_ -- with kinetics from (Iftinca et al., 2006) [1]_
+    as published in (Anwar, Hong & De Schutter, 2012) [2]_ -- are
+    inherited unchanged.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), default ``2.5e-4 cm/s``. Inherited from
+        :class:`Cav3p1_MA2020_GoC`.
+    V_sh : array-like or callable, optional
+        Accepted but read by no method of this class (see
+        :class:`Cav3p1_MA2020_GoC` Notes). Default ``0.0 mV``.
+        Inherited from :class:`Cav3p1_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature entering both the ``qt`` factor and the
+        GHK flux, default 22 degrees Celsius. Inherited from
+        :class:`Cav3p1_MA2020_GoC`.
+    q10 : array-like or callable, optional
+        Q10 factor for ``qt``, default ``3.0``. Inherited from
+        :class:`Cav3p1_MA2020_GoC`.
+    temp_ref : array-like, optional
+        Reference temperature for ``qt``, default 37 degrees Celsius.
+        Inherited from :class:`Cav3p1_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p1_MA2020_GoC : The base class; every equation, the GHK
+        helper's constants and the header corrections are documented
+        there.
+    Cav3p1_MA2024_PC_Frozen : Purkinje-cell counterpart with
+        numerically identical behaviour but a different class graph:
+        it subclasses :class:`~braincell.channel._base.HH` directly
+        and re-declares everything rather than inheriting.
+
+    Notes
+    -----
+    "Frozen" describes the gradient path, not the forward numerics and
+    not the channel states. Both gates keep integrating exactly as in
+    the base class -- nothing stops evolving. What
+    :meth:`current` changes is that the membrane potential handed to
+    the GHK helper is first passed through the module-level
+    ``_freeze_quantity_gradient``, which rebuilds the quantity from
+    :func:`jax.lax.stop_gradient` applied to its mantissa. The
+    explicit voltage dependence of the GHK driving force therefore
+    contributes nothing to reverse-mode gradients, while the value it
+    computes is unchanged.
+
+    The unfrozen ``V`` is still passed to
+    :meth:`~braincell.channel._base.HH.conductance_factor`, but that
+    method ignores its voltage argument entirely and reads only the
+    gate states, so the distinction has no effect on either the value
+    or the gradient. The gate states themselves are not frozen.
+
+    Provenance, the tau-embedded temperature handling, the GHK
+    helper's constants and the ``g_max``-is-a-permeability discrepancy
+    are identical to :class:`Cav3p1_MA2020_GoC`'s and are not repeated
+    here. Per the bibliography's attribution scan, this subclass
+    contributes no rate-function code of its own.
+
+    References
+    ----------
+    .. [1] Iftinca, M., McKay, B. E., Snutch, T. P., McRory, J. E.,
+           Turner, R. W., & Zamponi, G. W. (2006). Temperature
+           dependence of T-type calcium channel gating.
+           Neuroscience, 142(4), 1031-1042.
+           doi:10.1016/j.neuroscience.2006.07.010
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
 
@@ -1644,7 +2390,115 @@ class Cav3p1_MA2020_GoC_Frozen(Cav3p1_MA2020_GoC):
 
 @register_channel("Cav3p1_MA2024_PC_Frozen")
 class Cav3p1_MA2024_PC_Frozen(HH):
-    """Experimental Cav3.1 variant that freezes GHK voltage dependence in autodiff."""
+    r"""Purkinje cell Cav3.1 with the GHK drive frozen for autodiff.
+
+    A standalone Purkinje-cell Cav3.1 mechanism that stops the
+    gradient through the membrane potential where it enters the
+    constant-field (GHK) flux term. Its kinetics, its named
+    Boltzmann/tau parameter block and its forward current are
+    numerically identical to :class:`Cav3p1_MA2020_GoC`'s, and its
+    attribution is that of :class:`Cav3p1_MA2024_PC`: the Cav3.1 fit
+    to (Iftinca et al., 2006) [1]_ published in (Anwar, Hong & De
+    Schutter, 2012) [2]_, imported for the human Purkinje cell model
+    of (Masoli et al., 2024) [3]_. Unlike its Golgi-cell counterpart
+    it inherits none of that -- see Notes.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), despite the ``g_max`` name. Defaults to
+        ``2.5e-4 cm/s``.
+    V_sh : array-like or callable, optional
+        Threshold shift. Accepted and stored, but read by no method
+        of this class (see Notes). Defaults to ``0.0 mV``.
+    temp : array-like, optional
+        Absolute temperature. Enters both the ``qt`` factor and the
+        GHK flux. Defaults to 22 degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 factor for ``qt``. Defaults to ``3.0``.
+    temp_ref : array-like, optional
+        Reference temperature for ``qt``. Defaults to 37 degrees
+        Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p1_MA2024_PC : The unfrozen Purkinje-cell import of the same
+        mechanism. This class is **not** derived from it.
+    Cav3p1_MA2020_GoC : Where the equation set, the GHK helper's
+        constants, the tau-embedded temperature handling and the mod
+        header corrections are documented in full.
+    Cav3p1_MA2020_GoC_Frozen : Golgi-cell counterpart with the same
+        freezing behaviour, reached by inheritance instead.
+
+    Notes
+    -----
+    **This class is not a subclass of the unfrozen Purkinje-cell
+    import, and the two frozen Cav3.1 classes in this module are not
+    built the same way.** :class:`Cav3p1_MA2020_GoC_Frozen` derives
+    from :class:`Cav3p1_MA2020_GoC` and overrides :meth:`current`
+    alone.
+    This class derives from :class:`~braincell.channel._base.HH`
+    directly and re-declares everything: ``root_type``, both gates,
+    the whole constructor and parameter block, ``f_p_inf``,
+    ``f_q_inf``, ``f_p_tau``, ``f_q_tau`` and ``current``. The two
+    frozen variants therefore compute the same numbers while sharing
+    no code, and a change to :class:`Cav3p1_MA2020_GoC` propagates to
+    one of them and not to the other.
+
+    "Frozen" describes the gradient path, not the forward numerics and
+    not the channel states. Both gates keep integrating normally --
+    nothing stops evolving. :meth:`current` passes the membrane
+    potential through the module-level ``_freeze_quantity_gradient``,
+    which rebuilds the quantity from :func:`jax.lax.stop_gradient`
+    applied to its mantissa, before handing it to the GHK helper. The
+    unfrozen ``V`` still reaches
+    :meth:`~braincell.channel._base.HH.conductance_factor`, but that
+    method ignores its voltage argument and reads only the gate
+    states, so the distinction affects neither value nor gradient.
+
+    The kinetics are those of ``PC/channel/Cav3p1_MA24_PC.mod``, which
+    is identical to ``GoC/channel/Cav3p1_MA20_GoC.mod`` except for its
+    ``SUFFIX`` line and a dropped ``INDEPENDENT`` statement. No mod
+    file ships a frozen-gradient variant: freezing is a BrainCell
+    autodiff facility with no counterpart in NMODL, so it is not an
+    import deviation and changes nothing a NEURON comparison would
+    observe.
+
+    As in :class:`Cav3p1_MA2020_GoC`, ``g_max`` is a permeability in
+    ``cm/s`` rather than a conductance density, ``V_sh`` is accepted
+    and never read with no corresponding parameter in the mod file,
+    the temperature factor ``qt`` is embedded in the tau expressions
+    instead of in ``Gate``, the ``tau_p`` constant branch at
+    ``V <= -90 mV`` is not divided by ``qt``, and ``current()`` uses
+    the module-level ``_cav3p1_nmodl_ghk_flux`` helper with the mod
+    file's own ``F``/``R`` constants and its ``273.19 + celsius``
+    Kelvin conversion. The permeability default is the deposit's tuned
+    ``pcabar``, not a value reported by either origin paper.
+
+    References
+    ----------
+    .. [1] Iftinca, M., McKay, B. E., Snutch, T. P., McRory, J. E.,
+           Turner, R. W., & Zamponi, G. W. (2006). Temperature
+           dependence of T-type calcium channel gating.
+           Neuroscience, 142(4), 1031-1042.
+           doi:10.1016/j.neuroscience.2006.07.010
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -1721,18 +2575,114 @@ class Cav3p1_MA2024_PC_Frozen(HH):
 
 @register_channel("Cav3p1Test_PC24")
 class Cav3p1Test_PC24(HH):
-    r"""Template-based import of ``Cav3_1_test.mod``.
+    r"""Cav3.1 test variant with the GHK drive replaced by a constant.
 
-    This PC24 test variant removes the GHK drive entirely and uses a direct
-    conductance-density style current law:
+    A test variant of the Cav3.1 mechanism whose gating kinetics are
+    exactly those of :class:`Cav3p1_MA2024_PC` -- the Cav3.1 fit to
+    (Iftinca et al., 2006) [1]_ published in (Anwar, Hong & De
+    Schutter, 2012) [2]_ and imported for the human Purkinje cell
+    model of (Masoli et al., 2024) [3]_ -- but with the constant-field
+    (GHK) drive replaced by a direct conductance-density current law:
 
     .. math::
 
        I_{Ca} = g_{max} \, p^2 q
 
-    The source NMODL keeps the same steady-state and tau formulas as the
-    Cav3.1 template, including the gate-temperature handling encoded directly
-    in the tau expressions.
+    **This ohmic form is not the published one.** The published
+    mechanism is a GHK-driven permeability; this variant is not, and
+    its ``g_max = 2.5e-4`` carries ``S/cm2`` where the published
+    mechanism's ``pcabar = 2.5e-4`` carries ``cm/s`` -- the same
+    number in a different dimension. The class name's "Test" is
+    accurate: nothing in the source file or the deposit indicates
+    that this variant produced any published result. See Notes for
+    what the current law does and does not depend on.
+
+    The steady-state and tau formulas, including the temperature
+    factor embedded in the tau expressions and the ``V <= -90 mV``
+    constant branch of :math:`\tau_p`, are identical to
+    :class:`Cav3p1_MA2020_GoC`'s and are written out there.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Conductance density multiplying the gating product. Defaults
+        to ``2.5e-4 S/cm2`` (see above and Notes). This class takes
+        no ``V_sh``, unlike its Cav3.1 siblings.
+    temp : array-like, optional
+        Absolute temperature driving the ``qt`` factor. Defaults to
+        22 degrees Celsius. It does **not** enter a GHK term here,
+        because there is none.
+    q10 : array-like or callable, optional
+        Q10 factor for ``qt``. Defaults to ``3.0``.
+    temp_ref : array-like, optional
+        Reference temperature for ``qt``. Defaults to 37 degrees
+        Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p1_MA2024_PC : The published, GHK-driven Purkinje-cell
+        mechanism this variant's kinetics are taken from.
+    Cav3p1_MA2020_GoC : Where the full equation set and the
+        tau-embedded temperature handling are documented.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Cav3_1_test.mod``, which carries no
+    ``TITLE``, no ``COMMENT``, no author line and no reference of any
+    kind. Its provenance was established by comparison instead: it
+    declares the same named parameter block and the same four rate
+    expressions as ``PC/channel/Cav3p1_MA24_PC.mod``, character for
+    character, so it inherits that mechanism's attribution chain. The
+    sibling file ``Cav3_1_test2.mod`` is claimed by no BrainCell
+    symbol.
+
+    **The single difference between the two files is the current
+    law.** ``Cav3p1_MA24_PC.mod`` computes
+    ``ica = (1e3) * pcabar * m*m*h * g`` with ``g`` from GHK and
+    ``pcabar`` in ``cm/s``; ``Cav3_1_test.mod`` drops the GHK drive
+    entirely, redeclares ``pcabar = 2.5e-4 (S/cm2)`` as a conductance
+    density and computes ``ica = pcabar * m*m*h``. That right-hand
+    side is dimensionally inconsistent with the ``(mA/cm2)`` the same
+    file declares for ``ica``, so BrainCell's :meth:`current`
+    multiplies by ``1 mV`` purely to lift the value to a
+    current-density unit that can flow through the standard
+    compare/runtime paths. The multiplier is a fixed constant, not a
+    driving force: the resulting current carries no ``(v - eca)``
+    factor and no GHK factor, and therefore depends on voltage only
+    through the gates.
+
+    ``current()`` also negates the result, as every imported
+    mechanism in this module does, to match BrainCell's repo-wide
+    inward-positive convention against NEURON's outward-positive
+    ``ica``.
+
+    No import deviations are recorded for this mechanism: the file
+    carries no ``TABLE``, no ``derivimplicit`` and no rate-refresh
+    relocation, and it appears in none of the comparison suite's
+    deviation tables.
+
+    References
+    ----------
+    .. [1] Iftinca, M., McKay, B. E., Snutch, T. P., McRory, J. E.,
+           Turner, R. W., & Zamponi, G. W. (2006). Temperature
+           dependence of T-type calcium channel gating.
+           Neuroscience, 142(4), 1031-1042.
+           doi:10.1016/j.neuroscience.2006.07.010
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
     """
 
     __module__ = "braincell.channel"
@@ -2185,7 +3135,122 @@ class Cav3p3_MA2024_PC(Cav3p3_RI2021_SC):
 
 @register_channel("CaHVA_MA2020_GoC")
 class CaHVA_MA2020_GoC(OhmicHH):
-    """Template-based import of ``CaHVA_MA2020_GoC.mod``."""
+    r"""Golgi cell high-voltage-activated calcium current.
+
+    The high-voltage-activated (HVA) calcium current of the cerebellar
+    Golgi cell model of (Masoli et al., 2020) [2]_. Its kinetics are
+    those of the cerebellar granule cell model of (D'Angelo et al.,
+    2001) [1]_, reused unchanged for the Golgi cell. Gating is
+    :math:`s^2 u` in alpha/beta form with an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= g_{max} \, s^2 u \, (E_{Ca} - V) \\
+        \alpha_s &= 0.04944 \exp((V' + 29.06) / 15.873) \\
+        \beta_s &= 0.08298 \exp((V' + 18.66) / -25.641) \\
+        \alpha_u &= 0.0013 \exp((V' + 48) / -18.183) \\
+        \beta_u &= 0.0013 \exp((V' + 48) / 83.33)
+        \end{aligned}
+
+    where :math:`V' = V / \mathrm{mV}` and the rates are per
+    millisecond. Both gates are further scaled by
+    :meth:`~braincell.channel._base.HH.gate_phi` with
+    :math:`Q_{10} = 3` referred to 20 degrees Celsius (see Notes).
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.46 mS/cm2``,
+        the mod file's ``gcabar = 0.00046 mho/cm2`` (see Notes).
+    temp : array-like, optional
+        Absolute temperature driving the gates' Q10 factor. Defaults
+        to 30 degrees Celsius, matching the mod file's
+        ``celsius = 30``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaHVA_MA2020_GrC : The same mechanism imported from the granule
+        cell deposit; identical constants, different model citation,
+        and one different import deviation (see its Notes).
+    braincell.channel._base.OhmicHH : Template supplying the ohmic
+        driving force used above.
+
+    Notes
+    -----
+    Ported from ``GoC/channel/CaHVA_MA20_GoC.mod``. An earlier
+    revision of this docstring named the source file
+    ``CaHVA_MA2020_GoC.mod``, which does not exist; the shipped file
+    uses the two-digit year code, and that is corrected here. The
+    file's ``TITLE`` reads "Cerebellum Granule Cell Model" and its
+    ``COMMENT`` credits "E.D'Angelo, T.Nieus, A. Fontana" -- both
+    inherited from the granule cell original, which is where these
+    kinetics come from; the file is that mechanism re-deposited for
+    the Golgi cell model cited as [2]_. That credit names authors 1,
+    2 and 7 of the eight-author origin paper, so it is not turned
+    into a citation: entry [1]_ below lists all eight.
+
+    The mod file applies its Q10 factor inside each of the four rate
+    functions, as ``Q10 = 3^((celsius - 20)/10)`` multiplying
+    ``alp_s``, ``bet_s``, ``alp_u`` and ``bet_u``. BrainCell hoists it
+    to the gate level instead, as
+    ``Gate(q10=3.0, temp_ref=20 degC)``. For the alpha/beta form the
+    two are algebraically identical: with
+    :math:`\alpha = Q_{10} a` and :math:`\beta = Q_{10} b`,
+    :math:`\alpha (1 - x) - \beta x = Q_{10} (a (1 - x) - b x)`, which
+    is exactly what ``phi`` multiplies. The rate methods here
+    therefore return the unscaled ``a``/``b``.
+
+    The mod file's ``eca = 129.33 (mV)`` is not read by this class:
+    the reversal potential is supplied by the attached
+    :class:`~braincell.ion.Calcium` ion object.
+
+    **Import deviation -- interpolation table removed.** The original
+    ``TABLE`` directive tabulated ``s_inf``, ``tau_s``, ``u_inf`` and
+    ``tau_u`` over ``[-100, 30]`` mV, clamping to the boundary value
+    outside that range; BrainCell evaluates the continuous formulas
+    per call, so any BrainCell/NEURON divergence outside that window
+    is expected.
+
+    **Not an integration-method substitution.** Unlike its granule
+    cell twin, this mechanism was already ``cnexp`` upstream, so no
+    ``derivimplicit`` -> ``cnexp`` change was made for it.
+
+    **Import deviation -- NMODL default-precision rewrite.**
+    ``Kalpha_s`` is written ``15.87301587302`` in the mod source and
+    ``15.873`` here, because BrainCell aligns with the roughly
+    six-significant-figure defaults NEURON's generated C emits rather
+    than with the source text. Ordinary in-formula literals are not
+    subject to this rewrite and keep their source values.
+
+    NEURON's raw ``ica`` here is ``g * (v - eca)``, i.e.
+    outward-positive; :class:`~braincell.channel._base.OhmicHH`
+    computes ``g_max * s^2 u * (E - V)``, the same current under
+    BrainCell's repo-wide inward-positive convention.
+
+    ``g_max``'s default is the ``gcabar`` of the cell-model deposit
+    this mechanism was imported from -- a value tuned for that model,
+    not a conductance reported by the origin paper.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -2236,7 +3301,129 @@ class CaHVA_MA2020_GoC(OhmicHH):
 
 @register_channel("CaHVA_MA2020_GrC")
 class CaHVA_MA2020_GrC(OhmicHH):
-    """Template-based import of ``CaHVA_MA2020_GrC.mod``."""
+    r"""Granule cell high-voltage-activated calcium current.
+
+    The high-voltage-activated (HVA) calcium current of the cerebellar
+    granule cell model of (Masoli et al., 2020) [2]_, whose kinetics
+    are those of the earlier granule cell model of (D'Angelo et al.,
+    2001) [1]_. Gating is :math:`s^2 u` in alpha/beta form with an
+    ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= g_{max} \, s^2 u \, (E_{Ca} - V) \\
+        \alpha_s &= 0.04944 \exp((V' + 29.06) / 15.873) \\
+        \beta_s &= 0.08298 \exp((V' + 18.66) / -25.641) \\
+        \alpha_u &= 0.0013 \exp((V' + 48) / -18.183) \\
+        \beta_u &= 0.0013 \exp((V' + 48) / 83.33)
+        \end{aligned}
+
+    where :math:`V' = V / \mathrm{mV}` and the rates are per
+    millisecond. Both gates are further scaled by
+    :meth:`~braincell.channel._base.HH.gate_phi` with
+    :math:`Q_{10} = 3` referred to 20 degrees Celsius (see Notes).
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.46 mS/cm2``,
+        the mod file's ``gcabar = 0.00046 mho/cm2`` (see Notes).
+    temp : array-like, optional
+        Absolute temperature driving the gates' Q10 factor. Defaults
+        to 30 degrees Celsius, matching the mod file's
+        ``celsius = 30``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaHVA_MA2020_GoC : The same mechanism imported from the Golgi
+        cell deposit; identical constants, different model citation,
+        and one fewer import deviation (see its Notes).
+    braincell.channel._base.OhmicHH : Template supplying the ohmic
+        driving force used above.
+
+    Notes
+    -----
+    Ported from ``GrC/channel/CaHVA_MA20_GrC.mod``. An earlier
+    revision of this docstring named the source file
+    ``CaHVA_MA2020_GrC.mod``, which does not exist; the shipped file
+    uses the two-digit year code, and that is corrected here. That
+    file and ``GoC/channel/CaHVA_MA20_GoC.mod`` are identical apart
+    from the ``SUFFIX`` line, which is why the two BrainCell classes
+    carry the same constants; they are separate classes, not a
+    subclass pair, because they were imported from two different
+    deposits and therefore take two different model citations.
+
+    The file's ``COMMENT`` credits "E.D'Angelo, T.Nieus, A. Fontana",
+    naming authors 1, 2 and 7 of the eight-author origin paper. That
+    credit is not turned into a citation: entry [1]_ below lists all
+    eight.
+
+    The mod file applies its Q10 factor inside each of the four rate
+    functions, as ``Q10 = 3^((celsius - 20)/10)`` multiplying
+    ``alp_s``, ``bet_s``, ``alp_u`` and ``bet_u``. BrainCell hoists it
+    to the gate level instead, as
+    ``Gate(q10=3.0, temp_ref=20 degC)``. For the alpha/beta form the
+    two are algebraically identical: with
+    :math:`\alpha = Q_{10} a` and :math:`\beta = Q_{10} b`,
+    :math:`\alpha (1 - x) - \beta x = Q_{10} (a (1 - x) - b x)`, which
+    is exactly what ``phi`` multiplies. The rate methods here
+    therefore return the unscaled ``a``/``b``.
+
+    The mod file's ``eca = 129.33 (mV)`` is not read by this class:
+    the reversal potential is supplied by the attached
+    :class:`~braincell.ion.Calcium` ion object.
+
+    **Import deviation -- interpolation table removed.** The original
+    ``TABLE`` directive tabulated ``s_inf``, ``tau_s``, ``u_inf`` and
+    ``tau_u`` over ``[-100, 30]`` mV, clamping to the boundary value
+    outside that range; BrainCell evaluates the continuous formulas
+    per call, so any BrainCell/NEURON divergence outside that window
+    is expected.
+
+    **Import deviation -- integration method substituted.** The
+    upstream ``derivimplicit`` is replaced by ``cnexp``. This is the
+    granule cell mechanism's one difference in status from its Golgi
+    cell twin, which was already ``cnexp`` upstream. The substitution
+    is exact here, because the ``s`` and ``u`` gate ODEs are
+    independent of one another.
+
+    **Import deviation -- NMODL default-precision rewrite.**
+    ``Kalpha_s`` is written ``15.87301587302`` in the mod source and
+    ``15.873`` here, because BrainCell aligns with the roughly
+    six-significant-figure defaults NEURON's generated C emits rather
+    than with the source text. Ordinary in-formula literals are not
+    subject to this rewrite and keep their source values.
+
+    NEURON's raw ``ica`` here is ``g * (v - eca)``, i.e.
+    outward-positive; :class:`~braincell.channel._base.OhmicHH`
+    computes ``g_max * s^2 u * (E - V)``, the same current under
+    BrainCell's repo-wide inward-positive convention.
+
+    ``g_max``'s default is the ``gcabar`` of the cell-model deposit
+    this mechanism was imported from -- a value tuned for that model,
+    not a conductance reported by the origin paper.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -2250,7 +2250,7 @@ class Cav3p1_MA2024_PC(Cav3p1_MA2020_GoC):
     Notes
     -----
     Ported from ``PC/channel/Cav3p1_MA24_PC.mod``. An earlier revision
-    of this docstring named the source file ``Cav3p1_MA2024_PC.mod``,
+    of this docstring named the source file ``Cav3p1_MA24_PC.mod``,
     which does not exist; the shipped file uses the two-digit year
     code, and that is corrected here. That file is identical to
     ``GoC/channel/Cav3p1_MA20_GoC.mod`` except for its ``SUFFIX`` line
@@ -4380,7 +4380,7 @@ class CaHVA_MA2020_GoC(OhmicHH):
     -----
     Ported from ``GoC/channel/CaHVA_MA20_GoC.mod``. An earlier
     revision of this docstring named the source file
-    ``CaHVA_MA2020_GoC.mod``, which does not exist; the shipped file
+    ``CaHVA_MA20_GoC.mod``, which does not exist; the shipped file
     uses the two-digit year code, and that is corrected here. The
     file's ``TITLE`` reads "Cerebellum Granule Cell Model" and its
     ``COMMENT`` credits "E.D'Angelo, T.Nieus, A. Fontana" -- both
@@ -4546,7 +4546,7 @@ class CaHVA_MA2020_GrC(OhmicHH):
     -----
     Ported from ``GrC/channel/CaHVA_MA20_GrC.mod``. An earlier
     revision of this docstring named the source file
-    ``CaHVA_MA2020_GrC.mod``, which does not exist; the shipped file
+    ``CaHVA_MA20_GrC.mod``, which does not exist; the shipped file
     uses the two-digit year code, and that is corrected here. That
     file and ``GoC/channel/CaHVA_MA20_GoC.mod`` are identical apart
     from the ``SUFFIX`` line, which is why the two BrainCell classes

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -106,7 +106,7 @@ def _freeze_quantity_gradient(value):
 
 @register_channel("CaN_IS2008")
 class CaN_IS2008(HH):
-    r"""Inoue & Strowbridge 2008 calcium-activated non-selective cation current.
+    r"""Inoue & Strowbridge 2008 calcium-activated nonselective cation current.
 
     A calcium- and voltage-dependent non-selective cation current
     (:math:`I_{CAN}`) gated by a single activation variable and scaled
@@ -922,11 +922,11 @@ class CaL_IS2008(OhmicHH):
 
 @register_channel("CaHVA_SU2015_DCN")
 class CaHVA_SU2015_DCN(HH):
-    r"""High-voltage-activated calcium current of the DCN model (Sudhakar et al., 2015).
+    r"""HVA calcium current of the DCN model (Sudhakar 2015).
 
-    A GHK-driven calcium current with a single :math:`m^3` activation
-    gate, used for the deep cerebellar nucleus (DCN) neuron model of
-    (Sudhakar et al., 2015) [2]_:
+    A GHK-driven, high-voltage-activated (HVA) calcium current with a
+    single :math:`m^3` activation gate, used for the deep cerebellar
+    nucleus (DCN) neuron model of (Sudhakar et al., 2015) [2]_:
 
     .. math::
 
@@ -1064,7 +1064,7 @@ class CaHVA_SU2015_DCN(HH):
 
 @register_channel("CaL_SU2015_DCN")
 class CaL_SU2015_DCN(OhmicHH):
-    r"""Low-voltage-activated calcium current of the DCN model (Sudhakar et al., 2015).
+    r"""Ohmic-drive LVA calcium current of the DCN model (Sudhakar 2015).
 
     An ohmically-driven calcium current with :math:`m^2 h` HH gating
     against a fixed reversal potential, used for the deep cerebellar
@@ -1219,11 +1219,11 @@ class CaL_SU2015_DCN(OhmicHH):
 
 @register_channel("CaLVA_SU2015_DCN")
 class CaLVA_SU2015_DCN(HH):
-    r"""Low-voltage-activated calcium current of the DCN model (Sudhakar et al., 2015).
+    r"""GHK-drive LVA calcium current of the DCN model (Sudhakar 2015).
 
-    A GHK-driven calcium current with :math:`m^2 h` gating, used for
-    the deep cerebellar nucleus (DCN) neuron model of (Sudhakar et
-    al., 2015) [2]_:
+    A GHK-driven, low-voltage-activated (LVA) calcium current with
+    :math:`m^2 h` gating, used for the deep cerebellar nucleus (DCN)
+    neuron model of (Sudhakar et al., 2015) [2]_:
 
     .. math::
 
@@ -2324,7 +2324,7 @@ class Cav2p3_MA2020_GoC(OhmicHH):
 
 @register_channel("Ca_ZH2019_IO")
 class Ca_ZH2019_IO(HH):
-    r"""Somatic calcium current of the inferior-olive model (Zhang & Santaniello, 2019).
+    r"""Somatic calcium current of the inferior-olive model (Zhang 2019).
 
     A fixed-reversal-potential calcium current with an instantaneous,
     non-stateful cubic activation and one dynamic inactivation gate,
@@ -2468,7 +2468,7 @@ class Ca_ZH2019_IO(HH):
 
 @register_channel("Ca_ZH2019_IO_Frozen")
 class Ca_ZH2019_IO_Frozen(Ca_ZH2019_IO):
-    r""":class:`Ca_ZH2019_IO` with ``freeze_m_inf`` pinned unconditionally to ``True``.
+    r""":class:`Ca_ZH2019_IO` with ``freeze_m_inf`` pinned to ``True``.
 
     A registry-only subclass of :class:`Ca_ZH2019_IO` that always
     stops autodiff through the instantaneous activation factor,

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -2765,7 +2765,145 @@ class Cav3p1Test_PC24(HH):
 
 @register_channel("Cav2p1_RI2021_SC")
 class Cav2p1_RI2021_SC(HH):
-    """Template-based import of ``Cav2p1_RI21_SC.mod``."""
+    r"""Stellate cell Cav2.1 P-type calcium current with GHK drive.
+
+    The Cav2.1 (P-type) calcium current of the cerebellar stellate
+    cell model of (Rizza et al., 2021) [3]_. Its kinetics were built
+    from dissociated Purkinje neuron recordings reported by (Swensen
+    & Bean, 2005) [1]_ and published as part of the Purkinje-cell
+    calcium-buffering model of (Anwar, Hong & De Schutter, 2012)
+    [2]_. Gating is :math:`m^3` with a single activation state,
+    driven by a constant-field (GHK) calcium flux rather than an
+    ohmic term:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= -P \, m^3 \,
+                  \Phi(V', [Ca]_i, [Ca]_o, z{=}2, T) \\
+        m_\infty &= \frac{1}{1 + \exp(-(V' - v_{1/2}) / k)} \\
+        \tau_m &= \frac{1}{\phi_m} \begin{cases}
+                  0.2702 + 1.1622\, e^{-(V' + 26.798)^2 / 164.19}
+                  & V' \geq -40 \\
+                  0.6923\, e^{V' / 1089.372} & V' < -40
+                  \end{cases} \\
+        \phi_m &= 3^{(T - 23\,^\circ\mathrm{C}) / 10}
+        \end{aligned}
+
+    where :math:`V' = V - V_{sh}`, :math:`v_{1/2} = -29.458` mV,
+    :math:`k = 8.429` mV, :math:`P` is the calcium permeability and
+    :math:`\Phi` is :func:`~braincell.channel._base.ghk_flux`. The
+    :math:`\tau_m` branch reads :math:`V'` in millivolts and returns
+    milliseconds; its branch point is inclusive at exactly
+    :math:`-40` mV. :math:`\phi_m` is supplied by the ``Gate``
+    declaration, which divides :math:`\tau_m` by it.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability :math:`P` entering the GHK flux -- the
+        mod file's ``pcabar`` -- despite the ``g_max`` name and
+        conductance-like spelling. Defaults to ``2.2e-4 cm/s`` (see
+        Notes).
+    V_sh : array-like or callable, optional
+        Voltage shift subtracted from :math:`V` before every rate
+        and before the GHK term; the mod file's ``vshift``. Defaults
+        to ``0.0 mV``.
+    temp : array-like, optional
+        Absolute temperature. Enters both :math:`\phi_m` and the GHK
+        flux. Defaults to 23 degrees Celsius, at which
+        :math:`\phi_m = 1`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav2p1_MA2024_PC : The same mechanism re-imported for the human
+        Purkinje cell model; identical kinetics, different model
+        citation.
+    Cav2p1_MA2025_BC : The same mechanism re-imported for the basket
+        cell model; identical kinetics, different model citation.
+    Cav2p1_RI2021_SC_Frozen : Stellate-cell variant with the GHK
+        term's voltage dependence removed from the autodiff graph.
+        It is **not** a subclass of this class, and it is not
+        numerically identical to it (see its Notes).
+    braincell.channel._base.ghk_flux : Shared GHK flux helper called
+        by :meth:`current`; the constant-field derivation lives
+        there and is not restated here.
+
+    Notes
+    -----
+    Ported from ``SC/channel/Cav2p1_RI21_SC.mod``, whose ``COMMENT``
+    records that the mechanism was "Constructed from the recording
+    data provided by Bruce Bean" and cites (Swensen & Bean, 2005)
+    for those recordings. The same file also records the rename
+    "Suffix from newCaP to Cav2_1".
+
+    Two corrections to the mod header's own model-reference line,
+    "Anwar H, Hong S, De Schutter E (2010) ... in Purkinje cell":
+    the citable record is 2012 -- 2010 is the online-first date,
+    which is also why the DOI carries ``-010-`` -- and the published
+    title ends "Purkinje **cells**", plural. Entry [2]_ below is the
+    corrected form. The header's "Written by Sungho Hong" line names
+    the mechanism's author and is deliberately not turned into a
+    citation.
+
+    ``current()`` evaluates ``-g_max * m^3 * drive`` with ``drive``
+    from :func:`~braincell.channel._base.ghk_flux`, so ``g_max``
+    occupies that function's permeability slot :math:`P_s` and is a
+    permeability in ``cm/s``, not a conductance density. The
+    negation matches BrainCell's repo-wide inward-positive
+    convention against NEURON's outward-positive ``ica``.
+
+    **The shared helper's physical constants are not the mod
+    file's.** :func:`~braincell.channel._base.ghk_flux` uses the
+    CODATA Faraday and gas constants and the temperature exactly as
+    passed, whereas this mod file declares ``F = 9.6485e4``,
+    ``R = 8.3145`` and a ``kelvinfkt`` conversion of
+    ``273.19 + celsius``. The resulting flux differs by of order
+    :math:`10^{-4}` in relative terms. The frozen variants of this
+    mechanism route through a helper that does carry the mod file's
+    constants; see :class:`Cav2p1_MA2024_PC_Frozen`.
+
+    The mod file's ``vhalfh = -11.039 (mV)`` and
+    ``cvh = 16.098 (mV)`` are declared but never used -- the
+    mechanism has no inactivation state -- and BrainCell drops them.
+
+    The mod file computes ``taum = taumfkt(v - vshift) / qt`` with
+    ``qt = q10^((celsius - 23)/10)`` and ``q10 = 3``. That is
+    exactly the generic gate temperature path, in which
+    ``Gate(q10=..., temp_ref=...)`` divides the whole tau by the
+    factor, so the Q10 is declared on the gate here rather than
+    written into :meth:`f_m_tau`.
+
+    The ``RI2021`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for this mechanism.
+
+    ``g_max``'s default is the ``pcabar`` of the cell-model deposit
+    this mechanism was imported from -- a value tuned for that
+    model, not a permeability reported by either origin paper.
+
+    References
+    ----------
+    .. [1] Swensen, A. M., & Bean, B. P. (2005). Robustness of burst
+           firing in dissociated Purkinje neurons with acute or
+           long-term reductions in sodium conductance. The Journal
+           of Neuroscience, 25(14), 3509-3520.
+           doi:10.1523/JNEUROSCI.3929-04.2005
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -2815,21 +2953,285 @@ class Cav2p1_RI2021_SC(HH):
 
 @register_channel("Cav2p1_MA2025_BC")
 class Cav2p1_MA2025_BC(Cav2p1_RI2021_SC):
-    """Template-based import of ``Cav2p1_MA2025_BC.mod``."""
+    r"""Basket cell Cav2.1 P-type calcium current with GHK drive.
+
+    The same :math:`m^3` Cav2.1 kinetics and GHK current law
+    documented in :class:`Cav2p1_RI2021_SC`, reused unchanged for
+    the cerebellar basket cell model of (Masoli et al., 2025) [3]_.
+    The kinetics remain those built from the dissociated Purkinje
+    neuron recordings of (Swensen & Bean, 2005) [1]_ and published
+    in (Anwar, Hong & De Schutter, 2012) [2]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), default ``2.2e-4 cm/s``. Inherited from
+        :class:`Cav2p1_RI2021_SC`.
+    V_sh : array-like or callable, optional
+        Voltage shift, the mod file's ``vshift``, default
+        ``0.0 mV``. Inherited from :class:`Cav2p1_RI2021_SC`.
+    temp : array-like, optional
+        Absolute temperature entering both the gate's Q10 factor and
+        the GHK flux, default 23 degrees Celsius. Inherited from
+        :class:`Cav2p1_RI2021_SC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav2p1_RI2021_SC : The base class; the full equation set, the
+        permeability discrepancy and the mod header corrections are
+        documented there.
+    Cav2p1_MA2024_PC : The same mechanism imported for the human
+        Purkinje cell model.
+    Cav2p1_MA2025_BC_Frozen : Basket-cell variant with the GHK
+        term's voltage dependence removed from the autodiff graph.
+        It is **not** a subclass of this class (see its Notes).
+
+    Notes
+    -----
+    Ported from ``BC/channel/Cav2p1_MA25_BC.mod``, which is
+    byte-identical to ``SC/channel/Cav2p1_RI21_SC.mod`` except for
+    its ``SUFFIX`` line. Accordingly this class overrides nothing:
+    the constructor, the gate declaration, the named parameter block
+    and ``current`` are all inherited from
+    :class:`Cav2p1_RI2021_SC`. Only the ``register_channel`` key and
+    this docstring's model citation differ. Per the bibliography's
+    attribution scan, this subclass contributes no rate-function
+    code of its own; its zero literal overlap in that scan is an
+    artefact of the constants living in the base class.
+
+    The ``MA2025`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for ``Cav2p1``.
+
+    References
+    ----------
+    .. [1] Swensen, A. M., & Bean, B. P. (2005). Robustness of burst
+           firing in dissociated Purkinje neurons with acute or
+           long-term reductions in sodium conductance. The Journal
+           of Neuroscience, 25(14), 3509-3520.
+           doi:10.1523/JNEUROSCI.3929-04.2005
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav2p1_MA2024_PC")
 class Cav2p1_MA2024_PC(Cav2p1_RI2021_SC):
-    """Template-based import of ``Cav2p1_MA2024_PC.mod``."""
+    r"""Purkinje cell Cav2.1 P-type calcium current, GHK drive.
+
+    The same :math:`m^3` Cav2.1 kinetics and GHK current law
+    documented in :class:`Cav2p1_RI2021_SC`, reused unchanged for
+    the human Purkinje cell model of (Masoli et al., 2024) [3]_. The
+    kinetics remain those built from the dissociated Purkinje neuron
+    recordings of (Swensen & Bean, 2005) [1]_ and published in
+    (Anwar, Hong & De Schutter, 2012) [2]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), default ``2.2e-4 cm/s``. Inherited from
+        :class:`Cav2p1_RI2021_SC`.
+    V_sh : array-like or callable, optional
+        Voltage shift, the mod file's ``vshift``, default
+        ``0.0 mV``. Inherited from :class:`Cav2p1_RI2021_SC`.
+    temp : array-like, optional
+        Absolute temperature entering both the gate's Q10 factor and
+        the GHK flux, default 23 degrees Celsius. Inherited from
+        :class:`Cav2p1_RI2021_SC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav2p1_RI2021_SC : The base class; the full equation set, the
+        permeability discrepancy and the mod header corrections are
+        documented there.
+    Cav2p1_MA2025_BC : The same mechanism imported for the basket
+        cell model.
+    Cav2p1_MA2024_PC_Frozen : Purkinje-cell variant with the GHK
+        term's voltage dependence removed from the autodiff graph.
+        It is **not** a subclass of this class, and it is not
+        numerically identical to it (see its Notes).
+
+    Notes
+    -----
+    Ported from ``PC/channel/Cav2p1_MA24_PC.mod``, which is
+    identical to ``SC/channel/Cav2p1_RI21_SC.mod`` apart from its
+    ``SUFFIX`` line and the BrainCell-local ``g_equiv`` diagnostic
+    the stellate copy carries. Accordingly this class overrides
+    nothing: the constructor, the gate declaration, the named
+    parameter block and ``current`` are all inherited from
+    :class:`Cav2p1_RI2021_SC`. Only the ``register_channel`` key and
+    this docstring's model citation differ. Per the bibliography's
+    attribution scan, this subclass contributes no rate-function
+    code of its own; its zero literal overlap in that scan is an
+    artefact of the constants living in the base class.
+
+    The ``MA2024`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for ``Cav2p1``.
+
+    References
+    ----------
+    .. [1] Swensen, A. M., & Bean, B. P. (2005). Robustness of burst
+           firing in dissociated Purkinje neurons with acute or
+           long-term reductions in sodium conductance. The Journal
+           of Neuroscience, 25(14), 3509-3520.
+           doi:10.1523/JNEUROSCI.3929-04.2005
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav2p1_MA2024_PC_Frozen")
 class Cav2p1_MA2024_PC_Frozen(HH):
-    """Experimental Cav2.1 variant that freezes GHK voltage dependence in autodiff."""
+    r"""Purkinje cell Cav2.1 with the GHK drive frozen for autodiff.
+
+    A standalone Purkinje-cell Cav2.1 mechanism that stops the
+    gradient through the membrane potential where it enters the
+    constant-field (GHK) flux term. Its kinetics and its named
+    parameter block are those of :class:`Cav2p1_RI2021_SC`, and its
+    attribution is that of :class:`Cav2p1_MA2024_PC`: the Cav2.1
+    kinetics built from the dissociated Purkinje neuron recordings
+    of (Swensen & Bean, 2005) [1]_ and published in (Anwar, Hong &
+    De Schutter, 2012) [2]_, imported for the human Purkinje cell
+    model of (Masoli et al., 2024) [3]_. It inherits none of that
+    code, and its forward current is **not** identical to the
+    unfrozen class's -- see Notes.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), despite the ``g_max`` name. Defaults to
+        ``2.2e-4 cm/s``.
+    V_sh : array-like or callable, optional
+        Voltage shift subtracted from :math:`V` before every rate
+        and before the GHK term; the mod file's ``vshift``. Defaults
+        to ``0.0 mV``.
+    temp : array-like, optional
+        Absolute temperature. Enters both the gate's Q10 factor and
+        the GHK flux. Defaults to 23 degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav2p1_MA2024_PC : The unfrozen Purkinje-cell import of the same
+        mechanism. This class is **not** derived from it.
+    Cav2p1_RI2021_SC : Where the equation set, the permeability
+        discrepancy and the mod header corrections are documented in
+        full.
+    Cav2p1_RI2021_SC_Frozen : Stellate-cell frozen variant, which
+        *is* a subclass of this class and overrides nothing.
+    Cav2p1_MA2025_BC_Frozen : Basket-cell frozen variant, likewise a
+        subclass of this class overriding nothing.
+
+    Notes
+    -----
+    **This class is not a subclass of the unfrozen Purkinje-cell
+    import.** It derives from
+    :class:`~braincell.channel._base.HH` directly and re-declares
+    everything: ``root_type``, the gate, the whole constructor and
+    parameter block, ``f_m_inf``, ``f_m_tau`` and ``current``. A
+    change to :class:`Cav2p1_RI2021_SC` therefore does not propagate
+    here. The two Cav2.1 frozen siblings,
+    :class:`Cav2p1_RI2021_SC_Frozen` and
+    :class:`Cav2p1_MA2025_BC_Frozen`, are subclasses of *this* class
+    and add nothing but a registry key.
+
+    "Frozen" describes the gradient path, not the channel states.
+    The ``m`` gate keeps integrating exactly as in the unfrozen
+    class -- nothing stops evolving. :meth:`current` passes the
+    membrane potential through the module-level
+    ``_freeze_quantity_gradient``, which rebuilds the quantity from
+    :func:`jax.lax.stop_gradient` applied to its mantissa, before
+    handing it to the GHK helper. The unfrozen ``V`` still reaches
+    :meth:`~braincell.channel._base.HH.conductance_factor`, but that
+    method ignores its voltage argument and reads only the gate
+    states, so the distinction affects neither value nor gradient
+    there.
+
+    **The freezing is not the only difference from the unfrozen
+    class.** :meth:`current` here calls the module-level
+    ``_cav3p1_nmodl_ghk_flux`` helper, whereas
+    :class:`Cav2p1_RI2021_SC` calls the shared
+    :func:`~braincell.channel._base.ghk_flux`. The two helpers use
+    different physical constants: the shared one uses CODATA values
+    and the temperature as passed, while the NMODL helper uses
+    ``F = 9.6485e4 C/mol``, ``R = 8.3145 J/(K mol)`` and a
+    ``273.19 + celsius`` Kelvin conversion carried as
+    ``_CAV3P1_NMODL_TEMP_OFFSET``. Those are exactly the constants
+    ``Cav2p1_MA24_PC.mod`` itself declares, so the helper's
+    ``_cav3p1_`` name -- inherited from the Cav3.1 import, whose mod
+    file declares the same values -- understates its applicability
+    here. The consequence is that this class's forward current
+    differs from :class:`Cav2p1_MA2024_PC`'s by of order
+    :math:`10^{-4}` in relative terms, and that this class is the
+    closer of the two to the mod file. Nothing in the mod file
+    corresponds to the freezing itself: it is a BrainCell autodiff
+    facility with no NMODL counterpart, so it is not an import
+    deviation and changes nothing a NEURON comparison would observe.
+
+    As in :class:`Cav2p1_RI2021_SC`, ``g_max`` is a permeability in
+    ``cm/s`` rather than a conductance density, the mod file's
+    unused ``vhalfh``/``cvh`` are dropped, the Q10 is declared on
+    the ``Gate`` because the mod file divides the whole tau by it,
+    and ``current()`` negates NEURON's outward-positive ``ica`` to
+    match BrainCell's inward-positive convention. The permeability
+    default is the deposit's tuned ``pcabar``, not a value reported
+    by either origin paper.
+
+    References
+    ----------
+    .. [1] Swensen, A. M., & Bean, B. P. (2005). Robustness of burst
+           firing in dissociated Purkinje neurons with acute or
+           long-term reductions in sodium conductance. The Journal
+           of Neuroscience, 25(14), 3509-3520.
+           doi:10.1523/JNEUROSCI.3929-04.2005
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -2880,21 +3282,289 @@ class Cav2p1_MA2024_PC_Frozen(HH):
 
 @register_channel("Cav2p1_RI2021_SC_Frozen")
 class Cav2p1_RI2021_SC_Frozen(Cav2p1_MA2024_PC_Frozen):
-    """SC Cav2.1 variant reusing the frozen-GHK PC24 implementation."""
+    r"""Stellate cell Cav2.1 with the GHK drive frozen for autodiff.
+
+    The stellate-cell registration of the frozen-GHK Cav2.1
+    mechanism implemented by :class:`Cav2p1_MA2024_PC_Frozen`. The
+    kinetics are those built from the dissociated Purkinje neuron
+    recordings of (Swensen & Bean, 2005) [1]_ and published in
+    (Anwar, Hong & De Schutter, 2012) [2]_, imported here for the
+    cerebellar stellate cell model of (Rizza et al., 2021) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), default ``2.2e-4 cm/s``. Inherited from
+        :class:`Cav2p1_MA2024_PC_Frozen`.
+    V_sh : array-like or callable, optional
+        Voltage shift, the mod file's ``vshift``, default
+        ``0.0 mV``. Inherited from
+        :class:`Cav2p1_MA2024_PC_Frozen`.
+    temp : array-like, optional
+        Absolute temperature entering both the gate's Q10 factor and
+        the GHK flux, default 23 degrees Celsius. Inherited from
+        :class:`Cav2p1_MA2024_PC_Frozen`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav2p1_MA2024_PC_Frozen : The base class; the freezing
+        mechanism, the GHK helper's constants and the difference
+        from the unfrozen classes are documented there.
+    Cav2p1_RI2021_SC : The unfrozen stellate-cell import of the same
+        mechanism. This class is **not** derived from it, and is not
+        numerically identical to it.
+
+    Notes
+    -----
+    **The cell-type suffix in this class's name describes its model
+    citation, not its implementation.** The class body is empty
+    apart from ``__module__``: every gate, constant, rate function
+    and the ``current`` method come from
+    :class:`Cav2p1_MA2024_PC_Frozen`, the Purkinje-cell frozen
+    variant. That is sound because ``SC/channel/Cav2p1_RI21_SC.mod``
+    and ``PC/channel/Cav2p1_MA24_PC.mod`` are identical apart from
+    their ``SUFFIX`` lines and a ``g_equiv`` diagnostic, but it does
+    mean the stellate-cell class inherits from a Purkinje-cell one
+    rather than from :class:`Cav2p1_RI2021_SC`. Per the
+    bibliography's attribution scan this subclass contributes no
+    rate-function code of its own; its zero literal overlap in that
+    scan is an artefact of the constants living in the base class.
+
+    Everything in :class:`Cav2p1_MA2024_PC_Frozen`'s Notes applies
+    unchanged and is not repeated here: no channel state stops
+    evolving, the freezing affects reverse-mode gradients only, and
+    the frozen path uses the NMODL-constant GHK helper rather than
+    the shared :func:`~braincell.channel._base.ghk_flux`, so the
+    forward current differs slightly from
+    :class:`Cav2p1_RI2021_SC`'s.
+
+    The ``RI2021`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for ``Cav2p1``.
+
+    References
+    ----------
+    .. [1] Swensen, A. M., & Bean, B. P. (2005). Robustness of burst
+           firing in dissociated Purkinje neurons with acute or
+           long-term reductions in sodium conductance. The Journal
+           of Neuroscience, 25(14), 3509-3520.
+           doi:10.1523/JNEUROSCI.3929-04.2005
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav2p1_MA2025_BC_Frozen")
 class Cav2p1_MA2025_BC_Frozen(Cav2p1_MA2024_PC_Frozen):
-    """BC Cav2.1 variant reusing the frozen-GHK PC24 implementation."""
+    r"""Basket cell Cav2.1 with the GHK drive frozen for autodiff.
+
+    The basket-cell registration of the frozen-GHK Cav2.1 mechanism
+    implemented by :class:`Cav2p1_MA2024_PC_Frozen`. The kinetics
+    are those built from the dissociated Purkinje neuron recordings
+    of (Swensen & Bean, 2005) [1]_ and published in (Anwar, Hong &
+    De Schutter, 2012) [2]_, imported here for the cerebellar basket
+    cell model of (Masoli et al., 2025) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), default ``2.2e-4 cm/s``. Inherited from
+        :class:`Cav2p1_MA2024_PC_Frozen`.
+    V_sh : array-like or callable, optional
+        Voltage shift, the mod file's ``vshift``, default
+        ``0.0 mV``. Inherited from
+        :class:`Cav2p1_MA2024_PC_Frozen`.
+    temp : array-like, optional
+        Absolute temperature entering both the gate's Q10 factor and
+        the GHK flux, default 23 degrees Celsius. Inherited from
+        :class:`Cav2p1_MA2024_PC_Frozen`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav2p1_MA2024_PC_Frozen : The base class; the freezing
+        mechanism, the GHK helper's constants and the difference
+        from the unfrozen classes are documented there.
+    Cav2p1_MA2025_BC : The unfrozen basket-cell import of the same
+        mechanism. This class is **not** derived from it, and is not
+        numerically identical to it.
+
+    Notes
+    -----
+    **The cell-type suffix in this class's name describes its model
+    citation, not its implementation.** The class body is empty
+    apart from ``__module__``: every gate, constant, rate function
+    and the ``current`` method come from
+    :class:`Cav2p1_MA2024_PC_Frozen`, the Purkinje-cell frozen
+    variant. That is sound because ``BC/channel/Cav2p1_MA25_BC.mod``
+    and ``PC/channel/Cav2p1_MA24_PC.mod`` are identical apart from
+    their ``SUFFIX`` lines, but it does mean the basket-cell class
+    inherits from a Purkinje-cell one rather than from
+    :class:`Cav2p1_MA2025_BC`. Per the bibliography's attribution
+    scan this subclass contributes no rate-function code of its own;
+    its zero literal overlap in that scan is an artefact of the
+    constants living in the base class.
+
+    Everything in :class:`Cav2p1_MA2024_PC_Frozen`'s Notes applies
+    unchanged and is not repeated here: no channel state stops
+    evolving, the freezing affects reverse-mode gradients only, and
+    the frozen path uses the NMODL-constant GHK helper rather than
+    the shared :func:`~braincell.channel._base.ghk_flux`, so the
+    forward current differs slightly from
+    :class:`Cav2p1_MA2025_BC`'s.
+
+    The ``MA2025`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for ``Cav2p1``.
+
+    References
+    ----------
+    .. [1] Swensen, A. M., & Bean, B. P. (2005). Robustness of burst
+           firing in dissociated Purkinje neurons with acute or
+           long-term reductions in sodium conductance. The Journal
+           of Neuroscience, 25(14), 3509-3520.
+           doi:10.1523/JNEUROSCI.3929-04.2005
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav3p3_MA2024_PC_Frozen")
 class Cav3p3_MA2024_PC_Frozen(HH):
-    """Experimental Cav3.3 variant that freezes GHK voltage dependence in autodiff."""
+    r"""Purkinje cell Cav3.3 with the GHK drive frozen for autodiff.
+
+    A standalone Purkinje-cell Cav3.3 mechanism that stops the
+    gradient through the membrane potential where it enters the
+    constant-field (GHK) flux term. Its kinetics, its named
+    parameter block and its forward current are numerically
+    identical to :class:`Cav3p3_MA2024_PC`'s, and its attribution is
+    the same: the Cav3.3 kinetics of the CA3 hippocampal pyramidal
+    neuron model of (Xu & Clancy, 2008) [1]_, imported for the human
+    Purkinje cell model of (Masoli et al., 2024) [2]_. It inherits
+    none of that code -- see Notes.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    perm : array-like or callable, optional
+        Calcium permeability entering the GHK flux, the mod file's
+        ``pcabar``. Defaults to ``1.0e-4 cm/s``.
+    g_scale : array-like or callable, optional
+        Dimensionless empirical scale factor multiplying the flux,
+        carrying the numeric value of the mod file's
+        ``gCav3_3bar``. Defaults to ``1.0e-5``.
+    temp : array-like, optional
+        Absolute temperature. Enters both the gates' Q10 factor and
+        the GHK flux. Defaults to 36 degrees Celsius.
+    V_sh : array-like or callable, optional
+        Voltage shift subtracted from :math:`V` before every rate
+        and before the GHK term. Defaults to ``0.0 mV``. The mod
+        file declares no corresponding parameter.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p3_MA2024_PC : The unfrozen Purkinje-cell import of the same
+        mechanism. This class is **not** derived from it.
+    Cav3p3_RI2021_SC : Where the equation set, the GHK helper's
+        constants and the current-law scaling caveat are documented
+        in full.
+    Cav2p1_MA2024_PC_Frozen : The module's other standalone frozen
+        variant, which additionally swaps GHK helpers and so is
+        *not* numerically identical to its unfrozen counterpart.
+
+    Notes
+    -----
+    **This class is not a subclass of the unfrozen Purkinje-cell
+    import, and the module's frozen variants are not all built the
+    same way.** :class:`Cav3p3_MA2024_PC` derives from
+    :class:`Cav3p3_RI2021_SC`; this class derives from
+    :class:`~braincell.channel._base.HH` directly and re-declares
+    everything: ``root_type``, both gates, the whole constructor and
+    parameter block, ``f_n_inf``, ``f_l_inf``, ``f_n_tau``,
+    ``f_l_tau`` and ``current``. The two therefore compute the same
+    forward numbers while sharing no code, and a change to
+    :class:`Cav3p3_RI2021_SC` propagates to one and not the other.
+
+    "Frozen" describes the gradient path, not the forward numerics
+    and not the channel states. Both gates keep integrating normally
+    -- nothing stops evolving. :meth:`current` passes the membrane
+    potential through the module-level
+    ``_freeze_quantity_gradient``, which rebuilds the quantity from
+    :func:`jax.lax.stop_gradient` applied to its mantissa, before
+    handing it to the GHK helper. The unfrozen ``V`` still reaches
+    :meth:`~braincell.channel._base.HH.conductance_factor`, but that
+    method ignores its voltage argument and reads only the gate
+    states, so the distinction affects neither value nor gradient
+    there. **Unlike** :class:`Cav2p1_MA2024_PC_Frozen`, this class
+    calls the same ``_cav3p3_nmodl_ghk_flux`` helper its unfrozen
+    counterpart calls, so freezing is the only difference between
+    the two and the forward current is unchanged.
+
+    The kinetics are those of ``PC/channel/Cav3p3_MA24_PC.mod``,
+    which is identical to ``SC/channel/Cav3p3_RI21_SC.mod`` apart
+    from its ``SUFFIX`` line and a ``g_equiv`` diagnostic. No mod
+    file ships a frozen-gradient variant: freezing is a BrainCell
+    autodiff facility with no counterpart in NMODL, so it is not an
+    import deviation and changes nothing a NEURON comparison would
+    observe.
+
+    As in :class:`Cav3p3_RI2021_SC`, the mod file's current-law
+    scaling is not dimensionally self-consistent and ``g_scale`` is
+    therefore dimensionless, the GHK helper carries the mod file's
+    own ``F``/``R`` constants and its ``celsius + 273.14`` Kelvin
+    conversion plus a small-argument series branch the mod file
+    lacks, ``V_sh`` has no counterpart in the mod file, the Q10 is
+    declared on the ``Gate`` objects, and ``current()`` negates
+    NEURON's outward-positive ``ica``. The ``perm`` and ``g_scale``
+    defaults are the deposit's tuned values, not values reported by
+    the origin paper.
+
+    References
+    ----------
+    .. [1] Xu, J., & Clancy, C. E. (2008). Ionic mechanisms of
+           endogenous bursting in CA3 hippocampal pyramidal neurons:
+           A model study. PLoS ONE, 3(4), e2056.
+           doi:10.1371/journal.pone.0002056
+    .. [2] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium
@@ -2964,24 +3634,178 @@ class Cav3p3_MA2024_PC_Frozen(HH):
 
 @register_channel("Cav3p2_RI2021_SC")
 class Cav3p2_RI2021_SC(OhmicHH):
-    """Template-based import of ``Cav3p2_RI21_SC.mod``.
+    r"""Stellate cell Cav3.2 low-threshold T-type calcium current.
+
+    The Cav3.2 (T-type, alpha1H) low-threshold calcium current of
+    the cerebellar stellate cell model of (Rizza et al., 2021) [4]_.
+    It is Destexhe's 1992 NEURON implementation of the
+    low-threshold calcium current of (Huguenard & McCormick, 1992)
+    [1]_, with the biophysical properties refitted to recordings of
+    human recombinant Cav3.2 channels in HEK-293 cells by (Vitko et
+    al., 2005) [2]_ and transformed from those 23-25 degrees Celsius
+    data to 36 degrees Celsius using Q10 factors credited to
+    (Coulter, Huguenard & Prince, 1989) [3]_ (see Notes). Gating is
+    :math:`m^2 h` with an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= g_{max} \, m^2 h \, (E_{Ca} - V) \\
+        m_\infty &= \frac{1}{1 + \exp(-(V' + 54.8) / 7.4)} \\
+        h_\infty &= \frac{1}{1 + \exp((V' + 85.5) / 7.18)} \\
+        \tau_m &= \frac{1}{\phi_m}\left(1.9 +
+                  \frac{1}{e^{(V' + 37)/11.9}
+                  + e^{-(V' + 131.6)/21}}\right) \\
+        \tau_h &= 13.7 + \frac{1}{\phi_h}
+                  \cdot \frac{1942 + e^{(V' + 164)/9.2}}
+                  {1 + e^{(V' + 89.3)/3.7}} \\
+        \phi_m &= 5^{(36 - 24)/10}, \quad
+        \phi_h = 3^{(36 - 24)/10}
+        \end{aligned}
+
+    where :math:`V' = V + V_{sh}` read in millivolts and the time
+    constants are in milliseconds. :math:`\phi_m` is supplied by the
+    ``m`` gate's fixed ``phi``, while :math:`\phi_h` is written
+    directly into :meth:`f_h_tau` and the ``h`` gate's ``phi`` is
+    left at 1 -- because the additive ``13.7`` sits outside the
+    division and so does not fit the template's uniform
+    ``tau / phi`` shape. Both factors are constants, not functions
+    of ``temp``; see Notes.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to
+        ``8.0e-4 mS/cm2``, which is **not** the mod file's
+        ``gcabar`` converted (see Notes).
+    V_sh : array-like or callable, optional
+        Voltage shift added to :math:`V` before every rate, the mod
+        file's ``shift``. Defaults to ``0.0 mV``.
+    temp : array-like, optional
+        Absolute temperature. Accepted and stored, but read by no
+        method of this class (see Notes). Defaults to 36 degrees
+        Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p2_MA2024_PC : The same mechanism re-imported for the human
+        Purkinje cell model; identical kinetics, different model
+        citation.
+    Cav3p2_MA2025_BC : The same mechanism re-imported for the basket
+        cell model; identical kinetics, different model citation.
+    CaT_HM1992 : The other import in this module tracing to
+        (Huguenard & McCormick, 1992), by way of a different
+        Destexhe implementation and with different constants.
+    braincell.channel._base.OhmicHH : Template supplying the ohmic
+        driving force used above.
 
     Notes
     -----
-    This source mod is not especially clean as a reusable temperature- and
-    concentration-general mechanism:
+    Ported from ``SC/channel/Cav3p2_RI21_SC.mod``, whose header
+    reads "Model of Huguenard & McCormick, J Neurophysiol 68:
+    1373-1383, 1992", "Written by Alain Destexhe, Salk Institute,
+    Sept 18, 1992" and "Biophysical properties of the T current were
+    from recordings of human recombinant Cav3.2 T-channel in HEK-293
+    cells -- see Vitko et al." It also records the rename "Suffix
+    from CaT3_2 to Cav3_2". The Destexhe authorship line names the
+    mechanism's implementer and is deliberately not turned into a
+    citation; entry [1]_ is the paper his implementation models.
+    Note that the Boltzmann and tau constants above are the Vitko
+    refit, not the numbers of the original 1992 parameterisation.
 
-    - the original mod effectively bakes the gate-temperature conversion to
-      36 C into fixed phi factors derived from 24 C data;
-    - the compare path here uses fixed Ca concentrations to match the original
-      mod assumptions;
-    - ``tau_h`` is written in a special ``13.7 + term / phi_h`` form rather
-      than the usual ``tau / phi`` pattern used by most HH-style templates.
+    **What the Q10 citation does and does not support.** The mod
+    file's ``INITIAL`` block comments the 24-to-36 degrees Celsius
+    transformation as "assuming Q10 of 5 and 3 for m and h (as in
+    Coulter et al., J Physiol 414: 587, 1989)". Entry [3]_ is a
+    Q10 source only: it reports that the low-threshold current's
+    kinetic properties were temperature sensitive with Q10 values
+    greater than 2.5, and does **not** print the specific 5 and 3
+    used here. That split is Destexhe's parameterisation derived
+    from those data, and this docstring does not present [3]_ as a
+    source of kinetics.
 
-    The implementation below intentionally preserves those quirks so the
-    BrainCell behavior matches NEURON for one-to-one comparison. Longer term
-    this channel should probably be rewritten into a more general form instead
-    of carrying over the source mod's baked-in assumptions.
+    **The temperature conversion is baked in, and ``temp`` is
+    dead.** The mod file computes ``phi_m = 5^(12/10)`` and
+    ``phi_h = 3^(12/10)`` once, from the fixed literals 36 and 24
+    rather than from NEURON's ``celsius``. BrainCell reproduces that
+    exactly: the ``m`` gate carries ``phi=5.0 ** ((36.0 - 24.0) /
+    10.0)`` and :meth:`f_h_tau` recomputes the matching ``phi_h``
+    inline. Consequently the ``temp`` constructor parameter is
+    stored on the instance and never read -- neither gate declares a
+    ``q10``, and this mechanism has no GHK term for ``temp`` to
+    enter. Changing ``temp`` changes nothing.
+
+    **``g_max``'s default does not match the mod file.** The mod
+    file declares ``gcabar = .0008 (mho/cm2)``, i.e. 0.8 mS/cm2;
+    this class defaults to ``8.0e-4 mS/cm2``, the same numeric
+    literal carrying the millisiemens unit, which is a thousand
+    times smaller. Sibling imports in this module resolve the same
+    ``mho/cm2`` declaration the other way -- ``CaHVA_MA2020_GoC``
+    turns ``0.00046 mho/cm2`` into ``0.46 mS/cm2``, and
+    ``Cav1p2_MA2020_GoC`` keeps ``0.0002 S/cm2`` outright. The
+    divergence is recorded here rather than corrected: this is a
+    documentation-only description of the shipped default. It is
+    invisible to the NEURON comparison suite, which always passes
+    ``g_max`` explicitly in ``S/cm2``. Note also that even a
+    correctly converted default would be the cell-model deposit's
+    tuned ``gcabar``, not a conductance reported by any of the
+    origin papers.
+
+    **The mod file's fixed calcium concentrations are not read
+    here.** It declares ``cai = 2.4e-4 (mM)`` and ``cao = 2 (mM)``,
+    computes its own reversal potential from them by the Nernst
+    equation, and notes that ``cai`` was "adjusted for eca=120 mV".
+    :class:`~braincell.channel._base.OhmicHH` instead takes
+    :math:`E_{Ca}` from the attached
+    :class:`~braincell.ion.Calcium` ion object, so the comparison
+    path has to pin those concentrations externally to reproduce the
+    mod file's driving force.
+
+    Taken together -- the hard-coded 36 degrees Celsius conversion,
+    the externally pinned concentrations and the irregular
+    ``tau_h`` shape -- this mod file is not a clean reusable
+    temperature- and concentration-general mechanism. The
+    implementation here preserves its quirks deliberately, so that
+    BrainCell matches NEURON one for one; a more general rewrite
+    would have to break that correspondence.
+
+    NEURON's raw ``ica`` here is ``gcabar * m*m*h * (v - carev)``,
+    i.e. outward-positive;
+    :class:`~braincell.channel._base.OhmicHH` computes
+    ``g_max * m^2 h * (E - V)``, the same current under BrainCell's
+    repo-wide inward-positive convention.
+
+    The ``RI2021`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for this mechanism.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    .. [2] Vitko, I., Chen, Y., Arias, J. M., Shen, Y., Wu, X.-R., &
+           Perez-Reyes, E. (2005). Functional characterization and
+           neuronal modeling of the effects of childhood absence
+           epilepsy variants of CACNA1H, a T-type calcium channel.
+           The Journal of Neuroscience, 25(19), 4844-4855.
+           doi:10.1523/JNEUROSCI.0847-05.2005
+    .. [3] Coulter, D. A., Huguenard, J. R., & Prince, D. A. (1989).
+           Calcium currents in rat thalamocortical relay neurones:
+           kinetic properties of the transient, low-threshold
+           current. The Journal of Physiology, 414(1), 587-604.
+           doi:10.1113/jphysiol.1989.sp017705
+    .. [4] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
     """
 
     __module__ = "braincell.channel"
@@ -3033,32 +3857,335 @@ class Cav3p2_RI2021_SC(OhmicHH):
 
 @register_channel("Cav3p2_MA2025_BC")
 class Cav3p2_MA2025_BC(Cav3p2_RI2021_SC):
-    """Template-based import of ``Cav3p2_MA2025_BC.mod``."""
+    r"""Basket cell Cav3.2 low-threshold T-type calcium current.
+
+    The same :math:`m^2 h` Cav3.2 kinetics and ohmic current law
+    documented in :class:`Cav3p2_RI2021_SC`, reused unchanged for
+    the cerebellar basket cell model of (Masoli et al., 2025) [4]_.
+    The kinetics remain Destexhe's 1992 implementation of the
+    low-threshold current of (Huguenard & McCormick, 1992) [1]_,
+    refitted to the human recombinant Cav3.2 recordings of (Vitko et
+    al., 2005) [2]_ and transformed to 36 degrees Celsius with Q10
+    factors credited to (Coulter, Huguenard & Prince, 1989) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``8.0e-4 mS/cm2``,
+        which is not the mod file's ``gcabar`` converted (see
+        :class:`Cav3p2_RI2021_SC` Notes). Inherited from
+        :class:`Cav3p2_RI2021_SC`.
+    V_sh : array-like or callable, optional
+        Voltage shift, the mod file's ``shift``, default
+        ``0.0 mV``. Inherited from :class:`Cav3p2_RI2021_SC`.
+    temp : array-like, optional
+        Accepted but read by no method of this class (see
+        :class:`Cav3p2_RI2021_SC` Notes). Default 36 degrees
+        Celsius. Inherited from :class:`Cav3p2_RI2021_SC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p2_RI2021_SC : The base class; the full equation set, the
+        baked-in temperature conversion, the dead ``temp``
+        parameter and the ``g_max`` default divergence are
+        documented there.
+    Cav3p2_MA2024_PC : The same mechanism imported for the human
+        Purkinje cell model.
+
+    Notes
+    -----
+    Ported from ``BC/channel/Cav3p2_MA25_BC.mod``, which is
+    byte-identical to ``SC/channel/Cav3p2_RI21_SC.mod`` except for
+    its ``SUFFIX`` line. Accordingly this class overrides nothing:
+    the constructor, both gate declarations and the four rate
+    methods are all inherited from :class:`Cav3p2_RI2021_SC`. Only
+    the ``register_channel`` key and this docstring's model citation
+    differ. Per the bibliography's attribution scan, this subclass
+    contributes no rate-function code of its own; its zero literal
+    overlap in that scan is an artefact of the constants living in
+    the base class.
+
+    The ``MA2025`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for ``Cav3p2``.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    .. [2] Vitko, I., Chen, Y., Arias, J. M., Shen, Y., Wu, X.-R., &
+           Perez-Reyes, E. (2005). Functional characterization and
+           neuronal modeling of the effects of childhood absence
+           epilepsy variants of CACNA1H, a T-type calcium channel.
+           The Journal of Neuroscience, 25(19), 4844-4855.
+           doi:10.1523/JNEUROSCI.0847-05.2005
+    .. [3] Coulter, D. A., Huguenard, J. R., & Prince, D. A. (1989).
+           Calcium currents in rat thalamocortical relay neurones:
+           kinetic properties of the transient, low-threshold
+           current. The Journal of Physiology, 414(1), 587-604.
+           doi:10.1113/jphysiol.1989.sp017705
+    .. [4] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav3p2_MA2024_PC")
 class Cav3p2_MA2024_PC(Cav3p2_RI2021_SC):
-    """Template-based import of ``Cav3p2_MA2024_PC.mod``."""
+    r"""Purkinje cell Cav3.2 low-threshold T-type calcium current.
+
+    The same :math:`m^2 h` Cav3.2 kinetics and ohmic current law
+    documented in :class:`Cav3p2_RI2021_SC`, reused unchanged for
+    the human Purkinje cell model of (Masoli et al., 2024) [4]_. The
+    kinetics remain Destexhe's 1992 implementation of the
+    low-threshold current of (Huguenard & McCormick, 1992) [1]_,
+    refitted to the human recombinant Cav3.2 recordings of (Vitko et
+    al., 2005) [2]_ and transformed to 36 degrees Celsius with Q10
+    factors credited to (Coulter, Huguenard & Prince, 1989) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``8.0e-4 mS/cm2``,
+        which is not the mod file's ``gcabar`` converted (see
+        :class:`Cav3p2_RI2021_SC` Notes). Inherited from
+        :class:`Cav3p2_RI2021_SC`.
+    V_sh : array-like or callable, optional
+        Voltage shift, the mod file's ``shift``, default
+        ``0.0 mV``. Inherited from :class:`Cav3p2_RI2021_SC`.
+    temp : array-like, optional
+        Accepted but read by no method of this class (see
+        :class:`Cav3p2_RI2021_SC` Notes). Default 36 degrees
+        Celsius. Inherited from :class:`Cav3p2_RI2021_SC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p2_RI2021_SC : The base class; the full equation set, the
+        baked-in temperature conversion, the dead ``temp``
+        parameter and the ``g_max`` default divergence are
+        documented there.
+    Cav3p2_MA2025_BC : The same mechanism imported for the basket
+        cell model.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Cav3p2_MA24_PC.mod``, which is
+    identical to ``SC/channel/Cav3p2_RI21_SC.mod`` apart from its
+    ``SUFFIX`` line and the BrainCell-local ``g_equiv`` diagnostic
+    the stellate copy carries. Accordingly this class overrides
+    nothing: the constructor, both gate declarations and the four
+    rate methods are all inherited from
+    :class:`Cav3p2_RI2021_SC`. Only the ``register_channel`` key and
+    this docstring's model citation differ. Per the bibliography's
+    attribution scan, this subclass contributes no rate-function
+    code of its own; its zero literal overlap in that scan is an
+    artefact of the constants living in the base class.
+
+    The ``MA2024`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for ``Cav3p2``.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    .. [2] Vitko, I., Chen, Y., Arias, J. M., Shen, Y., Wu, X.-R., &
+           Perez-Reyes, E. (2005). Functional characterization and
+           neuronal modeling of the effects of childhood absence
+           epilepsy variants of CACNA1H, a T-type calcium channel.
+           The Journal of Neuroscience, 25(19), 4844-4855.
+           doi:10.1523/JNEUROSCI.0847-05.2005
+    .. [3] Coulter, D. A., Huguenard, J. R., & Prince, D. A. (1989).
+           Calcium currents in rat thalamocortical relay neurones:
+           kinetic properties of the transient, low-threshold
+           current. The Journal of Physiology, 414(1), 587-604.
+           doi:10.1113/jphysiol.1989.sp017705
+    .. [4] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Cav3p3_RI2021_SC")
 class Cav3p3_RI2021_SC(HH):
-    """Template-based import of ``Cav3p3_RI21_SC.mod``.
+    r"""Stellate cell Cav3.3 low-threshold calcium current, GHK drive.
+
+    The Cav3.3 (T-type, alpha1I) low-threshold calcium current of
+    the cerebellar stellate cell model of (Rizza et al., 2021) [2]_.
+    Its kinetics are those of the CA3 hippocampal pyramidal neuron
+    model of (Xu & Clancy, 2008) [1]_, reused unchanged for the
+    stellate cell. Gating is :math:`n^2 l`, driven by a
+    hand-written constant-field (GHK) calcium flux rather than an
+    ohmic term:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= -s \, P \, n^2 l \,
+                  \Phi(V', [Ca]_i, [Ca]_o, z{=}2, T) \\
+        n_\infty &= \frac{1}{1 + \exp(-(V' - v_{1/2,n}) / k_n)} \\
+        l_\infty &= \frac{1}{1 + \exp(-(V' - v_{1/2,l}) / k_l)} \\
+        \tau_n &= \frac{1}{\phi} \begin{cases}
+                  7.2 + 0.02\, e^{-V' / 14.7} & V' > -60 \\
+                  0.875\, e^{(V' + 120) / 41} & V' \leq -60
+                  \end{cases} \\
+        \tau_l &= \frac{1}{\phi} \begin{cases}
+                  79.5 + 2\, e^{-V' / 9.3} & V' > -60 \\
+                  260 & V' \leq -60
+                  \end{cases} \\
+        \phi &= 2.3^{(T - 28\,^\circ\mathrm{C}) / 10}
+        \end{aligned}
+
+    where :math:`V' = V - V_{sh}`, :math:`v_{1/2,n} = -41.5` mV,
+    :math:`k_n = 6.2` mV, :math:`v_{1/2,l} = -69.8` mV,
+    :math:`k_l = -6.1` mV, :math:`s` is ``g_scale``, :math:`P` is
+    ``perm`` and :math:`\Phi` is the module-level
+    ``_cav3p3_nmodl_ghk_flux`` helper (see Notes). The tau branches
+    read :math:`V'` in millivolts and return milliseconds; both are
+    exclusive at exactly :math:`-60` mV, and neither is continuous
+    across that point -- at :math:`V' = -60` mV the upper branches
+    give about 8.4 ms and 1347 ms against the lower branches' 3.8 ms
+    and 260 ms. That discontinuity is the mod file's, reproduced
+    rather than smoothed. :math:`\phi` is supplied by the ``Gate``
+    declarations, which divide each tau by it.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    perm : array-like or callable, optional
+        Calcium permeability :math:`P` entering the GHK flux, the
+        mod file's ``pcabar``. Defaults to ``1.0e-4 cm/s`` (see
+        Notes).
+    g_scale : array-like or callable, optional
+        Dimensionless empirical scale factor multiplying the flux,
+        carrying the numeric value of the mod file's
+        ``gCav3_3bar``. Defaults to ``1.0e-5`` (see Notes).
+    temp : array-like, optional
+        Absolute temperature. Enters both :math:`\phi` and the GHK
+        flux. Defaults to 36 degrees Celsius.
+    V_sh : array-like or callable, optional
+        Voltage shift subtracted from :math:`V` before every rate
+        and before the GHK term. Defaults to ``0.0 mV``. The mod
+        file declares no corresponding parameter (see Notes).
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p3_MA2024_PC : The same mechanism re-imported for the human
+        Purkinje cell model; identical kinetics, different model
+        citation.
+    Cav3p3_MA2024_PC_Frozen : Purkinje-cell variant with the GHK
+        term's voltage dependence removed from the autodiff graph.
+        It is **not** a subclass of this class (see its Notes).
+    braincell.channel._base.ghk_flux : The shared GHK helper, which
+        this class does **not** call (see Notes).
 
     Notes
     -----
-    The source mod uses a somewhat inconsistent current-law scaling: it mixes
-    ``pcabar`` (documented like a permeability, ``cm/s``), ``gCav3_3bar``
-    (documented like ``S/cm^2``), and a hand-written GHK expression with its
-    own built-in unit conversion constants. To keep the BrainCell current law
-    dimensionally consistent while still matching NEURON numerically,
-    ``g_scale`` is treated here as a dimensionless empirical scale factor
-    rather than as a physical conductance density. ``perm`` remains the
+    Ported from ``SC/channel/Cav3p3_RI21_SC.mod``, whose ``TITLE``
+    reads "CaV 3.3 CA3 hippocampal neuron" and whose ``COMMENT``
+    records "Created by jun xu @ Clancy Lab of Cornell University
+    Medical College" and cites (Xu & Clancy, 2008). The "CA3
+    hippocampal neuron" of the title is upstream provenance: this
+    class is the stellate cell port, used in the model cited as
+    [2]_.
+
+    **The mod file's current-law scaling is not dimensionally
+    self-consistent, and BrainCell's parameter units follow from
+    that.** The file mixes ``pcabar`` (declared like a permeability,
+    ``cm/s``), ``gCav3_3bar`` (declared like a conductance density,
+    ``S/cm2``) and a hand-written GHK expression carrying its own
+    built-in unit conversion constants, then multiplies all three
+    together. To keep the BrainCell current law dimensionally
+    consistent while still matching NEURON numerically, ``g_scale``
+    is treated here as a dimensionless empirical scale factor rather
+    than as a physical conductance density; ``perm`` remains the
     permeability-like term.
+
+    ``current()`` evaluates the constant-field equation through the
+    module-level ``_cav3p3_nmodl_ghk_flux`` helper rather than
+    :func:`~braincell.channel._base.ghk_flux`, so that it reproduces
+    this mod file's own constants exactly: ``F = 96520 C/mol``,
+    ``R = 8.3134 J/(K mol)`` and the mod file's
+    ``T = celsius + 273.14`` conversion, whose 0.01 K offset from
+    :func:`brainunit.celsius2kelvin` is carried as
+    ``_CAV3P3_NMODL_TEMP_OFFSET``. The helper writes the flux as
+    :math:`-zF(c_o - c_i e^{w}) w / (e^{w} - 1)` with
+    :math:`w = zFV'/(RT)`, matching the mod file line for line, and
+    adds one thing the mod file has no counterpart for: a
+    small-:math:`w` series branch
+    :math:`-zF(c_o - c_i e^{w})(1 - w/2)`, taken when
+    :math:`|e^{w} - 1| < 10^{-6}`, which avoids the division by
+    zero the mod file's expression has at :math:`V' = 0`.
+    ``current()`` negates the result to match BrainCell's repo-wide
+    inward-positive convention against NEURON's outward-positive
+    ``ica``.
+
+    ``V_sh`` has no counterpart in the mod file at all; it is a
+    BrainCell extension. Unlike the ``V_sh`` of the Cav3.1 classes
+    in this module it *is* read -- by all four rate methods and by
+    :meth:`current` -- but its ``0.0 mV`` default leaves the
+    mechanism at the mod file's behaviour.
+
+    The mod file applies its temperature factor as
+    ``tau = tau / qt`` with ``qt = q10^((celsius - 28)/10)`` and
+    ``q10 = 2.3``. That is exactly the generic gate temperature
+    path, so the Q10 is declared on the ``Gate`` objects here rather
+    than written into :meth:`f_n_tau` and :meth:`f_l_tau`. The mod
+    file reads NEURON's global ``celsius`` where this class reads
+    its own ``temp`` parameter, which defaults to 36 degrees
+    Celsius.
+
+    The mod file writes ``vhalfn``, ``vhalfl``, ``kn`` and ``kl`` as
+    bare numbers with a ``:mv`` comment rather than as united
+    quantities; BrainCell attaches ``u.mV`` to all four.
+
+    The ``RI2021`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for this mechanism.
+
+    ``perm`` and ``g_scale`` default to the ``pcabar`` and
+    ``gCav3_3bar`` of the cell-model deposit this mechanism was
+    imported from -- values tuned for that model, not values
+    reported by the origin paper.
+
+    References
+    ----------
+    .. [1] Xu, J., & Clancy, C. E. (2008). Ionic mechanisms of
+           endogenous bursting in CA3 hippocampal pyramidal neurons:
+           A model study. PLoS ONE, 3(4), e2056.
+           doi:10.1371/journal.pone.0002056
+    .. [2] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
     """
 
     __module__ = "braincell.channel"
@@ -3128,7 +4255,76 @@ class Cav3p3_RI2021_SC(HH):
 
 @register_channel("Cav3p3_MA2024_PC")
 class Cav3p3_MA2024_PC(Cav3p3_RI2021_SC):
-    """Template-based import of ``Cav3p3_MA2024_PC.mod``."""
+    r"""Purkinje cell Cav3.3 low-threshold calcium current, GHK drive.
+
+    The same :math:`n^2 l` Cav3.3 kinetics and hand-written GHK
+    current law documented in :class:`Cav3p3_RI2021_SC`, reused
+    unchanged for the human Purkinje cell model of (Masoli et al.,
+    2024) [2]_. The kinetics remain those of the CA3 hippocampal
+    pyramidal neuron model of (Xu & Clancy, 2008) [1]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    perm : array-like or callable, optional
+        Calcium permeability entering the GHK flux (the mod file's
+        ``pcabar``), default ``1.0e-4 cm/s``. Inherited from
+        :class:`Cav3p3_RI2021_SC`.
+    g_scale : array-like or callable, optional
+        Dimensionless scale factor carrying the numeric value of the
+        mod file's ``gCav3_3bar``, default ``1.0e-5``. Inherited
+        from :class:`Cav3p3_RI2021_SC`.
+    temp : array-like, optional
+        Absolute temperature entering both the gates' Q10 factor and
+        the GHK flux, default 36 degrees Celsius. Inherited from
+        :class:`Cav3p3_RI2021_SC`.
+    V_sh : array-like or callable, optional
+        Voltage shift with no counterpart in the mod file, default
+        ``0.0 mV``. Inherited from :class:`Cav3p3_RI2021_SC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p3_RI2021_SC : The base class; the full equation set, the
+        GHK helper's constants and the current-law scaling caveat
+        are documented there.
+    Cav3p3_MA2024_PC_Frozen : Purkinje-cell variant with the GHK
+        term's voltage dependence removed from the autodiff graph.
+        It is **not** a subclass of this class (see its Notes).
+
+    Notes
+    -----
+    Ported from ``PC/channel/Cav3p3_MA24_PC.mod``, which is
+    identical to ``SC/channel/Cav3p3_RI21_SC.mod`` apart from its
+    ``SUFFIX`` line and the BrainCell-local ``g_equiv`` diagnostic
+    the stellate copy carries. Accordingly this class overrides
+    nothing: the constructor, both gate declarations, the named
+    parameter block, the four rate methods and ``current`` are all
+    inherited from :class:`Cav3p3_RI2021_SC`. Only the
+    ``register_channel`` key and this docstring's model citation
+    differ. Per the bibliography's attribution scan, this subclass
+    contributes no rate-function code of its own.
+
+    The ``MA2024`` import-deviations tables list no ``TABLE``
+    removal, no ``derivimplicit`` -> ``cnexp`` substitution and no
+    rate-refresh relocation for ``Cav3p3``.
+
+    References
+    ----------
+    .. [1] Xu, J., & Clancy, C. E. (2008). Ionic mechanisms of
+           endogenous bursting in CA3 hippocampal pyramidal neurons:
+           A model study. PLoS ONE, 3(4), e2056.
+           doi:10.1371/journal.pone.0002056
+    .. [2] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
 
@@ -3474,7 +4670,135 @@ class CaHVA_MA2020_GrC(OhmicHH):
 
 @register_channel("Cav2p3_MA2020_GoC")
 class Cav2p3_MA2020_GoC(OhmicHH):
-    """Template-based import of ``Cav2p3_MA2020_GoC.mod``."""
+    r"""Golgi cell Cav2.3 R-type, medium-threshold calcium current.
+
+    The Cav2.3 (R-type) medium-threshold calcium current of the
+    cerebellar Golgi cell model of (Masoli et al., 2020) [3]_. Its
+    kinetics are those of the ``car`` mechanism of the CA1 pyramidal
+    cell model of (Poirazi, Brannon & Mel, 2003) [1]_ [2]_, reused
+    unchanged for the Golgi cell. Gating is :math:`m^3 h` with
+    voltage-independent time constants and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        I_{Ca} &= g_{max} \, m^3 h \, (E_{Ca} - V) \\
+        m_\infty &= \frac{1}{1 + \exp((V' + 48.5) / -3)} \\
+        h_\infty &= \frac{1}{1 + \exp((V' + 53) / 1)} \\
+        \tau_m &= 50 \ \mathrm{ms}, \quad \tau_h = 5 \ \mathrm{ms}
+        \end{aligned}
+
+    where :math:`V' = V / \mathrm{mV}`. Neither gate declares a Q10
+    or a ``phi``, so no temperature factor is applied to either time
+    constant.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.0 mS/cm2``,
+        matching the mod file's ``gcabar = 0 (mho/cm2)``, so the
+        mechanism contributes no current until a cell model sets it
+        (see Notes).
+    temp : array-like, optional
+        Absolute temperature. Accepted and stored, but read by no
+        method of this class (see Notes). Defaults to 34 degrees
+        Celsius, matching the mod file's ``celsius = 34``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    CaHVA_MA2020_GoC : The Golgi cell model's other
+        high-voltage-activated calcium current, from a different
+        origin.
+    braincell.channel._base.OhmicHH : Template supplying the ohmic
+        driving force used above.
+
+    Notes
+    -----
+    Ported from ``GoC/channel/Cav2p3_MA20_GoC.mod``, whose ``TITLE``
+    reads "Ca R-type channel with medium threshold for activation"
+    and whose header records that the mechanism is "used in distal
+    dendritic regions, together with calH.mod", that it "uses
+    channel conductance (not permeability)", that it was "written by
+    Yiota Poirazi on 11/13/00" and that BrainCell renamed it "From
+    car to Cav2_3". The Poirazi credit is unusual among these
+    cerebellar imports in naming an author of the origin papers
+    rather than an unrelated porter, but it is still not turned into
+    a citation on its own: entries [1]_ and [2]_ below are the
+    published records. The upstream ``car.mod`` and its sibling
+    ``calH.mod`` are both files of ModelDB accession 20212, the
+    shared CA1 pyramidal model deposit serving the two companion
+    papers; because the mechanism belongs to that shared biophysics
+    and cannot be assigned to one paper, both are cited.
+
+    **Import deviation -- interpolation table removed.** The
+    original ``TABLE`` directive tabulated the indexed ``inf`` and
+    ``tau`` arrays over ``[-100, 100]`` mV; NEURON clamped to the
+    boundary value outside that range, so any BrainCell/NEURON
+    divergence outside that window is expected. BrainCell evaluates
+    the formulas per call instead.
+
+    **The indexed rate structure was split into named methods.** The
+    mod file stores its steady states and time constants in
+    ``inf[2]`` and ``tau[2]``, filled by a ``FROM i=0 TO 1`` loop
+    over the helpers ``varss(v, i)`` and ``vartau(v, i)``. Index 0
+    is activation and index 1 is inactivation, per the mod file's
+    own trailing comments and its ``INITIAL`` block, which assigns
+    ``m = inf[0]`` and ``h = inf[1]``. BrainCell therefore maps
+    index 0 onto :meth:`f_m_inf` / :meth:`f_m_tau` -- the
+    ``(v + 48.5) / -3`` curve with ``tau = 50`` -- and index 1 onto
+    :meth:`f_h_inf` / :meth:`f_h_tau` -- the ``(v + 53) / 1`` curve
+    with ``tau = 5``. Both branch values were read back against the
+    mod file's ``if (i==0)`` / ``else if (i==1)`` arms.
+
+    **The default conductance is genuinely zero.** The mod file's
+    ``gcabar = 0 (mho/cm2)`` is commented "initialized conductance":
+    the deposit expects the cell-setup code to assign a density per
+    region, and BrainCell carries the same zero. This is not a
+    missing value or a failed unit conversion.
+
+    ``temp`` is accepted, stored on the instance and never read.
+    Neither ``Gate`` carries a ``q10`` or a ``phi``, and this
+    mechanism has no GHK term, so nothing in the class consumes a
+    temperature. The mod file likewise declares ``celsius = 34``
+    without using it in any rate expression.
+
+    The mod file's ``eca = 140 (mV)`` is not read by this class: the
+    reversal potential is supplied by the attached
+    :class:`~braincell.ion.Calcium` ion object. Its ``gmax``
+    running-maximum diagnostic, updated in ``BREAKPOINT`` by
+    ``if (g > gmax) { gmax = g }``, is a monitoring variable that
+    never feeds the current, and BrainCell drops it.
+
+    NEURON's raw ``ica`` here is ``g * (v - eca)``, i.e.
+    outward-positive; :class:`~braincell.channel._base.OhmicHH`
+    computes ``g_max * m^3 h * (E - V)``, the same current under
+    BrainCell's repo-wide inward-positive convention.
+
+    The mod file is already ``cnexp`` upstream, so no
+    ``derivimplicit`` -> ``cnexp`` substitution was made for it, and
+    the ``MA2020`` tables record no rate-refresh relocation and no
+    NMODL default-precision rewrite for this mechanism.
+
+    References
+    ----------
+    .. [1] Poirazi, P., Brannon, T., & Mel, B. W. (2003). Arithmetic
+           of subthreshold synaptic summation in a model CA1
+           pyramidal cell. Neuron, 37(6), 977-987.
+           doi:10.1016/S0896-6273(03)00148-X
+    .. [2] Poirazi, P., Brannon, T., & Mel, B. W. (2003). Pyramidal
+           neuron as two-layer neural network. Neuron, 37(6),
+           989-999.
+           doi:10.1016/S0896-6273(03)00149-1
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Calcium

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -106,7 +106,7 @@ def _freeze_quantity_gradient(value):
 
 @register_channel("CaN_IS2008")
 class CaN_IS2008(HH):
-    r"""Inoue & Strowbridge 2008 calcium-activated nonselective cation current.
+    r"""Inoue & Strowbridge 2008 Ca-activated nonselective cation current.
 
     A calcium- and voltage-dependent non-selective cation current
     (:math:`I_{CAN}`) gated by a single activation variable and scaled

--- a/braincell/channel/hyperpolarization_activated.py
+++ b/braincell/channel/hyperpolarization_activated.py
@@ -43,42 +43,59 @@ __all__ = [
 
 @register_channel("HCN_HM1992")
 class HCN_HM1992(OhmicHH):
-    r"""
-    The hyperpolarization-activated cation current model propsoed by (Huguenard & McCormick, 1992).
+    r"""Hyperpolarization-activated current of Huguenard & McCormick (1992).
 
-    The hyperpolarization-activated cation current model is adopted from
-    (Huguenard, et, al., 1992) [1]_. Its dynamics is given by:
+    Reproduces the thalamic relay-neuron :math:`I_h` model of
+    (Huguenard & McCormick, 1992) [1]_: a single Boltzmann-gated pore
+    driven by an ohmic force against a fixed reversal potential.
+    Dynamics:
 
     .. math::
 
         \begin{aligned}
-        I_h &= g_{\mathrm{max}} p \\
+        I_h &= g_{\mathrm{max}} \, p \, (E - V) \\
         \frac{dp}{dt} &= \phi \frac{p_{\infty} - p}{\tau_p} \\
-        p_{\infty} &=\frac{1}{1+\exp ((V+75) / 5.5)} \\
-        \tau_{p} &=\frac{1}{\exp (-0.086 V-14.59)+\exp (0.0701 V-1.87)}
+        p_{\infty} &= \frac{1}{1 + \exp((V + 75) / 5.5)} \\
+        \tau_p &= \frac{1}{\exp(-0.086 V - 14.59) +
+                  \exp(0.0701 V - 1.87)}
         \end{aligned}
 
-    where :math:`\phi=1` is a temperature-dependent factor.
+    where :math:`\phi = q_{10}^{(T - T_{\mathrm{ref}}) / 10}` and the
+    default ``q10 = 1.0`` makes :math:`\phi \equiv 1` for any ``temp``.
 
     Parameters
     ----------
-    g_max : float
-      The maximal conductance density (:math:`mS/cm^2`).
-    E : float
-      The reversal potential (mV).
-    temp : float
-      Absolute temperature used by the template temperature interface.
-    q10 : float
-      Q10 scaling factor for gate kinetics.
-    temp_ref : float
-      Reference temperature for the Q10 formula.
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``10.0 mS/cm2``.
+    E : array-like or callable, optional
+        Reversal potential, default ``43.0 mV``.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for the ``p`` gate, default ``1.0``.
+    temp_ref : array-like, optional
+        Reference temperature for the Q10 formula, default 36
+        degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    Notes
+    -----
+    This class overrides :meth:`reversal_potential` to return
+    ``self.E`` instead of an ion's reversal potential, so the current
+    is driven against the fixed ``E`` parameter, not an ion state --
+    the correct closed form is ``g_max * p * (E - V)``, not
+    ``g_max * p`` alone.
 
     References
     ----------
-    .. [1] Huguenard, John R., and David A. McCormick. "Simulation of the currents
-           involved in rhythmic oscillations in thalamic relay neuron." Journal
-           of neurophysiology 68, no. 4 (1992): 1373-1383.
-
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
     """
 
     __module__ = 'braincell.channel'
@@ -260,7 +277,91 @@ class HCN_HM1992(OhmicHH):
 
 @register_channel("HCN1_MA2025_BC")
 class HCN1_MA2025_BC(OhmicHH):
-    """Template-based import of ``HCN1_MA2025_BC.mod``."""
+    r"""HCN1 h-current imported for the cerebellar basket cell model.
+
+    Ports the single ``h`` gate NEURON mechanism
+    ``HCN1_MA2025_BC.mod`` used in the basket-cell deposit of
+    (Masoli et al., 2025) [3]_. The Boltzmann activation curve and
+    biexponential time constant are the same functional forms used
+    across the ``HCN1_MA2024_PC`` / ``HCN1_RI2021_SC`` siblings; only
+    the model citation differs.
+
+    .. math::
+
+        \begin{aligned}
+        h_\infty &= \frac{1}{1 + \exp\left(\dfrac{V - V_{1/2}}
+                    {k}\right)} \\
+        \tau_h &= \frac{\mathrm{ratetau}}{c \left[
+                   \exp\left(\dfrac{V - V_{\tau 1}}{k_1}\right) +
+                   \exp\left(\dfrac{V - V_{\tau 2}}{k_2}\right)
+                   \right]}
+        \end{aligned}
+
+    where :math:`V_{1/2} = V_{\infty,\mathrm{noljp}} - V_{\mathrm{ljp}}
+    = -99.6\ \mathrm{mV}`, :math:`k = 9.67\ \mathrm{mV}`,
+    :math:`V_{\tau 1} = V_{\tau 2} = V_{\tau,\mathrm{noljp}} -
+    V_{\mathrm{ljp}} = -77.3\ \mathrm{mV}`, :math:`k_1 = -22.0\
+    \mathrm{mV}`, :math:`k_2 = 7.14\ \mathrm{mV}`, :math:`c =
+    0.0018\ \mathrm{ms^{-1}}`, and :math:`\mathrm{ratetau} = 1.0`.
+    These six constants and ``ratetau`` are fixed internal values set
+    in ``__init__``; they are not exposed as parameters.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.1 mS/cm2``.
+    E : array-like or callable, optional
+        Reversal potential, default ``-34.4 mV``.
+    temp : array-like, optional
+        Absolute temperature driving the ``h`` gate's Q10 factor
+        (``q10=3.0``, ``temp_ref=37`` degrees Celsius), default 23
+        degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    HCN1_MA2024_PC : Same kinetics ported for a Purkinje-cell model.
+    HCN1_RI2021_SC : Same kinetics ported for a stellate-cell model.
+
+    Notes
+    -----
+    Ported from ``HCN1_MA2025_BC.mod``. This class overrides
+    :meth:`reversal_potential` to return ``self.E`` instead of an
+    ion's reversal potential.
+
+    ``HCN1_MA25_BC.mod`` inherits its comment verbatim from the
+    ``HCN1_MA24_PC.mod`` Purkinje-cell port, including the note
+    "We call it HCN1 as PC express only HCN1" -- a claim about
+    Purkinje cells, not this basket-cell channel, and not repeated
+    here as though it were. The default ``temp = 23`` degrees
+    Celsius is likewise carried over unchanged: Angelo et al. (2007)
+    [1]_ did not report a recording temperature, so 23 degrees
+    Celsius is the porter's assumption, not a value from that paper.
+
+    References
+    ----------
+    .. [1] Angelo, K., London, M., Christensen, S. R., & Hausser, M.
+           (2007). Local and global effects of Ih distribution in
+           dendrites of mammalian neurons. The Journal of
+           Neuroscience, 27(32), 8643-8653.
+           doi:10.1523/JNEUROSCI.5284-06.2007
+    .. [2] Santoro, B., Chen, S., Luthi, A., Pavlidis, P.,
+           Shumyatsky, G. P., Tibbs, G. R., & Siegelbaum, S. A.
+           (2000). Molecular and functional heterogeneity of
+           hyperpolarization-activated pacemaker channels in the
+           mouse CNS. Journal of Neuroscience, 20(14), 5264-5275.
+           doi:10.1523/JNEUROSCI.20-14-05264.2000
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2025). Cerebellar basket cell
+           filtering of Purkinje cell responses elicited by low
+           frequency parallel fibre transmission. Scientific
+           Reports, 15(1), 25192. doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
     root_type = HHTypedNeuron
@@ -308,7 +409,91 @@ class HCN1_MA2025_BC(OhmicHH):
 
 @register_channel("HCN1_MA2024_PC")
 class HCN1_MA2024_PC(OhmicHH):
-    """Template-based import of ``HCN1_MA2024_PC.mod``."""
+    r"""HCN1 h-current imported for the human Purkinje cell model.
+
+    Ports the single ``h`` gate NEURON mechanism
+    ``HCN1_MA2024_PC.mod`` used in the Purkinje-cell deposit of
+    (Masoli et al., 2024) [3]_. The Boltzmann activation curve and
+    biexponential time constant are the same functional forms used
+    across the ``HCN1_MA2025_BC`` / ``HCN1_RI2021_SC`` siblings; only
+    the model citation differs.
+
+    .. math::
+
+        \begin{aligned}
+        h_\infty &= \frac{1}{1 + \exp\left(\dfrac{V - V_{1/2}}
+                    {k}\right)} \\
+        \tau_h &= \frac{\mathrm{ratetau}}{c \left[
+                   \exp\left(\dfrac{V - V_{\tau 1}}{k_1}\right) +
+                   \exp\left(\dfrac{V - V_{\tau 2}}{k_2}\right)
+                   \right]}
+        \end{aligned}
+
+    where :math:`V_{1/2} = V_{\infty,\mathrm{noljp}} - V_{\mathrm{ljp}}
+    = -99.6\ \mathrm{mV}`, :math:`k = 9.67\ \mathrm{mV}`,
+    :math:`V_{\tau 1} = V_{\tau 2} = V_{\tau,\mathrm{noljp}} -
+    V_{\mathrm{ljp}} = -77.3\ \mathrm{mV}`, :math:`k_1 = -22.0\
+    \mathrm{mV}`, :math:`k_2 = 7.14\ \mathrm{mV}`, :math:`c =
+    0.0018\ \mathrm{ms^{-1}}`, and :math:`\mathrm{ratetau} = 1.0`.
+    These six constants and ``ratetau`` are fixed internal values set
+    in ``__init__``; they are not exposed as parameters.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.1 mS/cm2``.
+    E : array-like or callable, optional
+        Reversal potential, default ``-34.4 mV``.
+    temp : array-like, optional
+        Absolute temperature driving the ``h`` gate's Q10 factor
+        (``q10=3.0``, ``temp_ref=37`` degrees Celsius), default 23
+        degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    HCN1_MA2025_BC : Same kinetics ported for a basket-cell model.
+    HCN1_RI2021_SC : Same kinetics ported for a stellate-cell model.
+
+    Notes
+    -----
+    Ported from ``HCN1_MA2024_PC.mod``. This class overrides
+    :meth:`reversal_potential` to return ``self.E`` instead of an
+    ion's reversal potential.
+
+    ``HCN1_MA24_PC.mod`` carries the comment "We call it HCN1 as PC
+    express only HCN1 Santoro et al. 2000" -- correctly describing
+    this Purkinje-cell channel, and the origin of that "PC" claim is
+    the subunit-identity paper [2]_, not the kinetics paper [1]_. The
+    default ``temp = 23`` degrees Celsius is carried over unchanged
+    from the ``.mod`` file: Angelo et al. (2007) [1]_ did not report
+    a recording temperature, so 23 degrees Celsius is the porter's
+    assumption, not a value from that paper.
+
+    References
+    ----------
+    .. [1] Angelo, K., London, M., Christensen, S. R., & Hausser, M.
+           (2007). Local and global effects of Ih distribution in
+           dendrites of mammalian neurons. The Journal of
+           Neuroscience, 27(32), 8643-8653.
+           doi:10.1523/JNEUROSCI.5284-06.2007
+    .. [2] Santoro, B., Chen, S., Luthi, A., Pavlidis, P.,
+           Shumyatsky, G. P., Tibbs, G. R., & Siegelbaum, S. A.
+           (2000). Molecular and functional heterogeneity of
+           hyperpolarization-activated pacemaker channels in the
+           mouse CNS. The Journal of Neuroscience, 20(14), 5264-5275.
+           doi:10.1523/JNEUROSCI.20-14-05264.2000
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = HHTypedNeuron
@@ -356,7 +541,89 @@ class HCN1_MA2024_PC(OhmicHH):
 
 @register_channel("HCN1_RI2021_SC")
 class HCN1_RI2021_SC(OhmicHH):
-    """Template-based import of ``HCN1_RI2021_SC.mod``."""
+    r"""HCN1 h-current imported for the cerebellar stellate cell model.
+
+    Ports the single ``h`` gate NEURON mechanism
+    ``HCN1_RI2021_SC.mod`` used in the stellate-cell deposit of
+    (Rizza et al., 2021) [3]_. The Boltzmann activation curve and
+    biexponential time constant are the same functional forms used
+    across the ``HCN1_MA2025_BC`` / ``HCN1_MA2024_PC`` siblings; only
+    the model citation differs.
+
+    .. math::
+
+        \begin{aligned}
+        h_\infty &= \frac{1}{1 + \exp\left(\dfrac{V - V_{1/2}}
+                    {k}\right)} \\
+        \tau_h &= \frac{\mathrm{ratetau}}{c \left[
+                   \exp\left(\dfrac{V - V_{\tau 1}}{k_1}\right) +
+                   \exp\left(\dfrac{V - V_{\tau 2}}{k_2}\right)
+                   \right]}
+        \end{aligned}
+
+    where :math:`V_{1/2} = V_{\infty,\mathrm{noljp}} - V_{\mathrm{ljp}}
+    = -99.6\ \mathrm{mV}`, :math:`k = 9.67\ \mathrm{mV}`,
+    :math:`V_{\tau 1} = V_{\tau 2} = V_{\tau,\mathrm{noljp}} -
+    V_{\mathrm{ljp}} = -77.3\ \mathrm{mV}`, :math:`k_1 = -22.0\
+    \mathrm{mV}`, :math:`k_2 = 7.14\ \mathrm{mV}`, :math:`c =
+    0.0018\ \mathrm{ms^{-1}}`, and :math:`\mathrm{ratetau} = 1.0`.
+    These six constants and ``ratetau`` are fixed internal values set
+    in ``__init__``; they are not exposed as parameters.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.1 mS/cm2``.
+    E : array-like or callable, optional
+        Reversal potential, default ``-34.4 mV``.
+    temp : array-like, optional
+        Absolute temperature driving the ``h`` gate's Q10 factor
+        (``q10=3.0``, ``temp_ref=37`` degrees Celsius), default 23
+        degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    HCN1_MA2025_BC : Same kinetics ported for a basket-cell model.
+    HCN1_MA2024_PC : Same kinetics ported for a Purkinje-cell model.
+
+    Notes
+    -----
+    Ported from ``HCN1_RI2021_SC.mod``. This class overrides
+    :meth:`reversal_potential` to return ``self.E`` instead of an
+    ion's reversal potential.
+
+    ``HCN1_RI21_SC.mod`` carries the same inherited comment as the
+    basket-cell port, "We call it HCN1 as PC express only HCN1
+    Santoro et al. 2000" -- a claim about Purkinje cells, not this
+    stellate-cell channel, and not repeated here as though it were.
+    The default ``temp = 23`` degrees Celsius is carried over
+    unchanged from the ``.mod`` file: Angelo et al. (2007) [1]_ did
+    not report a recording temperature, so 23 degrees Celsius is the
+    porter's assumption, not a value from that paper.
+
+    References
+    ----------
+    .. [1] Angelo, K., London, M., Christensen, S. R., & Hausser, M.
+           (2007). Local and global effects of Ih distribution in
+           dendrites of mammalian neurons. The Journal of
+           Neuroscience, 27(32), 8643-8653.
+           doi:10.1523/JNEUROSCI.5284-06.2007
+    .. [2] Santoro, B., Chen, S., Luthi, A., Pavlidis, P.,
+           Shumyatsky, G. P., Tibbs, G. R., & Siegelbaum, S. A.
+           (2000). Molecular and functional heterogeneity of
+           hyperpolarization-activated pacemaker channels in the
+           mouse CNS. The Journal of Neuroscience, 20(14), 5264-5275.
+           doi:10.1523/JNEUROSCI.20-14-05264.2000
+    .. [3] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873. doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
     root_type = HHTypedNeuron
@@ -404,7 +671,104 @@ class HCN1_RI2021_SC(OhmicHH):
 
 @register_channel("HCN1_MA2020_GoC")
 class HCN1_MA2020_GoC(HH):
-    """Template-based import of ``HCN1_MA2020_GoC.mod``."""
+    r"""HCN1 fast/slow h-current imported for the Golgi cell model.
+
+    Ports the two-gate NEURON mechanism ``HCN1_MA2020_GoC.mod`` used
+    in the Golgi-cell deposit of (Masoli et al., 2020) [3]_. Two
+    independent open-state gates, ``o_fast`` and ``o_slow``, share
+    one Boltzmann steady state split by a linear mixing fraction
+    ``r(V)``:
+
+    .. math::
+
+        \begin{aligned}
+        I_h &= \phi_Q \, g_{\mathrm{max}} \,
+               (o_{\mathrm{fast}} + o_{\mathrm{slow}}) \, (E - V) \\
+        o_\infty(V) &= \frac{1}{1 + \exp((V - E_{1/2}) \, c)} \\
+        r(V) &= r_A V + r_B \\
+        o_{\mathrm{fast},\infty} &= r(V) \, o_\infty(V) \\
+        o_{\mathrm{slow},\infty} &= (1 - r(V)) \, o_\infty(V) \\
+        \tau_{\mathrm{fast}} &= \exp((t_{Cf} V - t_{Df}) \, t_{Ef}) \\
+        \tau_{\mathrm{slow}} &= \exp((t_{Cs} V - t_{Ds}) \, t_{Es})
+        \end{aligned}
+
+    with :math:`\phi_Q = Q_{10}^{(T - 23^{\circ}\mathrm{C}) / 10}`,
+    :math:`E_{1/2} = -72.49\ \mathrm{mV}`,
+    :math:`c = 0.11305\ \mathrm{mV^{-1}}`,
+    :math:`r_A = 0.002096\ \mathrm{mV^{-1}}`, :math:`r_B = 0.97596`,
+    :math:`t_{Cf} = 0.01371\ \mathrm{mV^{-1}}`, :math:`t_{Df} =
+    -3.368`, :math:`t_{Ef} = 2.30259`, :math:`t_{Cs} =
+    0.01451\ \mathrm{mV^{-1}}`, :math:`t_{Ds} = -4.056`,
+    :math:`t_{Es} = 2.30259`, and :math:`Q_{10} = 1.5`. ``r(V)`` is
+    not clamped for this isoform, unlike ``HCN2_MA2020_GoC``. Both
+    gates additionally carry ``q10=3.0``, ``temp_ref=23`` degrees
+    Celsius on their own state relaxation, independent of the
+    :math:`\phi_Q` conductance prefactor above. All eleven constants
+    are fixed internal values set in ``__init__``; they are not
+    exposed as parameters.
+
+    This class subclasses :class:`HH` directly, not
+    :class:`OhmicHH`, because :meth:`current` sums two gate values
+    before applying the driving force rather than taking a single
+    ``power``-weighted product.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.05 mS/cm2``.
+    E : array-like or callable, optional
+        Reversal potential, default ``-20.0 mV``.
+    temp : array-like, optional
+        Absolute temperature driving both the gate Q10 factors and
+        :math:`\phi_Q`, default 22 degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    HCN2_MA2020_GoC : Companion isoform with a clamped ``r(V)``.
+
+    Notes
+    -----
+    Ported from ``HCN1_MA2020_GoC.mod``. The former NEURON ``TABLE``
+    tabulated ``o_fast_inf``, ``o_slow_inf``, ``tau_f`` and ``tau_s``
+    over ``[-100, 30] mV`` and clamped outside that range; BrainCell
+    evaluates the continuous formulas above at every call instead, so
+    values outside ``[-100, 30] mV`` are expected to diverge from the
+    original NEURON boundary-clamped output.
+
+    ``.mod`` writes the time-constant exponent constants ``tEf`` and
+    ``tEs`` as ``2.302585092``; NEURON's compiled default rounds this
+    to ``2.30259``, and BrainCell follows the compiled value rather
+    than the ``.mod`` source text.
+
+    ``HCN1_MA20_GoC.mod`` credits its kinetics data to "Santoro et
+    al. J Neurosci. 2000" [2]_; the Boltzmann/exponential functional
+    forms trace to the cerebellar Golgi cell model of Solinas et al.
+    (2007) [1]_.
+
+    References
+    ----------
+    .. [1] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De
+           Schutter, E., & D'Angelo, E. (2007). Computational
+           reconstruction of pacemaking and intrinsic
+           electroresponsiveness in cerebellar Golgi cells. Frontiers
+           in Cellular Neuroscience, 1, 2.
+           doi:10.3389/neuro.03.002.2007
+    .. [2] Santoro, B., Chen, S., Luthi, A., Pavlidis, P.,
+           Shumyatsky, G. P., Tibbs, G. R., & Siegelbaum, S. A.
+           (2000). Molecular and functional heterogeneity of
+           hyperpolarization-activated pacemaker channels in the
+           mouse CNS. The Journal of Neuroscience, 20(14), 5264-5275.
+           doi:10.1523/JNEUROSCI.20-14-05264.2000
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = HHTypedNeuron
@@ -470,7 +834,105 @@ class HCN1_MA2020_GoC(HH):
 
 @register_channel("HCN2_MA2020_GoC")
 class HCN2_MA2020_GoC(HH):
-    """Template-based import of ``HCN2_MA2020_GoC.mod``."""
+    r"""HCN2 fast/slow h-current imported for the Golgi cell model.
+
+    Ports the two-gate NEURON mechanism ``HCN2_MA2020_GoC.mod`` used
+    in the Golgi-cell deposit of (Masoli et al., 2020) [3]_. Two
+    independent open-state gates, ``o_fast`` and ``o_slow``, share
+    one Boltzmann steady state split by a mixing fraction ``r(V)``
+    that is linear only inside a clamped voltage window:
+
+    .. math::
+
+        \begin{aligned}
+        I_h &= \phi_Q \, g_{\mathrm{max}} \,
+               (o_{\mathrm{fast}} + o_{\mathrm{slow}}) \, (E - V) \\
+        o_\infty(V) &= \frac{1}{1 + \exp((V - E_{1/2}) \, c)} \\
+        r(V) &= \begin{cases}
+                  0 & V \geq -64.70\ \mathrm{mV} \\
+                  1 & V \leq -108.70\ \mathrm{mV} \\
+                  r_A V + r_B & \text{otherwise}
+                \end{cases} \\
+        o_{\mathrm{fast},\infty} &= r(V) \, o_\infty(V) \\
+        o_{\mathrm{slow},\infty} &= (1 - r(V)) \, o_\infty(V) \\
+        \tau_{\mathrm{fast}} &= \exp((t_{Cf} V - t_{Df}) \, t_{Ef}) \\
+        \tau_{\mathrm{slow}} &= \exp((t_{Cs} V - t_{Ds}) \, t_{Es})
+        \end{aligned}
+
+    with :math:`\phi_Q = Q_{10}^{(T - 23^{\circ}\mathrm{C}) / 10}`,
+    :math:`E_{1/2} = -81.95\ \mathrm{mV}`,
+    :math:`c = 0.1661\ \mathrm{mV^{-1}}`,
+    :math:`r_A = -0.0227\ \mathrm{mV^{-1}}`, :math:`r_B = -1.4694`,
+    :math:`t_{Cf} = 0.0269\ \mathrm{mV^{-1}}`, :math:`t_{Df} =
+    -5.6111`, :math:`t_{Ef} = 2.3026`, :math:`t_{Cs} =
+    0.0152\ \mathrm{mV^{-1}}`, :math:`t_{Ds} = -5.2944`,
+    :math:`t_{Es} = 2.3026`, and :math:`Q_{10} = 1.5`. Both gates
+    additionally carry ``q10=3.0``, ``temp_ref=23`` degrees Celsius
+    on their own state relaxation, independent of the
+    :math:`\phi_Q` conductance prefactor above. All eleven constants
+    are fixed internal values set in ``__init__``; they are not
+    exposed as parameters.
+
+    This class subclasses :class:`HH` directly, not
+    :class:`OhmicHH`, because :meth:`current` sums two gate values
+    before applying the driving force rather than taking a single
+    ``power``-weighted product.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.08 mS/cm2``.
+    E : array-like or callable, optional
+        Reversal potential, default ``-20.0 mV``.
+    temp : array-like, optional
+        Absolute temperature driving both the gate Q10 factors and
+        :math:`\phi_Q`, default 22 degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    HCN1_MA2020_GoC : Companion isoform with an unclamped ``r(V)``.
+
+    Notes
+    -----
+    Ported from ``HCN2_MA2020_GoC.mod``. The former NEURON ``TABLE``
+    tabulated ``o_fast_inf``, ``o_slow_inf``, ``tau_f`` and ``tau_s``
+    over ``[-100, 30] mV`` and clamped outside that range; BrainCell
+    evaluates the continuous formulas above at every call instead, so
+    values outside ``[-100, 30] mV`` are expected to diverge from the
+    original NEURON boundary-clamped output. The explicit ``r(V)``
+    clamp to ``{0, 1}`` above ``-64.70 mV`` / below ``-108.70 mV`` is
+    reproduced directly in :meth:`r`, independent of the removed
+    ``TABLE`` boundary clamp.
+
+    ``HCN2_MA20_GoC.mod`` credits its kinetics data to "Santoro et
+    al. J Neurosci. 2000" [2]_; the Boltzmann/exponential functional
+    forms trace to the cerebellar Golgi cell model of Solinas et al.
+    (2007) [1]_.
+
+    References
+    ----------
+    .. [1] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De
+           Schutter, E., & D'Angelo, E. (2007). Computational
+           reconstruction of pacemaking and intrinsic
+           electroresponsiveness in cerebellar Golgi cells. Frontiers
+           in Cellular Neuroscience, 1, 2.
+           doi:10.3389/neuro.03.002.2007
+    .. [2] Santoro, B., Chen, S., Luthi, A., Pavlidis, P.,
+           Shumyatsky, G. P., Tibbs, G. R., & Siegelbaum, S. A.
+           (2000). Molecular and functional heterogeneity of
+           hyperpolarization-activated pacemaker channels in the
+           mouse CNS. The Journal of Neuroscience, 20(14), 5264-5275.
+           doi:10.1523/JNEUROSCI.20-14-05264.2000
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = HHTypedNeuron
@@ -544,7 +1006,74 @@ class HCN2_MA2020_GoC(HH):
 
 @register_channel("HCN_SU2015_DCN")
 class HCN_SU2015_DCN(OhmicHH):
-    """Template-based import of ``HCN_SU2015_DCN.mod``."""
+    r"""H-current imported for the deep cerebellar nucleus (DCN) model.
+
+    Ports the single ``m`` gate (power 2) NEURON mechanism
+    ``HCN_SU2015_DCN.mod`` used in the deep-cerebellar-nucleus
+    deposit of (Sudhakar et al., 2015) [2]_.
+
+    .. math::
+
+        \begin{aligned}
+        I_h &= g_{\mathrm{max}} \, m^2 \, (E - V) \\
+        m_\infty &= \frac{1}{1 + \exp((V + 80) / 5)} \\
+        \tau_m &= \frac{400}{\mathrm{qdeltat}}
+        \end{aligned}
+
+    :math:`\tau_m` is a voltage-independent constant, not a function
+    of :math:`V`; ``qdeltat`` is a fixed internal value (default
+    ``1.0``) set in ``__init__`` and is not exposed as a parameter.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.01 mS/cm2``.
+    E : array-like or callable, optional
+        Reversal potential, default ``-45.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    Notes
+    -----
+    This class overrides :meth:`reversal_potential` to return
+    ``self.E`` instead of an ion's reversal potential. The ``m``
+    gate carries no ``q10``/``phi``, so :meth:`HH.gate_phi` resolves
+    to the default ``1.0``.
+
+    Ported from ``HCN_SU2015_DCN.mod``. Its kinetics belong to the
+    deep cerebellar nucleus model of Steuber et al. (2011) [1]_,
+    translated from GENESIS to NEURON by Luthman et al. (2011), and
+    used in Sudhakar et al. (2015) [2]_. ``HCN`` is one of only four
+    mechanism names (with ``CaLVA``, ``NaP`` and ``SK``) that occur
+    as strings in the text of [2]_; the paper does not, however,
+    print the Boltzmann or time constants above for any mechanism --
+    those are established only by direct comparison against the
+    ``.mod`` source, not by a per-mechanism statement in either
+    paper.
+
+    :meth:`f_m_tau` returns the constant ``400.0 / qdeltat`` (400 ms
+    by default), a genuine, finite, voltage-independent time
+    constant -- the gate is **not** instantaneous. The former NEURON
+    ``TABLE`` directive tabulated only ``minf`` over ``[-150, 100]
+    mV``; ``taum`` was never tabulated because it does not depend on
+    voltage, not because it is zero or absent.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658. doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = HHTypedNeuron
@@ -575,7 +1104,85 @@ class HCN_SU2015_DCN(OhmicHH):
 
 @register_channel("HCN_ZH2019_IO")
 class HCN_ZH2019_IO(OhmicHH):
-    """Template-based import of ``HCN_ZH2019_IO.mod``."""
+    r"""Inferior olive somatic h-current, imported from ``HCN_ZH19_IO.mod``.
+
+    A single-gate hyperpolarization-activated current for the
+    single-compartment inferior olive somatic model of Zhang &
+    Santaniello (2019) [2]_. The gating kinetics originate in the
+    inferior olive compartmental model of Schweighofer, Doya, & Kawato
+    (1999) [1]_ and reached this class through the NEURON port of
+    Torben-Nielsen, Segev, & Yarom (2012) (see Notes).
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximum conductance, default ``0.15 mS/cm2``.
+    E : array-like or callable, optional
+        Fixed reversal potential used in place of an ion-derived
+        driving force, default ``-43.0 mV``.
+    name : str, optional
+        Optional module name.
+
+    Notes
+    -----
+    The current is
+
+    .. math::
+
+        I_h = g_{max} \, q \, (E - V)
+
+    with the single gate ``q`` following
+
+    .. math::
+
+        q_\infty(V) = \frac{1}{1 + \exp\left(\dfrac{V + 75\
+        \text{mV}}{5.5\ \text{mV}}\right)}
+
+    .. math::
+
+        \tau_q(V) = \frac{1}{\exp(-0.086\,V/\text{mV} - 14.6)
+        + \exp(0.07\,V/\text{mV} - 1.87)}\ \text{ms}
+
+    ``q`` carries no ``phi``/``q10`` in its :class:`~braincell.channel._base.Gate`
+    declaration, so :meth:`~braincell.channel._base.HH.gate_phi` resolves
+    to the default ``1.0`` and neither rate method is temperature-scaled.
+
+    This mechanism is ported from ``IO/channel/HCN_ZH19_IO.mod``, whose
+    header credits "Somatic h channel from Schweighofer et al., 1999"
+    and porter "Xu Zhang @ UConn, 6-22-2018". The inferior olive neurons
+    modelled by Zhang & Santaniello (2019) [2]_ are **single-compartment**
+    (``nseg = 1``); this class must not be described as part of a
+    multi-compartment inferior olive mechanism.
+
+    In the source `.mod` file the kinetics originate with Schweighofer,
+    Doya, & Kawato (1999) [1]_ and reached ``HCN_ZH19_IO.mod`` through
+    the intermediate NEURON port of Torben-Nielsen, Segev, & Yarom
+    (2012), credited in the header as "B. Torben-Nielsen @ HUJI" on the
+    sibling `Na`/`Kdr`/`Ca` files of the same deposit.
+
+    **Import deviation.** In the upstream `.mod` file the ``rates(v)``
+    call that refreshes ``q_inf``/``tau_q`` lives inside ``BREAKPOINT``;
+    in this deposit's ``HCN_ZH19_IO.mod`` it was relocated into
+    ``DERIVATIVE states``, so the rates are refreshed *before* the
+    ``cnexp`` state update rather than after it. This is a semantic
+    change, not a cosmetic one -- the only other difference from the
+    upstream file is the ``SUFFIX`` rename, and the ``COMMENT`` header
+    is otherwise untouched.
+
+    References
+    ----------
+    .. [1] Schweighofer, N., Doya, K., & Kawato, M. (1999).
+           Electrophysiological properties of inferior olive neurons: A
+           compartmental model. Journal of Neurophysiology, 82(2),
+           804-817. doi:10.1152/jn.1999.82.2.804
+    .. [2] Zhang, X., & Santaniello, S. (2019). Role of cerebellar
+           GABAergic dysfunctions in the origins of essential tremor.
+           Proceedings of the National Academy of Sciences of the
+           United States of America, 116(27), 13592-13601.
+           doi:10.1073/pnas.1817689116
+    """
 
     __module__ = "braincell.channel"
     root_type = HHTypedNeuron

--- a/braincell/channel/hyperpolarization_activated.py
+++ b/braincell/channel/hyperpolarization_activated.py
@@ -280,7 +280,7 @@ class HCN1_MA2025_BC(OhmicHH):
     r"""HCN1 h-current imported for the cerebellar basket cell model.
 
     Ports the single ``h`` gate NEURON mechanism
-    ``HCN1_MA2025_BC.mod`` used in the basket-cell deposit of
+    ``HCN1_MA25_BC.mod`` used in the basket-cell deposit of
     (Masoli et al., 2025) [3]_. The Boltzmann activation curve and
     biexponential time constant are the same functional forms used
     across the ``HCN1_MA2024_PC`` / ``HCN1_RI2021_SC`` siblings; only
@@ -328,16 +328,16 @@ class HCN1_MA2025_BC(OhmicHH):
 
     Notes
     -----
-    Ported from ``HCN1_MA2025_BC.mod``. This class overrides
+    Ported from ``HCN1_MA25_BC.mod``. This class overrides
     :meth:`reversal_potential` to return ``self.E`` instead of an
     ion's reversal potential.
 
     ``HCN1_MA25_BC.mod`` inherits its comment verbatim from the
     ``HCN1_MA24_PC.mod`` Purkinje-cell port, including the note
-    "We call it HCN1 as PC express only HCN1", whose origin is the
-    subunit-identity paper [2]_ -- a claim about Purkinje cells, not
-    this basket-cell channel, and not repeated here as though it
-    were. The default ``temp = 23`` degrees
+    "We call it HCN1 as PC express only HCN1 Santoro et al. 2000",
+    whose origin is the subunit-identity paper [2]_ -- a claim about
+    Purkinje cells, not this basket-cell channel, and not repeated
+    here as though it were. The default ``temp = 23`` degrees
     Celsius is likewise carried over unchanged: Angelo et al. (2007)
     [1]_ did not report a recording temperature, so 23 degrees
     Celsius is the porter's assumption, not a value from that paper.
@@ -412,7 +412,7 @@ class HCN1_MA2024_PC(OhmicHH):
     r"""HCN1 h-current imported for the human Purkinje cell model.
 
     Ports the single ``h`` gate NEURON mechanism
-    ``HCN1_MA2024_PC.mod`` used in the Purkinje-cell deposit of
+    ``HCN1_MA24_PC.mod`` used in the Purkinje-cell deposit of
     (Masoli et al., 2024) [3]_. The Boltzmann activation curve and
     biexponential time constant are the same functional forms used
     across the ``HCN1_MA2025_BC`` / ``HCN1_RI2021_SC`` siblings; only
@@ -460,7 +460,7 @@ class HCN1_MA2024_PC(OhmicHH):
 
     Notes
     -----
-    Ported from ``HCN1_MA2024_PC.mod``. This class overrides
+    Ported from ``HCN1_MA24_PC.mod``. This class overrides
     :meth:`reversal_potential` to return ``self.E`` instead of an
     ion's reversal potential.
 
@@ -544,7 +544,7 @@ class HCN1_RI2021_SC(OhmicHH):
     r"""HCN1 h-current imported for the cerebellar stellate cell model.
 
     Ports the single ``h`` gate NEURON mechanism
-    ``HCN1_RI2021_SC.mod`` used in the stellate-cell deposit of
+    ``HCN1_RI21_SC.mod`` used in the stellate-cell deposit of
     (Rizza et al., 2021) [3]_. The Boltzmann activation curve and
     biexponential time constant are the same functional forms used
     across the ``HCN1_MA2025_BC`` / ``HCN1_MA2024_PC`` siblings; only
@@ -592,7 +592,7 @@ class HCN1_RI2021_SC(OhmicHH):
 
     Notes
     -----
-    Ported from ``HCN1_RI2021_SC.mod``. This class overrides
+    Ported from ``HCN1_RI21_SC.mod``. This class overrides
     :meth:`reversal_potential` to return ``self.E`` instead of an
     ion's reversal potential.
 
@@ -675,7 +675,7 @@ class HCN1_RI2021_SC(OhmicHH):
 class HCN1_MA2020_GoC(HH):
     r"""HCN1 fast/slow h-current imported for the Golgi cell model.
 
-    Ports the two-gate NEURON mechanism ``HCN1_MA2020_GoC.mod`` used
+    Ports the two-gate NEURON mechanism ``HCN1_MA20_GoC.mod`` used
     in the Golgi-cell deposit of (Masoli et al., 2020) [3]_. Two
     independent open-state gates, ``o_fast`` and ``o_slow``, share
     one Boltzmann steady state split by a linear mixing fraction
@@ -734,7 +734,7 @@ class HCN1_MA2020_GoC(HH):
 
     Notes
     -----
-    Ported from ``HCN1_MA2020_GoC.mod``. The former NEURON ``TABLE``
+    Ported from ``HCN1_MA20_GoC.mod``. The former NEURON ``TABLE``
     tabulated ``o_fast_inf``, ``o_slow_inf``, ``tau_f`` and ``tau_s``
     over ``[-100, 30] mV`` and clamped outside that range; BrainCell
     evaluates the continuous formulas above at every call instead, so
@@ -838,7 +838,7 @@ class HCN1_MA2020_GoC(HH):
 class HCN2_MA2020_GoC(HH):
     r"""HCN2 fast/slow h-current imported for the Golgi cell model.
 
-    Ports the two-gate NEURON mechanism ``HCN2_MA2020_GoC.mod`` used
+    Ports the two-gate NEURON mechanism ``HCN2_MA20_GoC.mod`` used
     in the Golgi-cell deposit of (Masoli et al., 2020) [3]_. Two
     independent open-state gates, ``o_fast`` and ``o_slow``, share
     one Boltzmann steady state split by a mixing fraction ``r(V)``
@@ -900,7 +900,7 @@ class HCN2_MA2020_GoC(HH):
 
     Notes
     -----
-    Ported from ``HCN2_MA2020_GoC.mod``. The former NEURON ``TABLE``
+    Ported from ``HCN2_MA20_GoC.mod``. The former NEURON ``TABLE``
     tabulated ``o_fast_inf``, ``o_slow_inf``, ``tau_f`` and ``tau_s``
     over ``[-100, 30] mV`` and clamped outside that range; BrainCell
     evaluates the continuous formulas above at every call instead, so
@@ -1011,7 +1011,7 @@ class HCN_SU2015_DCN(OhmicHH):
     r"""H-current imported for the deep cerebellar nucleus (DCN) model.
 
     Ports the single ``m`` gate (power 2) NEURON mechanism
-    ``HCN_SU2015_DCN.mod`` used in the deep-cerebellar-nucleus
+    ``HCN_SU15_DCN.mod`` used in the deep-cerebellar-nucleus
     deposit of (Sudhakar et al., 2015) [2]_.
 
     .. math::
@@ -1044,7 +1044,7 @@ class HCN_SU2015_DCN(OhmicHH):
     gate carries no ``q10``/``phi``, so :meth:`HH.gate_phi` resolves
     to the default ``1.0``.
 
-    Ported from ``HCN_SU2015_DCN.mod``. Its kinetics belong to the
+    Ported from ``HCN_SU15_DCN.mod``. Its kinetics belong to the
     deep cerebellar nucleus model of Steuber et al. (2011) [1]_,
     translated from GENESIS to NEURON by Luthman et al. (2011), and
     used in Sudhakar et al. (2015) [2]_. ``HCN`` is one of only four

--- a/braincell/channel/hyperpolarization_activated.py
+++ b/braincell/channel/hyperpolarization_activated.py
@@ -334,9 +334,10 @@ class HCN1_MA2025_BC(OhmicHH):
 
     ``HCN1_MA25_BC.mod`` inherits its comment verbatim from the
     ``HCN1_MA24_PC.mod`` Purkinje-cell port, including the note
-    "We call it HCN1 as PC express only HCN1" -- a claim about
-    Purkinje cells, not this basket-cell channel, and not repeated
-    here as though it were. The default ``temp = 23`` degrees
+    "We call it HCN1 as PC express only HCN1", whose origin is the
+    subunit-identity paper [2]_ -- a claim about Purkinje cells, not
+    this basket-cell channel, and not repeated here as though it
+    were. The default ``temp = 23`` degrees
     Celsius is likewise carried over unchanged: Angelo et al. (2007)
     [1]_ did not report a recording temperature, so 23 degrees
     Celsius is the porter's assumption, not a value from that paper.
@@ -597,8 +598,9 @@ class HCN1_RI2021_SC(OhmicHH):
 
     ``HCN1_RI21_SC.mod`` carries the same inherited comment as the
     basket-cell port, "We call it HCN1 as PC express only HCN1
-    Santoro et al. 2000" -- a claim about Purkinje cells, not this
-    stellate-cell channel, and not repeated here as though it were.
+    Santoro et al. 2000" [2]_ -- a claim about Purkinje cells, not
+    this stellate-cell channel, and not repeated here as though it
+    were.
     The default ``temp = 23`` degrees Celsius is carried over
     unchanged from the ``.mod`` file: Angelo et al. (2007) [1]_ did
     not report a recording temperature, so 23 degrees Celsius is the

--- a/braincell/channel/hyperpolarization_activated.py
+++ b/braincell/channel/hyperpolarization_activated.py
@@ -352,7 +352,7 @@ class HCN1_MA2025_BC(OhmicHH):
            Shumyatsky, G. P., Tibbs, G. R., & Siegelbaum, S. A.
            (2000). Molecular and functional heterogeneity of
            hyperpolarization-activated pacemaker channels in the
-           mouse CNS. Journal of Neuroscience, 20(14), 5264-5275.
+           mouse CNS. The Journal of Neuroscience, 20(14), 5264-5275.
            doi:10.1523/JNEUROSCI.20-14-05264.2000
     .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
            Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
@@ -1123,7 +1123,7 @@ class HCN_ZH2019_IO(OhmicHH):
         Fixed reversal potential used in place of an ion-derived
         driving force, default ``-43.0 mV``.
     name : str, optional
-        Optional module name.
+        Optional channel name.
 
     Notes
     -----
@@ -1145,7 +1145,8 @@ class HCN_ZH2019_IO(OhmicHH):
         \tau_q(V) = \frac{1}{\exp(-0.086\,V/\text{mV} - 14.6)
         + \exp(0.07\,V/\text{mV} - 1.87)}\ \text{ms}
 
-    ``q`` carries no ``phi``/``q10`` in its :class:`~braincell.channel._base.Gate`
+    ``q`` carries no ``phi``/``q10`` in its
+    :class:`~braincell.channel._base.Gate`
     declaration, so :meth:`~braincell.channel._base.HH.gate_phi` resolves
     to the default ``1.0`` and neither rate method is temperature-scaled.
 

--- a/braincell/channel/hyperpolarization_activated.py
+++ b/braincell/channel/hyperpolarization_activated.py
@@ -354,13 +354,12 @@ class HCN1_MA2025_BC(OhmicHH):
            hyperpolarization-activated pacemaker channels in the
            mouse CNS. The Journal of Neuroscience, 20(14), 5264-5275.
            doi:10.1523/JNEUROSCI.20-14-05264.2000
-    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
-           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
-           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
-           A., & D'Angelo, E. (2025). Cerebellar basket cell
-           filtering of Purkinje cell responses elicited by low
-           frequency parallel fibre transmission. Scientific
-           Reports, 15(1), 25192. doi:10.1038/s41598-025-09964-2
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
     """
 
     __module__ = "braincell.channel"
@@ -622,7 +621,8 @@ class HCN1_RI2021_SC(OhmicHH):
            Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
            cell computational modeling predicts signal filtering in
            the molecular layer circuit of cerebellum. Scientific
-           Reports, 11(1), 3873. doi:10.1038/s41598-021-83209-w
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
     """
 
     __module__ = "braincell.channel"
@@ -1067,7 +1067,8 @@ class HCN_SU2015_DCN(OhmicHH):
            synaptic integration and heterogeneity in rebound firing
            explored with data-driven models of deep cerebellar
            nucleus cells. Journal of Computational Neuroscience,
-           30(3), 633-658. doi:10.1007/s10827-010-0282-z
+           30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
     .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
            (2015). Cerebellar nuclear neurons use time and rate
            coding to transmit Purkinje neuron pauses. PLOS
@@ -1177,7 +1178,8 @@ class HCN_ZH2019_IO(OhmicHH):
     .. [1] Schweighofer, N., Doya, K., & Kawato, M. (1999).
            Electrophysiological properties of inferior olive neurons: A
            compartmental model. Journal of Neurophysiology, 82(2),
-           804-817. doi:10.1152/jn.1999.82.2.804
+           804-817.
+           doi:10.1152/jn.1999.82.2.804
     .. [2] Zhang, X., & Santaniello, S. (2019). Role of cerebellar
            GABAergic dysfunctions in the origins of essential tremor.
            Proceedings of the National Academy of Sciences of the

--- a/braincell/channel/leaky.py
+++ b/braincell/channel/leaky.py
@@ -36,8 +36,28 @@ __all__ = [
 
 
 class LeakageChannel(Channel):
-    """
-    Base class for leakage channel dynamics.
+    """Base class for leakage channel dynamics.
+
+    A leak conductance is voltage-independent: it has no gating variables
+    and no state to integrate, so every lifecycle hook below is a no-op
+    (or, for :meth:`current`, an obligation for the subclass to fill in).
+    Subclass this directly to model a passive, always-open conductance
+    such as the resting leak of a compartment. Use an ion-specific
+    channel template instead -- :class:`~braincell.channel._base.HH` or
+    :class:`~braincell.channel._base.Markov` -- when the conductance
+    depends on voltage, time, or an ion concentration.
+
+    See Also
+    --------
+    IL : Concrete leak channel with a fixed conductance and reversal
+        potential.
+
+    Notes
+    -----
+    ``root_type`` is :class:`~braincell._base.HHTypedNeuron`: instances
+    are attached to a Hodgkin-Huxley-typed neuron, not to an ion. There
+    is no equation here -- :meth:`current` raises ``NotImplementedError``
+    and must be implemented by a subclass such as :class:`IL`.
     """
 
     __module__ = 'braincell.channel'
@@ -122,14 +142,40 @@ class LeakageChannel(Channel):
 
 @register_channel("IL", aliases=("leaky",))
 class IL(LeakageChannel):
-    """The leakage channel current.
+    r"""The leakage channel current.
+
+    A generic, fixed-conductance leak: :attr:`g_max` and :attr:`E` are
+    constants set at construction and never change with voltage, time,
+    or concentration. Use it for the passive resting leak of a
+    compartment, or as a placeholder before an ion-specific channel is
+    modeled.
 
     Parameters
     ----------
-    g_max : float
-      The leakage conductance.
-    E : float
-      The reversal potential.
+    size : int or sequence of int
+        Shape of the simulation target this channel is attached to.
+    g_max : ArrayLike or Callable, optional
+        Leakage conductance density. Default is ``0.1 mS/cm2``.
+    E : ArrayLike or Callable, optional
+        Leak reversal potential. Default is ``-70.0 mV``.
+    name : str, optional
+        Instance name. Default is ``None``, in which case a name is
+        auto-generated.
+
+    See Also
+    --------
+    LeakageChannel : Abstract base this class implements.
+
+    Notes
+    -----
+    The current follows Ohm's law with a constant driving force:
+
+    .. math::
+
+        I = g_{max} \cdot (E - V)
+
+    Registered with :func:`~braincell.mech.register_channel` under the
+    name ``"IL"``, with ``"leaky"`` as an alias.
     """
 
     __module__ = 'braincell.channel'

--- a/braincell/channel/potassium.py
+++ b/braincell/channel/potassium.py
@@ -2935,7 +2935,147 @@ class Kv1p5_MA2024_PC(HH):
 
 @register_channel("Kv3p3_MA2024_PC")
 class Kv3p3_MA2024_PC(HH):
-    """Template-based import of ``Kv3p3_MA24_PC.mod``."""
+    r"""Kv3.3 high-threshold potassium current of the Purkinje model.
+
+    Fast-activating, non-inactivating high-threshold potassium
+    current imported from the human Purkinje cell model of Masoli
+    et al. (2024) [3]_. Gating is a single ``n`` gate of power 4 in
+    alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_n &= 0.22 \, \exp((V + 16) / 26.5) \\
+        \beta_n &= 0.22 \, \exp(-(V + 16) / 26.5)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. Because the two prefactors are equal,
+    :math:`n_\infty = \alpha_n / (\alpha_n + \beta_n)` is exactly 0.5
+    at -16 mV, and the :math:`n^4` conductance reaches half its
+    maximum near +6.1 mV -- the high activation threshold the source
+    mechanism's ``TITLE`` line describes.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.005 S/cm2``,
+        equivalently ``5.0 mS/cm2``, which is exactly the source
+        mechanism's ``gbar = 0.005 S/cm2``. Most channels in this
+        module spell their default in ``mS/cm2``; this one keeps the
+        ``.mod`` file's own ``S/cm2``, so read the number with care.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        22 degrees Celsius. This equals the gate's reference
+        temperature, so the default temperature factor is exactly 1.
+    gateCurrent : array-like or callable, optional
+        Gating-current switch, default ``0.0`` (dimensionless, off).
+        Any non-zero value enables the gating-current term described
+        below.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv1p1_MA2024_PC : Kv1.1 current of the same model, sharing this
+        class's gating-current construction.
+    Kv3p4_MA2024_PC : The other Kv3-family current of the same model.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Kv3p3_MA24_PC.mod``. No other cell type
+    in this repository imports this mechanism, so unlike most
+    channels in this module it has no sibling ports.
+
+    **Why this class overrides** ``current``. The mechanism emits an
+    optional Kv gating current alongside the ionic current, so
+    :class:`OhmicHH` is not enough. :meth:`current` returns
+
+    .. math::
+
+        g_{\max} \, n^4 \, (E_K - V) - I_{\text{gate}}
+
+    with
+
+    .. math::
+
+        I_{\text{gate}} = n_c \cdot 10^{6} \cdot e_0 \cdot 4 \, z_n
+        \cdot \frac{\mathrm{d}n}{\mathrm{d}t}, \qquad
+        n_c = 10^{12} \, \frac{g_{\max}}{g_{\text{unit}}}
+
+    where :math:`g_{\text{unit}} = 16` pS is the unitary channel
+    conductance, :math:`z_n = 1.9196` the n-gate valence,
+    :math:`e_0 = 1.60217646 \times 10^{-19}` C the elementary charge
+    and :math:`\mathrm{d}n/\mathrm{d}t` the same
+    :math:`\phi(\alpha_n (1 - n) - \beta_n n)` the gate integrates.
+    NEURON emits this term as a separate ``NONSPECIFIC_CURRENT``;
+    BrainCell folds it into the single ``current()`` return, and the
+    subtraction reflects the package's inward-positive sign
+    convention against NMODL's outward-positive one. The term is
+    selected with ``u.math.where`` rather than a Python branch, so
+    ``gateCurrent`` may be an array and the choice stays traceable.
+    The construction is the one :class:`Kv1p1_MA2024_PC` uses; only
+    :math:`z_n` and the rate constants differ.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 2.7`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the rate balance by
+    :math:`\phi = 2.7^{(T - 22)/10}`. The ``.mod`` file instead
+    multiplies ``qt`` into ``alpha`` and ``beta``, which divides its
+    ``taun`` by the same factor. The two forms are algebraically
+    identical.
+
+    **Provenance.** The ``.mod`` header states that the six rate
+    parameters were obtained by least-squares fits to
+    :math:`G/G_{\max}(V)` and :math:`\tau_n(V)` data recorded from
+    rat cerebellar Purkinje neurons by Martina et al. (2007) [1]_,
+    and names the RIKEN implementation published by Akemann et al.
+    (2009) [2]_ as its model reference. The Purkinje-cell paper [3]_
+    names the model this parameterisation was imported from, not the
+    origin of the equations.
+
+    Two header transcription errors are worth knowing about, and
+    neither is reproduced above. The header prints the Martina page
+    range as "563-671"; the published range is 563-571, with a stray
+    unbalanced parenthesis before it. And the mechanism itself is
+    named for the Kv3 family as a whole -- its ``TITLE`` reads
+    "Voltage-gated potassium channel from Kv3 subunits" -- with the
+    specific ".3" arriving only through the ported file's own
+    ``: Suffix from Kv3 to Kv3_3`` rename line, not from either
+    origin paper.
+
+    **Conductance default.** ``0.005 S/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in any of the cited papers.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here.
+
+    References
+    ----------
+    .. [1] Martina, M., Metz, A. E., & Bean, B. P. (2007).
+           Voltage-dependent potassium currents during fast spikes of
+           rat cerebellar Purkinje neurons: inhibition by BDS-I
+           toxin. Journal of Neurophysiology, 97(1), 563-571.
+           doi:10.1152/jn.00269.2006
+    .. [2] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+           Effect of voltage sensitive fluorescent proteins on
+           neuronal excitability. Biophysical Journal, 96(10),
+           3959-3976.
+           doi:10.1016/j.bpj.2009.02.046
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
+
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -2985,7 +3125,160 @@ class Kv3p3_MA2024_PC(HH):
 
 @register_channel("Kv3p4_MA2025_BC")
 class Kv3p4_MA2025_BC(OhmicHH):
-    """Template-based import of ``Kv3p4_MA2025_BC.mod``."""
+    r"""Fast TEA-sensitive potassium current of the basket cell model.
+
+    High-threshold, fast-activating and only partially inactivating
+    potassium current, imported from the
+    cerebellar basket cell model of Masoli et al. (2025) [2]_.
+
+    Gating is an ``m`` gate of power 3 and an ``h`` gate of power 1,
+    both written in steady-state/time-constant form and both
+    evaluated at a junction-potential-corrected voltage
+    :math:`V' = V + 11`:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp(-(V' + 24) / 15.4)} \\
+        h_\infty &= 0.31
+          + \frac{0.69}{1 + \exp((V' + 5.802) / 11.2)}
+        \end{aligned}
+
+    where :math:`V'` is in millivolts. Inactivation is only partial:
+    :math:`h_\infty` decays to a floor of 0.31 rather than to zero,
+    so about 31 per cent of the conductance survives a maintained
+    depolarisation. Both time constants are piecewise, in
+    milliseconds:
+
+    .. math::
+
+        \tau_m = 10^3 \times \begin{cases}
+        3 \, (3.4225 \times 10^{-5}
+          + 0.00498 \, e^{V' / 28.29}), & V' < -35 \\
+        1.2851 \times 10^{-4} + \dfrac{1}{e^{(V' + 100.7)/12.9}
+          + e^{(V' - 56)/(-23.1)}}, & V' \ge -35
+        \end{cases}
+
+    .. math::
+
+        \tau_h = 10^3 \times \begin{cases}
+        0.0012 + 0.0023 \, e^{-0.141 \, V'}, & V' > 0 \\
+        1.2202 \times 10^{-5}
+          + 0.012 \, e^{-((V' + 56.3)/49.6)^2}, & V' \le 0
+        \end{cases}
+
+    Each ladder is selected with ``u.math.where`` on the predicates
+    ``V' < -35`` and ``V' > 0``, so the boundary value itself falls
+    to the second line in both.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.004 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        22 degrees Celsius. See the temperature note below: this
+        default is BrainCell's own, not a value the source mechanism
+        states.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv3p4_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv3p4_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv3p4_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv3p4_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``BC/channel/Kv3p4_MA25_BC.mod``. All five cell-type
+    ports of this mechanism carry the same equations and the same
+    constants, and so do the five BrainCell classes: everything above
+    is shared verbatim with :class:`Kv3p4_MA2020_GoC`,
+    :class:`Kv3p4_MA2020_GrC`, :class:`Kv3p4_MA2024_PC` and
+    :class:`Kv3p4_RI2021_SC`. What differs is only the deposit each
+    was imported from, and therefore the model paper cited below.
+
+    The ``BC`` file additionally declares a ``g_equiv`` RANGE variable
+    and assigns ``g_equiv = gkbar * m^3 * h`` in its ``BREAKPOINT``.
+    That is a diagnostic output for the NEURON comparison harness
+    rather than part of the dynamics, and BrainCell does not port it.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 37 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 37)/10}`. The ``.mod`` file instead
+    divides its ``mtau`` and ``htau`` by the same factor. The two
+    forms are algebraically identical, but it means :meth:`f_m_tau`
+    and :meth:`f_h_tau` return q10-free time constants rather than
+    the mechanism's ``mtau`` and ``htau``.
+
+    **The default temperature is BrainCell's, not the mechanism's.**
+    Unlike most channels in this module, this ``.mod`` file never
+    declares a ``celsius`` value; it reads NEURON's global instead.
+    The ``temp`` default of 22 degrees Celsius is therefore a
+    BrainCell choice, and because it sits 15 degrees below the
+    gates' reference it makes the default temperature factor
+    :math:`\phi \approx 0.192` -- gating roughly 5.2 times slower
+    than at 37 degrees Celsius. Callers reproducing a published
+    simulation should set ``temp`` explicitly.
+
+    **Provenance, and a name the sources do not support.** These files
+    are ModelDB accession 48332's ``kpkj.mod`` renamed. The header
+    lines ": HH TEA-sensitive Purkinje potassium current" and
+    ": Created 8/5/02 - nwg" are the deposit's own, "nwg" being
+    Nathan W. Gouwens, second author of Khaliq et al. (2003) [1]_, and
+    the parameters ``mivh = -24 mV``, ``mik = 15.4`` and
+    ``hiy0 = 0.31`` reproduce that paper's Table 1 row for the current
+    it calls **K fast**. The trailing ``: Suffix from kpkj to Kv3_4``
+    line is a BrainCell-local addition and is not in the deposit. The
+    model paper [2]_ names the deposit this parameterisation was
+    imported from, not the origin of the equations.
+
+    That rename line is the whole basis of the ``Kv3p4`` name, and
+    it does not survive contact with the source. Khaliq et al. call
+    this current K fast throughout and never name a Kv subunit; the
+    strings "Kv3.4", "Kv3.3" and "Kv3.1" appear nowhere in the
+    paper, and its only mention of Kv3 at all is one Discussion
+    sentence observing that the positive activation range is typical
+    of the Kv3 family. **The class name therefore asserts a subunit
+    identity the cited literature does not establish.** Under this
+    project's mismatch policy the name is documented rather than
+    changed: read ``Kv3p4`` as a label for the TEA-sensitive fast K
+    current of Khaliq et al. (2003), which those authors associate
+    with the Kv3 family, and not as a claim about Kv3.4.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here. Do not
+    assume it shares the deviations of its ``Kv4p3`` neighbour,
+    which has three.
+
+    References
+    ----------
+    .. [1] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [2] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -3049,7 +3342,156 @@ class Kv3p4_MA2025_BC(OhmicHH):
 
 @register_channel("Kv3p4_MA2024_PC")
 class Kv3p4_MA2024_PC(OhmicHH):
-    """Template-based import of ``Kv3p4_MA2024_PC.mod``."""
+    r"""Fast TEA-sensitive potassium current of the Purkinje cell model.
+
+    High-threshold, fast-activating and only partially inactivating
+    potassium current, imported from the
+    human Purkinje cell model of Masoli et al. (2024) [2]_.
+
+    Gating is an ``m`` gate of power 3 and an ``h`` gate of power 1,
+    both written in steady-state/time-constant form and both
+    evaluated at a junction-potential-corrected voltage
+    :math:`V' = V + 11`:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp(-(V' + 24) / 15.4)} \\
+        h_\infty &= 0.31
+          + \frac{0.69}{1 + \exp((V' + 5.802) / 11.2)}
+        \end{aligned}
+
+    where :math:`V'` is in millivolts. Inactivation is only partial:
+    :math:`h_\infty` decays to a floor of 0.31 rather than to zero,
+    so about 31 per cent of the conductance survives a maintained
+    depolarisation. Both time constants are piecewise, in
+    milliseconds:
+
+    .. math::
+
+        \tau_m = 10^3 \times \begin{cases}
+        3 \, (3.4225 \times 10^{-5}
+          + 0.00498 \, e^{V' / 28.29}), & V' < -35 \\
+        1.2851 \times 10^{-4} + \dfrac{1}{e^{(V' + 100.7)/12.9}
+          + e^{(V' - 56)/(-23.1)}}, & V' \ge -35
+        \end{cases}
+
+    .. math::
+
+        \tau_h = 10^3 \times \begin{cases}
+        0.0012 + 0.0023 \, e^{-0.141 \, V'}, & V' > 0 \\
+        1.2202 \times 10^{-5}
+          + 0.012 \, e^{-((V' + 56.3)/49.6)^2}, & V' \le 0
+        \end{cases}
+
+    Each ladder is selected with ``u.math.where`` on the predicates
+    ``V' < -35`` and ``V' > 0``, so the boundary value itself falls
+    to the second line in both.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.004 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        22 degrees Celsius. See the temperature note below: this
+        default is BrainCell's own, not a value the source mechanism
+        states.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv3p4_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv3p4_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv3p4_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv3p4_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Kv3p4_MA24_PC.mod``. All five cell-type
+    ports of this mechanism carry the same equations and the same
+    constants, and so do the five BrainCell classes: everything above
+    is shared verbatim with :class:`Kv3p4_MA2020_GoC`,
+    :class:`Kv3p4_MA2020_GrC`, :class:`Kv3p4_MA2025_BC` and
+    :class:`Kv3p4_RI2021_SC`. What differs is only the deposit each
+    was imported from, and therefore the model paper cited below.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 37 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 37)/10}`. The ``.mod`` file instead
+    divides its ``mtau`` and ``htau`` by the same factor. The two
+    forms are algebraically identical, but it means :meth:`f_m_tau`
+    and :meth:`f_h_tau` return q10-free time constants rather than
+    the mechanism's ``mtau`` and ``htau``.
+
+    **The default temperature is BrainCell's, not the mechanism's.**
+    Unlike most channels in this module, this ``.mod`` file never
+    declares a ``celsius`` value; it reads NEURON's global instead.
+    The ``temp`` default of 22 degrees Celsius is therefore a
+    BrainCell choice, and because it sits 15 degrees below the
+    gates' reference it makes the default temperature factor
+    :math:`\phi \approx 0.192` -- gating roughly 5.2 times slower
+    than at 37 degrees Celsius. Callers reproducing a published
+    simulation should set ``temp`` explicitly.
+
+    **Provenance, and a name the sources do not support.** These files
+    are ModelDB accession 48332's ``kpkj.mod`` renamed. The header
+    lines ": HH TEA-sensitive Purkinje potassium current" and
+    ": Created 8/5/02 - nwg" are the deposit's own, "nwg" being
+    Nathan W. Gouwens, second author of Khaliq et al. (2003) [1]_, and
+    the parameters ``mivh = -24 mV``, ``mik = 15.4`` and
+    ``hiy0 = 0.31`` reproduce that paper's Table 1 row for the current
+    it calls **K fast**. The trailing ``: Suffix from kpkj to Kv3_4``
+    line is a BrainCell-local addition and is not in the deposit. The
+    model paper [2]_ names the deposit this parameterisation was
+    imported from, not the origin of the equations.
+
+    That rename line is the whole basis of the ``Kv3p4`` name, and
+    it does not survive contact with the source. Khaliq et al. call
+    this current K fast throughout and never name a Kv subunit; the
+    strings "Kv3.4", "Kv3.3" and "Kv3.1" appear nowhere in the
+    paper, and its only mention of Kv3 at all is one Discussion
+    sentence observing that the positive activation range is typical
+    of the Kv3 family. **The class name therefore asserts a subunit
+    identity the cited literature does not establish.** Under this
+    project's mismatch policy the name is documented rather than
+    changed: read ``Kv3p4`` as a label for the TEA-sensitive fast K
+    current of Khaliq et al. (2003), which those authors associate
+    with the Kv3 family, and not as a claim about Kv3.4.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here. Do not
+    assume it shares the deviations of its ``Kv4p3`` neighbour,
+    which has three.
+
+    References
+    ----------
+    .. [1] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [2] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -3113,7 +3555,160 @@ class Kv3p4_MA2024_PC(OhmicHH):
 
 @register_channel("Kv3p4_RI2021_SC")
 class Kv3p4_RI2021_SC(OhmicHH):
-    """Template-based import of ``Kv3p4_RI2021_SC.mod``."""
+    r"""Fast TEA-sensitive potassium current of the stellate cell model.
+
+    High-threshold, fast-activating and only partially inactivating
+    potassium current, imported from the
+    cerebellar stellate cell model of Rizza et al. (2021) [2]_.
+
+    Gating is an ``m`` gate of power 3 and an ``h`` gate of power 1,
+    both written in steady-state/time-constant form and both
+    evaluated at a junction-potential-corrected voltage
+    :math:`V' = V + 11`:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp(-(V' + 24) / 15.4)} \\
+        h_\infty &= 0.31
+          + \frac{0.69}{1 + \exp((V' + 5.802) / 11.2)}
+        \end{aligned}
+
+    where :math:`V'` is in millivolts. Inactivation is only partial:
+    :math:`h_\infty` decays to a floor of 0.31 rather than to zero,
+    so about 31 per cent of the conductance survives a maintained
+    depolarisation. Both time constants are piecewise, in
+    milliseconds:
+
+    .. math::
+
+        \tau_m = 10^3 \times \begin{cases}
+        3 \, (3.4225 \times 10^{-5}
+          + 0.00498 \, e^{V' / 28.29}), & V' < -35 \\
+        1.2851 \times 10^{-4} + \dfrac{1}{e^{(V' + 100.7)/12.9}
+          + e^{(V' - 56)/(-23.1)}}, & V' \ge -35
+        \end{cases}
+
+    .. math::
+
+        \tau_h = 10^3 \times \begin{cases}
+        0.0012 + 0.0023 \, e^{-0.141 \, V'}, & V' > 0 \\
+        1.2202 \times 10^{-5}
+          + 0.012 \, e^{-((V' + 56.3)/49.6)^2}, & V' \le 0
+        \end{cases}
+
+    Each ladder is selected with ``u.math.where`` on the predicates
+    ``V' < -35`` and ``V' > 0``, so the boundary value itself falls
+    to the second line in both.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.004 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        22 degrees Celsius. See the temperature note below: this
+        default is BrainCell's own, not a value the source mechanism
+        states.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv3p4_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv3p4_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv3p4_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv3p4_MA2025_BC : Basket-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``SC/channel/Kv3p4_RI21_SC.mod``. All five cell-type
+    ports of this mechanism carry the same equations and the same
+    constants, and so do the five BrainCell classes: everything above
+    is shared verbatim with :class:`Kv3p4_MA2020_GoC`,
+    :class:`Kv3p4_MA2020_GrC`, :class:`Kv3p4_MA2024_PC` and
+    :class:`Kv3p4_MA2025_BC`. What differs is only the deposit each
+    was imported from, and therefore the model paper cited below.
+
+    The ``SC`` file additionally declares a ``g_equiv`` RANGE variable
+    and assigns ``g_equiv = gkbar * m^3 * h`` in its ``BREAKPOINT``.
+    That is a diagnostic output for the NEURON comparison harness
+    rather than part of the dynamics, and BrainCell does not port it.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 37 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 37)/10}`. The ``.mod`` file instead
+    divides its ``mtau`` and ``htau`` by the same factor. The two
+    forms are algebraically identical, but it means :meth:`f_m_tau`
+    and :meth:`f_h_tau` return q10-free time constants rather than
+    the mechanism's ``mtau`` and ``htau``.
+
+    **The default temperature is BrainCell's, not the mechanism's.**
+    Unlike most channels in this module, this ``.mod`` file never
+    declares a ``celsius`` value; it reads NEURON's global instead.
+    The ``temp`` default of 22 degrees Celsius is therefore a
+    BrainCell choice, and because it sits 15 degrees below the
+    gates' reference it makes the default temperature factor
+    :math:`\phi \approx 0.192` -- gating roughly 5.2 times slower
+    than at 37 degrees Celsius. Callers reproducing a published
+    simulation should set ``temp`` explicitly.
+
+    **Provenance, and a name the sources do not support.** These files
+    are ModelDB accession 48332's ``kpkj.mod`` renamed. The header
+    lines ": HH TEA-sensitive Purkinje potassium current" and
+    ": Created 8/5/02 - nwg" are the deposit's own, "nwg" being
+    Nathan W. Gouwens, second author of Khaliq et al. (2003) [1]_, and
+    the parameters ``mivh = -24 mV``, ``mik = 15.4`` and
+    ``hiy0 = 0.31`` reproduce that paper's Table 1 row for the current
+    it calls **K fast**. The trailing ``: Suffix from kpkj to Kv3_4``
+    line is a BrainCell-local addition and is not in the deposit. The
+    model paper [2]_ names the deposit this parameterisation was
+    imported from, not the origin of the equations.
+
+    That rename line is the whole basis of the ``Kv3p4`` name, and
+    it does not survive contact with the source. Khaliq et al. call
+    this current K fast throughout and never name a Kv subunit; the
+    strings "Kv3.4", "Kv3.3" and "Kv3.1" appear nowhere in the
+    paper, and its only mention of Kv3 at all is one Discussion
+    sentence observing that the positive activation range is typical
+    of the Kv3 family. **The class name therefore asserts a subunit
+    identity the cited literature does not establish.** Under this
+    project's mismatch policy the name is documented rather than
+    changed: read ``Kv3p4`` as a label for the TEA-sensitive fast K
+    current of Khaliq et al. (2003), which those authors associate
+    with the Kv3 family, and not as a claim about Kv3.4.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here. Do not
+    assume it shares the deviations of its ``Kv4p3`` neighbour,
+    which has three.
+
+    References
+    ----------
+    .. [1] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [2] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -3177,7 +3772,147 @@ class Kv3p4_RI2021_SC(OhmicHH):
 
 @register_channel("Kv4p3_MA2025_BC")
 class Kv4p3_MA2025_BC(OhmicHH):
-    """Template-based import of ``Kv4p3_MA2025_BC.mod``."""
+    r"""A-type transient potassium current of the basket cell model.
+
+    Fast-inactivating A-type potassium current, imported from the
+    cerebellar basket cell model of Masoli et al. (2025) [2]_.
+
+    Gating is an ``a`` gate of power 3 and a ``b`` gate of power 1,
+    each with an explicit Boltzmann steady state and a time constant
+    built from an alpha/beta pair:
+
+    .. math::
+
+        \begin{aligned}
+        a_\infty &= \frac{1}{1 + \exp((V + 38) / (-17))} \\
+        b_\infty &= \frac{1}{1 + \exp((V + 78.8) / 8.4)} \\
+        \tau_a &= \frac{1}{\alpha_a + \beta_a}, \qquad
+        \tau_b = \frac{1}{\alpha_b + \beta_b}
+        \end{aligned}
+
+    with, writing :math:`\sigma(x, y) = 1 / (e^{x/y} + 1)` for the
+    module-level ``_sigm`` helper,
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_a &= 0.8147 \, \sigma(V + 9.17203,\ -23.3271) \\
+        \beta_a &= 0.1655 \big/ e^{(V + 18.2791) / 19.4718} \\
+        \alpha_b &= 0.0368 \, \sigma(V + 111.332,\ 12.8433) \\
+        \beta_b &= 0.0345 \, \sigma(V + 49.9537,\ -8.90123)
+        \end{aligned}
+
+    where :math:`V` is in millivolts, the rates are per millisecond
+    and the time constants are in milliseconds. This class applies
+    no voltage shift, and the reversal potential comes from the
+    potassium ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``3.2 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.0032 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv4p3_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv4p3_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv4p3_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv4p3_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``BC/channel/Kv4p3_MA25_BC.mod``. The five cell-type
+    ports of this mechanism are byte-identical apart from their
+    ``SUFFIX`` line and their ``celsius`` default, and the five
+    BrainCell classes carry the same rate constants: every equation
+    above is shared verbatim with :class:`Kv4p3_MA2020_GoC`,
+    :class:`Kv4p3_MA2020_GrC`, :class:`Kv4p3_MA2024_PC` and
+    :class:`Kv4p3_RI2021_SC`. What differs is the default ``temp``,
+    the deposit each was imported from, and therefore the model paper
+    cited below.
+
+    ``Kalpha_a`` is stored here as a bare float and passed straight to
+    ``_sigm``, whereas :class:`Kv4p3_MA2020_GoC`,
+    :class:`Kv4p3_MA2020_GrC` and :class:`Kv4p3_RI2021_SC` attach
+    ``u.mV`` to it and convert with ``.to_decimal(u.mV)`` at use. The
+    arithmetic is identical -- both forms divide a millivolt
+    difference by -23.3271 -- but the inconsistency is real, and on
+    this documentation-only branch it is recorded rather than fixed.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 25.5 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 25.5)/10}` (about 1.64 at the default
+    30 degrees Celsius). The ``.mod`` file instead multiplies
+    the same ``Q10`` into ``alp_a``, ``bet_a``, ``alp_b`` and
+    ``bet_b``, which divides its ``tau_a`` and ``tau_b`` by that
+    factor. The two forms are algebraically identical, but it means
+    :meth:`f_a_tau` and :meth:`f_b_tau` return q10-free time
+    constants rather than the mechanism's ``tau_a`` and ``tau_b``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` header carries
+    ``Author: E.D'Angelo, T.Nieus, A. Fontana``. That credit line is
+    copy-pasted verbatim across every cell-type port of this
+    mechanism, and it names authors 1, 2 and 7 of an eight-author
+    paper, so it is not treated as a citation here. The kinetics
+    originate in the cerebellar granule cell model of D'Angelo et al.
+    (2001) [1]_; the model paper [2]_ names the deposit this
+    parameterisation was imported from, not the origin of the
+    equations. The commented-out alternatives that remain in the
+    ``.mod`` file -- ``linoid`` forms of each rate, and a
+    "Bardoni Belluzzi" steady-state block -- are never evaluated by
+    the mechanism and are not reproduced here.
+
+    **Conductance default.** ``3.2 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** Three, all recorded against this symbol.
+    First, the original mechanism's NMODL ``TABLE`` over
+    ``[-100, 30] mV``, covering ``a_inf``, ``tau_a``, ``b_inf`` and
+    ``tau_b``, is not reproduced: all four expressions are evaluated
+    per call. NEURON clamped tabulated values to the boundary
+    outside that window, so any BrainCell-versus-NEURON divergence
+    below -100 mV or above 30 mV is expected rather than a port
+    error. Second, the integration method was changed from
+    ``derivimplicit`` to ``cnexp``; the two gate ODEs are
+    independent, so the substitution is exact. Third, four
+    parameters are carried at NEURON's compiled six-significant-
+    figure precision rather than at the ``.mod`` source text's:
+    ``Kalpha_a`` ``-23.32708`` becomes ``-23.3271``, ``Kbeta_a``
+    ``19.47175`` becomes ``19.4718``, ``V0beta_a`` ``-18.27914``
+    becomes ``-18.2791`` and ``V0alpha_b`` ``-111.33209`` becomes
+    ``-111.332``. That rewrite reaches those four parameters only;
+    ordinary in-formula literals keep their source values.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -3252,7 +3987,148 @@ class Kv4p3_MA2025_BC(OhmicHH):
 
 @register_channel("Kv4p3_MA2024_PC")
 class Kv4p3_MA2024_PC(OhmicHH):
-    """Template-based import of ``Kv4p3_MA2024_PC.mod``."""
+    r"""A-type transient potassium current of the Purkinje cell model.
+
+    Fast-inactivating A-type potassium current, imported from the
+    human Purkinje cell model of Masoli et al. (2024) [2]_.
+
+    Gating is an ``a`` gate of power 3 and a ``b`` gate of power 1,
+    each with an explicit Boltzmann steady state and a time constant
+    built from an alpha/beta pair:
+
+    .. math::
+
+        \begin{aligned}
+        a_\infty &= \frac{1}{1 + \exp((V + 38) / (-17))} \\
+        b_\infty &= \frac{1}{1 + \exp((V + 78.8) / 8.4)} \\
+        \tau_a &= \frac{1}{\alpha_a + \beta_a}, \qquad
+        \tau_b = \frac{1}{\alpha_b + \beta_b}
+        \end{aligned}
+
+    with, writing :math:`\sigma(x, y) = 1 / (e^{x/y} + 1)` for the
+    module-level ``_sigm`` helper,
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_a &= 0.8147 \, \sigma(V + 9.17203,\ -23.3271) \\
+        \beta_a &= 0.1655 \big/ e^{(V + 18.2791) / 19.4718} \\
+        \alpha_b &= 0.0368 \, \sigma(V + 111.332,\ 12.8433) \\
+        \beta_b &= 0.0345 \, \sigma(V + 49.9537,\ -8.90123)
+        \end{aligned}
+
+    where :math:`V` is in millivolts, the rates are per millisecond
+    and the time constants are in milliseconds. This class applies
+    no voltage shift, and the reversal potential comes from the
+    potassium ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``3.2 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.0032 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv4p3_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv4p3_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv4p3_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv4p3_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Kv4p3_MA24_PC.mod``. The five cell-type
+    ports of this mechanism are byte-identical apart from their
+    ``SUFFIX`` line and their ``celsius`` default, and the five
+    BrainCell classes carry the same rate constants: every equation
+    above is shared verbatim with :class:`Kv4p3_MA2020_GoC`,
+    :class:`Kv4p3_MA2020_GrC`, :class:`Kv4p3_MA2025_BC` and
+    :class:`Kv4p3_RI2021_SC`. What differs is the default ``temp``,
+    the deposit each was imported from, and therefore the model paper
+    cited below.
+
+    ``Kalpha_a`` is stored here as a bare float and passed straight to
+    ``_sigm``, whereas :class:`Kv4p3_MA2020_GoC`,
+    :class:`Kv4p3_MA2020_GrC` and :class:`Kv4p3_RI2021_SC` attach
+    ``u.mV`` to it and convert with ``.to_decimal(u.mV)`` at use. The
+    arithmetic is identical -- both forms divide a millivolt
+    difference by -23.3271 -- but the inconsistency is real, and on
+    this documentation-only branch it is recorded rather than fixed.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 25.5 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 25.5)/10}` (about 1.64 at the default
+    30 degrees Celsius). The ``.mod`` file instead multiplies
+    the same ``Q10`` into ``alp_a``, ``bet_a``, ``alp_b`` and
+    ``bet_b``, which divides its ``tau_a`` and ``tau_b`` by that
+    factor. The two forms are algebraically identical, but it means
+    :meth:`f_a_tau` and :meth:`f_b_tau` return q10-free time
+    constants rather than the mechanism's ``tau_a`` and ``tau_b``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` header carries
+    ``Author: E.D'Angelo, T.Nieus, A. Fontana``. That credit line is
+    copy-pasted verbatim across every cell-type port of this
+    mechanism, and it names authors 1, 2 and 7 of an eight-author
+    paper, so it is not treated as a citation here. The kinetics
+    originate in the cerebellar granule cell model of D'Angelo et al.
+    (2001) [1]_; the model paper [2]_ names the deposit this
+    parameterisation was imported from, not the origin of the
+    equations. The commented-out alternatives that remain in the
+    ``.mod`` file -- ``linoid`` forms of each rate, and a
+    "Bardoni Belluzzi" steady-state block -- are never evaluated by
+    the mechanism and are not reproduced here.
+
+    **Conductance default.** ``3.2 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** Three, all recorded against this symbol.
+    First, the original mechanism's NMODL ``TABLE`` over
+    ``[-100, 30] mV``, covering ``a_inf``, ``tau_a``, ``b_inf`` and
+    ``tau_b``, is not reproduced: all four expressions are evaluated
+    per call. NEURON clamped tabulated values to the boundary
+    outside that window, so any BrainCell-versus-NEURON divergence
+    below -100 mV or above 30 mV is expected rather than a port
+    error. Second, the integration method was changed from
+    ``derivimplicit`` to ``cnexp``; the two gate ODEs are
+    independent, so the substitution is exact. Third, four
+    parameters are carried at NEURON's compiled six-significant-
+    figure precision rather than at the ``.mod`` source text's:
+    ``Kalpha_a`` ``-23.32708`` becomes ``-23.3271``, ``Kbeta_a``
+    ``19.47175`` becomes ``19.4718``, ``V0beta_a`` ``-18.27914``
+    becomes ``-18.2791`` and ``V0alpha_b`` ``-111.33209`` becomes
+    ``-111.332``. That rewrite reaches those four parameters only;
+    ordinary in-formula literals keep their source values.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -3327,7 +4203,147 @@ class Kv4p3_MA2024_PC(OhmicHH):
 
 @register_channel("Kv4p3_RI2021_SC")
 class Kv4p3_RI2021_SC(OhmicHH):
-    """Template-based import of ``Kv4p3_RI2021_SC.mod``."""
+    r"""A-type transient potassium current of the stellate cell model.
+
+    Fast-inactivating A-type potassium current, imported from the
+    cerebellar stellate cell model of Rizza et al. (2021) [2]_.
+
+    Gating is an ``a`` gate of power 3 and a ``b`` gate of power 1,
+    each with an explicit Boltzmann steady state and a time constant
+    built from an alpha/beta pair:
+
+    .. math::
+
+        \begin{aligned}
+        a_\infty &= \frac{1}{1 + \exp((V + 38) / (-17))} \\
+        b_\infty &= \frac{1}{1 + \exp((V + 78.8) / 8.4)} \\
+        \tau_a &= \frac{1}{\alpha_a + \beta_a}, \qquad
+        \tau_b = \frac{1}{\alpha_b + \beta_b}
+        \end{aligned}
+
+    with, writing :math:`\sigma(x, y) = 1 / (e^{x/y} + 1)` for the
+    module-level ``_sigm`` helper,
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_a &= 0.8147 \, \sigma(V + 9.17203,\ -23.3271) \\
+        \beta_a &= 0.1655 \big/ e^{(V + 18.2791) / 19.4718} \\
+        \alpha_b &= 0.0368 \, \sigma(V + 111.332,\ 12.8433) \\
+        \beta_b &= 0.0345 \, \sigma(V + 49.9537,\ -8.90123)
+        \end{aligned}
+
+    where :math:`V` is in millivolts, the rates are per millisecond
+    and the time constants are in milliseconds. This class applies
+    no voltage shift, and the reversal potential comes from the
+    potassium ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``3.2 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.0032 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv4p3_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv4p3_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv4p3_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv4p3_MA2025_BC : Basket-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``SC/channel/Kv4p3_RI21_SC.mod``. The five cell-type
+    ports of this mechanism are byte-identical apart from their
+    ``SUFFIX`` line and their ``celsius`` default, and the five
+    BrainCell classes carry the same rate constants: every equation
+    above is shared verbatim with :class:`Kv4p3_MA2020_GoC`,
+    :class:`Kv4p3_MA2020_GrC`, :class:`Kv4p3_MA2024_PC` and
+    :class:`Kv4p3_MA2025_BC`. What differs is the default ``temp``,
+    the deposit each was imported from, and therefore the model paper
+    cited below.
+
+    ``Kalpha_a`` is stored here as ``-23.3271 * u.mV`` and converted
+    with ``.to_decimal(u.mV)`` at use, whereas
+    :class:`Kv4p3_MA2024_PC` and :class:`Kv4p3_MA2025_BC` store the
+    same number as a bare float and pass it straight to ``_sigm``. The
+    arithmetic is identical -- both forms divide a millivolt
+    difference by -23.3271 -- but the inconsistency is real, and on
+    this documentation-only branch it is recorded rather than fixed.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 25.5 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 25.5)/10}` (about 1.64 at the default
+    30 degrees Celsius). The ``.mod`` file instead multiplies
+    the same ``Q10`` into ``alp_a``, ``bet_a``, ``alp_b`` and
+    ``bet_b``, which divides its ``tau_a`` and ``tau_b`` by that
+    factor. The two forms are algebraically identical, but it means
+    :meth:`f_a_tau` and :meth:`f_b_tau` return q10-free time
+    constants rather than the mechanism's ``tau_a`` and ``tau_b``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` header carries
+    ``Author: E.D'Angelo, T.Nieus, A. Fontana``. That credit line is
+    copy-pasted verbatim across every cell-type port of this
+    mechanism, and it names authors 1, 2 and 7 of an eight-author
+    paper, so it is not treated as a citation here. The kinetics
+    originate in the cerebellar granule cell model of D'Angelo et al.
+    (2001) [1]_; the model paper [2]_ names the deposit this
+    parameterisation was imported from, not the origin of the
+    equations. The commented-out alternatives that remain in the
+    ``.mod`` file -- ``linoid`` forms of each rate, and a
+    "Bardoni Belluzzi" steady-state block -- are never evaluated by
+    the mechanism and are not reproduced here.
+
+    **Conductance default.** ``3.2 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** Three, all recorded against this symbol.
+    First, the original mechanism's NMODL ``TABLE`` over
+    ``[-100, 30] mV``, covering ``a_inf``, ``tau_a``, ``b_inf`` and
+    ``tau_b``, is not reproduced: all four expressions are evaluated
+    per call. NEURON clamped tabulated values to the boundary
+    outside that window, so any BrainCell-versus-NEURON divergence
+    below -100 mV or above 30 mV is expected rather than a port
+    error. Second, the integration method was changed from
+    ``derivimplicit`` to ``cnexp``; the two gate ODEs are
+    independent, so the substitution is exact. Third, four
+    parameters are carried at NEURON's compiled six-significant-
+    figure precision rather than at the ``.mod`` source text's:
+    ``Kalpha_a`` ``-23.32708`` becomes ``-23.3271``, ``Kbeta_a``
+    ``19.47175`` becomes ``19.4718``, ``V0beta_a`` ``-18.27914``
+    becomes ``-18.2791`` and ``V0alpha_b`` ``-111.33209`` becomes
+    ``-111.332``. That rewrite reaches those four parameters only;
+    ordinary in-formula literals keep their source values.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -3733,7 +4749,157 @@ class Kv1p1_MA2020_GoC(HH):
 
 @register_channel("Kv3p4_MA2020_GoC")
 class Kv3p4_MA2020_GoC(OhmicHH):
-    """Template-based import of ``Kv3p4_MA2020_GoC.mod``."""
+    r"""Fast TEA-sensitive potassium current of the Golgi cell model.
+
+    High-threshold, fast-activating and only partially inactivating
+    potassium current, imported from the
+    cerebellar Golgi cell model of Masoli et al. (2020) [2]_.
+
+    Gating is an ``m`` gate of power 3 and an ``h`` gate of power 1,
+    both written in steady-state/time-constant form and both
+    evaluated at a junction-potential-corrected voltage
+    :math:`V' = V + 11`:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp(-(V' + 24) / 15.4)} \\
+        h_\infty &= 0.31
+          + \frac{0.69}{1 + \exp((V' + 5.802) / 11.2)}
+        \end{aligned}
+
+    where :math:`V'` is in millivolts. Inactivation is only partial:
+    :math:`h_\infty` decays to a floor of 0.31 rather than to zero,
+    so about 31 per cent of the conductance survives a maintained
+    depolarisation. Both time constants are piecewise, in
+    milliseconds:
+
+    .. math::
+
+        \tau_m = 10^3 \times \begin{cases}
+        3 \, (3.4225 \times 10^{-5}
+          + 0.00498 \, e^{V' / 28.29}), & V' < -35 \\
+        1.2851 \times 10^{-4} + \dfrac{1}{e^{(V' + 100.7)/12.9}
+          + e^{(V' - 56)/(-23.1)}}, & V' \ge -35
+        \end{cases}
+
+    .. math::
+
+        \tau_h = 10^3 \times \begin{cases}
+        0.0012 + 0.0023 \, e^{-0.141 \, V'}, & V' > 0 \\
+        1.2202 \times 10^{-5}
+          + 0.012 \, e^{-((V' + 56.3)/49.6)^2}, & V' \le 0
+        \end{cases}
+
+    Each ladder is selected with ``u.math.where`` on the predicates
+    ``V' < -35`` and ``V' > 0``, so the boundary value itself falls
+    to the second line in both.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.004 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        22 degrees Celsius. See the temperature note below: this
+        default is BrainCell's own, not a value the source mechanism
+        states.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv3p4_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv3p4_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv3p4_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv3p4_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``GoC/channel/Kv3p4_MA20_GoC.mod``. All five cell-type
+    ports of this mechanism carry the same equations and the same
+    constants, and so do the five BrainCell classes: everything above
+    is shared verbatim with :class:`Kv3p4_MA2020_GrC`,
+    :class:`Kv3p4_MA2024_PC`, :class:`Kv3p4_MA2025_BC` and
+    :class:`Kv3p4_RI2021_SC`. What differs is only the deposit each
+    was imported from, and therefore the model paper cited below.
+    Reference [2]_ is the Golgi-cell paper specifically -- the
+    companion granule-cell paper of the same year belongs to
+    :class:`Kv3p4_MA2020_GrC`, not to this class.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 37 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 37)/10}`. The ``.mod`` file instead
+    divides its ``mtau`` and ``htau`` by the same factor. The two
+    forms are algebraically identical, but it means :meth:`f_m_tau`
+    and :meth:`f_h_tau` return q10-free time constants rather than
+    the mechanism's ``mtau`` and ``htau``.
+
+    **The default temperature is BrainCell's, not the mechanism's.**
+    Unlike most channels in this module, this ``.mod`` file never
+    declares a ``celsius`` value; it reads NEURON's global instead.
+    The ``temp`` default of 22 degrees Celsius is therefore a
+    BrainCell choice, and because it sits 15 degrees below the
+    gates' reference it makes the default temperature factor
+    :math:`\phi \approx 0.192` -- gating roughly 5.2 times slower
+    than at 37 degrees Celsius. Callers reproducing a published
+    simulation should set ``temp`` explicitly.
+
+    **Provenance, and a name the sources do not support.** These files
+    are ModelDB accession 48332's ``kpkj.mod`` renamed. The header
+    lines ": HH TEA-sensitive Purkinje potassium current" and
+    ": Created 8/5/02 - nwg" are the deposit's own, "nwg" being
+    Nathan W. Gouwens, second author of Khaliq et al. (2003) [1]_, and
+    the parameters ``mivh = -24 mV``, ``mik = 15.4`` and
+    ``hiy0 = 0.31`` reproduce that paper's Table 1 row for the current
+    it calls **K fast**. The trailing ``: Suffix from kpkj to Kv3_4``
+    line is a BrainCell-local addition and is not in the deposit. The
+    model paper [2]_ names the deposit this parameterisation was
+    imported from, not the origin of the equations.
+
+    That rename line is the whole basis of the ``Kv3p4`` name, and
+    it does not survive contact with the source. Khaliq et al. call
+    this current K fast throughout and never name a Kv subunit; the
+    strings "Kv3.4", "Kv3.3" and "Kv3.1" appear nowhere in the
+    paper, and its only mention of Kv3 at all is one Discussion
+    sentence observing that the positive activation range is typical
+    of the Kv3 family. **The class name therefore asserts a subunit
+    identity the cited literature does not establish.** Under this
+    project's mismatch policy the name is documented rather than
+    changed: read ``Kv3p4`` as a label for the TEA-sensitive fast K
+    current of Khaliq et al. (2003), which those authors associate
+    with the Kv3 family, and not as a claim about Kv3.4.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here. Do not
+    assume it shares the deviations of its ``Kv4p3`` neighbour,
+    which has three.
+
+    References
+    ----------
+    .. [1] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [2] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -3797,7 +4963,150 @@ class Kv3p4_MA2020_GoC(OhmicHH):
 
 @register_channel("Kv4p3_MA2020_GoC")
 class Kv4p3_MA2020_GoC(OhmicHH):
-    """Template-based import of ``Kv4p3_MA2020_GoC.mod``."""
+    r"""A-type transient potassium current of the Golgi cell model.
+
+    Fast-inactivating A-type potassium current, imported from the
+    cerebellar Golgi cell model of Masoli et al. (2020) [2]_.
+
+    Gating is an ``a`` gate of power 3 and a ``b`` gate of power 1,
+    each with an explicit Boltzmann steady state and a time constant
+    built from an alpha/beta pair:
+
+    .. math::
+
+        \begin{aligned}
+        a_\infty &= \frac{1}{1 + \exp((V + 38) / (-17))} \\
+        b_\infty &= \frac{1}{1 + \exp((V + 78.8) / 8.4)} \\
+        \tau_a &= \frac{1}{\alpha_a + \beta_a}, \qquad
+        \tau_b = \frac{1}{\alpha_b + \beta_b}
+        \end{aligned}
+
+    with, writing :math:`\sigma(x, y) = 1 / (e^{x/y} + 1)` for the
+    module-level ``_sigm`` helper,
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_a &= 0.8147 \, \sigma(V + 9.17203,\ -23.3271) \\
+        \beta_a &= 0.1655 \big/ e^{(V + 18.2791) / 19.4718} \\
+        \alpha_b &= 0.0368 \, \sigma(V + 111.332,\ 12.8433) \\
+        \beta_b &= 0.0345 \, \sigma(V + 49.9537,\ -8.90123)
+        \end{aligned}
+
+    where :math:`V` is in millivolts, the rates are per millisecond
+    and the time constants are in milliseconds. This class applies
+    no voltage shift, and the reversal potential comes from the
+    potassium ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``3.2 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.0032 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        22 degrees Celsius. This matches the ``celsius = 22 (degC)``
+        written in the source mechanism's ``PARAMETER`` block -- the
+        one line that distinguishes it from the other four ports,
+        which all write 30.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv4p3_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv4p3_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv4p3_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv4p3_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``GoC/channel/Kv4p3_MA20_GoC.mod``. The five cell-type
+    ports of this mechanism are byte-identical apart from their
+    ``SUFFIX`` line and their ``celsius`` default, and the five
+    BrainCell classes carry the same rate constants: every equation
+    above is shared verbatim with :class:`Kv4p3_MA2020_GrC`,
+    :class:`Kv4p3_MA2024_PC`, :class:`Kv4p3_MA2025_BC` and
+    :class:`Kv4p3_RI2021_SC`. What differs is the default ``temp``,
+    the deposit each was imported from, and therefore the model paper
+    cited below. Reference [2]_ is the Golgi-cell paper specifically
+    -- the companion granule-cell paper of the same year belongs to
+    :class:`Kv4p3_MA2020_GrC`, not to this class.
+
+    ``Kalpha_a`` is stored here as ``-23.3271 * u.mV`` and converted
+    with ``.to_decimal(u.mV)`` at use, whereas
+    :class:`Kv4p3_MA2024_PC` and :class:`Kv4p3_MA2025_BC` store the
+    same number as a bare float and pass it straight to ``_sigm``. The
+    arithmetic is identical -- both forms divide a millivolt
+    difference by -23.3271 -- but the inconsistency is real, and on
+    this documentation-only branch it is recorded rather than fixed.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 25.5 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 25.5)/10}` (about 0.681 at the default
+    22 degrees Celsius). The ``.mod`` file instead multiplies
+    the same ``Q10`` into ``alp_a``, ``bet_a``, ``alp_b`` and
+    ``bet_b``, which divides its ``tau_a`` and ``tau_b`` by that
+    factor. The two forms are algebraically identical, but it means
+    :meth:`f_a_tau` and :meth:`f_b_tau` return q10-free time
+    constants rather than the mechanism's ``tau_a`` and ``tau_b``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` header carries
+    ``Author: E.D'Angelo, T.Nieus, A. Fontana``. That credit line is
+    copy-pasted verbatim across every cell-type port of this
+    mechanism, and it names authors 1, 2 and 7 of an eight-author
+    paper, so it is not treated as a citation here. The kinetics
+    originate in the cerebellar granule cell model of D'Angelo et al.
+    (2001) [1]_; the model paper [2]_ names the deposit this
+    parameterisation was imported from, not the origin of the
+    equations. The commented-out alternatives that remain in the
+    ``.mod`` file -- ``linoid`` forms of each rate, and a
+    "Bardoni Belluzzi" steady-state block -- are never evaluated by
+    the mechanism and are not reproduced here.
+
+    **Conductance default.** ``3.2 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** Three, all recorded against this symbol.
+    First, the original mechanism's NMODL ``TABLE`` over
+    ``[-100, 30] mV``, covering ``a_inf``, ``tau_a``, ``b_inf`` and
+    ``tau_b``, is not reproduced: all four expressions are evaluated
+    per call. NEURON clamped tabulated values to the boundary
+    outside that window, so any BrainCell-versus-NEURON divergence
+    below -100 mV or above 30 mV is expected rather than a port
+    error. Second, the integration method was changed from
+    ``derivimplicit`` to ``cnexp``; the two gate ODEs are
+    independent, so the substitution is exact. Third, four
+    parameters are carried at NEURON's compiled six-significant-
+    figure precision rather than at the ``.mod`` source text's:
+    ``Kalpha_a`` ``-23.32708`` becomes ``-23.3271``, ``Kbeta_a``
+    ``19.47175`` becomes ``19.4718``, ``V0beta_a`` ``-18.27914``
+    becomes ``-18.2791`` and ``V0alpha_b`` ``-111.33209`` becomes
+    ``-111.332``. That rewrite reaches those four parameters only;
+    ordinary in-formula literals keep their source values.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -4496,7 +5805,157 @@ class Kv2p2_0010_MA2020_GrC(OhmicHH):
 
 @register_channel("Kv3p4_MA2020_GrC")
 class Kv3p4_MA2020_GrC(OhmicHH):
-    """Template-based import of ``Kv3p4_MA2020_GrC.mod``."""
+    r"""Fast TEA-sensitive potassium current of the granule cell model.
+
+    High-threshold, fast-activating and only partially inactivating
+    potassium current, imported from the
+    cerebellar granule cell model of Masoli et al. (2020) [2]_.
+
+    Gating is an ``m`` gate of power 3 and an ``h`` gate of power 1,
+    both written in steady-state/time-constant form and both
+    evaluated at a junction-potential-corrected voltage
+    :math:`V' = V + 11`:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp(-(V' + 24) / 15.4)} \\
+        h_\infty &= 0.31
+          + \frac{0.69}{1 + \exp((V' + 5.802) / 11.2)}
+        \end{aligned}
+
+    where :math:`V'` is in millivolts. Inactivation is only partial:
+    :math:`h_\infty` decays to a floor of 0.31 rather than to zero,
+    so about 31 per cent of the conductance survives a maintained
+    depolarisation. Both time constants are piecewise, in
+    milliseconds:
+
+    .. math::
+
+        \tau_m = 10^3 \times \begin{cases}
+        3 \, (3.4225 \times 10^{-5}
+          + 0.00498 \, e^{V' / 28.29}), & V' < -35 \\
+        1.2851 \times 10^{-4} + \dfrac{1}{e^{(V' + 100.7)/12.9}
+          + e^{(V' - 56)/(-23.1)}}, & V' \ge -35
+        \end{cases}
+
+    .. math::
+
+        \tau_h = 10^3 \times \begin{cases}
+        0.0012 + 0.0023 \, e^{-0.141 \, V'}, & V' > 0 \\
+        1.2202 \times 10^{-5}
+          + 0.012 \, e^{-((V' + 56.3)/49.6)^2}, & V' \le 0
+        \end{cases}
+
+    Each ladder is selected with ``u.math.where`` on the predicates
+    ``V' < -35`` and ``V' > 0``, so the boundary value itself falls
+    to the second line in both.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.004 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        22 degrees Celsius. See the temperature note below: this
+        default is BrainCell's own, not a value the source mechanism
+        states.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv3p4_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv3p4_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv3p4_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv3p4_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``GrC/channel/Kv3p4_MA20_GrC.mod``. All five cell-type
+    ports of this mechanism carry the same equations and the same
+    constants, and so do the five BrainCell classes: everything above
+    is shared verbatim with :class:`Kv3p4_MA2020_GoC`,
+    :class:`Kv3p4_MA2024_PC`, :class:`Kv3p4_MA2025_BC` and
+    :class:`Kv3p4_RI2021_SC`. What differs is only the deposit each
+    was imported from, and therefore the model paper cited below.
+    Reference [2]_ is the granule-cell paper specifically -- the
+    companion Golgi-cell paper of the same year belongs to
+    :class:`Kv3p4_MA2020_GoC`, not to this class.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 37 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 37)/10}`. The ``.mod`` file instead
+    divides its ``mtau`` and ``htau`` by the same factor. The two
+    forms are algebraically identical, but it means :meth:`f_m_tau`
+    and :meth:`f_h_tau` return q10-free time constants rather than
+    the mechanism's ``mtau`` and ``htau``.
+
+    **The default temperature is BrainCell's, not the mechanism's.**
+    Unlike most channels in this module, this ``.mod`` file never
+    declares a ``celsius`` value; it reads NEURON's global instead.
+    The ``temp`` default of 22 degrees Celsius is therefore a
+    BrainCell choice, and because it sits 15 degrees below the
+    gates' reference it makes the default temperature factor
+    :math:`\phi \approx 0.192` -- gating roughly 5.2 times slower
+    than at 37 degrees Celsius. Callers reproducing a published
+    simulation should set ``temp`` explicitly.
+
+    **Provenance, and a name the sources do not support.** These files
+    are ModelDB accession 48332's ``kpkj.mod`` renamed. The header
+    lines ": HH TEA-sensitive Purkinje potassium current" and
+    ": Created 8/5/02 - nwg" are the deposit's own, "nwg" being
+    Nathan W. Gouwens, second author of Khaliq et al. (2003) [1]_, and
+    the parameters ``mivh = -24 mV``, ``mik = 15.4`` and
+    ``hiy0 = 0.31`` reproduce that paper's Table 1 row for the current
+    it calls **K fast**. The trailing ``: Suffix from kpkj to Kv3_4``
+    line is a BrainCell-local addition and is not in the deposit. The
+    model paper [2]_ names the deposit this parameterisation was
+    imported from, not the origin of the equations.
+
+    That rename line is the whole basis of the ``Kv3p4`` name, and
+    it does not survive contact with the source. Khaliq et al. call
+    this current K fast throughout and never name a Kv subunit; the
+    strings "Kv3.4", "Kv3.3" and "Kv3.1" appear nowhere in the
+    paper, and its only mention of Kv3 at all is one Discussion
+    sentence observing that the positive activation range is typical
+    of the Kv3 family. **The class name therefore asserts a subunit
+    identity the cited literature does not establish.** Under this
+    project's mismatch policy the name is documented rather than
+    changed: read ``Kv3p4`` as a label for the TEA-sensitive fast K
+    current of Khaliq et al. (2003), which those authors associate
+    with the Kv3 family, and not as a claim about Kv3.4.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here. Do not
+    assume it shares the deviations of its ``Kv4p3`` neighbour,
+    which has three.
+
+    References
+    ----------
+    .. [1] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates granule
+           cell subtypes enriching transmission properties at the
+           cerebellum input stage. Communications Biology, 3(1), 222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -4560,7 +6019,148 @@ class Kv3p4_MA2020_GrC(OhmicHH):
 
 @register_channel("Kv4p3_MA2020_GrC")
 class Kv4p3_MA2020_GrC(OhmicHH):
-    """Template-based import of ``Kv4p3_MA2020_GrC.mod``."""
+    r"""A-type transient potassium current of the granule cell model.
+
+    Fast-inactivating A-type potassium current, imported from the
+    cerebellar granule cell model of Masoli et al. (2020) [2]_.
+
+    Gating is an ``a`` gate of power 3 and a ``b`` gate of power 1,
+    each with an explicit Boltzmann steady state and a time constant
+    built from an alpha/beta pair:
+
+    .. math::
+
+        \begin{aligned}
+        a_\infty &= \frac{1}{1 + \exp((V + 38) / (-17))} \\
+        b_\infty &= \frac{1}{1 + \exp((V + 78.8) / 8.4)} \\
+        \tau_a &= \frac{1}{\alpha_a + \beta_a}, \qquad
+        \tau_b = \frac{1}{\alpha_b + \beta_b}
+        \end{aligned}
+
+    with, writing :math:`\sigma(x, y) = 1 / (e^{x/y} + 1)` for the
+    module-level ``_sigm`` helper,
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_a &= 0.8147 \, \sigma(V + 9.17203,\ -23.3271) \\
+        \beta_a &= 0.1655 \big/ e^{(V + 18.2791) / 19.4718} \\
+        \alpha_b &= 0.0368 \, \sigma(V + 111.332,\ 12.8433) \\
+        \beta_b &= 0.0345 \, \sigma(V + 49.9537,\ -8.90123)
+        \end{aligned}
+
+    where :math:`V` is in millivolts, the rates are per millisecond
+    and the time constants are in milliseconds. This class applies
+    no voltage shift, and the reversal potential comes from the
+    potassium ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``3.2 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.0032 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving both gates' q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv4p3_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv4p3_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv4p3_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv4p3_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``GrC/channel/Kv4p3_MA20_GrC.mod``. The five cell-type
+    ports of this mechanism are byte-identical apart from their
+    ``SUFFIX`` line and their ``celsius`` default, and the five
+    BrainCell classes carry the same rate constants: every equation
+    above is shared verbatim with :class:`Kv4p3_MA2020_GoC`,
+    :class:`Kv4p3_MA2024_PC`, :class:`Kv4p3_MA2025_BC` and
+    :class:`Kv4p3_RI2021_SC`. What differs is the default ``temp``,
+    the deposit each was imported from, and therefore the model paper
+    cited below. Reference [2]_ is the granule-cell paper specifically
+    -- the companion Golgi-cell paper of the same year belongs to
+    :class:`Kv4p3_MA2020_GoC`, not to this class.
+
+    ``Kalpha_a`` is stored here as ``-23.3271 * u.mV`` and converted
+    with ``.to_decimal(u.mV)`` at use, whereas
+    :class:`Kv4p3_MA2024_PC` and :class:`Kv4p3_MA2025_BC` store the
+    same number as a bare float and pass it straight to ``_sigm``. The
+    arithmetic is identical -- both forms divide a millivolt
+    difference by -23.3271 -- but the inconsistency is real, and on
+    this documentation-only branch it is recorded rather than fixed.
+
+    **Where the q10 factor is applied.** Both gates declare
+    ``q10 = 3.0`` at a reference of 25.5 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales each
+    :math:`(x_\infty - x)/\tau_x` term by
+    :math:`\phi = 3^{(T - 25.5)/10}` (about 1.64 at the default
+    30 degrees Celsius). The ``.mod`` file instead multiplies
+    the same ``Q10`` into ``alp_a``, ``bet_a``, ``alp_b`` and
+    ``bet_b``, which divides its ``tau_a`` and ``tau_b`` by that
+    factor. The two forms are algebraically identical, but it means
+    :meth:`f_a_tau` and :meth:`f_b_tau` return q10-free time
+    constants rather than the mechanism's ``tau_a`` and ``tau_b``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` header carries
+    ``Author: E.D'Angelo, T.Nieus, A. Fontana``. That credit line is
+    copy-pasted verbatim across every cell-type port of this
+    mechanism, and it names authors 1, 2 and 7 of an eight-author
+    paper, so it is not treated as a citation here. The kinetics
+    originate in the cerebellar granule cell model of D'Angelo et al.
+    (2001) [1]_; the model paper [2]_ names the deposit this
+    parameterisation was imported from, not the origin of the
+    equations. The commented-out alternatives that remain in the
+    ``.mod`` file -- ``linoid`` forms of each rate, and a
+    "Bardoni Belluzzi" steady-state block -- are never evaluated by
+    the mechanism and are not reproduced here.
+
+    **Conductance default.** ``3.2 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** Three, all recorded against this symbol.
+    First, the original mechanism's NMODL ``TABLE`` over
+    ``[-100, 30] mV``, covering ``a_inf``, ``tau_a``, ``b_inf`` and
+    ``tau_b``, is not reproduced: all four expressions are evaluated
+    per call. NEURON clamped tabulated values to the boundary
+    outside that window, so any BrainCell-versus-NEURON divergence
+    below -100 mV or above 30 mV is expected rather than a port
+    error. Second, the integration method was changed from
+    ``derivimplicit`` to ``cnexp``; the two gate ODEs are
+    independent, so the substitution is exact. Third, four
+    parameters are carried at NEURON's compiled six-significant-
+    figure precision rather than at the ``.mod`` source text's:
+    ``Kalpha_a`` ``-23.32708`` becomes ``-23.3271``, ``Kbeta_a``
+    ``19.47175`` becomes ``19.4718``, ``V0beta_a`` ``-18.27914``
+    becomes ``-18.2791`` and ``V0alpha_b`` ``-111.33209`` becomes
+    ``-111.332``. That rewrite reaches those four parameters only;
+    ordinary in-formula literals keep their source values.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates granule
+           cell subtypes enriching transmission properties at the
+           cerebellum input stage. Communications Biology, 3(1), 222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium

--- a/braincell/channel/potassium.py
+++ b/braincell/channel/potassium.py
@@ -5951,9 +5951,10 @@ class Kv3p4_MA2020_GrC(OhmicHH):
            study. The Journal of Neuroscience, 23(12), 4899-4912.
            doi:10.1523/JNEUROSCI.23-12-04899.2003
     .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
-           D'Angelo, E. (2020). Parameter tuning differentiates granule
-           cell subtypes enriching transmission properties at the
-           cerebellum input stage. Communications Biology, 3(1), 222.
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
            doi:10.1038/s42003-020-0953-x
     """
 
@@ -6156,9 +6157,10 @@ class Kv4p3_MA2020_GrC(OhmicHH):
            21(3), 759-770.
            doi:10.1523/JNEUROSCI.21-03-00759.2001
     .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
-           D'Angelo, E. (2020). Parameter tuning differentiates granule
-           cell subtypes enriching transmission properties at the
-           cerebellum input stage. Communications Biology, 3(1), 222.
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
            doi:10.1038/s42003-020-0953-x
     """
 

--- a/braincell/channel/potassium.py
+++ b/braincell/channel/potassium.py
@@ -93,7 +93,96 @@ def _x_over_one_minus_exp_neg_stable(x):
 
 @register_channel("KDR_Ba2002")
 class KDR_Ba2002(OhmicHH):
-    r"""Bazhenov 2002 delayed-rectifier potassium current."""
+    r"""Bazhenov 2002 delayed-rectifier potassium current.
+
+    The fast delayed-rectifier potassium current :math:`I_K` of the
+    thalamocortical sleep-oscillation model of (Bazhenov et al., 2002)
+    [1]_, with :math:`p^4` HH gating and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_p &= \frac{0.032 \times 5}
+                    {\mathrm{exprel}(-(V' - 15) / 5)} \\
+        \beta_p &= 0.5 \exp(-(V' - 10) / 40)
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}`,
+    :math:`\mathrm{exprel}(x) = (e^{x} - 1)/x`, and both rates are in
+    :math:`\mathrm{ms}^{-1}`. Away from :math:`V' = 15` the activation
+    rate is exactly the linoid
+    :math:`0.032 (15 - V') / (\exp((15 - V')/5) - 1)`; ``exprel`` is
+    used only to remove that expression's removable singularity, where
+    the code returns :math:`0.16\ \mathrm{ms}^{-1}` rather than
+    ``0/0``. The gate integrates
+    :math:`\dot{p} = \phi (\alpha_p (1 - p) - \beta_p p)` with
+    :math:`\phi` from :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``10.0 mS/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``3.0``.
+    temp_ref : array-like, optional
+        Reference temperature for ``q10``, default 36 degrees Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both rates, default ``-50.0 mV``
+        (see Notes).
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    K_TM1991 : The same two rate functions with different ``V_sh`` and
+        ``q10`` defaults (see Notes).
+    K_HH1952 : Classical squid-axon delayed rectifier, also :math:`p^4`
+        but with a different rate parameterisation.
+
+    Notes
+    -----
+    The rate functions above are algebraically identical to
+    :class:`K_TM1991`'s -- the Traub & Miles (1991) :math:`\alpha_n` /
+    :math:`\beta_n` pair, written here in the mirrored sign convention.
+    Expanding both classes term by term gives the same two
+    expressions, so the kinetics are not restated separately in
+    :class:`K_TM1991`. The two classes differ only in their shipped
+    defaults: ``V_sh = -50.0 mV`` and ``q10 = 3.0`` here against
+    ``-60.0 mV`` and ``1.0`` there. Their ``g_max`` defaults are the
+    same, ``10.0 mS/cm2``.
+
+    That default matches the value the paper's "Intrinsic currents:
+    thalamus" section gives for thalamocortical relay cells,
+    ``g_K = 10 mS/cm^2``, which is a stronger fingerprint for this
+    attribution than the rate equations alone. The same section states
+    that the model uses "a fast potassium current, I_K (Traub and
+    Miles, 1991)", so the authors themselves attribute these kinetics
+    to that book.
+
+    **The 2002 paper does not print these rate expressions.** It
+    defers them to Bazhenov, Timofeev, Steriade & Sejnowski (1998),
+    J Neurophysiol 79(5), 2730-2748. This docstring therefore records
+    only that the current is the one *used in* Bazhenov et al. (2002)
+    [1]_; in particular the ``V_sh = -50.0 mV`` shift could not be
+    traced to any equation printed in that paper.
+
+    With the shipped defaults ``temp`` equals ``temp_ref``, so the Q10
+    factor is unity and ``q10 = 3.0`` bites only when ``temp`` is
+    changed.
+
+    References
+    ----------
+    .. [1] Bazhenov, M., Timofeev, I., Steriade, M., & Sejnowski, T. J.
+           (2002). Model of thalamocortical slow-wave sleep
+           oscillations and transitions to activated states. The
+           Journal of Neuroscience, 22(19), 8691-8704.
+           doi:10.1523/JNEUROSCI.22-19-08691.2002
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -127,7 +216,96 @@ class KDR_Ba2002(OhmicHH):
 
 @register_channel("K_TM1991")
 class K_TM1991(OhmicHH):
-    r"""Traub and Miles 1991 delayed-rectifier potassium current."""
+    r"""Traub and Miles 1991 delayed-rectifier potassium current.
+
+    The delayed-rectifier potassium current of the hippocampal
+    pyramidal cell model of (Traub & Miles, 1991) [1]_, with
+    :math:`p^4` HH gating and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_p &= \frac{0.032 \times 5}
+                    {\mathrm{exprel}((15 - V') / 5)} \\
+        \beta_p &= 0.5 \exp((10 - V') / 40)
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}`,
+    :math:`\mathrm{exprel}(x) = (e^{x} - 1)/x`, and both rates are in
+    :math:`\mathrm{ms}^{-1}`. Away from :math:`V' = 15` the activation
+    rate is exactly the published linoid
+    :math:`0.032 (15 - V') / (\exp((15 - V')/5) - 1)`; ``exprel`` is
+    used only to remove that expression's removable singularity, where
+    the code returns :math:`0.16\ \mathrm{ms}^{-1}` rather than
+    ``0/0``. The gate integrates
+    :math:`\dot{p} = \phi (\alpha_p (1 - p) - \beta_p p)` with
+    :math:`\phi` from :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``10.0 mS/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``1.0``,
+        i.e. no temperature correction at any temperature (see Notes).
+    temp_ref : array-like, optional
+        Reference temperature for ``q10``, default 36 degrees Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both rates, default ``-60.0 mV``
+        -- **not** ``-63.0 mV`` (see Notes).
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KDR_Ba2002 : The same two rate functions with ``V_sh = -50.0 mV``
+        and ``q10 = 3.0``, as used by Bazhenov et al. (2002).
+    braincell.channel.sodium.Na_TM1991 : Sodium counterpart from the
+        same source mechanism, which ships ``V_sh = -63.0 mV``.
+
+    Notes
+    -----
+    Compared against ``HH2.mod`` from ModelDB accession 3670,
+    Destexhe's NEURON implementation, whose header reads "Equations
+    modified by Traub, for Hippocampal Pyramidal cells, in: Traub &
+    Miles, Neuronal Networks of the Hippocampus, Cambridge, 1991".
+    With ``v2 = v - vtraub`` in the mod file and
+    :math:`V' = (V - V_{sh})/\mathrm{mV}` here, the two rate functions
+    above and the :math:`p^4` gating match the mod file term for term.
+
+    **The shift default is -60 mV, and the two BrainCell ``TM1991``
+    classes do not agree with each other.**
+    :class:`braincell.channel.sodium.Na_TM1991` ships
+    ``V_sh = -63.0 mV`` while this class ships ``-60.0 mV``, although
+    both derive from the same mechanism; the 3 mV divergence is a
+    BrainCell choice, not something inherited from the source. Any
+    sentence about "the Traub & Miles -63 mV shift" is wrong for this
+    class. ``HH2.mod``'s own ``PARAMETER`` block ships a third value,
+    ``vtraub = -55 mV``; the rate equations are unaffected either way,
+    since the shift enters only through ``v2``/:math:`V'`.
+
+    The ``g_max`` default coincides with ``HH2.mod``'s
+    ``gkbar = 0.01 mho/cm^2`` (= ``10 mS/cm2``), but it is documented
+    here as a BrainCell default rather than as a value printed in the
+    book.
+
+    ``HH2.mod`` applies ``tadj = 3^((celsius - 36)/10)``, which is
+    unity at 36 degrees Celsius; the shipped ``q10 = 1.0`` with
+    ``temp_ref`` at 36 degrees Celsius agrees there, but stays unity at
+    every other temperature as well, so raising ``temp`` does not speed
+    this gate unless ``q10`` is also changed.
+
+    References
+    ----------
+    .. [1] Traub, R. D., & Miles, R. (1991). Neuronal networks of the
+           hippocampus. Cambridge University Press.
+           doi:10.1017/CBO9780511895401
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -161,7 +339,92 @@ class K_TM1991(OhmicHH):
 
 @register_channel("K_HH1952")
 class K_HH1952(OhmicHH):
-    r"""Hodgkin-Huxley 1952 potassium current."""
+    r"""Hodgkin-Huxley 1952 delayed-rectifier potassium current.
+
+    The squid giant axon potassium current :math:`I_K` of (Hodgkin &
+    Huxley, 1952) [1]_, with :math:`p^4` HH gating and an ohmic
+    driving force:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_p &= \frac{0.1}{\mathrm{exprel}(-(V' + 10) / 10)} \\
+        \beta_p &= 0.125 \exp(-(V' + 20) / 80)
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}`,
+    :math:`\mathrm{exprel}(x) = (e^{x} - 1)/x`, and both rates are in
+    :math:`\mathrm{ms}^{-1}`. Away from :math:`V' = -10` the
+    activation rate is exactly
+    :math:`0.01 (V' + 10) / (1 - \exp(-(V' + 10)/10))`; ``exprel``
+    only removes that expression's removable singularity, where the
+    code returns :math:`0.1\ \mathrm{ms}^{-1}` rather than ``0/0``.
+    The gate integrates
+    :math:`\dot{p} = \phi (\alpha_p (1 - p) - \beta_p p)` with
+    :math:`\phi` from :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    With the default ``V_sh = -45.0 mV`` -- which places rest at
+    -65 mV in the modern absolute-potential convention -- these expand
+    to the published rates
+    :math:`\alpha_n = 0.01 (V + 55)/(1 - \exp(-(V + 55)/10))` and
+    :math:`\beta_n = 0.125 \exp(-(V + 65)/80)`, with :math:`n^4`
+    gating.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``10.0 mS/cm2``,
+        which is **not** Hodgkin & Huxley's own value (see Notes).
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``3.0``.
+    temp_ref : array-like, optional
+        Reference temperature for ``q10``, default 36 degrees Celsius
+        (see Notes).
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both rates, default ``-45.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    braincell.channel.sodium.Na_HH1952 : Sodium counterpart of the
+        same model, whose ``g_max`` default does match the paper.
+    K_TM1991 : Traub & Miles reparameterisation of the same
+        :math:`p^4` delayed rectifier.
+
+    Notes
+    -----
+    Every rate constant was expanded by hand and compared with the
+    classical Hodgkin-Huxley rate equations; the implementation
+    reproduces them exactly. ``exprel`` changes no value: it removes
+    the removable singularity at the linoid's midpoint only.
+
+    **The default conductance is not the paper's.** Hodgkin & Huxley
+    give :math:`\bar{g}_K = 36\ \mathrm{mS/cm^2}`; this class ships
+    ``10.0 mS/cm2``. Document it as a BrainCell default, not as the
+    published value.
+
+    **The default temperature is not the paper's either.** The rates
+    above were measured at 6.3 degrees Celsius, whereas ``temp`` and
+    ``temp_ref`` both default to 36 degrees Celsius, which makes the
+    Q10 correction a no-op as shipped. ``q10 = 3.0`` is Hodgkin &
+    Huxley's own factor-of-three-per-ten-degrees, but the shipped
+    defaults do not reproduce the paper's 6.3 degrees Celsius
+    behaviour.
+
+    References
+    ----------
+    .. [1] Hodgkin, A. L., & Huxley, A. F. (1952). A quantitative
+           description of membrane current and its application to
+           conduction and excitation in nerve. The Journal of
+           Physiology, 117(4), 500-544.
+           doi:10.1113/jphysiol.1952.sp004764
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -195,7 +458,108 @@ class K_HH1952(OhmicHH):
 
 @register_channel("KA1_HM1992")
 class KA1_HM1992(OhmicHH):
-    r"""Huguenard & McCormick 1992 IA1 potassium current."""
+    r"""Huguenard & McCormick 1992 A-type potassium current (IA1).
+
+    The first of the two components into which (Huguenard &
+    McCormick, 1992) [1]_ splits the rapidly inactivating transient
+    potassium current :math:`I_A` of thalamic relay neurons, with
+    :math:`p^4 q` HH gating and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 60) / 8.5)} \\
+        \tau_p &= \frac{1}
+                  {\exp((V' + 35.8) / 19.7) + \exp(-(V' + 79.7) / 12.7)}
+                  + 0.37 \\
+        q_\infty &= \frac{1}{1 + \exp((V' + 78) / 6)} \\
+        \tau_q &= \begin{cases}
+                  \left[\exp((V' + 46) / 5)
+                  + \exp(-(V' + 238) / 37.5)\right]^{-1} & V' < -63 \\
+                  19 & V' \geq -63
+                  \end{cases}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and the time
+    constants are in milliseconds, further scaled per gate by
+    :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``30.0 mS/cm2``
+        (see Notes).
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``1.0``.
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 36 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default ``1.0``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 36 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``0.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KA2_HM1992 : The other :math:`I_A` component of the same model;
+        it differs from this class only in ``p_inf`` and ``g_max``
+        (see Notes).
+    KK2A_HM1992 : Slowly inactivating :math:`I_{K2}` component of the
+        same model.
+    KK2B_HM1992 : The other :math:`I_{K2}` component.
+
+    Notes
+    -----
+    The paper's published abstract enumerates exactly four currents,
+    which map onto BrainCell as: :math:`I_T` ->
+    :class:`~braincell.channel.CaT_HM1992`; :math:`I_A` ->
+    :class:`KA1_HM1992` / :class:`KA2_HM1992`; :math:`I_{K2}` ->
+    :class:`KK2A_HM1992` / :class:`KK2B_HM1992`; and :math:`I_h` ->
+    :class:`~braincell.channel.HCN_HM1992`.
+
+    **One divergence between the shipped pair and the paper's own
+    description, recorded rather than corrected.** The abstract says
+    :math:`I_A` "was modeled by assuming two components with different
+    time constants of inactivation". In BrainCell the two components'
+    inactivation is *identical*: :class:`KA1_HM1992` and
+    :class:`KA2_HM1992` carry the same ``q_inf``, the same piecewise
+    ``tau_q`` and even the same ``tau_p``, and differ only in the
+    activation midpoint and slope (-60 / 8.5 here, -36 / 20 there)
+    and in the default conductance (30 against 20 mS/cm2). The
+    :math:`I_{K2}` pair does differ in inactivation, as the paper
+    describes for that current.
+
+    The ``tau_q`` branches do not meet: at :math:`V' = -63` the lower
+    branch evaluates to about 23.4 ms while the class returns the
+    constant 19 ms. The discontinuity is in the source
+    parameterisation, not introduced here; the code applies the
+    expression strictly below -63 and the constant at and above it.
+
+    Both Q10 factors default to ``1.0``, so with the shipped defaults
+    neither gate is temperature-scaled at any temperature; each gate
+    has its own ``q10``/``temp_ref`` pair and is scaled independently.
+    The ``g_max`` default is a BrainCell value: the attribution for
+    this key was established from the paper's current inventory, not
+    by comparing conductance densities.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -248,7 +612,105 @@ class KA1_HM1992(OhmicHH):
 
 @register_channel("KA2_HM1992")
 class KA2_HM1992(OhmicHH):
-    r"""Huguenard & McCormick 1992 IA2 potassium current."""
+    r"""Huguenard & McCormick 1992 A-type potassium current (IA2).
+
+    The second of the two components into which (Huguenard &
+    McCormick, 1992) [1]_ splits the rapidly inactivating transient
+    potassium current :math:`I_A` of thalamic relay neurons, with
+    :math:`p^4 q` HH gating and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 36) / 20)} \\
+        \tau_p &= \frac{1}
+                  {\exp((V' + 35.8) / 19.7) + \exp(-(V' + 79.7) / 12.7)}
+                  + 0.37 \\
+        q_\infty &= \frac{1}{1 + \exp((V' + 78) / 6)} \\
+        \tau_q &= \begin{cases}
+                  \left[\exp((V' + 46) / 5)
+                  + \exp(-(V' + 238) / 37.5)\right]^{-1} & V' < -63 \\
+                  19 & V' \geq -63
+                  \end{cases}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and the time
+    constants are in milliseconds, further scaled per gate by
+    :meth:`~braincell.channel._base.HH.gate_phi`. Only
+    :math:`p_\infty` differs from :class:`KA1_HM1992`: its activation
+    curve is 24 mV more depolarized and considerably shallower.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``20.0 mS/cm2``
+        (see Notes).
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``1.0``.
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 36 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default ``1.0``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 36 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``0.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KA1_HM1992 : The other :math:`I_A` component of the same model,
+        with a lower activation midpoint and a steeper slope.
+    KK2A_HM1992 : Slowly inactivating :math:`I_{K2}` component of the
+        same model.
+    KK2B_HM1992 : The other :math:`I_{K2}` component.
+
+    Notes
+    -----
+    The paper's published abstract enumerates exactly four currents,
+    which map onto BrainCell as: :math:`I_T` ->
+    :class:`~braincell.channel.CaT_HM1992`; :math:`I_A` ->
+    :class:`KA1_HM1992` / :class:`KA2_HM1992`; :math:`I_{K2}` ->
+    :class:`KK2A_HM1992` / :class:`KK2B_HM1992`; and :math:`I_h` ->
+    :class:`~braincell.channel.HCN_HM1992`.
+
+    **One divergence between the shipped pair and the paper's own
+    description, recorded rather than corrected.** The abstract says
+    :math:`I_A` "was modeled by assuming two components with different
+    time constants of inactivation". In BrainCell the two components'
+    inactivation is *identical*: this class and :class:`KA1_HM1992`
+    carry the same ``q_inf``, the same piecewise ``tau_q`` and even
+    the same ``tau_p``, and differ only in the activation midpoint and
+    slope and in the default conductance. The :math:`I_{K2}` pair does
+    differ in inactivation, as the paper describes for that current.
+
+    The ``tau_q`` branches do not meet: at :math:`V' = -63` the lower
+    branch evaluates to about 23.4 ms while the class returns the
+    constant 19 ms. The discontinuity is in the source
+    parameterisation, not introduced here.
+
+    Both Q10 factors default to ``1.0``, so with the shipped defaults
+    neither gate is temperature-scaled at any temperature. The
+    ``g_max`` default is a BrainCell value: the attribution for this
+    key was established from the paper's current inventory, not by
+    comparing conductance densities.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -301,7 +763,92 @@ class KA2_HM1992(OhmicHH):
 
 @register_channel("KK2A_HM1992")
 class KK2A_HM1992(OhmicHH):
-    r"""Huguenard & McCormick 1992 IK2a potassium current."""
+    r"""Huguenard & McCormick 1992 slow potassium current (IK2a).
+
+    The first of the two components into which (Huguenard &
+    McCormick, 1992) [1]_ splits the slowly inactivating potassium
+    current :math:`I_{K2}` of thalamic relay neurons, with :math:`p q`
+    HH gating (both gates to the first power) and an ohmic driving
+    force:
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 43) / 17)} \\
+        \tau_p &= \frac{1}
+                  {\exp((V' - 81) / 25.6) + \exp(-(V' + 132) / 18)}
+                  + 9.9 \\
+        q_\infty &= \frac{1}{1 + \exp((V' + 58) / 10.6)} \\
+        \tau_q &= \frac{1}
+                  {\exp((V' - 1329) / 200) + \exp(-(V' + 130) / 7.1)}
+                  + 120
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and the time
+    constants are in milliseconds, further scaled per gate by
+    :meth:`~braincell.channel._base.HH.gate_phi`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``10.0 mS/cm2``
+        (see Notes).
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``1.0``.
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 36 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default ``1.0``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 36 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``0.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KK2B_HM1992 : The other :math:`I_{K2}` component of the same
+        model; it shares every rate function except ``tau_q``.
+    KA1_HM1992 : Transient :math:`I_A` component of the same model.
+    KA2_HM1992 : The other :math:`I_A` component.
+
+    Notes
+    -----
+    The paper's published abstract enumerates exactly four currents,
+    which map onto BrainCell as: :math:`I_T` ->
+    :class:`~braincell.channel.CaT_HM1992`; :math:`I_A` ->
+    :class:`KA1_HM1992` / :class:`KA2_HM1992`; :math:`I_{K2}` ->
+    :class:`KK2A_HM1992` / :class:`KK2B_HM1992`; and :math:`I_h` ->
+    :class:`~braincell.channel.HCN_HM1992`. The abstract states that
+    :math:`I_{K2}` "was also modeled by assuming two components", and
+    this pair does implement that split in the inactivation time
+    constant: ``tau_q`` here is the continuous expression above, while
+    :class:`KK2B_HM1992` evaluates the same bracket only below
+    :math:`V' = -70` and returns a constant 8.9 ms above it.
+
+    Both Q10 factors default to ``1.0``, so with the shipped defaults
+    neither gate is temperature-scaled at any temperature; each gate
+    has its own ``q10``/``temp_ref`` pair and is scaled independently.
+    The ``g_max`` default is a BrainCell value: the attribution for
+    this key was established from the paper's current inventory, not
+    by comparing conductance densities.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -350,7 +897,100 @@ class KK2A_HM1992(OhmicHH):
 
 @register_channel("KK2B_HM1992")
 class KK2B_HM1992(OhmicHH):
-    r"""Huguenard & McCormick 1992 IK2b potassium current."""
+    r"""Huguenard & McCormick 1992 slow potassium current (IK2b).
+
+    The second of the two components into which (Huguenard &
+    McCormick, 1992) [1]_ splits the slowly inactivating potassium
+    current :math:`I_{K2}` of thalamic relay neurons, with :math:`p q`
+    HH gating (both gates to the first power) and an ohmic driving
+    force:
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 43) / 17)} \\
+        \tau_p &= \frac{1}
+                  {\exp((V' - 81) / 25.6) + \exp(-(V' + 132) / 18)}
+                  + 9.9 \\
+        q_\infty &= \frac{1}{1 + \exp((V' + 58) / 10.6)} \\
+        \tau_q &= \begin{cases}
+                  \left[\exp((V' - 1329) / 200)
+                  + \exp(-(V' + 130) / 7.1)\right]^{-1} & V' < -70 \\
+                  8.9 & V' \geq -70
+                  \end{cases}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and the time
+    constants are in milliseconds, further scaled per gate by
+    :meth:`~braincell.channel._base.HH.gate_phi`. Only :math:`\tau_q`
+    differs from :class:`KK2A_HM1992`, which uses the same bracket at
+    every voltage and adds a constant 120 ms to it.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``10.0 mS/cm2``
+        (see Notes).
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factors, default 36
+        degrees Celsius.
+    q10_p : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``1.0``.
+    temp_ref_p : array-like, optional
+        Reference temperature for ``q10_p``, default 36 degrees
+        Celsius.
+    q10_q : array-like or callable, optional
+        Q10 scaling factor for the inactivation gate, default ``1.0``.
+    temp_ref_q : array-like, optional
+        Reference temperature for ``q10_q``, default 36 degrees
+        Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``0.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KK2A_HM1992 : The other :math:`I_{K2}` component of the same
+        model; it shares every rate function except ``tau_q``.
+    KA1_HM1992 : Transient :math:`I_A` component of the same model.
+    KA2_HM1992 : The other :math:`I_A` component.
+
+    Notes
+    -----
+    The paper's published abstract enumerates exactly four currents,
+    which map onto BrainCell as: :math:`I_T` ->
+    :class:`~braincell.channel.CaT_HM1992`; :math:`I_A` ->
+    :class:`KA1_HM1992` / :class:`KA2_HM1992`; :math:`I_{K2}` ->
+    :class:`KK2A_HM1992` / :class:`KK2B_HM1992`; and :math:`I_h` ->
+    :class:`~braincell.channel.HCN_HM1992`. The abstract states that
+    :math:`I_{K2}` "was also modeled by assuming two components", and
+    the inactivation time constant is where this pair differs.
+
+    **The two ``tau_q`` branches are far apart at the switch.** Just
+    below :math:`V' = -70` the expression evaluates to roughly 885 ms,
+    while at and above -70 the class returns 8.9 ms -- a jump of two
+    orders of magnitude at a single point. This is the shipped
+    parameterisation, transcribed here rather than smoothed; the code
+    applies the expression strictly below -70 and the constant at and
+    above it.
+
+    Both Q10 factors default to ``1.0``, so with the shipped defaults
+    neither gate is temperature-scaled at any temperature. The
+    ``g_max`` default is a BrainCell value: the attribution for this
+    key was established from the paper's current inventory, not by
+    comparing conductance densities.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of
+           the currents involved in rhythmic oscillations in thalamic
+           relay neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -403,7 +1043,92 @@ class KK2B_HM1992(OhmicHH):
 
 @register_channel("KNI_Ya1989")
 class KNI_Ya1989(OhmicHH):
-    r"""Yamada 1989 slow non-inactivating potassium current."""
+    r"""Yamada 1989 slow non-inactivating potassium current.
+
+    The muscarine-sensitive M current :math:`I_M` of (Yamada, Koch, &
+    Adams, 1989) [1]_ -- a slow, non-inactivating potassium current
+    with a single activation gate to the first power and an ohmic
+    driving force:
+
+    .. math::
+
+        \begin{aligned}
+        p_\infty &= \frac{1}{1 + \exp(-(V' + 35) / 10)} \\
+        \tau_p &= \frac{\tau_{max}}
+                  {3.3 \exp((V' + 35) / 20) + \exp(-(V' + 35) / 20)}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and
+    :math:`\tau_{max}` is the ``tau_max`` parameter read in
+    milliseconds. :math:`\tau_p` is further scaled by
+    :meth:`~braincell.channel._base.HH.gate_phi`. There is no
+    inactivation gate: the conductance is :math:`g_{max} p`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.004 mS/cm2``
+        (see Notes).
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for the activation gate, default ``1.0``,
+        i.e. no temperature correction (see Notes).
+    temp_ref : array-like, optional
+        Reference temperature for ``q10``, default 36 degrees Celsius.
+    tau_max : array-like or callable, optional
+        Peak time constant scaling :math:`\tau_p`. Defaults to
+        ``4000.0 ms`` (see Notes).
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both rates, default ``0.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KK2A_HM1992 : Slowly inactivating thalamic potassium current, for
+        contrast: this class does not inactivate at all.
+
+    Notes
+    -----
+    Compared against ``IM.mod`` from ModelDB accession 3817, whose
+    header reads "Model taken from Yamada, W.M., Koch, C. and Adams,
+    P.R. Multiple channels and calcium dynamics. In: Methods in
+    Neuronal Modeling, edited by C. Koch and I. Segev, MIT press,
+    1989, p 97-134." The mod file computes exactly the two functions
+    above and a single, non-inactivating, linear-in-:math:`m`
+    potassium conductance; this class implements them with one
+    :class:`~braincell.channel._base.Gate` of power 1. The current is
+    the M current of the bullfrog sympathetic ganglion B-type cell,
+    which is the chapter's subject.
+
+    **Two shipped defaults diverge from that reference
+    implementation.** ``IM.mod`` ships ``taumax = 1000 ms`` and
+    ``gkbar = 1e-6 mho/cm^2`` (= ``0.001 mS/cm2``), whereas this class
+    defaults to ``tau_max = 4000.0 ms`` and
+    ``g_max = 0.004 mS/cm2``. Both are BrainCell defaults and neither
+    is a value from the chapter.
+
+    **The temperature handling diverges too.** ``IM.mod`` assumes
+    Q10 = 2.3 referenced to 36 degrees Celsius; this class defaults to
+    ``q10 = 1.0``, so as shipped there is no temperature correction at
+    any temperature.
+
+    Sources disagree on the chapter's final page: the machine-readable
+    bibliographic record gives 97-133, used in the entry below, while
+    ``IM.mod``'s header gives 97-134. The discrepancy is recorded
+    rather than adjudicated.
+
+    References
+    ----------
+    .. [1] Yamada, W. M., Koch, C., & Adams, P. R. (1989). Multiple
+           channels and calcium dynamics. In C. Koch & I. Segev
+           (Eds.), Methods in neuronal modeling: From synapses to
+           networks (pp. 97-133). MIT Press.
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -440,7 +1165,50 @@ class KNI_Ya1989(OhmicHH):
 
 @register_channel("K_Leak")
 class K_Leak(Channel):
-    """Potassium leak current."""
+    r"""Potassium leak current.
+
+    A voltage-independent, always-open potassium conductance:
+
+    .. math::
+
+        I = g_{max} \, (E_K - V)
+
+    Unlike :class:`~braincell.channel.IL`, the reversal potential is
+    not a parameter of this class -- it is taken from the potassium
+    ion object this channel is attached to, so ``E_K`` follows whatever
+    the ion computes (fixed, Nernst, or concentration-driven). There
+    are no gating variables and no state to integrate:
+    :meth:`init_state`, :meth:`reset_state` and
+    :meth:`compute_derivative` are all no-ops.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Leak conductance density. Defaults to ``0.005 mS/cm2``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    braincell.channel.IL : Ion-independent leak with its own fixed
+        reversal potential parameter.
+    braincell.ion.Potassium : Ion object supplying ``E_K``.
+
+    Notes
+    -----
+    This class has **no primary literature source**, and that is a
+    determination rather than an omission: the current law is
+    textbook Ohm's law and the ``0.005 mS/cm2`` default is a
+    conventional placeholder that any caller overrides. No source
+    model was identified for it, so the class deliberately ships
+    without a ``References`` section.
+
+    ``root_type`` is :class:`~braincell.ion.Potassium`, so the channel
+    must be attached to a potassium ion; the ion, not the channel,
+    owns the driving force.
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -469,6 +1237,94 @@ class K_Leak(Channel):
 
 @register_channel("K_Kv_test")
 class K_Kv_test(OhmicHH):
+    r"""Scratch Kv fixture built on the generic vtrap rate form.
+
+    A single-gate potassium channel whose activation uses the generic
+    NEURON ``vtrap`` alpha/beta idiom, with the Boltzmann midpoint,
+    slope and the two rate scales exposed as parameters:
+
+    .. math::
+
+        \begin{aligned}
+        n_\infty &= \frac{1}{1 + \exp(-(V' - v_{12}) / q)} \\
+        \alpha_n &= \frac{R_a (V' - v_{12})}
+                    {1 - \exp(-(V' - v_{12}) / q)} \\
+        \beta_n &= \frac{R_b (V' - v_{12})}
+                   {\exp((V' - v_{12}) / q) - 1} \\
+        \tau_n &= \frac{1}{\alpha_n + \beta_n}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and :math:`v_{12}`
+    and :math:`q` are read in millivolts. The gate is declared in the
+    ``inf``/``tau`` form, so :math:`\alpha_n` and :math:`\beta_n`
+    above are assembled inside :meth:`f_n_tau` rather than exposed as
+    rate methods; the code writes :math:`\beta_n` equivalently as
+    :math:`-R_b (V' - v_{12}) / (1 - \exp((V' - v_{12}) / q))`.
+
+    **This class is a fixture, not a model of a published
+    mechanism** -- see Notes before using it for anything but
+    exercising the template layer.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.0 S/cm2``, i.e.
+        an instance carries no current until it is set.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to the rates, default ``0.0 mV``.
+    temp : array-like, optional
+        Absolute temperature, default 25 degrees Celsius. Inert as
+        shipped (see Notes).
+    Ra : array-like or callable, optional
+        Forward rate scale. Defaults to ``0.02 / (mV ms)``.
+    Rb : array-like or callable, optional
+        Backward rate scale. Defaults to ``0.006 / (mV ms)``.
+    q : array-like or callable, optional
+        Slope factor of the activation curve. Defaults to ``9.0 mV``.
+    v12 : array-like or callable, optional
+        Half-activation voltage. Defaults to ``25.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    K_HH1952 : Delayed rectifier with a verified literature source,
+        for a channel of this shape that is a model of something.
+
+    Notes
+    -----
+    This class has **no primary literature source**, and that is a
+    determination rather than an omission -- though a weaker one than
+    for the other citation-free symbols in this package. Three things
+    mark it as a scratch or template fixture: its name, its zero
+    default conductance, and its unit Q10. Its rate form is the
+    generic ``vtrap`` alpha/beta idiom that recurs across dozens of
+    unrelated NEURON ``kv.mod`` files and identifies no particular
+    one. **No specific source was pursued**, which is not the same as
+    establishing that none exists; if a later task identifies one,
+    that is an addition rather than a contradiction of anything
+    recorded here. The class therefore ships without a ``References``
+    section.
+
+    ``temp_ref`` (23 degrees Celsius) and ``Q10_n`` (``1.0``) are
+    assigned in :meth:`__init__` as fixed attributes rather than
+    exposed as constructor parameters. ``temp`` enters the gate only
+    through :math:`Q_{10}^{(T - T_{ref})/10}`, and with a unit
+    ``Q10_n`` that factor is 1 at every temperature, so changing
+    ``temp`` has no effect on this channel.
+
+    **Numerical caveat.** Unlike the sibling classes in this module,
+    which route their linoids through ``exprel`` or an explicit
+    ``where`` guard, :meth:`f_n_tau` evaluates the two quotients
+    directly. At exactly :math:`V' = v_{12}` both are ``0/0`` and the
+    method returns ``nan``, although the limit is finite --
+    :math:`1 / (q (R_a + R_b))`, about 4.3 ms with the shipped
+    defaults. Away from that single point the expression is
+    well-behaved.
+    """
+
     __module__ = "braincell.channel"
     root_type = Potassium
     gates = (Gate("n", q10="Q10_n", temp_ref="temp_ref"),)
@@ -516,7 +1372,91 @@ class K_Kv_test(OhmicHH):
 
 @register_channel("fKdr_SU2015_DCN")
 class fKdr_SU2015_DCN(OhmicHH):
-    """Template-based import of ``fKdr_SU2015_DCN.mod``."""
+    r"""Fast delayed rectifier of the DCN model (Sudhakar 2015).
+
+    The fast delayed-rectifier potassium current of the deep
+    cerebellar nucleus (DCN) neuron model used by (Sudhakar et al.,
+    2015) [2]_, with :math:`m^4` HH gating and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp((V + 40) / -7.8)} \\
+        \tau_m &= \left(\frac{13.9}
+                  {\exp((V + 40) / 12) + \exp((V + 40) / -13)}
+                  + 0.1\right) \Big/ q_{\Delta t}
+        \end{aligned}
+
+    where :math:`V` is in millivolts -- this class applies no voltage
+    shift -- and :math:`\tau_m` is in milliseconds. The reversal
+    potential comes from the potassium ion object, not from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.01 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gbar = 1e-5 siemens/cm2``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    sKdr_SU2015_DCN : Slow delayed rectifier of the same DCN model,
+        with the same gating shape and slower, more depolarized
+        kinetics.
+    braincell.channel.NaF_SU2015_DCN : Fast sodium current of the same
+        model.
+
+    Notes
+    -----
+    Ported from ``DCN/channel/fKdr_SU15_DCN.mod``, whose ``COMMENT``
+    reads "Translated from GENESIS by Johannes Luthman and Volker
+    Steuber." Accordingly, the kinetics originate in the GENESIS deep
+    cerebellar nucleus model of Steuber, Schultheiss, Silver, De
+    Schutter & Jaeger (2011) [1]_, were translated from GENESIS to
+    NEURON by Luthman, Hoebeek, Maex, Davey, Adams, De Zeeuw &
+    Steuber (2011), and were used in that translated form by Sudhakar
+    et al. (2015) [2]_. The 2011 translation paper is named in this
+    prose only, per house style, and not as a numbered reference.
+
+    **What this docstring does not claim.** No paper in that chain
+    was shown to print the Boltzmann and time-constant constants
+    above; the code-side check ran from the ``.mod`` file to this
+    class only. The string "fKdr" does not occur anywhere in the
+    Sudhakar et al. (2015) text, so this records that the mechanism is
+    part of the model published as [2]_, not that the paper names or
+    describes it.
+
+    ``qdeltat`` is set to ``1.0`` in :meth:`__init__` as a fixed
+    attribute rather than exposed as a constructor parameter; it
+    mirrors the mod file's ``GLOBAL qdeltat`` and divides
+    :math:`\tau_m` as shown.
+
+    **Import deviation.** The original mechanism's NMODL ``TABLE``
+    over ``[-150, 100] mV``, covering ``minf`` and ``taum``, is not
+    reproduced: both expressions are evaluated per call. NEURON
+    clamped tabulated values to the boundary outside that window, so
+    any BrainCell-versus-NEURON divergence below -150 mV or above
+    100 mV is expected rather than a port error.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -543,7 +1483,92 @@ class fKdr_SU2015_DCN(OhmicHH):
 
 @register_channel("sKdr_SU2015_DCN")
 class sKdr_SU2015_DCN(OhmicHH):
-    """Template-based import of ``sKdr_SU2015_DCN.mod``."""
+    r"""Slow delayed rectifier of the DCN model (Sudhakar 2015).
+
+    The slow delayed-rectifier potassium current of the deep
+    cerebellar nucleus (DCN) neuron model used by (Sudhakar et al.,
+    2015) [2]_, with :math:`m^4` HH gating and an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp((V + 50) / -9.1)} \\
+        \tau_m &= \left(\frac{14.95}
+                  {\exp((V + 50) / 21.74) + \exp((V + 50) / -13.91)}
+                  + 0.05\right) \Big/ q_{\Delta t}
+        \end{aligned}
+
+    where :math:`V` is in millivolts -- this class applies no voltage
+    shift -- and :math:`\tau_m` is in milliseconds. The reversal
+    potential comes from the potassium ion object, not from the class.
+    Compared with :class:`fKdr_SU2015_DCN`, activation is 10 mV more
+    hyperpolarized and shallower.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.01 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gbar = 1e-5 siemens/cm2``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    fKdr_SU2015_DCN : Fast delayed rectifier of the same DCN model,
+        with the same gating shape.
+    braincell.channel.NaF_SU2015_DCN : Fast sodium current of the same
+        model.
+
+    Notes
+    -----
+    Ported from ``DCN/channel/sKdr_SU15_DCN.mod``, whose ``COMMENT``
+    reads "Translated from GENESIS by Johannes Luthman and Volker
+    Steuber." Accordingly, the kinetics originate in the GENESIS deep
+    cerebellar nucleus model of Steuber, Schultheiss, Silver, De
+    Schutter & Jaeger (2011) [1]_, were translated from GENESIS to
+    NEURON by Luthman, Hoebeek, Maex, Davey, Adams, De Zeeuw &
+    Steuber (2011), and were used in that translated form by Sudhakar
+    et al. (2015) [2]_. The 2011 translation paper is named in this
+    prose only, per house style, and not as a numbered reference.
+
+    **What this docstring does not claim.** No paper in that chain
+    was shown to print the Boltzmann and time-constant constants
+    above; the code-side check ran from the ``.mod`` file to this
+    class only. The string "sKdr" does not occur anywhere in the
+    Sudhakar et al. (2015) text, so this records that the mechanism is
+    part of the model published as [2]_, not that the paper names or
+    describes it.
+
+    ``qdeltat`` is set to ``1.0`` in :meth:`__init__` as a fixed
+    attribute rather than exposed as a constructor parameter; it
+    mirrors the mod file's ``GLOBAL qdeltat`` and divides
+    :math:`\tau_m` as shown.
+
+    **Import deviation.** The original mechanism's NMODL ``TABLE``
+    over ``[-150, 100] mV``, covering ``minf`` and ``taum``, is not
+    reproduced: both expressions are evaluated per call. NEURON
+    clamped tabulated values to the boundary outside that window, so
+    any BrainCell-versus-NEURON divergence below -150 mV or above
+    100 mV is expected rather than a port error.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -1936,7 +2961,109 @@ class Kv4p3_MA2020_GrC(OhmicHH):
 
 @register_channel("Kdr_ZH2019_IO")
 class Kdr_ZH2019_IO(OhmicHH):
-    """Template-based import of ``Kdr_ZH2019_IO.mod``."""
+    r"""Delayed rectifier of the inferior-olive model (Zhang 2019).
+
+    The somatic delayed-rectifier potassium current of the
+    single-compartment inferior olive (IO) neurons in the
+    essential-tremor cortico-cerebello-thalamo-cortical loop model of
+    (Zhang & Santaniello, 2019) [2]_, with :math:`n^4` HH gating and
+    an ohmic driving force:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_n &= 10 \, S\!\left(\frac{V + 41}{10}\right),
+                    \quad S(x) = \frac{x}{1 - \exp(-x)} \\
+        \beta_n &= 12.5 \exp(-(V + 51) / 80) \\
+        n_\infty &= \frac{\alpha_n}{\alpha_n + \beta_n}, \qquad
+        \tau_n = \frac{10}{\alpha_n + \beta_n}
+        \end{aligned}
+
+    where :math:`V` is in millivolts -- this class applies no voltage
+    shift -- the rates are in :math:`\mathrm{ms}^{-1}` and
+    :math:`\tau_n` is in milliseconds. Expanding :math:`S` gives the
+    familiar linoid
+    :math:`\alpha_n = (V + 41)/(1 - \exp(-(V + 41)/10))` everywhere
+    except at its singular point (see Notes). The reversal potential
+    comes from the potassium ion object, not from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``18.0 mS/cm2``,
+        exactly the source mechanism's ``gbar``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    braincell.channel.Na_ZH2019_IO : Sodium current of the same
+        inferior-olive import family and the same bibliographic
+        origin.
+    braincell.channel.hyperpolarization_activated.HCN_ZH2019_IO :
+        H current of the same family.
+
+    Notes
+    -----
+    Ported from ``IO/channel/Kdr_ZH19_IO.mod``, whose header reads
+    "K_dr channel from Schweighofer et al 1999. The referred model is
+    an inferior olive neuron" with porter credit "B. Torben-Nielsen @
+    HUJI, 21-10-2010". The kinetics therefore originate with
+    Schweighofer, Doya, & Kawato (1999) [1]_ and reached this class
+    through the NEURON port of Torben-Nielsen, Segev, & Yarom (2012),
+    which Zhang & Santaniello (2019) [2]_ reused without further
+    modification credit. The 2012 port paper is named in this prose
+    only, per house style, and not as a numbered reference.
+
+    The inferior olive neurons in both of those models are
+    **single-compartment** (``nseg = 1``); the multi-compartment part
+    of that lineage is a separate Purkinje-cell population. This class
+    must not be described as part of a multi-compartment inferior
+    olive mechanism.
+
+    **Singularity guard: the mod file's branch is not reproduced.**
+    ``Kdr_ZH19_IO.mod`` guards the removable singularity of
+    :math:`\alpha_n` with ``if (fabs(v + 41.0) < 1e-6)`` and, inside
+    that branch, substitutes the perturbed literal ``41.00001``.
+    BrainCell instead routes the expression through the stable helper
+    :math:`S(x) = x/(1 - \exp(-x))`, which returns :math:`1 + x/2`
+    when ``abs(x) < 1e-6``. Because the guard now applies to the
+    scaled argument :math:`x = (V + 41)/10`, it triggers for
+    ``abs(V + 41) < 1e-5 mV`` and yields
+    :math:`\alpha_n \approx 10\ \mathrm{ms}^{-1}` there. The
+    substitution is exact away from the singular point and
+    better-behaved at it, but it is a BrainCell choice: the import
+    README explicitly excludes those in-formula literals from its
+    NMODL default-precision rewrites.
+
+    **Import deviation.** As for every mechanism of this ``ZH19``/IO
+    family, the ``rates(v)`` call moved from the NMODL ``BREAKPOINT``
+    into ``DERIVATIVE states``, so ``ninf``/``taun`` are refreshed
+    before the ``cnexp`` state update rather than after it. That is a
+    semantic change, not a cosmetic one.
+
+    Two further details of the source, recorded so they are not
+    mistaken for port errors: the mod file's ``ek = -75 mV``
+    ``PARAMETER`` is absent here because the reversal potential is
+    supplied by the ion object, and its ``taun`` numerator carries the
+    upstream comment ": was 5", i.e. the factor 10 above replaced an
+    earlier 5 before this port.
+
+    References
+    ----------
+    .. [1] Schweighofer, N., Doya, K., & Kawato, M. (1999).
+           Electrophysiological properties of inferior olive neurons: A
+           compartmental model. Journal of Neurophysiology, 82(2),
+           804-817.
+           doi:10.1152/jn.1999.82.2.804
+    .. [2] Zhang, X., & Santaniello, S. (2019). Role of cerebellar
+           GABAergic dysfunctions in the origins of essential tremor.
+           Proceedings of the National Academy of Sciences of the
+           United States of America, 116(27), 13592-13601.
+           doi:10.1073/pnas.1817689116
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium

--- a/braincell/channel/potassium.py
+++ b/braincell/channel/potassium.py
@@ -3076,7 +3076,6 @@ class Kv3p3_MA2024_PC(HH):
            doi:10.1038/s42003-023-05689-y
     """
 
-
     __module__ = "braincell.channel"
     root_type = Potassium
     gates = (Gate("n", power=4, q10=2.7, temp_ref=u.celsius2kelvin(22.0)),)

--- a/braincell/channel/potassium.py
+++ b/braincell/channel/potassium.py
@@ -1595,7 +1595,115 @@ class sKdr_SU2015_DCN(OhmicHH):
 
 @register_channel("KM_RI2021_SC")
 class KM_RI2021_SC(OhmicHH):
-    """Template-based import of ``KM_RI2021_SC.mod``."""
+    r"""M-type potassium current of the stellate cell model.
+
+    Slow, non-inactivating M-type potassium current imported from the
+    cerebellar stellate cell model of Rizza et al. (2021) [2]_. A
+    single first-order ``n`` gate of power 1 drives an ohmic current:
+
+    .. math::
+
+        \begin{aligned}
+        n_\infty &= \frac{1}{1 + \exp(-(V + 35) / 6)} \\
+        \alpha_n &= 0.0033 \, \exp((V + 30) / 40) \\
+        \beta_n &= 0.0033 \, \exp(-(V + 30) / 20) \\
+        \tau_n &= \frac{1}{\alpha_n + \beta_n}
+        \end{aligned}
+
+    where :math:`V` is in millivolts, the rates are per millisecond
+    and :math:`\tau_n` is in milliseconds. This class applies no
+    voltage shift, and the reversal potential comes from the potassium
+    ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.25 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.00025 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KM_MA2020_GoC : Golgi-cell port of the same mechanism.
+    KM_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kir2p3_RI2021_SC : Inward rectifier of the same stellate model,
+        sharing the same origin paper.
+
+    Notes
+    -----
+    Ported from ``SC/channel/KM_RI21_SC.mod``. That file, the Golgi
+    port ``GoC/channel/KM_MA20_GoC.mod`` and the granule port
+    ``GrC/channel/KM_MA20_GrC.mod`` are byte-identical apart from
+    their ``SUFFIX`` line, and so are the three BrainCell classes: the
+    rate constants above are shared verbatim with
+    :class:`KM_MA2020_GoC` and :class:`KM_MA2020_GrC`. What differs is
+    only the deposit each was imported from, and therefore the model
+    paper cited below.
+
+    The mechanism does not use the steady state implied by its own
+    rates. Its ``n_inf = a_n/(a_n + b_n)`` line is commented out in
+    the ``.mod`` source and replaced by the explicit Boltzmann shown
+    above, so :math:`n_\infty` and :math:`\tau_n` are independent
+    expressions here.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 3.0`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the whole
+    :math:`(n_\infty - n)/\tau_n` term by
+    :math:`\phi = 3^{(T - 22)/10}` (about 2.41 at the default 30
+    degrees Celsius). The ``.mod`` file instead multiplies ``Q10``
+    into ``alp_n`` and ``bet_n``, which divides its ``tau_n`` by the
+    same factor. The two forms are algebraically identical, but it
+    means :meth:`f_n_tau` returns the q10-free time constant rather
+    than the mechanism's ``tau_n``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` header carries ``Author: A. Fontana`` and
+    ``CoAuthor: T.Nieus``. That credit line is copy-pasted verbatim
+    across every cell-type port of this mechanism and names people
+    unrelated to the stellate-cell key, so it is not treated as a
+    citation here. The kinetics originate in the cerebellar granule
+    cell model of D'Angelo et al. (2001) [1]_; the stellate-cell
+    paper [2]_ names the model this parameterisation was imported
+    from, not the origin of the equations.
+
+    **Conductance default.** ``0.25 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** The original mechanism's NMODL ``TABLE``
+    over ``[-100, 30] mV``, covering ``n_inf`` and ``tau_n``, is not
+    reproduced: both expressions are evaluated per call. NEURON
+    clamped tabulated values to the boundary outside that window, so
+    any BrainCell-versus-NEURON divergence below -100 mV or above
+    30 mV is expected rather than a port error. The integration
+    method was also changed from ``derivimplicit`` to ``cnexp``;
+    with one independent gate ODE that substitution is exact.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -1638,7 +1746,117 @@ class KM_RI2021_SC(OhmicHH):
 
 @register_channel("Kir2p3_MA2025_BC")
 class Kir2p3_MA2025_BC(OhmicHH):
-    """Template-based import of ``Kir2p3_MA2025_BC.mod``."""
+    r"""Kir2.3 inward-rectifier current of the basket cell model.
+
+    Hyperpolarization-activated inward-rectifier potassium current
+    imported from the cerebellar basket cell model of Masoli et al.
+    (2025) [2]_. A single first-order ``d`` gate of power 1 drives an
+    ohmic current, with the gate written in alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_d &= 0.13289 \, \exp(-(V + 83.94) / 24.3902) \\
+        \beta_d &= 0.16994 \, \exp((V + 83.94) / 35.714)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. The template forms
+    :math:`d_\infty = \alpha_d / (\alpha_d + \beta_d)` and
+    :math:`\tau_d = 1 / (\alpha_d + \beta_d)` from these; half
+    activation falls near -87.5 mV, and :math:`d_\infty` rises towards
+    1 as the membrane hyperpolarizes. This class applies no voltage
+    shift, and the reversal potential comes from the potassium ion
+    object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.9 mS/cm2``, which
+        is exactly the source mechanism's ``gkbar = 0.0009 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kir2p3_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kir2p3_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kir2p3_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``BC/channel/Kir2p3_MA25_BC.mod``. That file and the
+    granule, Purkinje and stellate ports are byte-identical apart from
+    their ``SUFFIX`` line and, in the Purkinje port only, the
+    mechanism-local ``celsius`` default. The four BrainCell classes
+    are likewise identical, so the rate constants above are shared
+    verbatim with :class:`Kir2p3_MA2020_GrC`,
+    :class:`Kir2p3_MA2024_PC` and :class:`Kir2p3_RI2021_SC`. What
+    differs is only the deposit each was imported from, and therefore
+    the model paper cited below.
+
+    **The rectification lives in the gate, not in the current.** The
+    current expression is the plain ohmic
+    ``g_max * d * (E_K - V)`` supplied by :class:`OhmicHH`; there is
+    no Mg2+ or polyamine block term anywhere in the mechanism. The
+    inward-rectifier behaviour comes entirely from :math:`d_\infty`
+    increasing as the membrane hyperpolarizes.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 3.0`` at a reference of 20 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the whole
+    :math:`\alpha_d (1 - d) - \beta_d d` term by
+    :math:`\phi = 3^{(T - 20)/10}`, which is exactly 3 at the default
+    30 degrees Celsius. The ``.mod`` file instead multiplies ``Q10``
+    into ``alp_d`` and ``bet_d``. The two forms are algebraically
+    identical, but it means :meth:`f_d_alpha` and :meth:`f_d_beta`
+    return the q10-free rates rather than the mechanism's
+    ``alpha_d``/``beta_d``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` ``COMMENT`` carries a reference string that is the
+    published title of D'Angelo et al. (2001) truncated mid-subtitle,
+    plus the porting note "Suffix from Ubc_Kir to Kir2_3". Neither is
+    treated as a citation here. The kinetics originate in the
+    cerebellar granule cell model of D'Angelo et al. (2001) [1]_; the
+    basket-cell paper [2]_ names the model this parameterisation was
+    imported from, not the origin of the equations.
+
+    **Conductance default.** ``0.9 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** The original mechanism's NMODL ``TABLE``
+    over ``[-100, 100] mV``, covering ``d_inf`` and ``tau_d``, is not
+    reproduced: both expressions are evaluated per call. NEURON used
+    the boundary value outside that window, so any
+    BrainCell-versus-NEURON divergence below -100 mV or above 100 mV
+    is expected rather than a port error. The integration method was
+    also changed from ``derivimplicit`` to ``cnexp``; with one
+    independent gate ODE that substitution is exact.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -1672,7 +1890,129 @@ class Kir2p3_MA2025_BC(OhmicHH):
 
 @register_channel("Kir2p3_MA2024_PC")
 class Kir2p3_MA2024_PC(OhmicHH):
-    """Template-based import of ``Kir2p3_MA2024_PC.mod``."""
+    r"""Kir2.3 inward-rectifier current of the Purkinje cell model.
+
+    Hyperpolarization-activated inward-rectifier potassium current
+    imported from the human Purkinje cell model of Masoli et al.
+    (2024) [2]_. A single first-order ``d`` gate of power 1 drives an
+    ohmic current, with the gate written in alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_d &= 0.13289 \, \exp(-(V + 83.94) / 24.3902) \\
+        \beta_d &= 0.16994 \, \exp((V + 83.94) / 35.714)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. The template forms
+    :math:`d_\infty = \alpha_d / (\alpha_d + \beta_d)` and
+    :math:`\tau_d = 1 / (\alpha_d + \beta_d)` from these; half
+    activation falls near -87.5 mV, and :math:`d_\infty` rises towards
+    1 as the membrane hyperpolarizes. This class applies no voltage
+    shift, and the reversal potential comes from the potassium ion
+    object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.9 mS/cm2``, which
+        is exactly the source mechanism's ``gkbar = 0.0009 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        30 degrees Celsius. See the note below on the Purkinje port's
+        divergent mechanism-local ``celsius`` default.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kir2p3_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kir2p3_MA2025_BC : Basket-cell port of the same mechanism.
+    Kir2p3_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Kir2p3_MA24_PC.mod``. That file and the
+    granule, basket and stellate ports are byte-identical apart from
+    their ``SUFFIX`` line and one ``PARAMETER`` default described
+    below. The four BrainCell classes are likewise identical, so the
+    rate constants above are shared verbatim with
+    :class:`Kir2p3_MA2020_GrC`, :class:`Kir2p3_MA2025_BC` and
+    :class:`Kir2p3_RI2021_SC`. What differs is only the deposit each
+    was imported from, and therefore the model paper cited below.
+
+    **Recorded divergence: the mechanism-local temperature default.**
+    ``PC/channel/Kir2p3_MA24_PC.mod`` writes ``celsius = 10 (degC)``
+    in its ``PARAMETER`` block where the granule, basket and stellate
+    ports all write ``celsius = 30 (degC)``. BrainCell's ``temp``
+    default is 30 degrees Celsius in all four classes, so this class
+    alone does not reproduce its own source file's number. In NEURON
+    ``celsius`` is a simulator-wide global that the host model
+    normally sets, which is why a mechanism-local default carries
+    little weight; the difference is recorded here rather than
+    resolved, and the code is left unchanged. At 30 degrees Celsius
+    the gate's q10 factor is 3; at 10 degrees Celsius it would be
+    1/3.
+
+    **The rectification lives in the gate, not in the current.** The
+    current expression is the plain ohmic
+    ``g_max * d * (E_K - V)`` supplied by :class:`OhmicHH`; there is
+    no Mg2+ or polyamine block term anywhere in the mechanism. The
+    inward-rectifier behaviour comes entirely from :math:`d_\infty`
+    increasing as the membrane hyperpolarizes.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 3.0`` at a reference of 20 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the whole
+    :math:`\alpha_d (1 - d) - \beta_d d` term by
+    :math:`\phi = 3^{(T - 20)/10}`. The ``.mod`` file instead
+    multiplies ``Q10`` into ``alp_d`` and ``bet_d``. The two forms are
+    algebraically identical, but it means :meth:`f_d_alpha` and
+    :meth:`f_d_beta` return the q10-free rates rather than the
+    mechanism's ``alpha_d``/``beta_d``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` ``COMMENT`` carries a reference string that is the
+    published title of D'Angelo et al. (2001) truncated mid-subtitle.
+    It is not treated as a citation here. The kinetics originate in
+    the cerebellar granule cell model of D'Angelo et al. (2001) [1]_;
+    the Purkinje-cell paper [2]_ names the model this
+    parameterisation was imported from, not the origin of the
+    equations.
+
+    **Conductance default.** ``0.9 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** The original mechanism's NMODL ``TABLE``
+    over ``[-100, 100] mV``, covering ``d_inf`` and ``tau_d``, is not
+    reproduced: both expressions are evaluated per call. NEURON used
+    the boundary value outside that window, so any
+    BrainCell-versus-NEURON divergence below -100 mV or above 100 mV
+    is expected rather than a port error. The integration method was
+    also changed from ``derivimplicit`` to ``cnexp``; with one
+    independent gate ODE that substitution is exact.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -1706,7 +2046,119 @@ class Kir2p3_MA2024_PC(OhmicHH):
 
 @register_channel("Kir2p3_RI2021_SC")
 class Kir2p3_RI2021_SC(OhmicHH):
-    """Template-based import of ``Kir2p3_RI2021_SC.mod``."""
+    r"""Kir2.3 inward-rectifier current of the stellate cell model.
+
+    Hyperpolarization-activated inward-rectifier potassium current
+    imported from the cerebellar stellate cell model of Rizza et al.
+    (2021) [2]_. A single first-order ``d`` gate of power 1 drives an
+    ohmic current, with the gate written in alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_d &= 0.13289 \, \exp(-(V + 83.94) / 24.3902) \\
+        \beta_d &= 0.16994 \, \exp((V + 83.94) / 35.714)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. The template forms
+    :math:`d_\infty = \alpha_d / (\alpha_d + \beta_d)` and
+    :math:`\tau_d = 1 / (\alpha_d + \beta_d)` from these; half
+    activation falls near -87.5 mV, and :math:`d_\infty` rises towards
+    1 as the membrane hyperpolarizes. This class applies no voltage
+    shift, and the reversal potential comes from the potassium ion
+    object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.9 mS/cm2``, which
+        is exactly the source mechanism's ``gkbar = 0.0009 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kir2p3_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kir2p3_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kir2p3_MA2025_BC : Basket-cell port of the same mechanism.
+    KM_RI2021_SC : M-type current of the same stellate model, sharing
+        the same origin paper.
+
+    Notes
+    -----
+    Ported from ``SC/channel/Kir2p3_RI21_SC.mod``. That file and the
+    granule, Purkinje and basket ports are byte-identical apart from
+    their ``SUFFIX`` line and, in the Purkinje port only, the
+    mechanism-local ``celsius`` default. The four BrainCell classes
+    are likewise identical, so the rate constants above are shared
+    verbatim with :class:`Kir2p3_MA2020_GrC`,
+    :class:`Kir2p3_MA2024_PC` and :class:`Kir2p3_MA2025_BC`. What
+    differs is only the deposit each was imported from, and therefore
+    the model paper cited below.
+
+    **The rectification lives in the gate, not in the current.** The
+    current expression is the plain ohmic
+    ``g_max * d * (E_K - V)`` supplied by :class:`OhmicHH`; there is
+    no Mg2+ or polyamine block term anywhere in the mechanism. The
+    inward-rectifier behaviour comes entirely from :math:`d_\infty`
+    increasing as the membrane hyperpolarizes.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 3.0`` at a reference of 20 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the whole
+    :math:`\alpha_d (1 - d) - \beta_d d` term by
+    :math:`\phi = 3^{(T - 20)/10}`, which is exactly 3 at the default
+    30 degrees Celsius. The ``.mod`` file instead multiplies ``Q10``
+    into ``alp_d`` and ``bet_d``. The two forms are algebraically
+    identical, but it means :meth:`f_d_alpha` and :meth:`f_d_beta`
+    return the q10-free rates rather than the mechanism's
+    ``alpha_d``/``beta_d``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` ``COMMENT`` carries a reference string that is the
+    published title of D'Angelo et al. (2001) truncated mid-subtitle,
+    plus the porting note "Suffix from Ubc_Kir to Kir2_3". Neither is
+    treated as a citation here. The kinetics originate in the
+    cerebellar granule cell model of D'Angelo et al. (2001) [1]_; the
+    stellate-cell paper [2]_ names the model this parameterisation was
+    imported from, not the origin of the equations.
+
+    **Conductance default.** ``0.9 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** The original mechanism's NMODL ``TABLE``
+    over ``[-100, 100] mV``, covering ``d_inf`` and ``tau_d``, is not
+    reproduced: both expressions are evaluated per call. NEURON used
+    the boundary value outside that window, so any
+    BrainCell-versus-NEURON divergence below -100 mV or above 100 mV
+    is expected rather than a port error. The integration method was
+    also changed from ``derivimplicit`` to ``cnexp``; with one
+    independent gate ODE that substitution is exact.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -1740,7 +2192,137 @@ class Kir2p3_RI2021_SC(OhmicHH):
 
 @register_channel("Kv1p1_MA2025_BC")
 class Kv1p1_MA2025_BC(HH):
-    """Template-based import of ``Kv1p1_MA2025_BC.mod``."""
+    r"""Kv1.1 low-threshold potassium current of the basket cell model.
+
+    Non-inactivating, low-threshold potassium current carried by Kv1.1
+    subunits, imported from the cerebellar basket cell model of Masoli
+    et al. (2025) [3]_. Gating is a single ``n`` gate of power 4 in
+    alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_n &= 0.12889 \, \exp((V + 45) / 33.90877) \\
+        \beta_n &= 0.12889 \, \exp(-(V + 45) / 12.42101)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. Because the two prefactors are equal,
+    :math:`n_\infty = \alpha_n / (\alpha_n + \beta_n)` is exactly 0.5
+    at -45 mV, and the :math:`n^4` conductance reaches half its
+    maximum near -29.9 mV -- consistent with the
+    ``Vhalf = -28.8 +- 2.3 mV`` that the ``.mod`` header quotes from
+    the Zerr et al. (1998) recordings [1]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``, which
+        is exactly the source mechanism's ``gbar = 0.004 S/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        22 degrees Celsius. This equals the gate's reference
+        temperature, so the default temperature factor is exactly 1.
+    gateCurrent : array-like or callable, optional
+        Gating-current switch, default ``0.0`` (dimensionless, off).
+        Any non-zero value enables the gating-current term described
+        below.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv1p1_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv1p1_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv1p1_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv1p1_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``BC/channel/Kv1p1_MA25_BC.mod``. That file and the
+    Golgi, granule, Purkinje and stellate ports are identical apart
+    from their ``SUFFIX`` line and one line of indentation, and the
+    five BrainCell classes are identical too: the rate constants and
+    the gating-current constants above are shared verbatim with
+    :class:`Kv1p1_MA2020_GoC`, :class:`Kv1p1_MA2020_GrC`,
+    :class:`Kv1p1_MA2024_PC` and :class:`Kv1p1_RI2021_SC`. What
+    differs is only the deposit each was imported from, and therefore
+    the model paper cited below.
+
+    **Why this class overrides** ``current``. The mechanism emits an
+    optional Kv gating current alongside the ionic current, so
+    :class:`OhmicHH` is not enough. :meth:`current` returns
+
+    .. math::
+
+        g_{\max} \, n^4 \, (E_K - V) - I_{\text{gate}}
+
+    with
+
+    .. math::
+
+        I_{\text{gate}} = n_c \cdot 10^{6} \cdot e_0 \cdot 4 \, z_n
+        \cdot \frac{\mathrm{d}n}{\mathrm{d}t}, \qquad
+        n_c = 10^{12} \, \frac{g_{\max}}{g_{\text{unit}}}
+
+    where :math:`g_{\text{unit}} = 16` pS is the unitary channel
+    conductance, :math:`z_n = 2.7978` the n-gate valence,
+    :math:`e_0 = 1.60217646 \times 10^{-19}` C the elementary charge
+    and :math:`\mathrm{d}n/\mathrm{d}t` the same
+    :math:`\phi(\alpha_n (1 - n) - \beta_n n)` the gate integrates.
+    NEURON emits this term as a separate ``NONSPECIFIC_CURRENT``;
+    BrainCell folds it into the single ``current()`` return, and the
+    subtraction reflects the package's inward-positive sign
+    convention against NMODL's outward-positive one. The term is
+    selected with ``u.math.where`` rather than a Python branch, so
+    ``gateCurrent`` may be an array and the choice stays traceable.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 2.7`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the rate balance by
+    :math:`\phi = 2.7^{(T - 22)/10}`. The ``.mod`` file instead
+    divides its ``taun`` by the same factor. The two forms are
+    algebraically identical.
+
+    **Provenance.** The ``.mod`` header states that the six rate
+    parameters were obtained by least-squares fits to
+    :math:`G/G_{\max}(V)` and :math:`\tau(V)` data from human Kv1.1
+    expressed in Xenopus oocytes by Zerr et al. (1998) [1]_, and
+    names the RIKEN implementation published by Akemann et al. (2009)
+    [2]_ as its model reference. The basket-cell paper [3]_ names the
+    model this parameterisation was imported from, not the origin of
+    the equations.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in any of the cited papers.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here.
+
+    References
+    ----------
+    .. [1] Zerr, P., Adelman, J. P., & Maylie, J. (1998). Episodic
+           ataxia mutations in Kv1.1 alter potassium channel function
+           by dominant negative effects or haploinsufficiency. The
+           Journal of Neuroscience, 18(8), 2842-2848.
+           doi:10.1523/JNEUROSCI.18-08-02842.1998
+    .. [2] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+           Effect of voltage sensitive fluorescent proteins on
+           neuronal excitability. Biophysical Journal, 96(10),
+           3959-3976.
+           doi:10.1016/j.bpj.2009.02.046
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -1790,7 +2372,138 @@ class Kv1p1_MA2025_BC(HH):
 
 @register_channel("Kv1p1_MA2024_PC")
 class Kv1p1_MA2024_PC(HH):
-    """Template-based import of ``Kv1p1_MA2024_PC.mod``."""
+    r"""Kv1.1 low-threshold potassium current of the Purkinje model.
+
+    Non-inactivating, low-threshold potassium current carried by Kv1.1
+    subunits, imported from the human Purkinje cell model of Masoli
+    et al. (2024) [3]_. Gating is a single ``n`` gate of power 4 in
+    alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_n &= 0.12889 \, \exp((V + 45) / 33.90877) \\
+        \beta_n &= 0.12889 \, \exp(-(V + 45) / 12.42101)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. Because the two prefactors are equal,
+    :math:`n_\infty = \alpha_n / (\alpha_n + \beta_n)` is exactly 0.5
+    at -45 mV, and the :math:`n^4` conductance reaches half its
+    maximum near -29.9 mV -- consistent with the
+    ``Vhalf = -28.8 +- 2.3 mV`` that the ``.mod`` header quotes from
+    the Zerr et al. (1998) recordings [1]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``, which
+        is exactly the source mechanism's ``gbar = 0.004 S/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        22 degrees Celsius. This equals the gate's reference
+        temperature, so the default temperature factor is exactly 1.
+    gateCurrent : array-like or callable, optional
+        Gating-current switch, default ``0.0`` (dimensionless, off).
+        Any non-zero value enables the gating-current term described
+        below.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv1p1_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv1p1_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv1p1_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv1p1_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Kv1p1_MA24_PC.mod``. That file and the
+    Golgi, granule, basket and stellate ports are identical apart
+    from their ``SUFFIX`` line and one line of indentation, and the
+    five BrainCell classes are identical too: the rate constants and
+    the gating-current constants above are shared verbatim with
+    :class:`Kv1p1_MA2020_GoC`, :class:`Kv1p1_MA2020_GrC`,
+    :class:`Kv1p1_MA2025_BC` and :class:`Kv1p1_RI2021_SC`. What
+    differs is only the deposit each was imported from, and therefore
+    the model paper cited below.
+
+    **Why this class overrides** ``current``. The mechanism emits an
+    optional Kv gating current alongside the ionic current, so
+    :class:`OhmicHH` is not enough. :meth:`current` returns
+
+    .. math::
+
+        g_{\max} \, n^4 \, (E_K - V) - I_{\text{gate}}
+
+    with
+
+    .. math::
+
+        I_{\text{gate}} = n_c \cdot 10^{6} \cdot e_0 \cdot 4 \, z_n
+        \cdot \frac{\mathrm{d}n}{\mathrm{d}t}, \qquad
+        n_c = 10^{12} \, \frac{g_{\max}}{g_{\text{unit}}}
+
+    where :math:`g_{\text{unit}} = 16` pS is the unitary channel
+    conductance, :math:`z_n = 2.7978` the n-gate valence,
+    :math:`e_0 = 1.60217646 \times 10^{-19}` C the elementary charge
+    and :math:`\mathrm{d}n/\mathrm{d}t` the same
+    :math:`\phi(\alpha_n (1 - n) - \beta_n n)` the gate integrates.
+    NEURON emits this term as a separate ``NONSPECIFIC_CURRENT``;
+    BrainCell folds it into the single ``current()`` return, and the
+    subtraction reflects the package's inward-positive sign
+    convention against NMODL's outward-positive one. The term is
+    selected with ``u.math.where`` rather than a Python branch, so
+    ``gateCurrent`` may be an array and the choice stays traceable.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 2.7`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the rate balance by
+    :math:`\phi = 2.7^{(T - 22)/10}`. The ``.mod`` file instead
+    divides its ``taun`` by the same factor. The two forms are
+    algebraically identical.
+
+    **Provenance.** The ``.mod`` header states that the six rate
+    parameters were obtained by least-squares fits to
+    :math:`G/G_{\max}(V)` and :math:`\tau(V)` data from human Kv1.1
+    expressed in Xenopus oocytes by Zerr et al. (1998) [1]_, and
+    names the RIKEN implementation published by Akemann et al. (2009)
+    [2]_ as its model reference. The Purkinje-cell paper [3]_ names
+    the model this parameterisation was imported from, not the origin
+    of the equations.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in any of the cited papers.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here.
+
+    References
+    ----------
+    .. [1] Zerr, P., Adelman, J. P., & Maylie, J. (1998). Episodic
+           ataxia mutations in Kv1.1 alter potassium channel function
+           by dominant negative effects or haploinsufficiency. The
+           Journal of Neuroscience, 18(8), 2842-2848.
+           doi:10.1523/JNEUROSCI.18-08-02842.1998
+    .. [2] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+           Effect of voltage sensitive fluorescent proteins on
+           neuronal excitability. Biophysical Journal, 96(10),
+           3959-3976.
+           doi:10.1016/j.bpj.2009.02.046
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -1840,7 +2553,137 @@ class Kv1p1_MA2024_PC(HH):
 
 @register_channel("Kv1p1_RI2021_SC")
 class Kv1p1_RI2021_SC(HH):
-    """Template-based import of ``Kv1p1_RI2021_SC.mod``."""
+    r"""Kv1.1 low-threshold potassium current of the stellate model.
+
+    Non-inactivating, low-threshold potassium current carried by Kv1.1
+    subunits, imported from the cerebellar stellate cell model of
+    Rizza et al. (2021) [3]_. Gating is a single ``n`` gate of power 4
+    in alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_n &= 0.12889 \, \exp((V + 45) / 33.90877) \\
+        \beta_n &= 0.12889 \, \exp(-(V + 45) / 12.42101)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. Because the two prefactors are equal,
+    :math:`n_\infty = \alpha_n / (\alpha_n + \beta_n)` is exactly 0.5
+    at -45 mV, and the :math:`n^4` conductance reaches half its
+    maximum near -29.9 mV -- consistent with the
+    ``Vhalf = -28.8 +- 2.3 mV`` that the ``.mod`` header quotes from
+    the Zerr et al. (1998) recordings [1]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``, which
+        is exactly the source mechanism's ``gbar = 0.004 S/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        22 degrees Celsius. This equals the gate's reference
+        temperature, so the default temperature factor is exactly 1.
+    gateCurrent : array-like or callable, optional
+        Gating-current switch, default ``0.0`` (dimensionless, off).
+        Any non-zero value enables the gating-current term described
+        below.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv1p1_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv1p1_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv1p1_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv1p1_MA2025_BC : Basket-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``SC/channel/Kv1p1_RI21_SC.mod``. That file and the
+    Golgi, granule, Purkinje and basket ports are identical apart
+    from their ``SUFFIX`` line and one line of indentation, and the
+    five BrainCell classes are identical too: the rate constants and
+    the gating-current constants above are shared verbatim with
+    :class:`Kv1p1_MA2020_GoC`, :class:`Kv1p1_MA2020_GrC`,
+    :class:`Kv1p1_MA2024_PC` and :class:`Kv1p1_MA2025_BC`. What
+    differs is only the deposit each was imported from, and therefore
+    the model paper cited below.
+
+    **Why this class overrides** ``current``. The mechanism emits an
+    optional Kv gating current alongside the ionic current, so
+    :class:`OhmicHH` is not enough. :meth:`current` returns
+
+    .. math::
+
+        g_{\max} \, n^4 \, (E_K - V) - I_{\text{gate}}
+
+    with
+
+    .. math::
+
+        I_{\text{gate}} = n_c \cdot 10^{6} \cdot e_0 \cdot 4 \, z_n
+        \cdot \frac{\mathrm{d}n}{\mathrm{d}t}, \qquad
+        n_c = 10^{12} \, \frac{g_{\max}}{g_{\text{unit}}}
+
+    where :math:`g_{\text{unit}} = 16` pS is the unitary channel
+    conductance, :math:`z_n = 2.7978` the n-gate valence,
+    :math:`e_0 = 1.60217646 \times 10^{-19}` C the elementary charge
+    and :math:`\mathrm{d}n/\mathrm{d}t` the same
+    :math:`\phi(\alpha_n (1 - n) - \beta_n n)` the gate integrates.
+    NEURON emits this term as a separate ``NONSPECIFIC_CURRENT``;
+    BrainCell folds it into the single ``current()`` return, and the
+    subtraction reflects the package's inward-positive sign
+    convention against NMODL's outward-positive one. The term is
+    selected with ``u.math.where`` rather than a Python branch, so
+    ``gateCurrent`` may be an array and the choice stays traceable.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 2.7`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the rate balance by
+    :math:`\phi = 2.7^{(T - 22)/10}`. The ``.mod`` file instead
+    divides its ``taun`` by the same factor. The two forms are
+    algebraically identical.
+
+    **Provenance.** The ``.mod`` header states that the six rate
+    parameters were obtained by least-squares fits to
+    :math:`G/G_{\max}(V)` and :math:`\tau(V)` data from human Kv1.1
+    expressed in Xenopus oocytes by Zerr et al. (1998) [1]_, and
+    names the RIKEN implementation published by Akemann et al. (2009)
+    [2]_ as its model reference. The stellate-cell paper [3]_ names
+    the model this parameterisation was imported from, not the origin
+    of the equations.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in any of the cited papers.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here.
+
+    References
+    ----------
+    .. [1] Zerr, P., Adelman, J. P., & Maylie, J. (1998). Episodic
+           ataxia mutations in Kv1.1 alter potassium channel function
+           by dominant negative effects or haploinsufficiency. The
+           Journal of Neuroscience, 18(8), 2842-2848.
+           doi:10.1523/JNEUROSCI.18-08-02842.1998
+    .. [2] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+           Effect of voltage sensitive fluorescent proteins on
+           neuronal excitability. Biophysical Journal, 96(10),
+           3959-3976.
+           doi:10.1016/j.bpj.2009.02.046
+    .. [3] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -1890,7 +2733,142 @@ class Kv1p1_RI2021_SC(HH):
 
 @register_channel("Kv1p5_MA2024_PC")
 class Kv1p5_MA2024_PC(HH):
-    """Template-based import of the active K-current path in ``Kv1p5_MA24_PC.mod``."""
+    r"""Kv1.5 ultrarapid delayed-rectifier current (IKur), K path only.
+
+    Hodgkin-Huxley model of the cardiac ultrarapid delayed rectifier
+    IKur, fitted to human atrial myocyte recordings by Feng et al.
+    (1998) [1]_ and imported into BrainCell from the human Purkinje
+    cell model of Masoli et al. (2024) [2]_. Three gates -- ``m``
+    (power 3), ``n`` and ``u`` -- combine with a voltage-dependent
+    conductance factor, so :meth:`current` returns
+
+    .. math::
+
+        g_{\max} \left(0.1 + \frac{1}{1 + \exp(-(V - 15)/13)}\right)
+        m^3 n u \, (E_K - V)
+
+    with the gate kinetics
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp(-(V + 30.3)/9.6)} \\
+        \tau_m &= \frac{1}{3(\alpha_m + \beta_m)} T_{\text{act}},
+        \quad
+        \alpha_m = \frac{0.65 \, q_{10}}
+                        {\exp(-(V + 10)/8.5) + \exp(-(V - 30)/59)},
+        \quad
+        \beta_m = \frac{0.65 \, q_{10}}{2.5 + \exp((V + 82)/17)} \\
+        n_\infty &= 0.25 + \frac{1}{1.35 + \exp((V + 7)/14)} \\
+        \tau_n &= \frac{1}{3(\alpha_n + \beta_n)} T_{\text{inactf}},
+        \quad
+        \alpha_n = \frac{0.001 \, q_{10}}
+                        {2.4 + 10.9 \exp(-(V + 90)/78)},
+        \quad
+        \beta_n = 0.001 \, q_{10} \exp((V - 168)/16) \\
+        u_\infty &= 0.1 + \frac{1}{1.1 + \exp((V + 7)/14)} \\
+        \tau_u &= 6800 \, T_{\text{inacts}}
+        \end{aligned}
+
+    where :math:`V` is in millivolts, :math:`\tau` in milliseconds and
+    :math:`q_{10} = 2.2^{(T - 37)/10}` with :math:`T` in degrees
+    Celsius. The reversal potential comes from the potassium ion
+    object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default
+        ``0.13195e-3 siemens/cm2``. This is the BrainCell name for the
+        NEURON ``gKur`` parameter and is exactly its ``.mod`` value.
+    temp : array-like, optional
+        Absolute temperature entering :math:`q_{10}`, default
+        37 degrees Celsius. This equals the :math:`q_{10}` reference
+        temperature, so the default factor is exactly 1.
+    Tauact : array-like or callable, optional
+        Activation time-scale multiplier for :math:`\tau_m`, default
+        ``1.0`` (dimensionless).
+    Tauinactf : array-like or callable, optional
+        Fast-inactivation time-scale multiplier for :math:`\tau_n`,
+        default ``1.0`` (dimensionless).
+    Tauinacts : array-like or callable, optional
+        Slow-inactivation time-scale multiplier for :math:`\tau_u`,
+        default ``1.0`` (dimensionless).
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    braincell.channel.Kv1p5_MA2020_GrC : Granule-cell subclass that
+        inherits these gate kinetics and adds the nonspecific cation
+        current component.
+    Kv1p1_MA2024_PC : Low-threshold Kv1 current of the same Purkinje
+        cell model.
+
+    Notes
+    -----
+    Ported from ``PC/channel/Kv1p5_MA24_PC.mod``.
+
+    **This is a cardiac mechanism, not a cerebellar one.** The
+    ``.mod`` ``TITLE`` reads "Cardiac IKur current & nonspec cation
+    current with identical kinetics", and its kinetics were fitted to
+    human atrial myocyte recordings [1]_, not to any cerebellar
+    recording. The Purkinje-cell citation [2]_ names the model
+    BrainCell imported this parameterisation from, not the origin of
+    the kinetics.
+
+    **Only the potassium path is converted.** The Purkinje ``.mod``
+    file computes a nonspecific cation current ``ino`` with kinetics
+    identical to ``ik``, but its ``USEION no WRITE ino`` line is
+    commented out, so ``ino`` survives only as a ``RANGE`` variable
+    with no current owner. BrainCell converts the default ``ik`` path
+    alone; this class has no ``gnonspec`` parameter and emits no
+    nonspecific current. The granule-cell sibling
+    :class:`braincell.channel.Kv1p5_MA2020_GrC`, whose ``.mod`` file
+    leaves that line enabled, subclasses this one and adds the second
+    component.
+
+    **q10 asymmetry in** :meth:`f_u_tau`. Temperature scaling is not
+    attached through the gate objects: none of the three gates sets
+    ``phi`` or ``q10``, so :meth:`HH.gate_phi` resolves to ``1.0`` for
+    ``m``, ``n`` and ``u`` alike. Instead the private ``_q10`` method
+    computes :math:`2.2^{(T - 37)/10}` and multiplies it into the
+    ``alpha``/``beta`` rates used by :meth:`f_m_tau` and
+    :meth:`f_n_tau` only. :meth:`f_u_tau` returns the constant
+    ``6800 * Tauinacts`` milliseconds: it is voltage-independent, it
+    receives no :math:`q_{10}` scaling, and unlike its two siblings it
+    also carries no factor of :math:`1/3`. This reproduces the
+    ``.mod`` file's ``utau = 6800*Tauinacts`` exactly and is the
+    mechanism's own code path, not a BrainCell convention and not a
+    closed-form temperature dependence printed in either cited paper.
+
+    **Conductance default.** ``0.13195e-3 siemens/cm2`` is the
+    deposit's tuned value, carried across from the ``.mod`` file. It
+    is not a value printed in either cited paper.
+
+    **Import deviations.** The integration method was changed from
+    ``derivimplicit`` to ``cnexp``; the three gate ODEs are
+    independent, so the substitution is exact. This mechanism carries
+    no NMODL ``TABLE``, so no table-removal deviation applies.
+
+    References
+    ----------
+    .. [1] Feng, J., Xu, D., Wang, Z., & Nattel, S. (1998). Ultrarapid
+           delayed rectifier current inactivation in human atrial
+           myocytes: properties and consequences. American Journal of
+           Physiology-Heart and Circulatory Physiology, 275(5),
+           H1717-H1725.
+           doi:10.1152/ajpheart.1998.275.5.H1717
+    .. [2] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -2424,7 +3402,115 @@ class Kv4p3_RI2021_SC(OhmicHH):
 
 @register_channel("KM_MA2020_GoC")
 class KM_MA2020_GoC(OhmicHH):
-    """Template-based import of ``KM_MA2020_GoC.mod``."""
+    r"""M-type potassium current of the Golgi cell model.
+
+    Slow, non-inactivating M-type potassium current imported from the
+    cerebellar Golgi cell model of Masoli et al. (2020) [2]_. A single
+    first-order ``n`` gate of power 1 drives an ohmic current:
+
+    .. math::
+
+        \begin{aligned}
+        n_\infty &= \frac{1}{1 + \exp(-(V + 35) / 6)} \\
+        \alpha_n &= 0.0033 \, \exp((V + 30) / 40) \\
+        \beta_n &= 0.0033 \, \exp(-(V + 30) / 20) \\
+        \tau_n &= \frac{1}{\alpha_n + \beta_n}
+        \end{aligned}
+
+    where :math:`V` is in millivolts, the rates are per millisecond
+    and :math:`\tau_n` is in milliseconds. This class applies no
+    voltage shift, and the reversal potential comes from the potassium
+    ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.25 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.00025 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KM_MA2020_GrC : Granule-cell port of the same mechanism.
+    KM_RI2021_SC : Stellate-cell port of the same mechanism.
+    Kv1p1_MA2020_GoC : Low-threshold Kv1.1 current of the same Golgi
+        cell model.
+
+    Notes
+    -----
+    Ported from ``GoC/channel/KM_MA20_GoC.mod``. That file, the
+    granule port ``GrC/channel/KM_MA20_GrC.mod`` and the stellate port
+    ``SC/channel/KM_RI21_SC.mod`` are byte-identical apart from their
+    ``SUFFIX`` line, and so are the three BrainCell classes: the rate
+    constants above are shared verbatim with :class:`KM_MA2020_GrC`
+    and :class:`KM_RI2021_SC`. What differs is only the deposit each
+    was imported from, and therefore the model paper cited below.
+
+    The mechanism does not use the steady state implied by its own
+    rates. Its ``n_inf = a_n/(a_n + b_n)`` line is commented out in
+    the ``.mod`` source and replaced by the explicit Boltzmann shown
+    above, so :math:`n_\infty` and :math:`\tau_n` are independent
+    expressions here.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 3.0`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the whole
+    :math:`(n_\infty - n)/\tau_n` term by
+    :math:`\phi = 3^{(T - 22)/10}` (about 2.41 at the default 30
+    degrees Celsius). The ``.mod`` file instead multiplies ``Q10``
+    into ``alp_n`` and ``bet_n``, which divides its ``tau_n`` by the
+    same factor. The two forms are algebraically identical, but it
+    means :meth:`f_n_tau` returns the q10-free time constant rather
+    than the mechanism's ``tau_n``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` header carries ``Author: A. Fontana`` and
+    ``CoAuthor: T.Nieus``. That credit line is copy-pasted verbatim
+    across every cell-type port of this mechanism and names people
+    unrelated to the Golgi-cell key, so it is not treated as a
+    citation here. The kinetics originate in the cerebellar granule
+    cell model of D'Angelo et al. (2001) [1]_; the Golgi-cell paper
+    [2]_ names the model this parameterisation was imported from, not
+    the origin of the equations. Reference [2]_ is the Golgi-cell
+    paper specifically -- the companion granule-cell paper of the same
+    year belongs to :class:`KM_MA2020_GrC`, not to this class.
+
+    **Conductance default.** ``0.25 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** The original mechanism's NMODL ``TABLE``
+    over ``[-100, 30] mV``, covering ``n_inf`` and ``tau_n``, is not
+    reproduced: both expressions are evaluated per call. NEURON
+    clamped tabulated values to the boundary outside that window, so
+    any BrainCell-versus-NEURON divergence below -100 mV or above
+    30 mV is expected rather than a port error. The integration
+    method was also changed from ``derivimplicit`` to ``cnexp``;
+    with one independent gate ODE that substitution is exact.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -2467,7 +3553,137 @@ class KM_MA2020_GoC(OhmicHH):
 
 @register_channel("Kv1p1_MA2020_GoC")
 class Kv1p1_MA2020_GoC(HH):
-    """Template-based import of ``Kv1p1_MA2020_GoC.mod``."""
+    r"""Kv1.1 low-threshold potassium current of the Golgi cell model.
+
+    Non-inactivating, low-threshold potassium current carried by Kv1.1
+    subunits, imported from the cerebellar Golgi cell model of Masoli
+    et al. (2020) [3]_. Gating is a single ``n`` gate of power 4 in
+    alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_n &= 0.12889 \, \exp((V + 45) / 33.90877) \\
+        \beta_n &= 0.12889 \, \exp(-(V + 45) / 12.42101)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. Because the two prefactors are equal,
+    :math:`n_\infty = \alpha_n / (\alpha_n + \beta_n)` is exactly 0.5
+    at -45 mV, and the :math:`n^4` conductance reaches half its
+    maximum near -29.9 mV -- consistent with the
+    ``Vhalf = -28.8 +- 2.3 mV`` that the ``.mod`` header quotes from
+    the Zerr et al. (1998) recordings [1]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``, which
+        is exactly the source mechanism's ``gbar = 0.004 S/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        22 degrees Celsius. This equals the gate's reference
+        temperature, so the default temperature factor is exactly 1.
+    gateCurrent : array-like or callable, optional
+        Gating-current switch, default ``0.0`` (dimensionless, off).
+        Any non-zero value enables the gating-current term described
+        below.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv1p1_MA2020_GrC : Granule-cell port of the same mechanism.
+    Kv1p1_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv1p1_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv1p1_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``GoC/channel/Kv1p1_MA20_GoC.mod``. That file and the
+    granule, Purkinje, basket and stellate ports are identical apart
+    from their ``SUFFIX`` line and one line of indentation, and the
+    five BrainCell classes are identical too: the rate constants and
+    the gating-current constants above are shared verbatim with
+    :class:`Kv1p1_MA2020_GrC`, :class:`Kv1p1_MA2024_PC`,
+    :class:`Kv1p1_MA2025_BC` and :class:`Kv1p1_RI2021_SC`. What
+    differs is only the deposit each was imported from, and therefore
+    the model paper cited below.
+
+    **Why this class overrides** ``current``. The mechanism emits an
+    optional Kv gating current alongside the ionic current, so
+    :class:`OhmicHH` is not enough. :meth:`current` returns
+
+    .. math::
+
+        g_{\max} \, n^4 \, (E_K - V) - I_{\text{gate}}
+
+    with
+
+    .. math::
+
+        I_{\text{gate}} = n_c \cdot 10^{6} \cdot e_0 \cdot 4 \, z_n
+        \cdot \frac{\mathrm{d}n}{\mathrm{d}t}, \qquad
+        n_c = 10^{12} \, \frac{g_{\max}}{g_{\text{unit}}}
+
+    where :math:`g_{\text{unit}} = 16` pS is the unitary channel
+    conductance, :math:`z_n = 2.7978` the n-gate valence,
+    :math:`e_0 = 1.60217646 \times 10^{-19}` C the elementary charge
+    and :math:`\mathrm{d}n/\mathrm{d}t` the same
+    :math:`\phi(\alpha_n (1 - n) - \beta_n n)` the gate integrates.
+    NEURON emits this term as a separate ``NONSPECIFIC_CURRENT``;
+    BrainCell folds it into the single ``current()`` return, and the
+    subtraction reflects the package's inward-positive sign
+    convention against NMODL's outward-positive one. The term is
+    selected with ``u.math.where`` rather than a Python branch, so
+    ``gateCurrent`` may be an array and the choice stays traceable.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 2.7`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the rate balance by
+    :math:`\phi = 2.7^{(T - 22)/10}`. The ``.mod`` file instead
+    divides its ``taun`` by the same factor. The two forms are
+    algebraically identical.
+
+    **Provenance.** The ``.mod`` header states that the six rate
+    parameters were obtained by least-squares fits to
+    :math:`G/G_{\max}(V)` and :math:`\tau(V)` data from human Kv1.1
+    expressed in Xenopus oocytes by Zerr et al. (1998) [1]_, and
+    names the RIKEN implementation published by Akemann et al. (2009)
+    [2]_ as its model reference. The Golgi-cell paper [3]_ names the
+    model this parameterisation was imported from, not the origin of
+    the equations; the companion granule-cell paper of the same year
+    belongs to :class:`Kv1p1_MA2020_GrC`, not to this class.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in any of the cited papers.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here.
+
+    References
+    ----------
+    .. [1] Zerr, P., Adelman, J. P., & Maylie, J. (1998). Episodic
+           ataxia mutations in Kv1.1 alter potassium channel function
+           by dominant negative effects or haploinsufficiency. The
+           Journal of Neuroscience, 18(8), 2842-2848.
+           doi:10.1523/JNEUROSCI.18-08-02842.1998
+    .. [2] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+           Effect of voltage sensitive fluorescent proteins on
+           neuronal excitability. Biophysical Journal, 96(10),
+           3959-3976.
+           doi:10.1016/j.bpj.2009.02.046
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -2656,7 +3872,116 @@ class Kv4p3_MA2020_GoC(OhmicHH):
 
 @register_channel("KM_MA2020_GrC")
 class KM_MA2020_GrC(OhmicHH):
-    """Template-based import of ``KM_MA2020_GrC.mod``."""
+    r"""M-type potassium current of the granule cell model.
+
+    Slow, non-inactivating M-type potassium current imported from the
+    cerebellar granule cell model of Masoli et al. (2020) [2]_. A
+    single first-order ``n`` gate of power 1 drives an ohmic current:
+
+    .. math::
+
+        \begin{aligned}
+        n_\infty &= \frac{1}{1 + \exp(-(V + 35) / 6)} \\
+        \alpha_n &= 0.0033 \, \exp((V + 30) / 40) \\
+        \beta_n &= 0.0033 \, \exp(-(V + 30) / 20) \\
+        \tau_n &= \frac{1}{\alpha_n + \beta_n}
+        \end{aligned}
+
+    where :math:`V` is in millivolts, the rates are per millisecond
+    and :math:`\tau_n` is in milliseconds. This class applies no
+    voltage shift, and the reversal potential comes from the potassium
+    ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.25 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gkbar = 0.00025 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    KM_MA2020_GoC : Golgi-cell port of the same mechanism.
+    KM_RI2021_SC : Stellate-cell port of the same mechanism.
+    Kir2p3_MA2020_GrC : Inward rectifier of the same granule cell
+        model, sharing the same origin paper.
+
+    Notes
+    -----
+    Ported from ``GrC/channel/KM_MA20_GrC.mod``. That file, the Golgi
+    port ``GoC/channel/KM_MA20_GoC.mod`` and the stellate port
+    ``SC/channel/KM_RI21_SC.mod`` are byte-identical apart from their
+    ``SUFFIX`` line, and so are the three BrainCell classes: the rate
+    constants above are shared verbatim with :class:`KM_MA2020_GoC`
+    and :class:`KM_RI2021_SC`. What differs is only the deposit each
+    was imported from, and therefore the model paper cited below.
+
+    The mechanism does not use the steady state implied by its own
+    rates. Its ``n_inf = a_n/(a_n + b_n)`` line is commented out in
+    the ``.mod`` source and replaced by the explicit Boltzmann shown
+    above, so :math:`n_\infty` and :math:`\tau_n` are independent
+    expressions here.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 3.0`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the whole
+    :math:`(n_\infty - n)/\tau_n` term by
+    :math:`\phi = 3^{(T - 22)/10}` (about 2.41 at the default 30
+    degrees Celsius). The ``.mod`` file instead multiplies ``Q10``
+    into ``alp_n`` and ``bet_n``, which divides its ``tau_n`` by the
+    same factor. The two forms are algebraically identical, but it
+    means :meth:`f_n_tau` returns the q10-free time constant rather
+    than the mechanism's ``tau_n``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` header carries ``Author: A. Fontana`` and
+    ``CoAuthor: T.Nieus``. That credit line is copy-pasted verbatim
+    across every cell-type port of this mechanism and names people
+    unrelated to the granule-cell key, so it is not treated as a
+    citation here. The kinetics originate in the cerebellar granule
+    cell model of D'Angelo et al. (2001) [1]_; the granule-cell paper
+    [2]_ names the model this parameterisation was imported from, not
+    the origin of the equations. Reference [2]_ is the granule-cell
+    paper specifically -- the companion Golgi-cell paper of the same
+    year belongs to :class:`KM_MA2020_GoC`, not to this class.
+
+    **Conductance default.** ``0.25 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** The original mechanism's NMODL ``TABLE``
+    over ``[-100, 30] mV``, covering ``n_inf`` and ``tau_n``, is not
+    reproduced: both expressions are evaluated per call. NEURON
+    clamped tabulated values to the boundary outside that window, so
+    any BrainCell-versus-NEURON divergence below -100 mV or above
+    30 mV is expected rather than a port error. The integration
+    method was also changed from ``derivimplicit`` to ``cnexp``;
+    with one independent gate ODE that substitution is exact.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -2699,7 +4024,122 @@ class KM_MA2020_GrC(OhmicHH):
 
 @register_channel("Kir2p3_MA2020_GrC")
 class Kir2p3_MA2020_GrC(OhmicHH):
-    """Template-based import of ``Kir2p3_MA2020_GrC.mod``."""
+    r"""Kir2.3 inward-rectifier current of the granule cell model.
+
+    Hyperpolarization-activated inward-rectifier potassium current
+    imported from the cerebellar granule cell model of Masoli et al.
+    (2020) [2]_. A single first-order ``d`` gate of power 1 drives an
+    ohmic current, with the gate written in alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_d &= 0.13289 \, \exp(-(V + 83.94) / 24.3902) \\
+        \beta_d &= 0.16994 \, \exp((V + 83.94) / 35.714)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. The template forms
+    :math:`d_\infty = \alpha_d / (\alpha_d + \beta_d)` and
+    :math:`\tau_d = 1 / (\alpha_d + \beta_d)` from these; half
+    activation falls near -87.5 mV, and :math:`d_\infty` rises towards
+    1 as the membrane hyperpolarizes. This class applies no voltage
+    shift, and the reversal potential comes from the potassium ion
+    object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.9 mS/cm2``, which
+        is exactly the source mechanism's ``gkbar = 0.0009 mho/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        30 degrees Celsius. This matches the ``celsius = 30 (degC)``
+        written in the source mechanism's ``PARAMETER`` block.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kir2p3_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kir2p3_MA2025_BC : Basket-cell port of the same mechanism.
+    Kir2p3_RI2021_SC : Stellate-cell port of the same mechanism.
+    KM_MA2020_GrC : M-type current of the same granule cell model,
+        sharing the same origin paper.
+
+    Notes
+    -----
+    Ported from ``GrC/channel/Kir2p3_MA20_GrC.mod``. That file and the
+    Purkinje, basket and stellate ports are byte-identical apart from
+    their ``SUFFIX`` line and, in the Purkinje port only, the
+    mechanism-local ``celsius`` default. The four BrainCell classes
+    are likewise identical, so the rate constants above are shared
+    verbatim with :class:`Kir2p3_MA2024_PC`,
+    :class:`Kir2p3_MA2025_BC` and :class:`Kir2p3_RI2021_SC`. What
+    differs is only the deposit each was imported from, and therefore
+    the model paper cited below.
+
+    **The rectification lives in the gate, not in the current.** The
+    current expression is the plain ohmic
+    ``g_max * d * (E_K - V)`` supplied by :class:`OhmicHH`; there is
+    no Mg2+ or polyamine block term anywhere in the mechanism. The
+    inward-rectifier behaviour comes entirely from :math:`d_\infty`
+    increasing as the membrane hyperpolarizes.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 3.0`` at a reference of 20 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the whole
+    :math:`\alpha_d (1 - d) - \beta_d d` term by
+    :math:`\phi = 3^{(T - 20)/10}`, which is exactly 3 at the default
+    30 degrees Celsius. The ``.mod`` file instead multiplies ``Q10``
+    into ``alp_d`` and ``bet_d``. The two forms are algebraically
+    identical, but it means :meth:`f_d_alpha` and :meth:`f_d_beta`
+    return the q10-free rates rather than the mechanism's
+    ``alpha_d``/``beta_d``.
+
+    **Provenance, and what the header does not establish.** The
+    ``.mod`` ``COMMENT`` carries a reference string that is the
+    published title of D'Angelo et al. (2001) truncated mid-subtitle,
+    plus the porting note "Suffix from Ubc_Kir to Kir2_3". Neither is
+    treated as a citation here. The kinetics originate in the
+    cerebellar granule cell model of D'Angelo et al. (2001) [1]_; the
+    granule-cell paper [2]_ names the model this parameterisation was
+    imported from, not the origin of the equations. Reference [2]_ is
+    the granule-cell paper specifically -- the companion Golgi-cell
+    paper of the same year covers a different deposit and is not
+    cited here.
+
+    **Conductance default.** ``0.9 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in either cited paper.
+
+    **Import deviations.** The original mechanism's NMODL ``TABLE``
+    over ``[-100, 100] mV``, covering ``d_inf`` and ``tau_d``, is not
+    reproduced: both expressions are evaluated per call. NEURON used
+    the boundary value outside that window, so any
+    BrainCell-versus-NEURON divergence below -100 mV or above 100 mV
+    is expected rather than a port error. The integration method was
+    also changed from ``derivimplicit`` to ``cnexp``; with one
+    independent gate ODE that substitution is exact.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+           Taglietti, V., Fontana, A., & Naldi, G. (2001).
+           Theta-frequency bursting and resonance in cerebellar
+           granule cells: experimental evidence and modeling of a
+           slow K+-dependent mechanism. The Journal of Neuroscience,
+           21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -2733,7 +4173,138 @@ class Kir2p3_MA2020_GrC(OhmicHH):
 
 @register_channel("Kv1p1_MA2020_GrC")
 class Kv1p1_MA2020_GrC(HH):
-    """Template-based import of ``Kv1p1_MA2020_GrC.mod``."""
+    r"""Kv1.1 low-threshold potassium current of the granule model.
+
+    Non-inactivating, low-threshold potassium current carried by Kv1.1
+    subunits, imported from the cerebellar granule cell model of
+    Masoli et al. (2020) [3]_. Gating is a single ``n`` gate of power
+    4 in alpha/beta form:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_n &= 0.12889 \, \exp((V + 45) / 33.90877) \\
+        \beta_n &= 0.12889 \, \exp(-(V + 45) / 12.42101)
+        \end{aligned}
+
+    where :math:`V` is in millivolts and the rates are per
+    millisecond. Because the two prefactors are equal,
+    :math:`n_\infty = \alpha_n / (\alpha_n + \beta_n)` is exactly 0.5
+    at -45 mV, and the :math:`n^4` conductance reaches half its
+    maximum near -29.9 mV -- consistent with the
+    ``Vhalf = -28.8 +- 2.3 mV`` that the ``.mod`` header quotes from
+    the Zerr et al. (1998) recordings [1]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``4.0 mS/cm2``, which
+        is exactly the source mechanism's ``gbar = 0.004 S/cm2``.
+    temp : array-like, optional
+        Absolute temperature driving the gate's q10 factor, default
+        22 degrees Celsius. This equals the gate's reference
+        temperature, so the default temperature factor is exactly 1.
+    gateCurrent : array-like or callable, optional
+        Gating-current switch, default ``0.0`` (dimensionless, off).
+        Any non-zero value enables the gating-current term described
+        below.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kv1p1_MA2020_GoC : Golgi-cell port of the same mechanism.
+    Kv1p1_MA2024_PC : Purkinje-cell port of the same mechanism.
+    Kv1p1_MA2025_BC : Basket-cell port of the same mechanism.
+    Kv1p1_RI2021_SC : Stellate-cell port of the same mechanism.
+
+    Notes
+    -----
+    Ported from ``GrC/channel/Kv1p1_MA20_GrC.mod``. That file and the
+    Golgi, Purkinje, basket and stellate ports are identical apart
+    from their ``SUFFIX`` line and one line of indentation, and the
+    five BrainCell classes are identical too: the rate constants and
+    the gating-current constants above are shared verbatim with
+    :class:`Kv1p1_MA2020_GoC`, :class:`Kv1p1_MA2024_PC`,
+    :class:`Kv1p1_MA2025_BC` and :class:`Kv1p1_RI2021_SC`. What
+    differs is only the deposit each was imported from, and therefore
+    the model paper cited below.
+
+    **Why this class overrides** ``current``. The mechanism emits an
+    optional Kv gating current alongside the ionic current, so
+    :class:`OhmicHH` is not enough. :meth:`current` returns
+
+    .. math::
+
+        g_{\max} \, n^4 \, (E_K - V) - I_{\text{gate}}
+
+    with
+
+    .. math::
+
+        I_{\text{gate}} = n_c \cdot 10^{6} \cdot e_0 \cdot 4 \, z_n
+        \cdot \frac{\mathrm{d}n}{\mathrm{d}t}, \qquad
+        n_c = 10^{12} \, \frac{g_{\max}}{g_{\text{unit}}}
+
+    where :math:`g_{\text{unit}} = 16` pS is the unitary channel
+    conductance, :math:`z_n = 2.7978` the n-gate valence,
+    :math:`e_0 = 1.60217646 \times 10^{-19}` C the elementary charge
+    and :math:`\mathrm{d}n/\mathrm{d}t` the same
+    :math:`\phi(\alpha_n (1 - n) - \beta_n n)` the gate integrates.
+    NEURON emits this term as a separate ``NONSPECIFIC_CURRENT``;
+    BrainCell folds it into the single ``current()`` return, and the
+    subtraction reflects the package's inward-positive sign
+    convention against NMODL's outward-positive one. The term is
+    selected with ``u.math.where`` rather than a Python branch, so
+    ``gateCurrent`` may be an array and the choice stays traceable.
+
+    **Where the q10 factor is applied.** The gate declares
+    ``q10 = 2.7`` at a reference of 22 degrees Celsius, so
+    :meth:`HH.compute_derivative` scales the rate balance by
+    :math:`\phi = 2.7^{(T - 22)/10}`. The ``.mod`` file instead
+    divides its ``taun`` by the same factor. The two forms are
+    algebraically identical.
+
+    **Provenance.** The ``.mod`` header states that the six rate
+    parameters were obtained by least-squares fits to
+    :math:`G/G_{\max}(V)` and :math:`\tau(V)` data from human Kv1.1
+    expressed in Xenopus oocytes by Zerr et al. (1998) [1]_, and
+    names the RIKEN implementation published by Akemann et al. (2009)
+    [2]_ as its model reference. The granule-cell paper [3]_ names
+    the model this parameterisation was imported from, not the origin
+    of the equations; the companion Golgi-cell paper of the same year
+    belongs to :class:`Kv1p1_MA2020_GoC`, not to this class.
+
+    **Conductance default.** ``4.0 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in any of the cited papers.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream, so
+    neither the table-removal nor the ``derivimplicit`` substitution
+    recorded for other channels in this model applies here.
+
+    References
+    ----------
+    .. [1] Zerr, P., Adelman, J. P., & Maylie, J. (1998). Episodic
+           ataxia mutations in Kv1.1 alter potassium channel function
+           by dominant negative effects or haploinsufficiency. The
+           Journal of Neuroscience, 18(8), 2842-2848.
+           doi:10.1523/JNEUROSCI.18-08-02842.1998
+    .. [2] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+           Effect of voltage sensitive fluorescent proteins on
+           neuronal excitability. Biophysical Journal, 96(10),
+           3959-3976.
+           doi:10.1016/j.bpj.2009.02.046
+    .. [3] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium
@@ -2783,7 +4354,110 @@ class Kv1p1_MA2020_GrC(HH):
 
 @register_channel("Kv2p2_0010_MA2020_GrC")
 class Kv2p2_0010_MA2020_GrC(OhmicHH):
-    """Template-based import of ``Kv2p2_0010_MA2020_GrC.mod``."""
+    r"""Kv2.2 delayed-rectifier current of the granule cell model.
+
+    Slowly inactivating delayed-rectifier potassium current attributed
+    to Kv2.2, imported from the cerebellar granule cell model of
+    Masoli et al. (2020) [3]_. Two first-order gates of power 1, an
+    activation ``m`` and an inactivation ``h``, drive an ohmic
+    current:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp(-(V - 5) / 12)} \\
+        \tau_m &= \frac{130}{1 + \exp(-(V + 46.56) / 44.14)} \\
+        h_\infty &= \frac{1}{1 + \exp((V + 16.3) / 4.8)} \\
+        \tau_h &= \frac{10000}{1 + \exp(-(V + 46.56) / 44.14)}
+        \end{aligned}
+
+    where :math:`V` is in millivolts and both time constants are in
+    milliseconds. The two time constants share a denominator and
+    differ only by a factor of about 77, so inactivation is very slow
+    -- :math:`\tau_h` approaches 10 seconds at depolarized potentials.
+    This class applies no voltage shift, and the reversal potential
+    comes from the potassium ion object rather than from the class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density. Defaults to ``0.01 mS/cm2``,
+        which is exactly the source mechanism's
+        ``gKv2_2bar = 0.00001 S/cm2``.
+    BBiD : array-like or callable, optional
+        Channelpedia ion-channel identifier, default ``10.0``
+        (dimensionless). This is inert metadata, not a kinetic
+        parameter; see the note below.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kir2p3_MA2020_GrC : Inward rectifier of the same granule cell
+        model.
+    KM_MA2020_GrC : M-type current of the same granule cell model.
+
+    Notes
+    -----
+    Ported from ``GrC/channel/Kv2p2_0010_MA20_GrC.mod``.
+
+    **No temperature dependence.** Neither gate declares ``phi`` or
+    ``q10``, so :meth:`HH.gate_phi` resolves to ``1.0``, and the class
+    takes no ``temp`` parameter at all. This is faithful: the ``.mod``
+    file contains no ``celsius`` reference and no Q10 term.
+
+    **``BBiD`` is metadata, not a parameter of the model.** In the
+    ``.mod`` file ``BBiD = 10`` is declared ``RANGE`` but never
+    appears in any equation, and BrainCell likewise stores it and
+    never reads it. It is the Channelpedia identifier for Kv2.2 (gene
+    *KCNB2*), and it is also the ``0010`` embedded in the class name.
+
+    **How this mechanism was produced.** The ``.mod`` file is machine
+    generated, not hand written: its version-control keywords name the
+    EPFL Blue Brain ``xmlTomod/CreateMOD.c`` generator behind the
+    Channelpedia database of Ranjan et al. (2011) [2]_. That record is
+    cited here for the toolchain and the channel identity only -- it
+    is not the source of the rate constants above. Those come from the
+    delayed-rectifier component identified in gastrointestinal smooth
+    muscle by Schmalz et al. (1998) [1]_, which the ``.mod`` header's
+    own ``:Reference :`` line names. The granule-cell paper [3]_ names
+    the model this parameterisation was imported from; the companion
+    Golgi-cell paper of the same year covers a different deposit and
+    is not cited here.
+
+    **Conductance default.** ``0.01 mS/cm2`` is the deposit's tuned
+    value, carried across from the ``.mod`` file. It is not a value
+    printed in any of the cited papers.
+
+    **Import deviations: none.** This mechanism carries no NMODL
+    ``TABLE`` and was already integrated with ``cnexp`` upstream. Its
+    rate block is wrapped in ``UNITSOFF``/``UNITSON``, which BrainCell
+    reproduces by evaluating the expressions on the dimensionless
+    millivolt value of ``V``.
+
+    References
+    ----------
+    .. [1] Schmalz, F., Kinsella, J., Koh, S. D., Vogalis, F.,
+           Schneider, A., Flynn, E. R. M., Kenyon, J. L., & Horowitz,
+           B. (1998). Molecular identification of a component of
+           delayed rectifier current in gastrointestinal smooth
+           muscles. American Journal of Physiology-Gastrointestinal
+           and Liver Physiology, 274(5), G901-G911.
+           doi:10.1152/ajpgi.1998.274.5.G901
+    .. [2] Ranjan, R., Khazen, G., Gambazzi, L., Ramaswamy, S., Hill,
+           S. L., Schurmann, F., & Markram, H. (2011). Channelpedia:
+           an integrative and interactive database for ion channels.
+           Frontiers in Neuroinformatics, 5, 36.
+           doi:10.3389/fninf.2011.00036
+    .. [3] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Potassium

--- a/braincell/channel/potassium_calcium.py
+++ b/braincell/channel/potassium_calcium.py
@@ -349,7 +349,10 @@ class Kca3p1_MA2020_GoC(OhmicHH):
 
     Notes
     -----
-    Ported from ``Kca3p1_MA20_GoC.mod``.
+    Ported from ``Kca3p1_MA20_GoC.mod``, whose header credits the
+    implementation to Rubin & Cleland (2006) [1]_, the parameters to
+    Bhalla & Bower (1993) [2]_, and the mod file itself to Andrew
+    Davison [3]_.
 
     **``q10_base`` and ``temp`` are accepted but never read.** Both
     are stored on ``self`` in ``__init__`` but no method in this
@@ -479,7 +482,11 @@ class Kca3p1_MA2025_BC(Kca3p1_MA2020_GoC):
 
     Notes
     -----
-    Ported from ``Kca3p1_MA25_BC.mod``. This class does not override
+    Ported from ``Kca3p1_MA25_BC.mod``, whose header carries the same
+    credits as the Golgi-cell file: the implementation to Rubin &
+    Cleland (2006) [1]_, the parameters to Bhalla & Bower (1993)
+    [2]_, and the mod file itself to Andrew Davison [3]_.
+    This class does not override
     ``__init__``: the constructor, the rate methods and the fixed
     ``p_beta = 0.05`` constant are all inherited unchanged from
     :class:`Kca3p1_MA2020_GoC`. Only the ``register_channel`` key and
@@ -556,7 +563,11 @@ class Kca3p1_MA2024_PC(Kca3p1_MA2020_GoC):
 
     Notes
     -----
-    Ported from ``Kca3p1_MA24_PC.mod``. This class does not override
+    Ported from ``Kca3p1_MA24_PC.mod``, whose header carries the same
+    credits as the Golgi-cell file: the implementation to Rubin &
+    Cleland (2006) [1]_, the parameters to Bhalla & Bower (1993)
+    [2]_, and the mod file itself to Andrew Davison [3]_.
+    This class does not override
     ``__init__``: the constructor, the rate methods and the fixed
     ``p_beta = 0.05`` constant are all inherited unchanged from
     :class:`Kca3p1_MA2020_GoC`. Only the ``register_channel`` key and
@@ -787,8 +798,11 @@ class Kca2p2_MA2025_BC(Kca2p2_MA2020_GoC):
     r"""Kca2.2 calcium-activated K current, basket-cell parameterisation.
 
     The same seven-state Kca2.2 Markov scheme documented in
-    :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
-    basket cell model of (Masoli et al., 2025) [3]_.
+    :class:`Kca2p2_MA2020_GoC` -- kinetics from the recombinant
+    SK-channel gating scheme of (Hirschberg et al., 1998) [1]_ as
+    implemented by (Solinas et al., 2007) [2]_ -- reused unchanged
+    for the cerebellar basket cell model of
+    (Masoli et al., 2025) [3]_.
 
     Parameters
     ----------
@@ -859,8 +873,11 @@ class Kca2p2_MA2020_GrC(Kca2p2_MA2020_GoC):
     r"""Kca2.2 calcium-activated K current, granule-cell parameterisation.
 
     The same seven-state Kca2.2 Markov scheme documented in
-    :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
-    granule cell subtype model of (Masoli et al., 2020) [3]_. This
+    :class:`Kca2p2_MA2020_GoC` -- kinetics from the recombinant
+    SK-channel gating scheme of (Hirschberg et al., 1998) [1]_ as
+    implemented by (Solinas et al., 2007) [2]_ -- reused unchanged
+    for the cerebellar granule cell subtype model of
+    (Masoli et al., 2020) [3]_. This
     class is a Python subclass of :class:`Kca2p2_MA2020_GoC`, but
     that inheritance relationship is purely a code-reuse device: the
     kinetics and model citation below belong to the granule cell
@@ -939,8 +956,11 @@ class Kca2p2_MA2024_PC(Kca2p2_MA2020_GoC):
     r"""Kca2.2 calcium-activated K current, Purkinje-cell parameterisation.
 
     The same seven-state Kca2.2 Markov scheme documented in
-    :class:`Kca2p2_MA2020_GoC`, reused unchanged for the human
-    Purkinje cell model of (Masoli et al., 2024) [3]_.
+    :class:`Kca2p2_MA2020_GoC` -- kinetics from the recombinant
+    SK-channel gating scheme of (Hirschberg et al., 1998) [1]_ as
+    implemented by (Solinas et al., 2007) [2]_ -- reused unchanged
+    for the human Purkinje cell model of
+    (Masoli et al., 2024) [3]_.
 
     Parameters
     ----------
@@ -1012,8 +1032,11 @@ class Kca2p2_RI2021_SC(Kca2p2_MA2020_GoC):
     r"""Kca2.2 calcium-activated K current, stellate-cell parameterisation.
 
     The same seven-state Kca2.2 Markov scheme documented in
-    :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
-    stellate cell model of (Rizza et al., 2021) [3]_.
+    :class:`Kca2p2_MA2020_GoC` -- kinetics from the recombinant
+    SK-channel gating scheme of (Hirschberg et al., 1998) [1]_ as
+    implemented by (Solinas et al., 2007) [2]_ -- reused unchanged
+    for the cerebellar stellate cell model of
+    (Rizza et al., 2021) [3]_.
 
     Parameters
     ----------
@@ -1338,8 +1361,11 @@ class Kca1p1_MA2025_BC(Kca1p1_MA2020_GoC):
     r"""Kca1.1 Ca- and voltage-activated K current, basket-cell variant.
 
     The same ten-state Kca1.1 Markov scheme documented in
-    :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
-    basket cell model of (Masoli et al., 2025) [3]_.
+    :class:`Kca1p1_MA2020_GoC` -- parameters from the allosteric
+    BK-channel gating scheme of (Cox, Cui, & Aldrich, 1997) [1]_ as
+    adapted by (Anwar, Hong, & De Schutter, 2012) [2]_ -- reused
+    unchanged for the cerebellar basket cell model of
+    (Masoli et al., 2025) [3]_.
 
     Parameters
     ----------
@@ -1404,8 +1430,11 @@ class Kca1p1_MA2020_GrC(Kca1p1_MA2020_GoC):
     r"""Kca1.1 Ca- and voltage-activated K current, granule-cell variant.
 
     The same ten-state Kca1.1 Markov scheme documented in
-    :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
-    granule cell subtype model of (Masoli et al., 2020) [3]_. This
+    :class:`Kca1p1_MA2020_GoC` -- parameters from the allosteric
+    BK-channel gating scheme of (Cox, Cui, & Aldrich, 1997) [1]_ as
+    adapted by (Anwar, Hong, & De Schutter, 2012) [2]_ -- reused
+    unchanged for the cerebellar granule cell subtype model of
+    (Masoli et al., 2020) [3]_. This
     class is a Python subclass of :class:`Kca1p1_MA2020_GoC`, but
     that inheritance relationship is purely a code-reuse device: the
     kinetics and model citation below belong to the granule cell
@@ -1478,8 +1507,11 @@ class Kca1p1_MA2024_PC(Kca1p1_MA2020_GoC):
     r"""Kca1.1 Ca- and voltage-activated K current, Purkinje-cell variant.
 
     The same ten-state Kca1.1 Markov scheme documented in
-    :class:`Kca1p1_MA2020_GoC`, reused unchanged for the human
-    Purkinje cell model of (Masoli et al., 2024) [3]_.
+    :class:`Kca1p1_MA2020_GoC` -- parameters from the allosteric
+    BK-channel gating scheme of (Cox, Cui, & Aldrich, 1997) [1]_ as
+    adapted by (Anwar, Hong, & De Schutter, 2012) [2]_ -- reused
+    unchanged for the human Purkinje cell model of
+    (Masoli et al., 2024) [3]_.
 
     Parameters
     ----------
@@ -1545,8 +1577,11 @@ class Kca1p1_RI2021_SC(Kca1p1_MA2020_GoC):
     r"""Kca1.1 Ca- and voltage-activated K current, stellate-cell variant.
 
     The same ten-state Kca1.1 Markov scheme documented in
-    :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
-    stellate cell model of (Rizza et al., 2021) [3]_.
+    :class:`Kca1p1_MA2020_GoC` -- parameters from the allosteric
+    BK-channel gating scheme of (Cox, Cui, & Aldrich, 1997) [1]_ as
+    adapted by (Anwar, Hong, & De Schutter, 2012) [2]_ -- reused
+    unchanged for the cerebellar stellate cell model of
+    (Rizza et al., 2021) [3]_.
 
     Parameters
     ----------

--- a/braincell/channel/potassium_calcium.py
+++ b/braincell/channel/potassium_calcium.py
@@ -149,10 +149,9 @@ class AHP_De1994(OhmicHH):
 
     References
     ----------
-    .. [1] Destexhe, A., Contreras, D., Sejnowski, T. J., & Steriade,
-           M. (1994). A model of spindle rhythmicity in the isolated
-           thalamic reticular nucleus. Journal of Neurophysiology,
-           72(2), 803-818.
+    .. [1] Destexhe, A., Contreras, D., Sejnowski, T. J., & Steriade, M.
+           (1994). A model of spindle rhythmicity in the isolated thalamic
+           reticular nucleus. Journal of Neurophysiology, 72(2), 803-818.
            doi:10.1152/jn.1994.72.2.803
     """
 

--- a/braincell/channel/potassium_calcium.py
+++ b/braincell/channel/potassium_calcium.py
@@ -297,7 +297,7 @@ class SK_SU2015_DCN(OhmicHH):
 
 @register_channel("Kca3p1_MA2020_GoC")
 class Kca3p1_MA2020_GoC(OhmicHH):
-    r"""Kca3.1 (intermediate-conductance) calcium-activated K current, Golgi cell.
+    r"""Kca3.1 (IK) calcium-activated K current, Golgi cell.
 
     Template-based import of ``Kca3p1_MA20_GoC.mod``, part of the
     cerebellar Golgi cell model of (Masoli et al., 2020) [4]_. A
@@ -600,7 +600,7 @@ class Kca3p1_MA2024_PC(Kca3p1_MA2020_GoC):
 
 @register_channel("Kca2p2_MA2020_GoC")
 class Kca2p2_MA2020_GoC(Markov):
-    r"""Kca2.2 (SK2) small-conductance calcium-activated K current, Golgi cell.
+    r"""Kca2.2 (SK2) calcium-activated K current, Golgi cell.
 
     Template-based import of ``Kca2p2_MA20_GoC.mod``, part of the
     cerebellar Golgi cell model of (Masoli et al., 2020) [3]_, with
@@ -785,7 +785,7 @@ class Kca2p2_MA2020_GoC(Markov):
 
 @register_channel("Kca2p2_MA2025_BC")
 class Kca2p2_MA2025_BC(Kca2p2_MA2020_GoC):
-    r"""Kca2.2 (SK2) calcium-activated K current, basket-cell parameterisation.
+    r"""Kca2.2 calcium-activated K current, basket-cell parameterisation.
 
     The same seven-state Kca2.2 Markov scheme documented in
     :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
@@ -857,7 +857,7 @@ class Kca2p2_MA2025_BC(Kca2p2_MA2020_GoC):
 
 @register_channel("Kca2p2_MA2020_GrC")
 class Kca2p2_MA2020_GrC(Kca2p2_MA2020_GoC):
-    r"""Kca2.2 (SK2) calcium-activated K current, granule-cell parameterisation.
+    r"""Kca2.2 calcium-activated K current, granule-cell parameterisation.
 
     The same seven-state Kca2.2 Markov scheme documented in
     :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
@@ -928,7 +928,8 @@ class Kca2p2_MA2020_GrC(Kca2p2_MA2020_GoC):
            D'Angelo, E. (2020). Parameter tuning differentiates
            granule cell subtypes enriching transmission properties
            at the cerebellum input stage. Communications Biology,
-           3(1), 222. doi:10.1038/s42003-020-0953-x
+           3(1), 222.
+           doi:10.1038/s42003-020-0953-x
     """
 
     __module__ = "braincell.channel"
@@ -936,7 +937,7 @@ class Kca2p2_MA2020_GrC(Kca2p2_MA2020_GoC):
 
 @register_channel("Kca2p2_MA2024_PC")
 class Kca2p2_MA2024_PC(Kca2p2_MA2020_GoC):
-    r"""Kca2.2 (SK2) calcium-activated K current, Purkinje-cell parameterisation.
+    r"""Kca2.2 calcium-activated K current, Purkinje-cell parameterisation.
 
     The same seven-state Kca2.2 Markov scheme documented in
     :class:`Kca2p2_MA2020_GoC`, reused unchanged for the human
@@ -1009,7 +1010,7 @@ class Kca2p2_MA2024_PC(Kca2p2_MA2020_GoC):
 
 @register_channel("Kca2p2_RI2021_SC")
 class Kca2p2_RI2021_SC(Kca2p2_MA2020_GoC):
-    r"""Kca2.2 (SK2) calcium-activated K current, stellate-cell parameterisation.
+    r"""Kca2.2 calcium-activated K current, stellate-cell parameterisation.
 
     The same seven-state Kca2.2 Markov scheme documented in
     :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
@@ -1072,7 +1073,8 @@ class Kca2p2_RI2021_SC(Kca2p2_MA2020_GoC):
            Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
            cell computational modeling predicts signal filtering in
            the molecular layer circuit of cerebellum. Scientific
-           Reports, 11(1), 3873. doi:10.1038/s41598-021-83209-w
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
     """
 
     __module__ = "braincell.channel"
@@ -1080,7 +1082,7 @@ class Kca2p2_RI2021_SC(Kca2p2_MA2020_GoC):
 
 @register_channel("Kca1p1_MA2020_GoC")
 class Kca1p1_MA2020_GoC(Markov):
-    r"""Kca1.1 (BK/mslo) large-conductance calcium- and voltage-activated K current, Golgi cell.
+    r"""Kca1.1 (BK/mslo) Ca- and voltage-activated K current, Golgi cell.
 
     Template-based import of ``Kca1p1_MA20_GoC.mod``, part of the
     cerebellar Golgi cell model of (Masoli et al., 2020) [3]_, with
@@ -1098,9 +1100,9 @@ class Kca1p1_MA2020_GoC(Markov):
         \begin{aligned}
         I &= g_{\mathrm{max}} \, (O_0 + O_1 + O_2 + O_3 + O_4) \,
              (E_K - V) \\
-        C_i \underset{i K_c k_1}{\overset{(4-i)[\mathrm{Ca}]_i k_1}{
+        C_i \underset{(i+1) K_c k_1}{\overset{(4-i)[\mathrm{Ca}]_i k_1}{
             \rightleftharpoons}} C_{i+1}, &\qquad
-        O_i \underset{i K_o k_1}{\overset{(4-i)[\mathrm{Ca}]_i k_1}{
+        O_i \underset{(i+1) K_o k_1}{\overset{(4-i)[\mathrm{Ca}]_i k_1}{
             \rightleftharpoons}} O_{i+1}, \qquad i = 0,\dots,3 \\
         C_i \underset{\mathrm{pb}_i \, \beta(V)}{\overset{
             \mathrm{pf}_i \, \alpha(V)}{\rightleftharpoons}} O_i,
@@ -1110,8 +1112,11 @@ class Kca1p1_MA2020_GoC(Markov):
         \end{aligned}
 
     where :math:`[\mathrm{Ca}]_i` is expressed in mM, :math:`k_1`,
-    :math:`K_c`, :math:`K_o` are fixed rate/dissociation constants,
-    every rate additionally carries the multiplicative factor
+    :math:`K_c`, :math:`K_o` are fixed rate/dissociation constants;
+    each unbinding step is standard mass-action, so its rate scales
+    with the number of calcium ions bound in the state being left,
+    i.e. :math:`(i+1)` for the departure from :math:`C_{i+1}` or
+    :math:`O_{i+1}`. Every rate additionally carries the multiplicative factor
     :math:`\phi = q_{10}^{(T - 296.15\,\mathrm{K}) / 10}`
     (:math:`23\,^{\circ}\mathrm{C}` reference), :math:`F` is the
     Faraday constant, :math:`R` the gas constant, and :math:`Q_o`,
@@ -1331,7 +1336,7 @@ class Kca1p1_MA2020_GoC(Markov):
 
 @register_channel("Kca1p1_MA2025_BC")
 class Kca1p1_MA2025_BC(Kca1p1_MA2020_GoC):
-    r"""Kca1.1 (BK/mslo) calcium- and voltage-activated K current, basket-cell parameterisation.
+    r"""Kca1.1 Ca- and voltage-activated K current, basket-cell variant.
 
     The same ten-state Kca1.1 Markov scheme documented in
     :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
@@ -1397,7 +1402,7 @@ class Kca1p1_MA2025_BC(Kca1p1_MA2020_GoC):
 
 @register_channel("Kca1p1_MA2020_GrC")
 class Kca1p1_MA2020_GrC(Kca1p1_MA2020_GoC):
-    r"""Kca1.1 (BK/mslo) calcium- and voltage-activated K current, granule-cell parameterisation.
+    r"""Kca1.1 Ca- and voltage-activated K current, granule-cell variant.
 
     The same ten-state Kca1.1 Markov scheme documented in
     :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
@@ -1462,7 +1467,8 @@ class Kca1p1_MA2020_GrC(Kca1p1_MA2020_GoC):
            D'Angelo, E. (2020). Parameter tuning differentiates
            granule cell subtypes enriching transmission properties
            at the cerebellum input stage. Communications Biology,
-           3(1), 222. doi:10.1038/s42003-020-0953-x
+           3(1), 222.
+           doi:10.1038/s42003-020-0953-x
     """
 
     __module__ = "braincell.channel"
@@ -1470,7 +1476,7 @@ class Kca1p1_MA2020_GrC(Kca1p1_MA2020_GoC):
 
 @register_channel("Kca1p1_MA2024_PC")
 class Kca1p1_MA2024_PC(Kca1p1_MA2020_GoC):
-    r"""Kca1.1 (BK/mslo) calcium- and voltage-activated K current, Purkinje-cell parameterisation.
+    r"""Kca1.1 Ca- and voltage-activated K current, Purkinje-cell variant.
 
     The same ten-state Kca1.1 Markov scheme documented in
     :class:`Kca1p1_MA2020_GoC`, reused unchanged for the human
@@ -1537,7 +1543,7 @@ class Kca1p1_MA2024_PC(Kca1p1_MA2020_GoC):
 
 @register_channel("Kca1p1_RI2021_SC")
 class Kca1p1_RI2021_SC(Kca1p1_MA2020_GoC):
-    r"""Kca1.1 (BK/mslo) calcium- and voltage-activated K current, stellate-cell parameterisation.
+    r"""Kca1.1 Ca- and voltage-activated K current, stellate-cell variant.
 
     The same ten-state Kca1.1 Markov scheme documented in
     :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
@@ -1594,7 +1600,8 @@ class Kca1p1_RI2021_SC(Kca1p1_MA2020_GoC):
            Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
            cell computational modeling predicts signal filtering in
            the molecular layer circuit of cerebellum. Scientific
-           Reports, 11(1), 3873. doi:10.1038/s41598-021-83209-w
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
     """
 
     __module__ = "braincell.channel"

--- a/braincell/channel/potassium_calcium.py
+++ b/braincell/channel/potassium_calcium.py
@@ -14,7 +14,26 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Calcium-dependent potassium channels built directly on templates."""
+"""Calcium-dependent potassium channels built directly on templates.
+
+Two mechanism families live in this module. The first is gated purely
+by intracellular calcium: :class:`AHP_De1994`, :class:`SK_SU2015_DCN`,
+the ``Kca3p1_*`` group and the ``Kca2p2_*`` group all read only
+``Ca.Ci`` in their transition/gate rates, with no voltage dependence.
+The second is the BK/mslo family, the ``Kca1p1_*`` group: a
+large-conductance channel gated jointly by voltage and [Ca]_i,
+following the Horrigan-Aldrich allosteric scheme, in which calcium
+binding and the voltage-dependent conformational change act on
+independent legs of the same state graph.
+
+Every public channel class here sets
+``root_type = _KCA_ROOT_TYPE = brainstate.mixin.JointTypes[Potassium,
+Calcium]``: the host cell must provide both a
+:class:`~braincell.ion.Potassium` and a :class:`~braincell.ion.Calcium`
+ion, because every rate method takes both ``K`` and ``Ca`` as
+:class:`~braincell._base.IonInfo` arguments, even where only ``Ca.Ci``
+actually drives the kinetics.
+"""
 
 from typing import Callable, Optional, Union
 
@@ -56,7 +75,86 @@ def _q10_factor(temp, q10, *, ref_celsius: float):
 
 @register_channel("AHP_De1994")
 class AHP_De1994(OhmicHH):
-    r"""Destexhe 1994 calcium-dependent after-hyperpolarization current."""
+    r"""Calcium-activated after-hyperpolarization current.
+
+    Reproduces the slow Ca2+-activated K+ (AHP) current of the
+    thalamic reticular nucleus spindle-rhythmicity model of
+    (Destexhe et al., 1994) [1]_: a two-site calcium-binding gate
+    with no voltage dependence, of the closed form
+    ``<closed> + n Ca_i <-> <open> (alpha, beta)``.
+
+    .. math::
+
+        \begin{aligned}
+        I_{AHP} &= g_{\mathrm{max}} \, p^2 \, (E_K - V) \\
+        \frac{dp}{dt} &= \phi \left(\alpha_p \, (1 - p) -
+                          \beta_p \, p\right) \\
+        \alpha_p &= \alpha \, \left([\mathrm{Ca}]_i /
+                     \mathrm{mM}\right)^n \\
+        \beta_p &= \beta
+        \end{aligned}
+
+    i.e. a Hodgkin-Huxley-style gate whose forward rate is a power
+    law in intracellular calcium and whose backward rate is a fixed
+    constant.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    n : array-like or callable, optional
+        Calcium-binding exponent used inside :math:`\alpha_p`,
+        default ``2``. Independent of the gate's conductance exponent
+        (see Notes): changing ``n`` alters only the calcium-binding
+        rate law, not the ``p ** 2`` factor in the current.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``10.0 mS/cm2``.
+    alpha : array-like or callable, optional
+        Forward (calcium-binding) rate coefficient, default ``48.0``
+        (units ``mM^-n ms^-1``).
+    beta : array-like or callable, optional
+        Backward (unbinding) rate, default ``0.09 ms^-1``. See Notes:
+        this default is three times the reference value.
+    phi : array-like or callable, optional
+        Rate-scaling factor multiplying both :math:`\alpha_p` and
+        :math:`\beta_p`, default ``1.0``.
+    name : str, optional
+        Optional channel name.
+
+    Notes
+    -----
+    No ``.mod`` file under this repository carries a
+    ``De1994``/``De19`` filename fragment; this class has no in-repo
+    NMODL counterpart to name here.
+
+    The gate's conductance exponent is fixed at ``power=2`` by this
+    class's ``gates`` declaration and is independent of the ``n``
+    constructor parameter, which only exponentiates
+    ``[Ca]_i`` inside the forward rate. Both default to ``2``, which
+    is why the two are easy to conflate; they do not have to agree.
+
+    **BrainCell's ``beta`` default is three times the reference
+    value.** BrainCell defaults to ``beta = 0.09 ms^-1``, but the
+    reference value is ``beta = 0.03 ms^-1`` -- the value used by the
+    authors' reference implementation, and quoted from the paper by
+    BrainPy. (The 1994 paper itself is paywalled; only its PubMed
+    abstract was read for this documentation pass, so the 0.03 figure
+    could not be checked directly against the published text.) The
+    ``alpha = 48.0`` default is unaffected by this discrepancy: it is
+    exactly ``beta / cac ** n = 0.03 / 0.025 ** 2 = 48 mM^-2 ms^-1``
+    from the reference implementation's own ``beta`` and ``cac``, and
+    BrainCell reproduces it exactly -- evidence that the rest of the
+    parameterisation is faithful even though the ``beta`` default
+    drifted.
+
+    References
+    ----------
+    .. [1] Destexhe, A., Contreras, D., Sejnowski, T. J., & Steriade,
+           M. (1994). A model of spindle rhythmicity in the isolated
+           thalamic reticular nucleus. Journal of Neurophysiology,
+           72(2), 803-818.
+           doi:10.1152/jn.1994.72.2.803
+    """
 
     __module__ = "braincell.channel"
     root_type = _KCA_ROOT_TYPE
@@ -89,7 +187,81 @@ class AHP_De1994(OhmicHH):
 
 @register_channel("SK_SU2015_DCN")
 class SK_SU2015_DCN(OhmicHH):
-    r"""Template-based import of ``SK_SU15_DCN.mod``."""
+    r"""Small-conductance calcium-activated potassium current, DCN.
+
+    Template-based import of ``SK_SU15_DCN.mod``, part of the deep
+    cerebellar nuclei (DCN) neuron model of (Sudhakar et al., 2015)
+    [2]_.
+
+    .. math::
+
+        \begin{aligned}
+        I_{SK} &= g_{\mathrm{max}} \, z \, (E_K - V) \\
+        \frac{dz}{dt} &= \frac{z_{\infty} - z}{\tau_z} \\
+        z_{\infty} &= \frac{[\mathrm{Ca}]_i^4}
+                           {[\mathrm{Ca}]_i^4 + 8.1 \times 10^{-15}} \\
+        \tau_z &= \begin{cases}
+            1 - 186.67 \, [\mathrm{Ca}]_i &
+                [\mathrm{Ca}]_i < 0.005~\mathrm{mM} \\
+            0.0667 & [\mathrm{Ca}]_i \geq 0.005~\mathrm{mM}
+        \end{cases}
+        \end{aligned}
+
+    where :math:`[\mathrm{Ca}]_i` is expressed in mM and
+    :math:`\tau_z` in ms before being divided by ``qdeltat``.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.01 mS/cm2``.
+    qdeltat : array-like or callable, optional
+        Divisor applied to :math:`\tau_z` after evaluation, default
+        ``1.0``.
+    name : str, optional
+        Optional channel name.
+
+    Notes
+    -----
+    Ported from ``SK_SU15_DCN.mod``. The mechanism name ``SK`` and
+    the rate constants above appear only in the deposited NMODL code,
+    not in the body of the Sudhakar et al. (2015) article, which
+    documents the DCN model as reused from a previously published
+    model rather than reprinting per-mechanism constants. The origin
+    chain, reached only through the ``.mod`` file's own credit line
+    (not through either paper's text): kinetics from the deep
+    cerebellar nucleus model of Steuber et al. (2011) [1]_,
+    translated from GENESIS to NEURON by Luthman et al. (2011), and
+    used unchanged in Sudhakar et al. (2015) [2]_. Luthman et al.
+    (2011) does not appear anywhere in the Sudhakar et al. (2015)
+    text and is recorded here only as the translation step, not as a
+    numbered reference.
+
+    **Import deviation, distinct from the code's own branch.** The
+    upstream ``.mod`` file tabulated ``zinf`` and ``tauz`` over a
+    clamped ``cai`` range of ``[0, 0.01]`` mM via a NEURON ``TABLE``
+    statement; BrainCell evaluates the closed-form expressions above
+    on every call instead. This former-``TABLE`` clamp is a separate
+    fact from the ``[Ca]_i < 0.005`` mM branch inside :math:`\tau_z`
+    itself, which is the model's own piecewise definition and is not
+    an artefact of removing the table.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = _KCA_ROOT_TYPE
@@ -125,7 +297,108 @@ class SK_SU2015_DCN(OhmicHH):
 
 @register_channel("Kca3p1_MA2020_GoC")
 class Kca3p1_MA2020_GoC(OhmicHH):
-    r"""Template-based import of ``Kca3p1_MA20_GoC.mod``."""
+    r"""Kca3.1 (intermediate-conductance) calcium-activated K current, Golgi cell.
+
+    Template-based import of ``Kca3p1_MA20_GoC.mod``, part of the
+    cerebellar Golgi cell model of (Masoli et al., 2020) [4]_. A
+    single gate whose forward rate factors into an independent
+    voltage-dependent term and a piecewise calcium-dependent term.
+
+    .. math::
+
+        \begin{aligned}
+        I &= g_{\mathrm{max}} \, p \, (E_K - V) \\
+        \frac{dp}{dt} &= \frac{p_{\infty} - p}{\tau_p} \\
+        p_{\infty} &= \frac{p_{\alpha}}{p_{\alpha} + p_{\beta}}, \quad
+        \tau_p = \frac{1}{p_{\alpha} + p_{\beta}} \\
+        p_{\alpha} &= \exp\!\left(\frac{V' + 70}{27}\right)
+                      \cdot Y_{\mathrm{concdep}} \\
+        Y_{\mathrm{concdep}} &= \begin{cases}
+            \dfrac{500 \times 0.0013}
+                  {\operatorname{exprel}\!\left(\dfrac{0.015 -
+                   [\mathrm{Ca}]_i}{0.0013}\right)} &
+                [\mathrm{Ca}]_i < 0.01~\mathrm{mM} \\[6pt]
+            \dfrac{500 \times 0.005}{\exp(0.005 / 0.0013) - 1} &
+                [\mathrm{Ca}]_i \geq 0.01~\mathrm{mM}
+        \end{cases} \\
+        p_{\beta} &= 0.05
+        \end{aligned}
+
+    where :math:`V' = V / \mathrm{mV}`, :math:`[\mathrm{Ca}]_i` is
+    expressed in mM, and :math:`\operatorname{exprel}(y) =
+    (e^y - 1) / y` (evaluated without the removable singularity at
+    :math:`y = 0`).
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``120.0 mS/cm2``.
+    q10_base : array-like, optional
+        Accepted but not used; see Notes. Default ``3.0``.
+    temp : array-like, optional
+        Accepted but not used; see Notes. Default 22 degrees
+        Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kca3p1_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca3p1_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca3p1_MA20_GoC.mod``.
+
+    **``q10_base`` and ``temp`` are accepted but never read.** Both
+    are stored on ``self`` in ``__init__`` but no method in this
+    class -- there is no ``_phi()`` here, unlike the ``Kca2p2_*`` and
+    ``Kca1p1_*`` classes below -- references either attribute. This
+    is a discrepancy between the constructor signature and the
+    implemented kinetics; it is documented rather than fixed, and
+    the signature is left unchanged. The same holds for
+    :class:`Kca3p1_MA2025_BC` and :class:`Kca3p1_MA2024_PC`, whose
+    ``__init__`` is inherited unchanged from this class.
+
+    ``p_beta = 0.05`` is a fixed internal constant assigned in
+    ``__init__``, not a constructor parameter.
+
+    **Import deviation, distinct from the code's own branch.** The
+    upstream ``.mod`` file tabulated ``Yvdep`` and ``Yconcdep`` via a
+    NEURON ``TABLE`` statement over ``V`` in ``[-100, 100]`` mV and
+    ``cai`` clamped to ``[0, 0.01]`` mM; BrainCell evaluates the
+    closed-form expressions above on every call instead. This former
+    table clamp happens to share its upper concentration bound
+    (0.01 mM) with the model's own ``[Ca]_i < 0.01`` mM branch inside
+    :math:`Y_{\mathrm{concdep}}`, but the two are independent facts:
+    the branch is the model's own definition, unaffected by table
+    removal; the clamp is a NEURON interpolation-range artefact that
+    no longer applies.
+
+    References
+    ----------
+    .. [1] Rubin, D. B., & Cleland, T. A. (2006). Dynamical
+           mechanisms of odor processing in olfactory bulb mitral
+           cells. Journal of Neurophysiology, 96(2), 555-568.
+           doi:10.1152/jn.00264.2006
+    .. [2] Bhalla, U. S., & Bower, J. M. (1993). Exploring parameter
+           space in detailed single neuron models: simulations of
+           the mitral and granule cells of the olfactory bulb.
+           Journal of Neurophysiology, 69(6), 1948-1965.
+           doi:10.1152/jn.1993.69.6.1948
+    .. [3] Davison, A. P., Feng, J., & Brown, D. (2000). A reduced
+           compartmental model of the mitral cell for use in network
+           models of the olfactory bulb. Brain Research Bulletin,
+           51(5), 393-399.
+           doi:10.1016/S0361-9230(99)00256-7
+    .. [4] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = _KCA_ROOT_TYPE
@@ -174,21 +447,258 @@ class Kca3p1_MA2020_GoC(OhmicHH):
 
 @register_channel("Kca3p1_MA2025_BC")
 class Kca3p1_MA2025_BC(Kca3p1_MA2020_GoC):
-    """Thin variant of ``Kca3p1_MA25_BC.mod`` using GoC kinetics."""
+    r"""Kca3.1 calcium-activated K current, basket-cell parameterisation.
+
+    The same single-gate Kca3.1 kinetics documented in
+    :class:`Kca3p1_MA2020_GoC`, reused unchanged for the cerebellar
+    basket cell model of (Masoli et al., 2025) [4]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``120.0 mS/cm2``.
+        Inherited from :class:`Kca3p1_MA2020_GoC`.
+    q10_base : array-like, optional
+        Accepted but not used (see :class:`Kca3p1_MA2020_GoC`
+        Notes). Default ``3.0``. Inherited from
+        :class:`Kca3p1_MA2020_GoC`.
+    temp : array-like, optional
+        Accepted but not used (see :class:`Kca3p1_MA2020_GoC`
+        Notes). Default 22 degrees Celsius. Inherited from
+        :class:`Kca3p1_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kca3p1_MA2020_GoC : The base class; full equations and the
+        ``q10_base``/``temp`` unused-parameter discrepancy are
+        documented there.
+    Kca3p1_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca3p1_MA25_BC.mod``. This class does not override
+    ``__init__``: the constructor, the rate methods and the fixed
+    ``p_beta = 0.05`` constant are all inherited unchanged from
+    :class:`Kca3p1_MA2020_GoC`. Only the ``register_channel`` key and
+    this docstring's model citation differ -- the ``.mod`` file this
+    class ports from parameterises the identical mechanism for a
+    different cell type, not a different kinetic scheme.
+
+    No import deviation is recorded for this mechanism beyond the
+    ``TABLE`` removal already documented on
+    :class:`Kca3p1_MA2020_GoC`, which applies identically here
+    (``examples/neuron_compare/Cerebellum_mod/README.md``'s
+    ``MA2025`` import-deviations table lists the same ``V``/``cai``
+    range and tabulated quantities).
+
+    References
+    ----------
+    .. [1] Rubin, D. B., & Cleland, T. A. (2006). Dynamical
+           mechanisms of odor processing in olfactory bulb mitral
+           cells. Journal of Neurophysiology, 96(2), 555-568.
+           doi:10.1152/jn.00264.2006
+    .. [2] Bhalla, U. S., & Bower, J. M. (1993). Exploring parameter
+           space in detailed single neuron models: simulations of
+           the mitral and granule cells of the olfactory bulb.
+           Journal of Neurophysiology, 69(6), 1948-1965.
+           doi:10.1152/jn.1993.69.6.1948
+    .. [3] Davison, A. P., Feng, J., & Brown, D. (2000). A reduced
+           compartmental model of the mitral cell for use in network
+           models of the olfactory bulb. Brain Research Bulletin,
+           51(5), 393-399.
+           doi:10.1016/S0361-9230(99)00256-7
+    .. [4] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca3p1_MA2024_PC")
 class Kca3p1_MA2024_PC(Kca3p1_MA2020_GoC):
-    """Thin variant of ``Kca3p1_MA24_PC.mod`` using GoC kinetics."""
+    r"""Kca3.1 calcium-activated K current, Purkinje-cell parameterisation.
+
+    The same single-gate Kca3.1 kinetics documented in
+    :class:`Kca3p1_MA2020_GoC`, reused unchanged for the human
+    Purkinje cell model of (Masoli et al., 2024) [4]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``120.0 mS/cm2``.
+        Inherited from :class:`Kca3p1_MA2020_GoC`.
+    q10_base : array-like, optional
+        Accepted but not used (see :class:`Kca3p1_MA2020_GoC`
+        Notes). Default ``3.0``. Inherited from
+        :class:`Kca3p1_MA2020_GoC`.
+    temp : array-like, optional
+        Accepted but not used (see :class:`Kca3p1_MA2020_GoC`
+        Notes). Default 22 degrees Celsius. Inherited from
+        :class:`Kca3p1_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Kca3p1_MA2020_GoC : The base class; full equations and the
+        ``q10_base``/``temp`` unused-parameter discrepancy are
+        documented there.
+    Kca3p1_MA2025_BC : Same kinetics, basket-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca3p1_MA24_PC.mod``. This class does not override
+    ``__init__``: the constructor, the rate methods and the fixed
+    ``p_beta = 0.05`` constant are all inherited unchanged from
+    :class:`Kca3p1_MA2020_GoC`. Only the ``register_channel`` key and
+    this docstring's model citation differ -- the ``.mod`` file this
+    class ports from parameterises the identical mechanism for a
+    different cell type, not a different kinetic scheme.
+
+    The ``MA2024`` import-deviations table records the same ``TABLE``
+    removal already documented on :class:`Kca3p1_MA2020_GoC`
+    (``V`` in ``[-100, 100] mV``, ``cai`` clamped to
+    ``[0, 0.01] mM``, tabulating ``Yvdep``/``Yconcdep``).
+
+    References
+    ----------
+    .. [1] Rubin, D. B., & Cleland, T. A. (2006). Dynamical
+           mechanisms of odor processing in olfactory bulb mitral
+           cells. Journal of Neurophysiology, 96(2), 555-568.
+           doi:10.1152/jn.00264.2006
+    .. [2] Bhalla, U. S., & Bower, J. M. (1993). Exploring parameter
+           space in detailed single neuron models: simulations of
+           the mitral and granule cells of the olfactory bulb.
+           Journal of Neurophysiology, 69(6), 1948-1965.
+           doi:10.1152/jn.1993.69.6.1948
+    .. [3] Davison, A. P., Feng, J., & Brown, D. (2000). A reduced
+           compartmental model of the mitral cell for use in network
+           models of the olfactory bulb. Brain Research Bulletin,
+           51(5), 393-399.
+           doi:10.1016/S0361-9230(99)00256-7
+    .. [4] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca2p2_MA2020_GoC")
 class Kca2p2_MA2020_GoC(Markov):
-    r"""Template-based import of ``Kca2p2_MA20_GoC.mod``."""
+    r"""Kca2.2 (SK2) small-conductance calcium-activated K current, Golgi cell.
+
+    Template-based import of ``Kca2p2_MA20_GoC.mod``, part of the
+    cerebellar Golgi cell model of (Masoli et al., 2020) [3]_, with
+    kinetics from the recombinant SK-channel gating scheme of
+    (Hirschberg et al., 1998) [1]_ as implemented for the Golgi cell
+    by (Solinas et al., 2007) [2]_. A seven-state, purely
+    calcium-dependent Markov scheme: four closed states in series
+    (``C1``-``C4``) with two open states (``O1``, ``O2``) branching
+    off ``C3`` and ``C4``. ``C1`` is the algebraically eliminated
+    state.
+
+    .. math::
+
+        \begin{aligned}
+        I &= g_{\mathrm{max}} \, (O_1 + O_2) \, (E_K - V) \\
+        C_1 \underset{k_{c1}}{\overset{k_{c2}[\mathrm{Ca}]_i}{
+            \rightleftharpoons}} C_2
+            \underset{k_{c2}}{\overset{k_{c3}[\mathrm{Ca}]_i}{
+            \rightleftharpoons}} C_3
+            \underset{k_{c3}}{\overset{k_{c4}[\mathrm{Ca}]_i}{
+            \rightleftharpoons}} C_4 \\
+        C_3 \underset{k_{o1}^{-}}{\overset{k_{o1}^{+}}{
+            \rightleftharpoons}} O_1, \qquad
+        C_4 \underset{k_{o2}^{-}}{\overset{k_{o2}^{+}}{
+            \rightleftharpoons}} O_2
+        \end{aligned}
+
+    where every forward (calcium-binding) rate is
+    :math:`\phi \cdot k / d` with :math:`d` the ``diff`` diffusion
+    factor and :math:`[\mathrm{Ca}]_i` in mM, every backward
+    (unbinding) rate is :math:`\phi \cdot k`, and
+    :math:`\phi = q_{10}^{(T - 296.15\,\mathrm{K}) / 10}` uses
+    :math:`23\,^{\circ}\mathrm{C}` (296.15 K) as the reference
+    temperature regardless of the ``temp`` default below.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``38.0 mS/cm2``.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``.
+    diff : array-like, optional
+        Calcium diffusion-shell divisor applied to every forward
+        (calcium-binding) rate, default ``3.0``.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. See Notes
+        for the 22/23 degree distinction.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca2p2_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca2p2_MA2020_GrC : Same kinetics, granule-cell model citation.
+    Kca2p2_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+    Kca2p2_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca2p2_MA20_GoC.mod``. ``current`` is overridden to
+    sum only the two open states, ``O1`` and ``O2``; ``C1``-``C4`` do
+    not conduct.
+
+    ``_phi`` evaluates the Q10 scaling relative to a fixed
+    :math:`23\,^{\circ}\mathrm{C}` reference (``ref_celsius=23.0``),
+    while the ``temp`` constructor default is
+    :math:`22\,^{\circ}\mathrm{C}`. The two temperatures are
+    independent: the reference is the condition the rate constants
+    below were tuned at, and the default is simply this class's
+    default operating temperature, one degree below that reference.
+    This is unlike :class:`Kca3p1_MA2020_GoC`, whose analogous
+    ``q10_base``/``temp`` parameters are accepted but never read.
+
+    References
+    ----------
+    .. [1] Hirschberg, B., Maylie, J., Adelman, J. P., & Marrion,
+           N. V. (1998). Gating of recombinant small-conductance
+           Ca-activated K+ channels by calcium. The Journal of
+           General Physiology, 111(4), 565-581.
+           doi:10.1085/jgp.111.4.565
+    .. [2] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De
+           Schutter, E., & D'Angelo, E. (2007). Computational
+           reconstruction of pacemaking and intrinsic
+           electroresponsiveness in cerebellar Golgi cells. Frontiers
+           in Cellular Neuroscience, 1, 2.
+           doi:10.3389/neuro.03.002.2007
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = _KCA_ROOT_TYPE
@@ -275,35 +785,399 @@ class Kca2p2_MA2020_GoC(Markov):
 
 @register_channel("Kca2p2_MA2025_BC")
 class Kca2p2_MA2025_BC(Kca2p2_MA2020_GoC):
-    r"""Template-based import of ``Kca2p2_MA25_BC.mod``."""
+    r"""Kca2.2 (SK2) calcium-activated K current, basket-cell parameterisation.
+
+    The same seven-state Kca2.2 Markov scheme documented in
+    :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
+    basket cell model of (Masoli et al., 2025) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``38.0 mS/cm2``.
+        Inherited from :class:`Kca2p2_MA2020_GoC`.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    diff : array-like, optional
+        Calcium diffusion-shell divisor, default ``3.0``. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca2p2_MA2020_GoC : The base class; full state topology,
+        equations, and the 22/23 degree Celsius temperature note
+        are documented there.
+    Kca2p2_MA2020_GrC : Same kinetics, granule-cell model citation.
+    Kca2p2_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+    Kca2p2_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca2p2_MA25_BC.mod``. This class does not override
+    ``__init__``: the constructor, state topology, and rate methods
+    are all inherited unchanged from :class:`Kca2p2_MA2020_GoC`.
+    Only the ``register_channel`` key and this docstring's model
+    citation differ.
+
+    References
+    ----------
+    .. [1] Hirschberg, B., Maylie, J., Adelman, J. P., & Marrion,
+           N. V. (1998). Gating of recombinant small-conductance
+           Ca-activated K+ channels by calcium. The Journal of
+           General Physiology, 111(4), 565-581.
+           doi:10.1085/jgp.111.4.565
+    .. [2] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De
+           Schutter, E., & D'Angelo, E. (2007). Computational
+           reconstruction of pacemaking and intrinsic
+           electroresponsiveness in cerebellar Golgi cells. Frontiers
+           in Cellular Neuroscience, 1, 2.
+           doi:10.3389/neuro.03.002.2007
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca2p2_MA2020_GrC")
 class Kca2p2_MA2020_GrC(Kca2p2_MA2020_GoC):
-    r"""Template-based import of ``Kca2p2_MA20_GrC.mod``."""
+    r"""Kca2.2 (SK2) calcium-activated K current, granule-cell parameterisation.
+
+    The same seven-state Kca2.2 Markov scheme documented in
+    :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
+    granule cell subtype model of (Masoli et al., 2020) [3]_. This
+    class is a Python subclass of :class:`Kca2p2_MA2020_GoC`, but
+    that inheritance relationship is purely a code-reuse device: the
+    kinetics and model citation below belong to the granule cell
+    paper, not to the Golgi cell paper cited on the base class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``38.0 mS/cm2``.
+        Inherited from :class:`Kca2p2_MA2020_GoC`.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    diff : array-like, optional
+        Calcium diffusion-shell divisor, default ``3.0``. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca2p2_MA2020_GoC : The Python base class supplying the shared
+        state topology and rate equations; cites the Golgi cell
+        paper, not the granule cell paper cited here.
+    Kca2p2_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca2p2_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+    Kca2p2_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca2p2_MA20_GrC.mod``. This class does not override
+    ``__init__``: the constructor, state topology, and rate methods
+    are all inherited unchanged from :class:`Kca2p2_MA2020_GoC`.
+    Only the ``register_channel`` key and this docstring's model
+    citation differ. Despite the Python inheritance from the *Golgi*
+    cell class, the correct model citation is the *granule* cell
+    paper below -- the two cerebellar cell-type papers were published
+    together and this citation is not interchangeable with the one
+    on :class:`Kca2p2_MA2020_GoC`.
+
+    References
+    ----------
+    .. [1] Hirschberg, B., Maylie, J., Adelman, J. P., & Marrion,
+           N. V. (1998). Gating of recombinant small-conductance
+           Ca-activated K+ channels by calcium. The Journal of
+           General Physiology, 111(4), 565-581.
+           doi:10.1085/jgp.111.4.565
+    .. [2] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De
+           Schutter, E., & D'Angelo, E. (2007). Computational
+           reconstruction of pacemaking and intrinsic
+           electroresponsiveness in cerebellar Golgi cells. Frontiers
+           in Cellular Neuroscience, 1, 2.
+           doi:10.3389/neuro.03.002.2007
+    .. [3] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222. doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca2p2_MA2024_PC")
 class Kca2p2_MA2024_PC(Kca2p2_MA2020_GoC):
-    r"""Template-based import of ``Kca2p2_MA24_PC.mod``."""
+    r"""Kca2.2 (SK2) calcium-activated K current, Purkinje-cell parameterisation.
+
+    The same seven-state Kca2.2 Markov scheme documented in
+    :class:`Kca2p2_MA2020_GoC`, reused unchanged for the human
+    Purkinje cell model of (Masoli et al., 2024) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``38.0 mS/cm2``.
+        Inherited from :class:`Kca2p2_MA2020_GoC`.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    diff : array-like, optional
+        Calcium diffusion-shell divisor, default ``3.0``. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca2p2_MA2020_GoC : The base class; full state topology,
+        equations, and the 22/23 degree Celsius temperature note
+        are documented there.
+    Kca2p2_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca2p2_MA2020_GrC : Same kinetics, granule-cell model citation.
+    Kca2p2_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca2p2_MA24_PC.mod``. This class does not override
+    ``__init__``: the constructor, state topology, and rate methods
+    are all inherited unchanged from :class:`Kca2p2_MA2020_GoC`.
+    Only the ``register_channel`` key and this docstring's model
+    citation differ.
+
+    References
+    ----------
+    .. [1] Hirschberg, B., Maylie, J., Adelman, J. P., & Marrion,
+           N. V. (1998). Gating of recombinant small-conductance
+           Ca-activated K+ channels by calcium. The Journal of
+           General Physiology, 111(4), 565-581.
+           doi:10.1085/jgp.111.4.565
+    .. [2] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De
+           Schutter, E., & D'Angelo, E. (2007). Computational
+           reconstruction of pacemaking and intrinsic
+           electroresponsiveness in cerebellar Golgi cells. Frontiers
+           in Cellular Neuroscience, 1, 2.
+           doi:10.3389/neuro.03.002.2007
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca2p2_RI2021_SC")
 class Kca2p2_RI2021_SC(Kca2p2_MA2020_GoC):
-    r"""Template-based import of ``Kca2p2_RI21_SC.mod``."""
+    r"""Kca2.2 (SK2) calcium-activated K current, stellate-cell parameterisation.
+
+    The same seven-state Kca2.2 Markov scheme documented in
+    :class:`Kca2p2_MA2020_GoC`, reused unchanged for the cerebellar
+    stellate cell model of (Rizza et al., 2021) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``38.0 mS/cm2``.
+        Inherited from :class:`Kca2p2_MA2020_GoC`.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    diff : array-like, optional
+        Calcium diffusion-shell divisor, default ``3.0``. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. Inherited
+        from :class:`Kca2p2_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca2p2_MA2020_GoC : The base class; full state topology,
+        equations, and the 22/23 degree Celsius temperature note
+        are documented there.
+    Kca2p2_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca2p2_MA2020_GrC : Same kinetics, granule-cell model citation.
+    Kca2p2_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca2p2_RI21_SC.mod``. This class does not override
+    ``__init__``: the constructor, state topology, and rate methods
+    are all inherited unchanged from :class:`Kca2p2_MA2020_GoC`.
+    Only the ``register_channel`` key and this docstring's model
+    citation differ.
+
+    References
+    ----------
+    .. [1] Hirschberg, B., Maylie, J., Adelman, J. P., & Marrion,
+           N. V. (1998). Gating of recombinant small-conductance
+           Ca-activated K+ channels by calcium. The Journal of
+           General Physiology, 111(4), 565-581.
+           doi:10.1085/jgp.111.4.565
+    .. [2] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De
+           Schutter, E., & D'Angelo, E. (2007). Computational
+           reconstruction of pacemaking and intrinsic
+           electroresponsiveness in cerebellar Golgi cells. Frontiers
+           in Cellular Neuroscience, 1, 2.
+           doi:10.3389/neuro.03.002.2007
+    .. [3] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873. doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca1p1_MA2020_GoC")
 class Kca1p1_MA2020_GoC(Markov):
-    r"""Template-based import of ``Kca1p1_MA20_GoC.mod``."""
+    r"""Kca1.1 (BK/mslo) large-conductance calcium- and voltage-activated K current, Golgi cell.
+
+    Template-based import of ``Kca1p1_MA20_GoC.mod``, part of the
+    cerebellar Golgi cell model of (Masoli et al., 2020) [3]_, with
+    parameters from the allosteric BK-channel gating scheme of
+    (Cox, Cui, & Aldrich, 1997) [1]_ as adapted for calcium buffering
+    in Purkinje cells by (Anwar, Hong, & De Schutter, 2012) [2]_. Ten
+    states arranged as a 5x2 grid: a closed ladder ``C0``-``C4`` and
+    an open ladder ``O0``-``O4``, each ladder stepping through 0-4
+    bound calcium ions, with five vertical closed-to-open
+    transitions, one per occupancy level. ``C0`` is the algebraically
+    eliminated state.
+
+    .. math::
+
+        \begin{aligned}
+        I &= g_{\mathrm{max}} \, (O_0 + O_1 + O_2 + O_3 + O_4) \,
+             (E_K - V) \\
+        C_i \underset{i K_c k_1}{\overset{(4-i)[\mathrm{Ca}]_i k_1}{
+            \rightleftharpoons}} C_{i+1}, &\qquad
+        O_i \underset{i K_o k_1}{\overset{(4-i)[\mathrm{Ca}]_i k_1}{
+            \rightleftharpoons}} O_{i+1}, \qquad i = 0,\dots,3 \\
+        C_i \underset{\mathrm{pb}_i \, \beta(V)}{\overset{
+            \mathrm{pf}_i \, \alpha(V)}{\rightleftharpoons}} O_i,
+            &\qquad i = 0,\dots,4 \\
+        \alpha(V) &= \exp\!\left(\frac{Q_o F V}{R T}\right), \qquad
+        \beta(V) = \exp\!\left(\frac{Q_c F V}{R T}\right)
+        \end{aligned}
+
+    where :math:`[\mathrm{Ca}]_i` is expressed in mM, :math:`k_1`,
+    :math:`K_c`, :math:`K_o` are fixed rate/dissociation constants,
+    every rate additionally carries the multiplicative factor
+    :math:`\phi = q_{10}^{(T - 296.15\,\mathrm{K}) / 10}`
+    (:math:`23\,^{\circ}\mathrm{C}` reference), :math:`F` is the
+    Faraday constant, :math:`R` the gas constant, and :math:`Q_o`,
+    :math:`Q_c` are the Horrigan-Aldrich gating charges for the
+    opening and closing conformational change.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``10.0 mS/cm2``.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. See Notes
+        for the 22/23 degree distinction.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca1p1_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca1p1_MA2020_GrC : Same kinetics, granule-cell model citation.
+    Kca1p1_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+    Kca1p1_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca1p1_MA20_GoC.mod``. ``current`` is overridden to
+    sum all five open states, ``O0`` through ``O4``; ``C0``-``C4`` do
+    not conduct.
+
+    ``_phi`` evaluates the Q10 scaling relative to a fixed
+    :math:`23\,^{\circ}\mathrm{C}` reference (``ref_celsius=23.0``),
+    while the ``temp`` constructor default is
+    :math:`22\,^{\circ}\mathrm{C}`, one degree below that reference.
+    This is unlike :class:`Kca3p1_MA2020_GoC`, whose analogous
+    ``q10_base``/``temp`` parameters are accepted but never read.
+
+    ``self.L0 = 1806`` is assigned in ``__init__`` alongside the
+    other Horrigan-Aldrich constants but is never read by any rate
+    method or by ``current``; it is documented here rather than
+    removed, since removing an assigned-but-unused attribute is a
+    behavior change out of scope for a documentation pass.
+
+    References
+    ----------
+    .. [1] Cox, D. H., Cui, J., & Aldrich, R. W. (1997). Allosteric
+           gating of a large conductance Ca-activated K+ channel.
+           The Journal of General Physiology, 110(3), 257-281.
+           doi:10.1085/jgp.110.3.257
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = _KCA_ROOT_TYPE
@@ -457,27 +1331,270 @@ class Kca1p1_MA2020_GoC(Markov):
 
 @register_channel("Kca1p1_MA2025_BC")
 class Kca1p1_MA2025_BC(Kca1p1_MA2020_GoC):
-    r"""Template-based import of ``Kca1p1_MA25_BC.mod``."""
+    r"""Kca1.1 (BK/mslo) calcium- and voltage-activated K current, basket-cell parameterisation.
+
+    The same ten-state Kca1.1 Markov scheme documented in
+    :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
+    basket cell model of (Masoli et al., 2025) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``10.0 mS/cm2``.
+        Inherited from :class:`Kca1p1_MA2020_GoC`.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``. Inherited
+        from :class:`Kca1p1_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. Inherited
+        from :class:`Kca1p1_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca1p1_MA2020_GoC : The base class; full state topology,
+        equations, the 22/23 degree Celsius temperature note, and
+        the unused ``L0`` attribute are documented there.
+    Kca1p1_MA2020_GrC : Same kinetics, granule-cell model citation.
+    Kca1p1_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+    Kca1p1_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca1p1_MA25_BC.mod``. This class does not override
+    ``__init__``: the constructor, state topology, and rate methods
+    are all inherited unchanged from :class:`Kca1p1_MA2020_GoC`.
+    Only the ``register_channel`` key and this docstring's model
+    citation differ.
+
+    References
+    ----------
+    .. [1] Cox, D. H., Cui, J., & Aldrich, R. W. (1997). Allosteric
+           gating of a large conductance Ca-activated K+ channel.
+           The Journal of General Physiology, 110(3), 257-281.
+           doi:10.1085/jgp.110.3.257
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca1p1_MA2020_GrC")
 class Kca1p1_MA2020_GrC(Kca1p1_MA2020_GoC):
-    r"""Template-based import of ``Kca1p1_MA20_GrC.mod``."""
+    r"""Kca1.1 (BK/mslo) calcium- and voltage-activated K current, granule-cell parameterisation.
+
+    The same ten-state Kca1.1 Markov scheme documented in
+    :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
+    granule cell subtype model of (Masoli et al., 2020) [3]_. This
+    class is a Python subclass of :class:`Kca1p1_MA2020_GoC`, but
+    that inheritance relationship is purely a code-reuse device: the
+    kinetics and model citation below belong to the granule cell
+    paper, not to the Golgi cell paper cited on the base class.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``10.0 mS/cm2``.
+        Inherited from :class:`Kca1p1_MA2020_GoC`.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``. Inherited
+        from :class:`Kca1p1_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. Inherited
+        from :class:`Kca1p1_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca1p1_MA2020_GoC : The Python base class supplying the shared
+        state topology and rate equations; cites the Golgi cell
+        paper, not the granule cell paper cited here.
+    Kca1p1_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca1p1_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+    Kca1p1_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca1p1_MA20_GrC.mod``. This class does not override
+    ``__init__``: the constructor, state topology, and rate methods
+    are all inherited unchanged from :class:`Kca1p1_MA2020_GoC`.
+    Only the ``register_channel`` key and this docstring's model
+    citation differ. Despite the Python inheritance from the *Golgi*
+    cell class, the correct model citation is the *granule* cell
+    paper below -- the two cerebellar cell-type papers were published
+    together and this citation is not interchangeable with the one
+    on :class:`Kca1p1_MA2020_GoC`.
+
+    References
+    ----------
+    .. [1] Cox, D. H., Cui, J., & Aldrich, R. W. (1997). Allosteric
+           gating of a large conductance Ca-activated K+ channel.
+           The Journal of General Physiology, 110(3), 257-281.
+           doi:10.1085/jgp.110.3.257
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222. doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca1p1_MA2024_PC")
 class Kca1p1_MA2024_PC(Kca1p1_MA2020_GoC):
-    r"""Template-based import of ``Kca1p1_MA24_PC.mod``."""
+    r"""Kca1.1 (BK/mslo) calcium- and voltage-activated K current, Purkinje-cell parameterisation.
+
+    The same ten-state Kca1.1 Markov scheme documented in
+    :class:`Kca1p1_MA2020_GoC`, reused unchanged for the human
+    Purkinje cell model of (Masoli et al., 2024) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``10.0 mS/cm2``.
+        Inherited from :class:`Kca1p1_MA2020_GoC`.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``. Inherited
+        from :class:`Kca1p1_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. Inherited
+        from :class:`Kca1p1_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca1p1_MA2020_GoC : The base class; full state topology,
+        equations, the 22/23 degree Celsius temperature note, and
+        the unused ``L0`` attribute are documented there.
+    Kca1p1_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca1p1_MA2020_GrC : Same kinetics, granule-cell model citation.
+    Kca1p1_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca1p1_MA24_PC.mod``. This class does not override
+    ``__init__``: the constructor, state topology, and rate methods
+    are all inherited unchanged from :class:`Kca1p1_MA2020_GoC`.
+    Only the ``register_channel`` key and this docstring's model
+    citation differ.
+
+    References
+    ----------
+    .. [1] Cox, D. H., Cui, J., & Aldrich, R. W. (1997). Allosteric
+           gating of a large conductance Ca-activated K+ channel.
+           The Journal of General Physiology, 110(3), 257-281.
+           doi:10.1085/jgp.110.3.257
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
 
 
 @register_channel("Kca1p1_RI2021_SC")
 class Kca1p1_RI2021_SC(Kca1p1_MA2020_GoC):
-    r"""Template-based import of ``Kca1p1_RI21_SC.mod``."""
+    r"""Kca1.1 (BK/mslo) calcium- and voltage-activated K current, stellate-cell parameterisation.
+
+    The same ten-state Kca1.1 Markov scheme documented in
+    :class:`Kca1p1_MA2020_GoC`, reused unchanged for the cerebellar
+    stellate cell model of (Rizza et al., 2021) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``10.0 mS/cm2``.
+        Inherited from :class:`Kca1p1_MA2020_GoC`.
+    q10_base : array-like, optional
+        Q10 temperature coefficient, default ``3.0``. Inherited
+        from :class:`Kca1p1_MA2020_GoC`.
+    temp : array-like, optional
+        Absolute temperature, default 22 degrees Celsius. Inherited
+        from :class:`Kca1p1_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Markov-chain integration scheme.
+    substeps : int, optional
+        Number of solver substeps per integration step.
+
+    See Also
+    --------
+    Kca1p1_MA2020_GoC : The base class; full state topology,
+        equations, the 22/23 degree Celsius temperature note, and
+        the unused ``L0`` attribute are documented there.
+    Kca1p1_MA2025_BC : Same kinetics, basket-cell model citation.
+    Kca1p1_MA2020_GrC : Same kinetics, granule-cell model citation.
+    Kca1p1_MA2024_PC : Same kinetics, Purkinje-cell model citation.
+
+    Notes
+    -----
+    Ported from ``Kca1p1_RI21_SC.mod``. This class does not override
+    ``__init__``: the constructor, state topology, and rate methods
+    are all inherited unchanged from :class:`Kca1p1_MA2020_GoC`.
+    Only the ``register_channel`` key and this docstring's model
+    citation differ.
+
+    References
+    ----------
+    .. [1] Cox, D. H., Cui, J., & Aldrich, R. W. (1997). Allosteric
+           gating of a large conductance Ca-activated K+ channel.
+           The Journal of General Physiology, 110(3), 257-281.
+           doi:10.1085/jgp.110.3.257
+    .. [2] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [3] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873. doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"

--- a/braincell/channel/potassium_sodium.py
+++ b/braincell/channel/potassium_sodium.py
@@ -145,9 +145,10 @@ class Kv1p5_MA2020_GrC(Kv1p5_MA2024_PC):
            H1717-H1725.
            doi:10.1152/ajpheart.1998.275.5.H1717
     .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
-           D'Angelo, E. (2020). Parameter tuning differentiates granule
-           cell subtypes enriching transmission properties at the
-           cerebellum input stage. Communications Biology, 3(1), 222.
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
            doi:10.1038/s42003-020-0953-x
     """
 

--- a/braincell/channel/potassium_sodium.py
+++ b/braincell/channel/potassium_sodium.py
@@ -35,7 +35,7 @@ __all__ = [
 
 @register_channel("Kv1p5_MA2020_GrC")
 class Kv1p5_MA2020_GrC(Kv1p5_MA2024_PC):
-    """Granule-cell Kv1.5 channel with two current owners.
+    r"""Granule-cell Kv1.5 channel with two current owners.
 
     This channel imports the two-current form of the NEURON mechanism
     ``Kv1p5_MA20_GrC.mod``. The relevant source lines are quoted here
@@ -53,22 +53,30 @@ class Kv1p5_MA2020_GrC(Kv1p5_MA2024_PC):
     size : brainstate.typing.Size
         Channel state shape.
     g_max : array-like or callable, optional
-        Maximum potassium conductance. This is the BrainCell name for
-        the NEURON ``gKur`` parameter.
+        Maximum potassium conductance, default ``0.13195e-3 S/cm2``.
+        This is the BrainCell name for the NEURON ``gKur`` parameter.
     gnonspec : array-like or callable, optional
         Maximum nonspecific cation conductance for the ``ino``
-        component.
+        component, default ``0.0 S/cm2``.
     temp : array-like, optional
         Absolute temperature used by the q10 and nonspecific reversal
-        expressions.
+        expressions, default 37 degrees Celsius.
     Tauact : array-like or callable, optional
-        Activation time-scale multiplier.
+        Activation time-scale multiplier, default ``1.0``
+        (dimensionless).
     Tauinactf : array-like or callable, optional
-        Fast inactivation time-scale multiplier.
+        Fast inactivation time-scale multiplier, default ``1.0``
+        (dimensionless).
     Tauinacts : array-like or callable, optional
-        Slow inactivation time-scale multiplier.
+        Slow inactivation time-scale multiplier, default ``1.0``
+        (dimensionless).
     name : str, optional
         Optional module name.
+
+    See Also
+    --------
+    Kv1p5_MA2024_PC : Purkinje-cell parent class that supplies the
+        inherited gate kinetics.
 
     Notes
     -----
@@ -80,15 +88,66 @@ class Kv1p5_MA2020_GrC(Kv1p5_MA2024_PC):
     placeholder ion that receives the nonspecific current contribution.
 
     The inherited Kv1.5 gate kinetics are potassium kinetics and are
-    reused verbatim. Gate methods declare only the ion arguments they
-    read, so the inherited ``f_m_inf(self, V, K)`` and friends bind to
-    potassium alone even though this channel is rooted on three ions.
+    reused verbatim from :class:`Kv1p5_MA2024_PC`. Gate methods declare
+    only the ion arguments they read, so the inherited
+    ``f_m_inf(self, V, K)`` and friends bind to potassium alone even
+    though this channel is rooted on three ions. The parent declares
+    three gates -- ``m`` (power 3), ``n`` (power 1) and ``u`` (power
+    1) -- so the shared gate product used by both current components
+    is
+
+    .. math::
+
+        m^3 \, n \, u
+
+    and both components are further scaled by the shared voltage
+    factor computed in ``_voltage_factor``:
+
+    .. math::
+
+        0.1 + \frac{1}{1 + \exp\left(-\dfrac{V - 15\ \text{mV}}
+        {13\ \text{mV}}\right)}
+
+    Temperature scaling is *not* attached through the gate objects:
+    the parent's ``gates`` tuple sets neither ``phi`` nor ``q10``, so
+    :meth:`HH.gate_phi` resolves to the default ``1.0`` for ``m``,
+    ``n`` and ``u`` alike. Instead the parent's own ``_q10`` method
+    computes ``2.2 ** ((temp_K - 310.15) / 10)`` (``310.15 K`` is 37
+    degrees Celsius) and multiplies it into the ``alpha``/``beta``
+    rates used inside ``f_m_tau`` and ``f_n_tau`` only; ``f_u_tau``
+    returns the constant ``6800 * Tauinacts`` and receives no q10
+    scaling at all. This is the mechanism's own code path, not a
+    general BrainCell convention, and it is reproduced here rather
+    than any closed-form temperature dependence printed in the cited
+    papers.
 
     BrainCell channel currents use the package convention
     ``conductance * (E - V)``. The quoted NEURON source assigns
     ``(v - E)`` currents, so this implementation uses the sign
     convention already used by the surrounding BrainCell channel
     catalogue.
+
+    This mechanism is a **cardiac** IKur channel, not a cerebellar
+    one: the ``.mod`` file ``Kv1p5_MA20_GrC.mod`` carries the ``TITLE``
+    "Cardiac IKur current & nonspec cation current with identical
+    kinetics", and its kinetics were fitted to human atrial myocyte
+    recordings by Feng et al. (1998) [1]_, not to any cerebellar
+    recording. The granule-cell citation [2]_ names the model
+    BrainCell imported this parameterisation from -- the ``MA2020``
+    granule-cell deposit -- not the origin of the kinetics.
+
+    References
+    ----------
+    .. [1] Feng, J., Xu, D., Wang, Z., & Nattel, S. (1998). Ultrarapid
+           delayed rectifier current inactivation in human atrial
+           myocytes: properties and consequences. American Journal of
+           Physiology-Heart and Circulatory Physiology, 275(5),
+           H1717-H1725. doi:10.1152/ajpheart.1998.275.5.H1717
+    .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates granule
+           cell subtypes enriching transmission properties at the
+           cerebellum input stage. Communications Biology, 3(1), 222.
+           doi:10.1038/s42003-020-0953-x
     """
 
     __module__ = "braincell.channel"

--- a/braincell/channel/potassium_sodium.py
+++ b/braincell/channel/potassium_sodium.py
@@ -142,7 +142,8 @@ class Kv1p5_MA2020_GrC(Kv1p5_MA2024_PC):
            delayed rectifier current inactivation in human atrial
            myocytes: properties and consequences. American Journal of
            Physiology-Heart and Circulatory Physiology, 275(5),
-           H1717-H1725. doi:10.1152/ajpheart.1998.275.5.H1717
+           H1717-H1725.
+           doi:10.1152/ajpheart.1998.275.5.H1717
     .. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
            D'Angelo, E. (2020). Parameter tuning differentiates granule
            cell subtypes enriching transmission properties at the

--- a/braincell/channel/sodium.py
+++ b/braincell/channel/sodium.py
@@ -799,7 +799,7 @@ class Nav1p6_MA2020_GoC(Markov):
 
     Notes
     -----
-    Ported from ``Nav1p6_MA2020_GoC.mod``. All of ``Con``, ``Coff``,
+    Ported from ``Nav1p6_MA20_GoC.mod``. All of ``Con``, ``Coff``,
     ``Oon``, ``Ooff``, ``alpha``, ``beta``, ``gamma``, ``delta``,
     ``epsilon``, ``zeta``, ``x1``-``x6``, ``vshifta``, ``vshifti``,
     ``vshiftk``, ``alfac`` and ``btfac`` are fixed internal constants
@@ -978,7 +978,7 @@ class Nav1p6_MA2024_PC(Nav1p6_MA2020_GoC):
 
     Notes
     -----
-    Ported from ``Nav1p6_MA2024_PC.mod``. This class does not override
+    Ported from ``Nav1p6_MA24_PC.mod``. This class does not override
     ``__init__``: the constructor, the transition-rate lambdas, the
     fixed kinetic constants and :meth:`current` are all inherited
     unchanged from :class:`Nav1p6_MA2020_GoC`. Only the
@@ -1062,7 +1062,7 @@ class Nav1p6_MA2025_BC(Nav1p6_MA2020_GoC):
 
     Notes
     -----
-    Ported from ``Nav1p6_MA2025_BC.mod``. This class does not override
+    Ported from ``Nav1p6_MA25_BC.mod``. This class does not override
     ``__init__``: the constructor, the transition-rate lambdas, the
     fixed kinetic constants and :meth:`current` are all inherited
     unchanged from :class:`Nav1p6_MA2020_GoC`. Only the
@@ -1143,7 +1143,7 @@ class Nav1p6_RI2021_SC(Nav1p6_MA2020_GoC):
 
     Notes
     -----
-    Ported from ``Nav1p6_RI2021_SC.mod``. This class does not override
+    Ported from ``Nav1p6_RI21_SC.mod``. This class does not override
     ``__init__``: the constructor, the transition-rate lambdas, the
     fixed kinetic constants and :meth:`current` are all inherited
     unchanged from :class:`Nav1p6_MA2020_GoC`. Only the
@@ -1264,7 +1264,7 @@ class Nav1p1_MA2025_BC(Nav1p6_MA2020_GoC):
 
     Notes
     -----
-    Ported from ``Nav1p1_MA2025_BC.mod``, whose own header describes
+    Ported from ``Nav1p1_MA25_BC.mod``, whose own header describes
     the mechanism as "derived from the Narsg channel of Khaliq et al.,
     J. Neurosci. 23(2003)4899" -- i.e. via :class:`Nav1p6_MA2020_GoC`'s
     origin, not an independently republished scheme.
@@ -1386,7 +1386,7 @@ class Nav1p1_RI2021_SC(Nav1p1_MA2025_BC):
 
     Notes
     -----
-    Ported from ``Nav1p1_RI2021_SC.mod``. This class does not override
+    Ported from ``Nav1p1_RI21_SC.mod``. This class does not override
     ``__init__``: the constructor signature, the 13-state kinetics,
     the :math:`\phi` temperature scaling, the ``Oon``/``epsilon``/
     ``zgate``/``gunit``/``e0`` constants and the gating-current term
@@ -1505,7 +1505,7 @@ class Nav_MA2020_GrC(Markov, IndependentIntegration):
 
     Notes
     -----
-    Ported from ``Nav_MA2020_GrC.mod``, whose header attributes the
+    Ported from ``Nav_MA20_GrC.mod``, whose header attributes the
     scheme to "Raman 13 state model. Adapted from Magistretti et al,
     2006." This class does not subclass :class:`Nav1p6_MA2020_GoC`;
     it is an independent implementation with its own ``__init__`` and
@@ -1731,9 +1731,9 @@ class NaFHF_MA2020_GrC(Markov, IndependentIntegration):
 
     Notes
     -----
-    Ported from ``NaFHF_MA2020_GrC.mod``. Its own ``COMMENT`` block is
+    Ported from ``NaFHF_MA20_GrC.mod``. Its own ``COMMENT`` block is
     empty, which is not a provenance gap: it inherits
-    ``Nav_MA2020_GrC.mod``'s "Based on Raman 13 state model. Adapted
+    ``Nav_MA20_GrC.mod``'s "Based on Raman 13 state model. Adapted
     from Magistretti et al, 2006." attribution, per the bibliography.
 
     This class ships ``ACon = 0.025`` and ``AOoff = 0.002`` -- unlike

--- a/braincell/channel/sodium.py
+++ b/braincell/channel/sodium.py
@@ -449,15 +449,16 @@ class NaF_SU2015_DCN(OhmicHH):
     References
     ----------
     .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
-           Schutter, E., & Jaeger, D. (2011). Determinants of synaptic
-           integration and heterogeneity in rebound firing explored
-           with data-driven models of deep cerebellar nucleus cells.
-           Journal of Computational Neuroscience, 30(3), 633-658.
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
            doi:10.1007/s10827-010-0282-z
     .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
-           (2015). Cerebellar nuclear neurons use time and rate coding
-           to transmit Purkinje neuron pauses. PLOS Computational
-           Biology, 11(12), e1004641.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
            doi:10.1371/journal.pcbi.1004641
     """
 
@@ -547,15 +548,16 @@ class NaP_SU2015_DCN(OhmicHH):
     References
     ----------
     .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
-           Schutter, E., & Jaeger, D. (2011). Determinants of synaptic
-           integration and heterogeneity in rebound firing explored
-           with data-driven models of deep cerebellar nucleus cells.
-           Journal of Computational Neuroscience, 30(3), 633-658.
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
            doi:10.1007/s10827-010-0282-z
     .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
-           (2015). Cerebellar nuclear neurons use time and rate coding
-           to transmit Purkinje neuron pauses. PLOS Computational
-           Biology, 11(12), e1004641.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
            doi:10.1371/journal.pcbi.1004641
     """
 
@@ -657,8 +659,8 @@ class Na_ZH2019_IO(OhmicHH):
     References
     ----------
     .. [1] Schweighofer, N., Doya, K., & Kawato, M. (1999).
-           Electrophysiological properties of inferior olive neurons:
-           A compartmental model. Journal of Neurophysiology, 82(2),
+           Electrophysiological properties of inferior olive neurons: A
+           compartmental model. Journal of Neurophysiology, 82(2),
            804-817.
            doi:10.1152/jn.1999.82.2.804
     .. [2] Zhang, X., & Santaniello, S. (2019). Role of cerebellar
@@ -1005,8 +1007,8 @@ class Nav1p6_MA2024_PC(Nav1p6_MA2020_GoC):
            doi:10.1523/JNEUROSCI.5204-05.2006
     .. [4] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
            Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
-           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz, A.,
-           & D'Angelo, E. (2024). Human Purkinje cells outperform
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
            mouse Purkinje cells in dendritic complexity and
            computational capacity. Communications Biology, 7(1), 5.
            doi:10.1038/s42003-023-05689-y
@@ -1085,10 +1087,10 @@ class Nav1p6_MA2025_BC(Nav1p6_MA2020_GoC):
            Journal of Neuroscience, 26(17), 4602-4612.
            doi:10.1523/JNEUROSCI.5204-05.2006
     .. [4] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
-           Munoz, A., Prestori, F., & D'Angelo, E. (2025). Cerebellar
-           basket cell filtering of Purkinje cell responses elicited
-           by low frequency parallel fibre transmission. Scientific
-           Reports, 15(1), 25192.
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
            doi:10.1038/s41598-025-09964-2
     """
 
@@ -1283,10 +1285,10 @@ class Nav1p1_MA2025_BC(Nav1p6_MA2020_GoC):
            3959-3976.
            doi:10.1016/j.bpj.2009.02.046
     .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
-           Munoz, A., Prestori, F., & D'Angelo, E. (2025). Cerebellar
-           basket cell filtering of Purkinje cell responses elicited
-           by low frequency parallel fibre transmission. Scientific
-           Reports, 15(1), 25192.
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
            doi:10.1038/s41598-025-09964-2
     """
 
@@ -1535,9 +1537,9 @@ class Nav_MA2020_GrC(Markov, IndependentIntegration):
            doi:10.1016/S0006-3495(01)76052-3
     .. [3] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
            D'Angelo, E. (2020). Parameter tuning differentiates
-           granule cell subtypes enriching transmission properties at
-           the cerebellum input stage. Communications Biology, 3(1),
-           222.
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
            doi:10.1038/s42003-020-0953-x
     """
 
@@ -1754,9 +1756,9 @@ class NaFHF_MA2020_GrC(Markov, IndependentIntegration):
            doi:10.1016/S0006-3495(01)76052-3
     .. [3] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
            D'Angelo, E. (2020). Parameter tuning differentiates
-           granule cell subtypes enriching transmission properties at
-           the cerebellum input stage. Communications Biology, 3(1),
-           222.
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222.
            doi:10.1038/s42003-020-0953-x
     """
 

--- a/braincell/channel/sodium.py
+++ b/braincell/channel/sodium.py
@@ -728,7 +728,8 @@ class Nav1p6_MA2020_GoC(Markov):
     r"""Resurgent Nav1.6 sodium current, Golgi-cell parameterisation.
 
     The 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
-    sodium Markov scheme, as parameterised for the Golgi cell model of
+    sodium Markov scheme, as implemented by Akemann & Knopfel (2006)
+    [3]_ and parameterised for the Golgi cell model of
     (Masoli et al., 2020) [4]_. Five closed states ``C1``-``C5`` form
     an activation ladder that opens into ``O``; ``O`` can additionally
     transition into a blocked state ``B`` (the resurgent-current
@@ -944,8 +945,9 @@ class Nav1p6_MA2024_PC(Nav1p6_MA2020_GoC):
     r"""Resurgent Nav1.6 sodium current, Purkinje-cell parameterisation.
 
     The same 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
-    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`,
-    reused unchanged for the human Purkinje-cell model of
+    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`, as
+    implemented by Akemann & Knopfel (2006) [3]_ and reused unchanged
+    for the human Purkinje-cell model of
     (Masoli et al., 2024) [4]_.
 
     Parameters
@@ -1025,8 +1027,9 @@ class Nav1p6_MA2025_BC(Nav1p6_MA2020_GoC):
     r"""Resurgent Nav1.6 sodium current, basket-cell parameterisation.
 
     The same 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
-    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`,
-    reused unchanged for the basket-cell model of
+    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`, as
+    implemented by Akemann & Knopfel (2006) [3]_ and reused unchanged
+    for the basket-cell model of
     (Masoli et al., 2025) [4]_.
 
     Parameters
@@ -1105,8 +1108,9 @@ class Nav1p6_RI2021_SC(Nav1p6_MA2020_GoC):
     r"""Resurgent Nav1.6 sodium current, stellate-cell parameterisation.
 
     The same 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
-    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`,
-    reused unchanged for the stellate-cell model of
+    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`, as
+    implemented by Akemann & Knopfel (2006) [3]_ and reused unchanged
+    for the stellate-cell model of
     (Rizza et al., 2021) [4]_.
 
     Parameters

--- a/braincell/channel/sodium.py
+++ b/braincell/channel/sodium.py
@@ -57,7 +57,77 @@ def _x_over_one_minus_exp_neg_stable(x):
 
 @register_channel("Na_Ba2002")
 class Na_Ba2002(OhmicHH):
-    r"""Bazhenov 2002 sodium current with :math:`p^3 q` HH gating."""
+    r"""Bazhenov 2002 sodium current with :math:`p^3 q` HH gating.
+
+    The thalamocortical-cell fast sodium current used in the slow-wave
+    sleep oscillation model of (Bazhenov et al., 2002) [1]_, with the
+    mirrored-sign Traub-Miles rate forms (see Notes):
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_p &= \frac{0.32 \times 4}
+                    {\operatorname{exprel}(-(V' - 13) / 4)} \\
+        \beta_p &= \frac{0.28 \times 5}
+                   {\operatorname{exprel}((V' - 40) / 5)} \\
+        \alpha_q &= 0.128 \exp(-(V' - 17) / 18) \\
+        \beta_q &= \frac{4}{1 + \exp(-(V' - 40) / 5)}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and
+    :math:`\operatorname{exprel}(x) = (\exp(x) - 1) / x`, used only to
+    remove the removable singularity at each Boltzmann midpoint; it
+    does not change the function value. Gating is :math:`p^3 q`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``90.0 mS/cm2`` --
+        matches the TC-cell value reported in (Bazhenov et al., 2002)
+        [1]_.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for both gates, default ``3.0``.
+    temp_ref : array-like, optional
+        Reference temperature for the Q10 formula, default 36
+        degrees Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``-50.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Na_TM1991 : Same Traub-Miles rate functions with ``V_sh = -63 mV``
+        and ``q10 = 1.0`` instead.
+
+    Notes
+    -----
+    Algebraically these are the same Traub & Miles (1991) rate
+    functions used by :class:`Na_TM1991`, written with the sign of
+    ``V - V_sh`` mirrored; the only numeric differences are this
+    class's ``V_sh = -50.0 mV`` in place of ``Na_TM1991``'s
+    ``-63.0 mV``, and ``q10 = 3.0`` in place of ``1.0``. (Bazhenov et
+    al., 2002) [1]_ attribute the current's kinetics to Traub & Miles
+    (1991) but do **not** print the alpha/beta expressions themselves
+    -- the paper's Methods defer them to Bazhenov et al. (1998). This
+    docstring's equations are transcribed from this class's own rate
+    methods, confirmed algebraically equivalent to the Traub-Miles
+    forms, not copied from the 2002 paper's text.
+
+    References
+    ----------
+    .. [1] Bazhenov, M., Timofeev, I., Steriade, M., & Sejnowski, T. J.
+           (2002). Model of thalamocortical slow-wave sleep
+           oscillations and transitions to activated states. The
+           Journal of Neuroscience, 22(19), 8691-8704.
+           doi:10.1523/JNEUROSCI.22-19-08691.2002
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium
@@ -102,7 +172,81 @@ class Na_Ba2002(OhmicHH):
 
 @register_channel("Na_TM1991")
 class Na_TM1991(OhmicHH):
-    r"""Traub and Miles 1991 sodium current with :math:`p^3 q` HH gating."""
+    r"""Traub and Miles 1991 sodium current with :math:`p^3 q` HH gating.
+
+    The hippocampal pyramidal-cell fast sodium current from the
+    Traub & Miles (1991) [1]_ reduced model, as packaged in the
+    NEURON ``HH2.mod`` mechanism:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_p &= \frac{0.32 \times 4}
+                    {\operatorname{exprel}(-(V' - 13) / 4)} \\
+        \beta_p &= \frac{0.28 \times 5}
+                   {\operatorname{exprel}((V' - 40) / 5)} \\
+        \alpha_q &= 0.128 \exp(-(V' - 17) / 18) \\
+        \beta_q &= \frac{4}{1 + \exp(-(V' - 40) / 5)}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and
+    :math:`\operatorname{exprel}(x) = (\exp(x) - 1) / x` removes the
+    removable singularity at each Boltzmann midpoint without changing
+    the function value. Gating is :math:`p^3 q`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``120.0 mS/cm2``. This
+        value is a BrainCell default, not a Traub & Miles (1991)
+        [1]_ figure -- ``HH2.mod`` itself ships ``gnabar = 0.1
+        mho/cm2`` (100 mS/cm2).
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for both gates, default ``1.0`` (no
+        temperature scaling at the reference temperature).
+    temp_ref : array-like, optional
+        Reference temperature for the Q10 formula, default 36
+        degrees Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``-63.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Na_Ba2002 : Same Traub-Miles rate functions with ``V_sh = -50 mV``
+        and ``q10 = 3.0`` instead.
+
+    Notes
+    -----
+    Ported from ``HH2.mod``. Algebraically these are the same rate
+    functions used by :class:`Na_Ba2002`; the only numeric
+    differences are this class's ``V_sh = -63.0 mV`` in place of
+    ``Na_Ba2002``'s ``-50.0 mV``, and ``q10 = 1.0`` in place of
+    ``3.0``.
+
+    The ``-63.0 mV`` default is the value Destexhe's network ``.hoc``
+    files assign to ``vtraub`` for this current, and it is the offset
+    associated with the Traub-Miles hippocampal pyramidal cell that
+    this class is named for. It is **not** ``HH2.mod``'s own default,
+    which is ``-55 mV``. This class's potassium sibling,
+    :class:`K_TM1991`, ships a different default shift
+    (``-60.0 mV``) from the same ``.mod`` file; the two classes do
+    **not** share a shift, and neither should be read as implying a
+    single canonical Traub-Miles offset.
+
+    References
+    ----------
+    .. [1] Traub, R. D., & Miles, R. (1991). Neuronal networks of the
+           hippocampus. Cambridge University Press.
+           doi:10.1017/CBO9780511895401
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium
@@ -147,7 +291,71 @@ class Na_TM1991(OhmicHH):
 
 @register_channel("Na_HH1952")
 class Na_HH1952(OhmicHH):
-    r"""Hodgkin-Huxley 1952 sodium current with :math:`p^3 q` HH gating."""
+    r"""Hodgkin-Huxley 1952 sodium current with :math:`p^3 q` HH gating.
+
+    The original squid giant axon fast sodium current of
+    (Hodgkin & Huxley, 1952) [1]_:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_p &= \frac{1}{\operatorname{exprel}(-(V' - 5) / 10)} \\
+        \beta_p &= 4 \exp(-(V' + 20) / 18) \\
+        \alpha_q &= 0.07 \exp(-(V' + 20) / 20) \\
+        \beta_q &= \frac{1}{1 + \exp(-(V' - 10) / 10)}
+        \end{aligned}
+
+    where :math:`V' = (V - V_{sh}) / \mathrm{mV}` and
+    :math:`\operatorname{exprel}(x) = (\exp(x) - 1) / x` removes the
+    removable singularity at the Boltzmann midpoint without changing
+    the function value. With the default ``V_sh = -45 mV`` (so
+    ``V' = (V/mV) + 45``, placing rest at -65 mV in the modern
+    absolute-potential convention), these expand to exactly the
+    published forms
+    :math:`\alpha_m = 0.1 (V+40) / (1 - \exp(-(V+40)/10))`,
+    :math:`\beta_m = 4 \exp(-(V+65)/18)`,
+    :math:`\alpha_h = 0.07 \exp(-(V+65)/20)`,
+    :math:`\beta_h = 1 / (1 + \exp(-(V+35)/10))`. Gating is
+    :math:`p^3 q`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``120.0 mS/cm2`` --
+        matches (Hodgkin & Huxley, 1952) [1]_'s :math:`g_{Na}`.
+    temp : array-like, optional
+        Absolute temperature driving the Q10 factor, default 36
+        degrees Celsius.
+    q10 : array-like or callable, optional
+        Q10 scaling factor for both gates, default ``3.0`` -- the
+        paper's own factor-of-3-per-10-degree-Celsius correction.
+    temp_ref : array-like, optional
+        Reference temperature for the Q10 formula, default 36
+        degrees Celsius.
+    V_sh : array-like or callable, optional
+        Threshold shift applied to both gates' rates, default
+        ``-45.0 mV``.
+    name : str, optional
+        Optional channel name.
+
+    Notes
+    -----
+    (Hodgkin & Huxley, 1952) [1]_ measured these rates at 6.3 degrees
+    Celsius, not this class's ``temp_ref = 36`` degrees Celsius
+    default. Because ``temp`` and ``temp_ref`` are equal by default,
+    the Q10 correction is a no-op at construction time; the defaults
+    do **not** reproduce the original 6.3-degree-Celsius kinetics.
+
+    References
+    ----------
+    .. [1] Hodgkin, A. L., & Huxley, A. F. (1952). A quantitative
+           description of membrane current and its application to
+           conduction and excitation in nerve. The Journal of
+           Physiology, 117(4), 500-544.
+           doi:10.1113/jphysiol.1952.sp004764
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium
@@ -192,7 +400,66 @@ class Na_HH1952(OhmicHH):
 
 @register_channel("NaF_SU2015_DCN")
 class NaF_SU2015_DCN(OhmicHH):
-    """Template-based import of ``NaF_SU2015_DCN.mod``."""
+    r"""Fast sodium current of the deep cerebellar nuclei model.
+
+    Deep cerebellar nucleus (DCN) fast sodium current, part of the
+    model published as (Sudhakar et al., 2015) [2]_:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp((V + 45) / -7.3)} \\
+        \tau_m &= \left[\frac{5.83}{\exp((V - 6.4)/-9)
+                   + \exp((V + 97)/17)} + 0.025\right] / q \\
+        h_\infty &= \frac{1}{1 + \exp((V + 42) / 5.9)} \\
+        \tau_h &= \left[\frac{16.67}{\exp((V - 8.3)/-29)
+                   + \exp((V + 66)/9)} + 0.2\right] / q
+        \end{aligned}
+
+    with :math:`V` in mV and :math:`q` = ``qdeltat``. Gating is
+    :math:`m^3 h`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.01 mS/cm2``.
+    name : str, optional
+        Optional channel name.
+
+    Notes
+    -----
+    Ported from ``NaF_SU15_DCN.mod``. The mechanism name ``NaF`` does
+    not appear anywhere in the text of (Sudhakar et al., 2015) [2]_;
+    this docstring says only that the mechanism is part of the
+    published model, not that the paper names or describes it.
+
+    Kinetics originate in the GENESIS deep cerebellar nucleus model of
+    Steuber et al. (2011) [1]_, translated to NEURON by Luthman et al.
+    (2011), and reused by (Sudhakar et al., 2015) [2]_, which cites
+    only the GENESIS model and not the NEURON translation.
+
+    The former NEURON ``TABLE`` tabulated ``minf``, ``taum``, ``hinf``
+    and ``tauh`` over ``[-150, 100] mV`` and clamped outside that
+    range; BrainCell evaluates the continuous formulas above at every
+    call instead, so values outside ``[-150, 100] mV`` are expected to
+    diverge from the original NEURON boundary-clamped output.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of synaptic
+           integration and heterogeneity in rebound firing explored
+           with data-driven models of deep cerebellar nucleus cells.
+           Journal of Computational Neuroscience, 30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate coding
+           to transmit Purkinje neuron pauses. PLOS Computational
+           Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium
@@ -230,7 +497,67 @@ class NaF_SU2015_DCN(OhmicHH):
 
 @register_channel("NaP_SU2015_DCN")
 class NaP_SU2015_DCN(OhmicHH):
-    """Template-based import of ``NaP_SU2015_DCN.mod``."""
+    r"""Persistent sodium current of the deep cerebellar nuclei model.
+
+    Deep cerebellar nucleus (DCN) persistent sodium current, part of
+    the model published as (Sudhakar et al., 2015) [2]_:
+
+    .. math::
+
+        \begin{aligned}
+        m_\infty &= \frac{1}{1 + \exp((V + 70) / -4.1)} \\
+        \tau_m &= 50 / q \\
+        h_\infty &= \frac{1}{1 + \exp((V + 80) / 4)} \\
+        \tau_h &= \left[\frac{1750}{1 + \exp((V + 65)/-8)}
+                   + 250\right] / q
+        \end{aligned}
+
+    with :math:`V` in mV and :math:`q` = ``qdeltat``; :math:`\tau_m`
+    is a bare constant with no voltage dependence. Gating is
+    :math:`m^3 h`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``0.01 mS/cm2``.
+    name : str, optional
+        Optional channel name.
+
+    Notes
+    -----
+    Ported from ``NaP_SU15_DCN.mod``. ``NaP`` is one of only four
+    mechanism names (with ``CaLVA``, ``HCN`` and ``SK``) that actually
+    occur in the text of (Sudhakar et al., 2015) [2]_; even so, the
+    paper does not print these Boltzmann constants.
+
+    Kinetics originate in the GENESIS deep cerebellar nucleus model of
+    Steuber et al. (2011) [1]_, translated to NEURON by Luthman et al.
+    (2011), and reused by (Sudhakar et al., 2015) [2]_, which cites
+    only the GENESIS model and not the NEURON translation.
+
+    The former NEURON ``TABLE`` tabulated ``minf``, ``hinf`` and
+    ``tauh`` (but not ``taum``, which does not depend on voltage) over
+    ``[-150, 100] mV`` and clamped outside that range; BrainCell
+    evaluates the continuous formulas above at every call instead, so
+    values outside ``[-150, 100] mV`` are expected to diverge from the
+    original NEURON boundary-clamped output.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of synaptic
+           integration and heterogeneity in rebound firing explored
+           with data-driven models of deep cerebellar nucleus cells.
+           Journal of Computational Neuroscience, 30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate coding
+           to transmit Purkinje neuron pauses. PLOS Computational
+           Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium
@@ -267,7 +594,79 @@ class NaP_SU2015_DCN(OhmicHH):
 
 @register_channel("Na_ZH2019_IO")
 class Na_ZH2019_IO(OhmicHH):
-    """Template-based import of ``Na_ZH2019_IO.mod``."""
+    r"""Inferior olive somatic sodium current, Schweighofer kinetics.
+
+    Inferior olive (IO) somatic fast sodium current from the
+    essential-tremor cortico-cerebello-thalamo-cortical loop model of
+    (Zhang & Santaniello, 2019) [2]_:
+
+    .. math::
+
+        \begin{aligned}
+        \alpha_m &= x/(1 - \exp(-x)),\ x = (V + 41) / 10 \\
+        \beta_m &= 9 \exp(-(V + 66) / 20) \\
+        \alpha_h &= 5 \exp(-(V + 60) / 15) \\
+        \beta_h &= 10 y/(1 - \exp(-y)),\ y = (V + 50) / 10
+        \end{aligned}
+
+    with :math:`V` in mV,
+    :math:`m_\infty = \alpha_m / (\alpha_m + \beta_m)`,
+    :math:`\tau_m = 0.001` ms (effectively instantaneous),
+    :math:`h_\infty = \alpha_h / (\alpha_h + \beta_h)`,
+    :math:`\tau_h = 250 / (\alpha_h + \beta_h)`. Gating is
+    :math:`m^3 h`. Both :math:`x/(1-\exp(-x))` terms are evaluated by
+    the module-level helper ``_x_over_one_minus_exp_neg_stable``,
+    which substitutes the Taylor form ``1 + x/2`` for
+    ``|x| < 1e-6`` and the closed form otherwise -- this is the
+    numerically stable replacement for the removable singularity at
+    :math:`x = 0`, not the naive textbook fraction.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``70.0 mS/cm2``.
+    name : str, optional
+        Optional channel name.
+
+    Notes
+    -----
+    Ported from ``Na_ZH19_IO.mod``. Kinetics originate in the
+    single-compartment inferior olive model of Schweighofer, Doya &
+    Kawato (1999) [1]_, reaching this class through the NEURON port of
+    Torben-Nielsen, Segev & Yarom (2012), and reused by (Zhang &
+    Santaniello, 2019) [2]_.
+
+    ``Na_ZH19_IO.mod`` guards the removable singularities in
+    ``alpha_m`` and ``beta_h`` with an explicit
+    ``if (fabs(v + 41.0) < 1e-6)`` / ``if (fabs(v + 50.0) < 1e-6)``
+    branch that substitutes the perturbed literal ``41.000001`` /
+    ``50.000001``. BrainCell replaces both branches with
+    ``_x_over_one_minus_exp_neg_stable`` instead of reproducing the
+    perturbed-literal branch; this is exact away from the singularity
+    and better-behaved at it, but it is a BrainCell substitution, not
+    a reproduction of the ``.mod`` file's own guard.
+
+    The upstream ``rates(v)`` call was relocated from ``BREAKPOINT``
+    into ``DERIVATIVE states``, so ``m``/``h`` steady states and time
+    constants are refreshed before the ``cnexp`` state update rather
+    than after it -- a semantic change carried over from the source
+    ``.mod`` file, not introduced by this port.
+
+    References
+    ----------
+    .. [1] Schweighofer, N., Doya, K., & Kawato, M. (1999).
+           Electrophysiological properties of inferior olive neurons:
+           A compartmental model. Journal of Neurophysiology, 82(2),
+           804-817.
+           doi:10.1152/jn.1999.82.2.804
+    .. [2] Zhang, X., & Santaniello, S. (2019). Role of cerebellar
+           GABAergic dysfunctions in the origins of essential tremor.
+           Proceedings of the National Academy of Sciences of the
+           United States of America, 116(27), 13592-13601.
+           doi:10.1073/pnas.1817689116
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium
@@ -324,7 +723,113 @@ class Na_ZH2019_IO(OhmicHH):
 
 @register_channel("Nav1p6_MA2020_GoC")
 class Nav1p6_MA2020_GoC(Markov):
-    """Template-based import of ``Nav1p6_MA2020_GoC.mod``."""
+    r"""Resurgent Nav1.6 sodium current, Golgi-cell parameterisation.
+
+    The 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
+    sodium Markov scheme, as parameterised for the Golgi cell model of
+    (Masoli et al., 2020) [4]_. Five closed states ``C1``-``C5`` form
+    an activation ladder that opens into ``O``; ``O`` can additionally
+    transition into a blocked state ``B`` (the resurgent-current
+    mechanism) or into a deep-inactivated state ``I6``; each closed
+    state ``Cn`` has a matching inactivated state ``In``
+    (``n = 1..5``), themselves connected in the same ladder topology
+    as the closed states and converging on ``I6`` from ``I5``.
+    ``I6`` is eliminated algebraically (``dependent_state``).
+
+    .. math::
+
+        \begin{aligned}
+        f_{0,n} &= (5-n)\,\alpha \exp(V'/x_1)\,\phi,
+                   &\quad b_{0,n} &= n\,\beta
+                   \exp((V' + v_a)/(x_2 + v_k))\,\phi \\
+        f_{0O} &= \gamma \exp(V'/x_3)\,\phi,
+                  &\quad b_{0O} &= \delta \exp(V'/x_4)\,\phi \\
+        f_{ip} &= \epsilon \exp(V'/x_5)\,\phi,
+                  &\quad b_{ip} &= \zeta \exp(V'/x_6)\,\phi \\
+        f_{1,n} &= (5-n)\,\alpha\,a \exp((V' + v_i)/x_1)\,\phi,
+                   &\quad b_{1,n} &= n\,\beta\,b
+                   \exp((V' + v_i)/x_2)\,\phi \\
+        f_{1n} &= \gamma \exp(V'/x_3)\,\phi,
+                  &\quad b_{1n} &= \delta \exp(V'/x_4)\,\phi \\
+        f_{i,n} &= C_{on}\,a^{\,n-1}\,\phi,
+                   &\quad b_{i,n} &= C_{off}\,b^{\,n-1}\,\phi \\
+        f_{in} &= O_{on}\,\phi, &\quad b_{in} &= O_{off}\,\phi
+        \end{aligned}
+
+    for :math:`n = 1..4` (:math:`f_{0,n}`/:math:`b_{0,n}`,
+    :math:`f_{1,n}`/:math:`b_{1,n}`) and :math:`n = 1..5`
+    (:math:`f_{i,n}`/:math:`b_{i,n}`), where :math:`V' = V/\mathrm{mV}`,
+    :math:`a` = ``alfac`` :math:`= (O_{on}/C_{on})^{1/4}`, :math:`b` =
+    ``btfac`` :math:`= (O_{off}/C_{off})^{1/4}`, and
+    :math:`\phi = 3^{(T - 22)/10}` with :math:`T` in degrees Celsius.
+    The current is :math:`g_{max} \cdot O \cdot (E_{Na} - V)`, taken
+    directly from the open-state occupancy rather than a
+    ``power``-weighted gate product.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    temp : array-like, optional
+        Absolute temperature driving the :math:`\phi` factor, default
+        22 degrees Celsius (the reference temperature itself, so
+        :math:`\phi = 1`).
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``16.0 mS/cm2``.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Override for :class:`Markov`'s default ODE solver.
+    substeps : int, optional
+        Override for :class:`Markov`'s default substep count.
+
+    See Also
+    --------
+    Nav1p6_MA2024_PC : Same scheme and constants, Purkinje-cell model
+        citation.
+    Nav1p6_MA2025_BC : Same scheme and constants, basket-cell model
+        citation.
+    Nav1p6_RI2021_SC : Same scheme and constants, stellate-cell model
+        citation.
+    Nav1p1_MA2025_BC : Same 13-state topology with an independently
+        overridden constant set for the non-resurgent Nav1.1 variant.
+
+    Notes
+    -----
+    Ported from ``Nav1p6_MA2020_GoC.mod``. All of ``Con``, ``Coff``,
+    ``Oon``, ``Ooff``, ``alpha``, ``beta``, ``gamma``, ``delta``,
+    ``epsilon``, ``zeta``, ``x1``-``x6``, ``vshifta``, ``vshifti``,
+    ``vshiftk``, ``alfac`` and ``btfac`` are fixed internal constants
+    set in ``__init__`` and are not exposed as ``__init__`` parameters.
+
+    No import deviation (``TABLE`` removal, ``derivimplicit`` ->
+    ``cnexp`` substitution, rate-refresh relocation, or NMODL
+    default-precision rewrite) is recorded for this mechanism in the
+    bibliography's ``MA2020`` import-deviations tables.
+
+    References
+    ----------
+    .. [1] Raman, I. M., & Bean, B. P. (2001). Inactivation and
+           recovery of sodium currents in cerebellar Purkinje neurons:
+           evidence for two mechanisms. Biophysical Journal, 80(2),
+           729-737.
+           doi:10.1016/S0006-3495(01)76052-3
+    .. [2] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [3] Akemann, W., & Knopfel, T. (2006). Interaction of Kv3
+           potassium channels and resurgent sodium current influences
+           the rate of spontaneous firing of Purkinje neurons. The
+           Journal of Neuroscience, 26(17), 4602-4612.
+           doi:10.1523/JNEUROSCI.5204-05.2006
+    .. [4] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium
@@ -434,7 +939,78 @@ class Nav1p6_MA2020_GoC(Markov):
 
 @register_channel("Nav1p6_MA2024_PC")
 class Nav1p6_MA2024_PC(Nav1p6_MA2020_GoC):
-    """Template-based import of ``Nav1p6_MA2024_PC.mod``."""
+    r"""Resurgent Nav1.6 sodium current, Purkinje-cell parameterisation.
+
+    The same 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
+    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`,
+    reused unchanged for the human Purkinje-cell model of
+    (Masoli et al., 2024) [4]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    temp : array-like, optional
+        Absolute temperature driving the :math:`\phi` factor, default
+        22 degrees Celsius. Inherited from :class:`Nav1p6_MA2020_GoC`.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``16.0 mS/cm2``.
+        Inherited from :class:`Nav1p6_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Override for :class:`Markov`'s default ODE solver.
+    substeps : int, optional
+        Override for :class:`Markov`'s default substep count.
+
+    See Also
+    --------
+    Nav1p6_MA2020_GoC : The base class; full equations, state
+        topology and constant values are documented there.
+    Nav1p6_MA2025_BC : Same scheme and constants, basket-cell model
+        citation.
+    Nav1p6_RI2021_SC : Same scheme and constants, stellate-cell model
+        citation.
+
+    Notes
+    -----
+    Ported from ``Nav1p6_MA2024_PC.mod``. This class does not override
+    ``__init__``: the constructor, the transition-rate lambdas, the
+    fixed kinetic constants and :meth:`current` are all inherited
+    unchanged from :class:`Nav1p6_MA2020_GoC`. Only the
+    ``register_channel`` key and this docstring's model citation
+    differ -- the ``.mod`` file this class ports from parameterises
+    the identical mechanism for a different cell type, not a
+    different kinetic scheme.
+
+    No import deviation is recorded for this mechanism in the
+    bibliography's ``MA2024`` import-deviations tables.
+
+    References
+    ----------
+    .. [1] Raman, I. M., & Bean, B. P. (2001). Inactivation and
+           recovery of sodium currents in cerebellar Purkinje neurons:
+           evidence for two mechanisms. Biophysical Journal, 80(2),
+           729-737.
+           doi:10.1016/S0006-3495(01)76052-3
+    .. [2] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [3] Akemann, W., & Knopfel, T. (2006). Interaction of Kv3
+           potassium channels and resurgent sodium current influences
+           the rate of spontaneous firing of Purkinje neurons. The
+           Journal of Neuroscience, 26(17), 4602-4612.
+           doi:10.1523/JNEUROSCI.5204-05.2006
+    .. [4] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz, A.,
+           & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
 
     __module__ = "braincell.channel"
 
@@ -444,7 +1020,77 @@ class Nav1p6_MA2024_PC(Nav1p6_MA2020_GoC):
 
 @register_channel("Nav1p6_MA2025_BC")
 class Nav1p6_MA2025_BC(Nav1p6_MA2020_GoC):
-    """Template-based import of ``Nav1p6_MA2025_BC.mod``."""
+    r"""Resurgent Nav1.6 sodium current, basket-cell parameterisation.
+
+    The same 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
+    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`,
+    reused unchanged for the basket-cell model of
+    (Masoli et al., 2025) [4]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    temp : array-like, optional
+        Absolute temperature driving the :math:`\phi` factor, default
+        22 degrees Celsius. Inherited from :class:`Nav1p6_MA2020_GoC`.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``16.0 mS/cm2``.
+        Inherited from :class:`Nav1p6_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Override for :class:`Markov`'s default ODE solver.
+    substeps : int, optional
+        Override for :class:`Markov`'s default substep count.
+
+    See Also
+    --------
+    Nav1p6_MA2020_GoC : The base class; full equations, state
+        topology and constant values are documented there.
+    Nav1p6_MA2024_PC : Same scheme and constants, Purkinje-cell model
+        citation.
+    Nav1p6_RI2021_SC : Same scheme and constants, stellate-cell model
+        citation.
+    Nav1p1_MA2025_BC : Non-resurgent Nav1.1 sibling for the same
+        basket-cell model, with its own overridden constants.
+
+    Notes
+    -----
+    Ported from ``Nav1p6_MA2025_BC.mod``. This class does not override
+    ``__init__``: the constructor, the transition-rate lambdas, the
+    fixed kinetic constants and :meth:`current` are all inherited
+    unchanged from :class:`Nav1p6_MA2020_GoC`. Only the
+    ``register_channel`` key and this docstring's model citation
+    differ.
+
+    No import deviation is recorded for this mechanism in the
+    bibliography's ``MA2025`` import-deviations tables.
+
+    References
+    ----------
+    .. [1] Raman, I. M., & Bean, B. P. (2001). Inactivation and
+           recovery of sodium currents in cerebellar Purkinje neurons:
+           evidence for two mechanisms. Biophysical Journal, 80(2),
+           729-737.
+           doi:10.1016/S0006-3495(01)76052-3
+    .. [2] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [3] Akemann, W., & Knopfel, T. (2006). Interaction of Kv3
+           potassium channels and resurgent sodium current influences
+           the rate of spontaneous firing of Purkinje neurons. The
+           Journal of Neuroscience, 26(17), 4602-4612.
+           doi:10.1523/JNEUROSCI.5204-05.2006
+    .. [4] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025). Cerebellar
+           basket cell filtering of Purkinje cell responses elicited
+           by low frequency parallel fibre transmission. Scientific
+           Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
@@ -454,7 +1100,77 @@ class Nav1p6_MA2025_BC(Nav1p6_MA2020_GoC):
 
 @register_channel("Nav1p6_RI2021_SC")
 class Nav1p6_RI2021_SC(Nav1p6_MA2020_GoC):
-    """Template-based import of ``Nav1p6_RI2021_SC.mod``."""
+    r"""Resurgent Nav1.6 sodium current, stellate-cell parameterisation.
+
+    The same 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
+    sodium Markov scheme documented in :class:`Nav1p6_MA2020_GoC`,
+    reused unchanged for the stellate-cell model of
+    (Rizza et al., 2021) [4]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    temp : array-like, optional
+        Absolute temperature driving the :math:`\phi` factor, default
+        22 degrees Celsius. Inherited from :class:`Nav1p6_MA2020_GoC`.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``16.0 mS/cm2``.
+        Inherited from :class:`Nav1p6_MA2020_GoC`.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Override for :class:`Markov`'s default ODE solver.
+    substeps : int, optional
+        Override for :class:`Markov`'s default substep count.
+
+    See Also
+    --------
+    Nav1p6_MA2020_GoC : The base class; full equations, state
+        topology and constant values are documented there.
+    Nav1p6_MA2024_PC : Same scheme and constants, Purkinje-cell model
+        citation.
+    Nav1p6_MA2025_BC : Same scheme and constants, basket-cell model
+        citation.
+    Nav1p1_RI2021_SC : Non-resurgent Nav1.1 sibling for the same
+        stellate-cell model.
+
+    Notes
+    -----
+    Ported from ``Nav1p6_RI2021_SC.mod``. This class does not override
+    ``__init__``: the constructor, the transition-rate lambdas, the
+    fixed kinetic constants and :meth:`current` are all inherited
+    unchanged from :class:`Nav1p6_MA2020_GoC`. Only the
+    ``register_channel`` key and this docstring's model citation
+    differ.
+
+    No import deviation is recorded for this mechanism in the
+    bibliography's ``RI2021`` import-deviations tables.
+
+    References
+    ----------
+    .. [1] Raman, I. M., & Bean, B. P. (2001). Inactivation and
+           recovery of sodium currents in cerebellar Purkinje neurons:
+           evidence for two mechanisms. Biophysical Journal, 80(2),
+           729-737.
+           doi:10.1016/S0006-3495(01)76052-3
+    .. [2] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [3] Akemann, W., & Knopfel, T. (2006). Interaction of Kv3
+           potassium channels and resurgent sodium current influences
+           the rate of spontaneous firing of Purkinje neurons. The
+           Journal of Neuroscience, 26(17), 4602-4612.
+           doi:10.1523/JNEUROSCI.5204-05.2006
+    .. [4] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
 
@@ -464,7 +1180,115 @@ class Nav1p6_RI2021_SC(Nav1p6_MA2020_GoC):
 
 @register_channel("Nav1p1_MA2025_BC")
 class Nav1p1_MA2025_BC(Nav1p6_MA2020_GoC):
-    """Template-based import of ``Nav1p1_MA2025_BC.mod``."""
+    r"""Non-resurgent Nav1.1 sodium current, basket-cell parameterisation.
+
+    The non-resurgent ``Narsg`` sodium current derived from the
+    Khaliq et al. (2003) [1]_ resurgent-current model and used for
+    Kv3/Nav1.1 excitability studies by Akemann, Lundby, Mutoh &
+    Knopfel (2009) [2]_, reparameterised for the basket-cell model of
+    (Masoli et al., 2025) [3]_.
+
+    This class inherits the 13-state Markov ``pairs`` topology, the
+    transition-rate lambdas and the :math:`\phi` temperature-scaling
+    formula from :class:`Nav1p6_MA2020_GoC` (see that class for the
+    full state diagram and rate equations), but overrides three of
+    the fixed kinetic constants and recomputes :math:`\phi` with a
+    different base:
+
+    .. math::
+
+        \phi = 2.7^{(T - 22)/10}, \quad
+        O_{on} = 2.3\ \mathrm{ms^{-1}}, \quad
+        \epsilon = 10^{-12}\ \mathrm{ms^{-1}}, \quad
+        a = \left(\frac{O_{on}}{C_{on}}\right)^{1/4}
+
+    with :math:`C_{on}` unchanged from :class:`Nav1p6_MA2020_GoC`'s
+    ``0.005``, so ``alfac`` is recomputed to a different value than
+    the base class's. :meth:`current` adds an optional gating-current
+    correction on top of the inherited ionic current:
+
+    .. math::
+
+        \begin{aligned}
+        I &= g_{max}\, O\, (E_{Na} - V) - \mathbb{1}[\text{gateCurrent}
+             \neq 0]\, I_{gate} \\
+        I_{gate} &= n_c \times 10^6\, e_0\, z_{gate}\,
+                     \dot{q} \\
+        \dot{q} &= f_{01} C_1 + (f_{02}{-}b_{01}) C_2
+                    + (f_{03}{-}b_{02}) C_3
+                    + (f_{04}{-}b_{03}) C_4 - b_{04} C_5 \\
+                 &\ + f_{11} I_1 + (f_{12}{-}b_{11}) I_2
+                    + (f_{13}{-}b_{12}) I_3
+                    + (f_{14}{-}b_{13}) I_4 - b_{14} I_5 \\
+        n_c &= 10^{12}\, g_{max} / g_{unit}
+        \end{aligned}
+
+    where :math:`\dot{q}` is the net probability flux through the
+    activation/inactivation ladders (excluding ``O``, ``B`` and
+    ``I6``), :math:`n_c` estimates the channel count from ``g_max``
+    and a fixed unitary conductance ``gunit``, and :math:`e_0` is the
+    elementary charge.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    temp : array-like, optional
+        Absolute temperature driving the :math:`\phi` factor, default
+        22 degrees Celsius.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``8.0 mS/cm2`` (half
+        :class:`Nav1p6_MA2020_GoC`'s default).
+    gateCurrent : array-like or callable, optional
+        Enables the gating-current correction in :meth:`current` when
+        nonzero, default ``0.0`` (disabled).
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Override for :class:`Markov`'s default ODE solver.
+    substeps : int, optional
+        Override for :class:`Markov`'s default substep count.
+
+    See Also
+    --------
+    Nav1p1_RI2021_SC : Same scheme and constants, stellate-cell model
+        citation.
+    Nav1p6_MA2025_BC : Resurgent Nav1.6 sibling for the same
+        basket-cell model, with its own (unoverridden) constants.
+
+    Notes
+    -----
+    Ported from ``Nav1p1_MA2025_BC.mod``, whose own header describes
+    the mechanism as "derived from the Narsg channel of Khaliq et al.,
+    J. Neurosci. 23(2003)4899" -- i.e. via :class:`Nav1p6_MA2020_GoC`'s
+    origin, not an independently republished scheme.
+
+    ``zgate = 2.5435``, ``gunit = 15e-9 mS`` and
+    ``e0 = 1.60217646e-19 C`` are fixed internal constants set in
+    ``__init__`` and are not exposed as ``__init__`` parameters.
+
+    No import deviation is recorded for this mechanism in the
+    bibliography's ``MA2025`` import-deviations tables.
+
+    References
+    ----------
+    .. [1] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [2] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+           Effect of voltage sensitive fluorescent proteins on
+           neuronal excitability. Biophysical Journal, 96(10),
+           3959-3976.
+           doi:10.1016/j.bpj.2009.02.046
+    .. [3] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025). Cerebellar
+           basket cell filtering of Purkinje cell responses elicited
+           by low frequency parallel fibre transmission. Scientific
+           Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
+    """
 
     __module__ = "braincell.channel"
 
@@ -519,7 +1343,73 @@ class Nav1p1_MA2025_BC(Nav1p6_MA2020_GoC):
 
 @register_channel("Nav1p1_RI2021_SC")
 class Nav1p1_RI2021_SC(Nav1p1_MA2025_BC):
-    """Template-based import of ``Nav1p1_RI2021_SC.mod``."""
+    r"""Non-resurgent Nav1.1 sodium current, stellate-cell parameterisation.
+
+    The same non-resurgent ``Narsg`` sodium current documented on
+    :class:`Nav1p1_MA2025_BC` -- derived from the Khaliq et al. (2003)
+    [1]_ resurgent-current model and used for Kv3/Nav1.1 excitability
+    studies by Akemann, Lundby, Mutoh & Knopfel (2009) [2]_ -- imported
+    here for the stellate-cell model of Rizza et al. (2021) [3]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    temp : array-like, optional
+        Absolute temperature driving the :math:`\phi` factor, default
+        22 degrees Celsius.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``8.0 mS/cm2``.
+    gateCurrent : array-like or callable, optional
+        Enables the gating-current correction in :meth:`current` when
+        nonzero, default ``0.0`` (disabled).
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Override for :class:`Markov`'s default ODE solver.
+    substeps : int, optional
+        Override for :class:`Markov`'s default substep count.
+
+    See Also
+    --------
+    Nav1p1_MA2025_BC : Same 13-state scheme and overridden constants,
+        basket-cell model citation; the full kinetics, :math:`\phi`
+        formula and gating-current formula are documented there.
+    Nav1p6_RI2021_SC : Resurgent Nav1.6 sibling for the same
+        stellate-cell model.
+
+    Notes
+    -----
+    Ported from ``Nav1p1_RI2021_SC.mod``. This class does not override
+    ``__init__``: the constructor signature, the 13-state kinetics,
+    the :math:`\phi` temperature scaling, the ``Oon``/``epsilon``/
+    ``zgate``/``gunit``/``e0`` constants and the gating-current term
+    in :meth:`current` are all inherited unchanged from
+    :class:`Nav1p1_MA2025_BC`; only the citation and registration key
+    differ.
+
+    No import deviation is recorded for this mechanism in the
+    bibliography's ``RI2021`` import-deviations tables.
+
+    References
+    ----------
+    .. [1] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+           contribution of resurgent sodium current to high-frequency
+           firing in Purkinje neurons: an experimental and modeling
+           study. The Journal of Neuroscience, 23(12), 4899-4912.
+           doi:10.1523/JNEUROSCI.23-12-04899.2003
+    .. [2] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+           Effect of voltage sensitive fluorescent proteins on
+           neuronal excitability. Biophysical Journal, 96(10),
+           3959-3976.
+           doi:10.1016/j.bpj.2009.02.046
+    .. [3] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
+    """
 
     __module__ = "braincell.channel"
 
@@ -529,7 +1419,127 @@ class Nav1p1_RI2021_SC(Nav1p1_MA2025_BC):
 
 @register_channel("Nav_MA2020_GrC")
 class Nav_MA2020_GrC(Markov, IndependentIntegration):
-    """Template-based import of ``Nav_MA2020_GrC.mod``."""
+    r"""Resurgent Nav sodium current, granule-cell parameterisation.
+
+    A 13-state Raman & Bean (2001) [2]_-style resurgent sodium Markov
+    scheme, refitted to the transient/persistent/resurgent granule-cell
+    recordings and kinetic scheme of Magistretti et al. (2006) [1]_ and
+    imported here for the granule-cell model of (Masoli et al., 2020)
+    [3]_. Five closed states ``C1``-``C5`` form an activation ladder
+    mirrored by five inactivated states ``I1``-``I5``; ``C5`` opens
+    into ``O``, which can transition into a blocked state ``OB`` or
+    into the shared deep-inactivated state ``I6`` (also reachable from
+    ``I5``); ``I6`` is algebraically eliminated as ``dependent_state``.
+
+    All transition rates share one temperature factor and a small set
+    of voltage-dependent and constant primitives:
+
+    .. math::
+
+        \begin{aligned}
+        \phi &= 3^{(T - 20)/10} \\
+        \alpha(V) &= \phi\, A_\alpha\, e^{V/V_\alpha}, \quad
+        \beta(V) = \phi\, A_\beta\, e^{-V/V_\beta}, \quad
+        \theta(V) = \phi\, A_\theta\, e^{-V/V_\theta} \\
+        \gamma &= \phi A_\gamma, \quad \delta = \phi A_\delta, \quad
+        \varepsilon = \phi A_\varepsilon \\
+        C_{on} &= \phi A_{Con}, \quad C_{off} = \phi A_{Coff}, \quad
+        O_{on} = \phi A_{Oon}, \quad O_{off} = \phi A_{Ooff} \\
+        a &= (O_{on}/C_{on})^{1/4}, \quad b = (O_{off}/C_{off})^{1/4}
+        \end{aligned}
+
+    with :math:`V` in mV (unitless argument to the exponentials) and
+    :math:`T` the temperature in degrees Celsius. The closed and
+    inactivated ladders share the same scaling weights
+    :math:`n_1{=}5.422,\ n_2{=}3.279,\ n_3{=}1.83,\ n_4{=}0.738`:
+
+    .. math::
+
+        \begin{aligned}
+        f_{0k} &= n_k\, \alpha(V), &
+        b_{0k} &= n_{5-k}\, \beta(V), & k&=1,\dots,4 \\
+        f_{1k} &= n_k\, \alpha(V)\, a, &
+        b_{1k} &= n_{5-k}\, \beta(V)\, b, & k&=1,\dots,4 \\
+        f_{ik} &= C_{on}\, a^{\,k-1}, &
+        b_{ik} &= C_{off}\, b^{\,k-1}, & k&=1,\dots,5 \\
+        f_{0O} &= \gamma, & b_{0O} &= \delta \\
+        f_{ip} &= \varepsilon, & b_{ip} &= \theta \\
+        f_{1n} &= \gamma, & b_{1n} &= \delta \\
+        f_{in} &= O_{on}, & b_{in} &= O_{off}
+        \end{aligned}
+
+    where subscript ``0k``/``1k`` index the ``Ck<->Ck+1``/
+    ``Ik<->Ik+1`` ladder steps, ``ik`` the ``Ck<->Ik`` cross-links,
+    ``0O`` the ``C5<->O`` opening step, ``ip`` the ``O<->OB`` blocking
+    step, and ``1n``/``in`` the ``I5<->I6``/``O<->I6`` deep-inactivation
+    links.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    temp : array-like, optional
+        Absolute temperature driving :math:`\phi`, default 32 degrees
+        Celsius.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``13.0 mS/cm2``.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Override for :class:`Markov`'s default ODE solver.
+    substeps : int, optional
+        Override for :class:`Markov`'s default substep count.
+
+    See Also
+    --------
+    NaFHF_MA2020_GrC : Same 13-state scheme with an additional
+        slow-blocked branch (``L3``-``L6``) enabled.
+    Nav1p6_MA2020_GoC : Same general resurgent-Markov family, fitted
+        instead to Purkinje-cell kinetics with its own constants.
+
+    Notes
+    -----
+    Ported from ``Nav_MA2020_GrC.mod``, whose header attributes the
+    scheme to "Raman 13 state model. Adapted from Magistretti et al,
+    2006." This class does not subclass :class:`Nav1p6_MA2020_GoC`;
+    it is an independent implementation with its own ``__init__`` and
+    rate constants. :math:`\phi` is referenced to 20 degrees Celsius
+    here, unlike the Nav1.6/Nav1.1 Golgi/Purkinje/basket/stellate
+    family, which references 22 degrees Celsius.
+
+    **Discrepancy between code and bibliography record.** This class
+    ships ``ACon = 0.005`` and ``AOoff = 0.005``. The bibliography's
+    cross-checked fingerprint for the ``MA2020`` granule sodium pair
+    states that ``Nav_MA2020_GrC`` and ``NaFHF_MA2020_GrC`` share
+    ``ACon = 0.025`` and ``AOoff = 0.002`` -- those values are correct
+    for :class:`NaFHF_MA2020_GrC` (confirmed against its own code) but
+    not for this class. The values documented above are read directly
+    from this class's ``__init__`` and are the ones in effect at
+    runtime.
+
+    No import deviation is recorded for this mechanism in the
+    bibliography's ``MA2020`` import-deviations tables.
+
+    References
+    ----------
+    .. [1] Magistretti, J., Castelli, L., Forti, L., & D'Angelo, E.
+           (2006). Kinetic and functional analysis of transient,
+           persistent and resurgent sodium currents in rat cerebellar
+           granule cells in situ: an electrophysiological and
+           modelling study. The Journal of Physiology, 573(1), 83-106.
+           doi:10.1113/jphysiol.2006.106682
+    .. [2] Raman, I. M., & Bean, B. P. (2001). Inactivation and
+           recovery of sodium currents in cerebellar Purkinje neurons:
+           evidence for two mechanisms. Biophysical Journal, 80(2),
+           729-737.
+           doi:10.1016/S0006-3495(01)76052-3
+    .. [3] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties at
+           the cerebellum input stage. Communications Biology, 3(1),
+           222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium
@@ -650,7 +1660,105 @@ class Nav_MA2020_GrC(Markov, IndependentIntegration):
 
 @register_channel("NaFHF_MA2020_GrC")
 class NaFHF_MA2020_GrC(Markov, IndependentIntegration):
-    """Template-based import of ``NaFHF_MA2020_GrC.mod``."""
+    r"""Resurgent Nav sodium current with slow block, granule-cell model.
+
+    The same 13-state Raman & Bean (2001) [2]_-style resurgent sodium
+    Markov scheme documented on :class:`Nav_MA2020_GrC` -- fitted to
+    the granule-cell kinetics of Magistretti et al. (2006) [1]_ and
+    imported for the granule-cell model of (Masoli et al., 2020) [3]_
+    -- extended with a second, slower blocked-state ladder
+    ``L3``-``L6`` branching off ``C3``, ``C4``, ``C5`` and ``O``. It
+    is the same mechanism as :class:`Nav_MA2020_GrC` with this
+    slow-blocked branch enabled, not an independently derived model.
+
+    The shared primitives (:math:`\phi`, :math:`\alpha`, :math:`\beta`,
+    :math:`\theta`, :math:`\gamma`, :math:`\delta`, :math:`\varepsilon`,
+    :math:`C_{on}`, :math:`C_{off}`, :math:`O_{on}`, :math:`O_{off}`,
+    :math:`a`, :math:`b`) and the ``C1``-``C5``/``I1``-``I5``/``O``/
+    ``OB``/``I6`` transition-rate formulas are exactly as given on
+    :class:`Nav_MA2020_GrC`. The added ``L3``-``L6`` branch uses two
+    further constant rate factors :math:`L_{on} = \phi A_{Lon}` and
+    :math:`L_{off} = \phi A_{Loff}` and fixed scale factors
+    :math:`c = 20.0`, :math:`d = 0.075`:
+
+    .. math::
+
+        \begin{aligned}
+        f_{33} &= n_3\, \alpha(V)\, c, &
+        b_{33} &= n_2\, \alpha(V)\, d \\
+        f_{34} &= n_4\, \alpha(V)\, c, &
+        b_{34} &= n_1\, \alpha(V)\, d \\
+        f_{3n} &= \gamma, & b_{3n} &= \delta \\
+        f_{l3} &= L_{on}, & b_{l3} &= L_{off} \\
+        f_{l4} &= L_{on}\, c, & b_{l4} &= L_{off}\, d \\
+        f_{l5} &= L_{on}\, c^2, & b_{l5} &= L_{off}\, d^2 \\
+        f_{l6} &= L_{on}\, c^2, & b_{l6} &= L_{off}\, d^2
+        \end{aligned}
+
+    where ``f33``/``b33`` and ``f34``/``b34`` are the ``C3<->C4``/
+    ``C4<->C5`` steps of the ``L``-branch's own closed-ladder mirror
+    (``L3``/``L4``/``L5`` gate through the same alfa/beta primitives
+    as ``C3``-``C5`` but scaled by ``c``/``d``), ``f3n``/``b3n`` is the
+    ``L5<->L6`` step, and ``fl3``-``fl6``/``bl3``-``bl6`` are the
+    ``C3<->L3``, ``C4<->L4``, ``C5<->L5`` and ``O<->L6`` cross-links.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    temp : array-like, optional
+        Absolute temperature driving :math:`\phi`, default 32 degrees
+        Celsius.
+    g_max : array-like or callable, optional
+        Maximal conductance density, default ``13.0 mS/cm2``.
+    name : str, optional
+        Optional channel name.
+    solver : str, optional
+        Override for :class:`Markov`'s default ODE solver.
+    substeps : int, optional
+        Override for :class:`Markov`'s default substep count.
+
+    See Also
+    --------
+    Nav_MA2020_GrC : Same scheme without the slow-blocked branch; the
+        shared primitives and ladder formulas are documented there.
+
+    Notes
+    -----
+    Ported from ``NaFHF_MA2020_GrC.mod``. Its own ``COMMENT`` block is
+    empty, which is not a provenance gap: it inherits
+    ``Nav_MA2020_GrC.mod``'s "Based on Raman 13 state model. Adapted
+    from Magistretti et al, 2006." attribution, per the bibliography.
+
+    This class ships ``ACon = 0.025`` and ``AOoff = 0.002`` -- unlike
+    :class:`Nav_MA2020_GrC`, these values match the bibliography's
+    cross-checked fingerprint for the ``MA2020`` granule sodium pair
+    exactly. See :class:`Nav_MA2020_GrC`'s Notes for the discrepancy
+    recorded against its own ``ACon``/``AOoff`` values.
+
+    No import deviation is recorded for this mechanism in the
+    bibliography's ``MA2020`` import-deviations tables.
+
+    References
+    ----------
+    .. [1] Magistretti, J., Castelli, L., Forti, L., & D'Angelo, E.
+           (2006). Kinetic and functional analysis of transient,
+           persistent and resurgent sodium currents in rat cerebellar
+           granule cells in situ: an electrophysiological and
+           modelling study. The Journal of Physiology, 573(1), 83-106.
+           doi:10.1113/jphysiol.2006.106682
+    .. [2] Raman, I. M., & Bean, B. P. (2001). Inactivation and
+           recovery of sodium currents in cerebellar Purkinje neurons:
+           evidence for two mechanisms. Biophysical Journal, 80(2),
+           729-737.
+           doi:10.1016/S0006-3495(01)76052-3
+    .. [3] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties at
+           the cerebellum input stage. Communications Biology, 3(1),
+           222.
+           doi:10.1038/s42003-020-0953-x
+    """
 
     __module__ = "braincell.channel"
     root_type = Sodium

--- a/braincell/ion/_base.py
+++ b/braincell/ion/_base.py
@@ -541,9 +541,11 @@ class KineticIon(IndependentIntegration):
     ----------
     .. [1] Hines, M. L., & Carnevale, N. T. (2000). Expanding NEURON's
            repertoire of mechanisms with NMODL. Neural Computation,
-           12(5), 995-1007. doi:10.1162/089976600300015475
+           12(5), 995-1007.
+           doi:10.1162/089976600300015475
     .. [2] Carnevale, N. T., & Hines, M. L. (2006). The NEURON book.
-           Cambridge University Press. doi:10.1017/CBO9780511541612
+           Cambridge University Press.
+           doi:10.1017/CBO9780511541612
 
     Attributes
     ----------

--- a/braincell/ion/_base.py
+++ b/braincell/ion/_base.py
@@ -387,7 +387,15 @@ class DynamicNernstIon(brainstate.mixin.Mixin):
             \log\!\left(\frac{C_o}{C_i}\right)
 
     so ``E`` always reflects the live ``Ci`` state rather than a value
-    cached at the last lifecycle hook. :meth:`derivative` itself raises
+    cached at the last lifecycle hook.
+
+    As with the sibling mixins, ``Co`` and ``valence`` fall back to
+    ``type(self).default_Co`` and ``type(self).default_valence`` when
+    left as ``None``. ``Ci_initializer`` falls back the same way, to
+    ``type(self).default_Ci`` -- so omitting it does not leave ``Ci``
+    unset, it seeds the dynamic state from the species' fixed default.
+
+    :meth:`derivative` itself raises
     :class:`NotImplementedError` on this mixin; a concrete subclass
     must override it to return ``dCi/dt`` for its own dynamic ion
     model.

--- a/braincell/ion/_base.py
+++ b/braincell/ion/_base.py
@@ -534,8 +534,8 @@ class KineticIon(IndependentIntegration):
     The NMODL semantics this template reproduces -- ``KINETIC`` reaction
     statements, ``COMPARTMENT`` volume/factor scaling, and the
     ``CONSERVE`` statement for algebraic species -- are documented by
-    ``.. [1]``, the primary source for NMODL itself. ``.. [2]`` is the
-    reference text for the surrounding NEURON mechanism model.
+    [1]_, the primary source for NMODL itself. [2]_ is the reference
+    text for the surrounding NEURON mechanism model.
 
     References
     ----------

--- a/braincell/ion/_base.py
+++ b/braincell/ion/_base.py
@@ -52,6 +52,12 @@ class Factor:
         Callable ``value(owner)`` returning the factor for the concrete ion
         instance. This factor is treated as constant during one integration
         step.
+
+    See Also
+    --------
+    Species : May reference this factor by name via its ``factor`` field.
+    KineticIon : Template that consumes ``Factor`` entries through its
+        ``factors`` class variable.
     """
 
     name: str
@@ -72,6 +78,15 @@ class Species:
     factor : str or None, optional
         Optional :class:`Factor` name used for visible/amount conversion.
         ``None`` denotes identity conversion.
+
+    See Also
+    --------
+    Factor : Optional conversion factor referenced by name via ``factor``.
+    Reaction : References species by name in ``lhs``/``rhs``.
+    Source : References one species by name via ``target``.
+    Conserve : References species by name via ``species``/``algebraic``.
+    KineticIon : Template that consumes ``Species`` entries through its
+        ``species`` class variable.
     """
 
     name: str
@@ -100,6 +115,12 @@ class Reaction:
         Optional callable for the reverse direction. ``None`` denotes a
         single-direction reaction. As with ``forward``, its returned value is
         multiplied directly by the right-hand visible species product.
+
+    See Also
+    --------
+    Species : Declares the species named in ``lhs``/``rhs``.
+    KineticIon : Template that consumes ``Reaction`` entries through its
+        ``reactions`` class variable.
     """
 
     lhs: dict[str, int]
@@ -120,6 +141,12 @@ class Source:
         Callable ``flux(owner, V, species_values)`` returning a contribution to
         the factor-scaled derivative of ``target``. When ``target`` has no
         factor this reduces to the ordinary visible derivative.
+
+    See Also
+    --------
+    Species : Declares the species named by ``target``.
+    KineticIon : Template that consumes ``Source`` entries through its
+        ``sources`` class variable.
     """
 
     target: str
@@ -139,6 +166,12 @@ class Conserve:
     total : callable
         Callable ``total(owner, V, species_values)`` returning the conserved
         pool size in factor-scaled units.
+
+    See Also
+    --------
+    Species : Declares the species named in ``species``/``algebraic``.
+    KineticIon : Template that consumes ``Conserve`` entries through its
+        ``conserves`` class variable.
     """
 
     species: tuple[str, ...]
@@ -147,7 +180,31 @@ class Conserve:
 
 
 class FixedIon(brainstate.mixin.Mixin):
-    """Helper mixin for ions with fixed ``Ci/Co/E`` state."""
+    """Mixin for ions with a fixed ``Ci``/``Co``/``E`` triple.
+
+    A concrete ion subclass calls :meth:`_init_fixed_ion` from its own
+    ``__init__`` to materialize ``Ci``, ``Co``, ``E``, and ``valence`` as
+    plain (non-state) attributes; none of the four evolve during
+    simulation. ``Ci``, ``Co``, and ``valence`` each fall back to the
+    class-level ``default_Ci``, ``default_Co``, and ``default_valence``
+    (resolved via ``type(self)``, so a subclass's own overrides win)
+    when passed ``None``. ``E`` has no such fallback and must be
+    supplied explicitly.
+
+    Raises
+    ------
+    ValueError
+        If :meth:`_init_fixed_ion` is called with ``E`` left as
+        ``None``.
+
+    See Also
+    --------
+    InitNernstIon : Sibling mixin with fixed ``Ci``/``Co`` but a stored
+        reversal potential computed once from the Nernst equation
+        instead of supplied directly.
+    DynamicNernstIon : Sibling mixin with a dynamic ``Ci`` state and a
+        reversal potential recomputed from Nernst on every read.
+    """
 
     def _init_fixed_ion(self, *, Ci=None, Co=None, E=None, valence=None):
         """Materialize one fixed ion payload onto ``self``.
@@ -188,7 +245,50 @@ class FixedIon(brainstate.mixin.Mixin):
 
 
 class InitNernstIon(brainstate.mixin.Mixin):
-    """Helper mixin for ions with fixed ``Ci/Co`` and stored Nernst ``E``."""
+    r"""Mixin for ions with fixed ``Ci``/``Co`` and a stored Nernst ``E``.
+
+    A concrete ion subclass calls :meth:`_init_nernst_ion` from its own
+    ``__init__`` to materialize ``Ci``, ``Co``, ``valence``, and
+    ``temp`` as plain (non-state) attributes, exactly as
+    :class:`FixedIon` does for its own three. ``E`` is not stored
+    directly at construction time; see Notes.
+
+    Raises
+    ------
+    ValueError
+        If :meth:`_init_nernst_ion` is called with ``temp`` left as
+        ``None``.
+
+    See Also
+    --------
+    FixedIon : Sibling mixin with a fixed reversal potential supplied
+        directly instead of computed from Nernst.
+    DynamicNernstIon : Sibling mixin with a dynamic ``Ci`` state and a
+        reversal potential recomputed from Nernst on every read, rather
+        than stored once.
+
+    Notes
+    -----
+    ``_init_nernst_ion`` sets ``self.E = None`` immediately, and
+    :meth:`_update_reversal` fills it in only later, from the
+    ``_ion_init_state_hook`` and ``_ion_reset_state_hook`` lifecycle
+    hooks. Between construction and the first state initialization or
+    reset, ``E`` is ``None``.
+
+    The stored formula, transcribed as ``_update_reversal`` writes it,
+    is
+
+    .. math::
+
+        E = \frac{R \cdot \mathrm{temp}}{\mathrm{valence} \cdot F}
+            \log\!\left(\frac{C_o}{C_i}\right)
+
+    where :math:`R` is the gas constant and :math:`F` is the Faraday
+    constant. The argument to the logarithm is :math:`C_o / C_i`
+    (extracellular over intracellular), and ``valence`` divides inside
+    the prefactor rather than appearing as a separate multiplicative
+    term.
+    """
 
     def _init_nernst_ion(self, *, Ci=None, Co=None, temp=None, valence=None):
         """Initialize fixed concentrations and stored-Nernst parameters.
@@ -245,7 +345,63 @@ class InitNernstIon(brainstate.mixin.Mixin):
 
 
 class DynamicNernstIon(brainstate.mixin.Mixin):
-    """Helper mixin for ions with dynamic ``Ci`` and computed Nernst ``E``."""
+    r"""Mixin for ions with a dynamic ``Ci`` state and Nernst-computed ``E``.
+
+    Unlike :class:`FixedIon` and :class:`InitNernstIon`, a concrete ion
+    subclass built on this mixin takes a ``Ci_initializer`` instead of a
+    fixed ``Ci`` value: :meth:`_init_dynamic_nernst_ion` materializes
+    ``Co``, ``valence``, and ``temp`` as plain (non-state) attributes and
+    only *remembers* the initializer, in ``self._Ci_initializer``. The
+    runtime ``Ci`` :class:`~brainstate.State` itself is created later, by
+    :meth:`_ion_init_state_hook`, and refreshed by
+    :meth:`_ion_reset_state_hook`; its time derivative is written by
+    :meth:`_ion_compute_derivative_hook`, which delegates to the
+    subclass's own :meth:`derivative`.
+
+    Raises
+    ------
+    ValueError
+        If :meth:`_init_dynamic_nernst_ion` is called with ``temp`` left
+        as ``None`` -- the same failure mode as
+        :meth:`InitNernstIon._init_nernst_ion`, not
+        :meth:`FixedIon._init_fixed_ion`, which instead requires an
+        explicit ``E``.
+
+    See Also
+    --------
+    FixedIon : Sibling mixin with a fixed reversal potential and no
+        dynamic state.
+    InitNernstIon : Sibling mixin with fixed ``Ci``/``Co`` and a
+        reversal potential computed once and cached, rather than
+        recomputed on every read.
+
+    Notes
+    -----
+    ``E`` is a property, not a stored attribute: every read recomputes
+    it from the current ``Ci``, ``Co``, ``temp``, and ``valence`` via the
+    same Nernst formula as :class:`InitNernstIon`,
+
+    .. math::
+
+        E = \frac{R \cdot \mathrm{temp}}{\mathrm{valence} \cdot F}
+            \log\!\left(\frac{C_o}{C_i}\right)
+
+    so ``E`` always reflects the live ``Ci`` state rather than a value
+    cached at the last lifecycle hook. :meth:`derivative` itself raises
+    :class:`NotImplementedError` on this mixin; a concrete subclass
+    must override it to return ``dCi/dt`` for its own dynamic ion
+    model.
+
+    Attributes
+    ----------
+    uses_total_current : bool, default False
+        When ``True``, :meth:`_ion_compute_derivative_hook` precomputes
+        the aggregate ion current -- reusing a step-start cached value
+        on ``self._cached_total_current`` when present, otherwise
+        evaluating ``self.current(V, include_external=True)`` -- and
+        passes it to ``derivative(..., total_current=...)``. When
+        ``False`` (the default), ``total_current`` is always ``None``.
+    """
 
     #: When true, the template precomputes the aggregate ion current and passes
     #: it to ``derivative(..., total_current=...)``.
@@ -341,6 +497,24 @@ class KineticIon(IndependentIntegration):
     intracellular concentration; ``Co``, ``temp``, and ``valence`` remain
     ion-level fields.
 
+    Raises
+    ------
+    ValueError
+        If :meth:`_init_kinetic_ion` is called with ``temp`` left as
+        ``None``, or with ``substeps`` (after falling back to
+        :attr:`default_substeps` when not supplied) less than ``1``.
+
+    See Also
+    --------
+    Factor : Declares one conversion factor consumed via :attr:`factors`.
+    Species : Declares one reaction-network species consumed via
+        :attr:`species`.
+    Reaction : Declares one mass-action reaction consumed via
+        :attr:`reactions`.
+    Source : Declares one source term consumed via :attr:`sources`.
+    Conserve : Declares one algebraic conservation relation consumed via
+        :attr:`conserves`.
+
     Notes
     -----
     Species live in visible units during integration. ``factor`` only mediates
@@ -348,6 +522,46 @@ class KineticIon(IndependentIntegration):
     mapping; species values are not stored in scaled form. Reaction laws remain
     in the visible domain, matching NEURON's ``KINETIC``/``COMPARTMENT``
     behavior.
+
+    The NMODL semantics this template reproduces -- ``KINETIC`` reaction
+    statements, ``COMPARTMENT`` volume/factor scaling, and the
+    ``CONSERVE`` statement for algebraic species -- are documented by
+    ``.. [1]``, the primary source for NMODL itself. ``.. [2]`` is the
+    reference text for the surrounding NEURON mechanism model.
+
+    References
+    ----------
+    .. [1] Hines, M. L., & Carnevale, N. T. (2000). Expanding NEURON's
+           repertoire of mechanisms with NMODL. Neural Computation,
+           12(5), 995-1007. doi:10.1162/089976600300015475
+    .. [2] Carnevale, N. T., & Hines, M. L. (2006). The NEURON book.
+           Cambridge University Press. doi:10.1017/CBO9780511541612
+
+    Attributes
+    ----------
+    factors : tuple of Factor, default ()
+        Conversion factors available to :attr:`species`, by name.
+    species : tuple of Species, default ()
+        The reaction-network species table. Must contain exactly one
+        entry named ``"Ci"``.
+    reactions : tuple of Reaction, default ()
+        Mass-action reactions among the declared species.
+    sources : tuple of Source, default ()
+        Source terms contributing directly to a diffeq species'
+        derivative.
+    conserves : tuple of Conserve, default ()
+        Algebraic conservation relations resolving one species per
+        entry from the others in its pool.
+    uses_total_current : bool, default False
+        When ``True``, the template precomputes the aggregate ion
+        current and passes it to ``derivative(..., total_current=...)``.
+    default_solver : str, default "backward_euler"
+        Solver name used when :meth:`_init_kinetic_ion` is not passed an
+        explicit ``solver``.
+    default_substeps : int, default 1
+        Number of substeps run inside one parent update, used when
+        :meth:`_init_kinetic_ion` is not passed an explicit
+        ``substeps``.
     """
 
     factors: ClassVar[tuple[Factor, ...]] = ()

--- a/braincell/ion/_docstring_test.py
+++ b/braincell/ion/_docstring_test.py
@@ -3,15 +3,19 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
+from braincell.ion import nonspecific
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = ()
+_COVERED_MODULES = (nonspecific,)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new ion that lands undocumented fails instead of
 # silently inheriting an exemption.
-_NO_PRIMARY_SOURCE = frozenset()
+_NO_PRIMARY_SOURCE = frozenset({
+    "NonSpecific",
+    "NonSpecificFixed",
+})
 
 
 class IonDocstringTest(DocstringConformanceTests, unittest.TestCase):

--- a/braincell/ion/_docstring_test.py
+++ b/braincell/ion/_docstring_test.py
@@ -1,0 +1,23 @@
+"""Docstring conformance guard for :mod:`braincell.ion`."""
+
+import unittest
+
+from braincell._testing import DocstringConformanceTests
+
+# Extended by one module per docstring task. A module is listed only once
+# every one of its public symbols satisfies the shared assertions.
+_COVERED_MODULES = ()
+
+# Public symbols with no primary literature source. Membership must be a
+# deliberate decision: a new ion that lands undocumented fails instead of
+# silently inheriting an exemption.
+_NO_PRIMARY_SOURCE = frozenset()
+
+
+class IonDocstringTest(DocstringConformanceTests, unittest.TestCase):
+    covered_modules = _COVERED_MODULES
+    no_primary_source = _NO_PRIMARY_SOURCE
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/braincell/ion/_docstring_test.py
+++ b/braincell/ion/_docstring_test.py
@@ -3,11 +3,11 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
-from braincell.ion import nonspecific, potassium
+from braincell.ion import nonspecific, potassium, sodium
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = (nonspecific, potassium)
+_COVERED_MODULES = (nonspecific, potassium, sodium)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new ion that lands undocumented fails instead of
@@ -18,6 +18,9 @@ _NO_PRIMARY_SOURCE = frozenset({
     "Potassium",
     "PotassiumFixed",
     "PotassiumInitNernst",
+    "Sodium",
+    "SodiumFixed",
+    "SodiumInitNernst",
 })
 
 

--- a/braincell/ion/_docstring_test.py
+++ b/braincell/ion/_docstring_test.py
@@ -3,11 +3,11 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
-from braincell.ion import nonspecific
+from braincell.ion import nonspecific, potassium
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = (nonspecific,)
+_COVERED_MODULES = (nonspecific, potassium)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new ion that lands undocumented fails instead of
@@ -15,6 +15,9 @@ _COVERED_MODULES = (nonspecific,)
 _NO_PRIMARY_SOURCE = frozenset({
     "NonSpecific",
     "NonSpecificFixed",
+    "Potassium",
+    "PotassiumFixed",
+    "PotassiumInitNernst",
 })
 
 

--- a/braincell/ion/_docstring_test.py
+++ b/braincell/ion/_docstring_test.py
@@ -12,33 +12,35 @@ _COVERED_MODULES = (_base, calcium, nonspecific, potassium, sodium)
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new ion that lands undocumented fails instead of
 # silently inheriting an exemption.
-_NO_PRIMARY_SOURCE = frozenset({
-    "NonSpecific",
-    "NonSpecificFixed",
-    "Potassium",
-    "PotassiumFixed",
-    "PotassiumInitNernst",
-    "Sodium",
-    "SodiumFixed",
-    "SodiumInitNernst",
-    "Factor",
-    "Species",
-    "Reaction",
-    "Source",
-    "Conserve",
-    "FixedIon",
-    "InitNernstIon",
-    "DynamicNernstIon",
-    "Calcium",
-    "CalciumFixed",
-    "CalciumInitNernst",
-    "CalciumFirstOrder",
-    "ToyCaBindingKinetic_SU2015_DCN",
-    "ToyCaBindingSourceKinetic_SU2015_DCN",
-    "ToyCaBindingIcaSourceKinetic_SU2015_DCN",
-    "ToyDiamFactorKinetic_SU2015_DCN",
-    "ToyCaPumpFactorKinetic_SU2015_DCN",
-})
+_NO_PRIMARY_SOURCE = frozenset(
+    {
+        "NonSpecific",
+        "NonSpecificFixed",
+        "Potassium",
+        "PotassiumFixed",
+        "PotassiumInitNernst",
+        "Sodium",
+        "SodiumFixed",
+        "SodiumInitNernst",
+        "Factor",
+        "Species",
+        "Reaction",
+        "Source",
+        "Conserve",
+        "FixedIon",
+        "InitNernstIon",
+        "DynamicNernstIon",
+        "Calcium",
+        "CalciumFixed",
+        "CalciumInitNernst",
+        "CalciumFirstOrder",
+        "ToyCaBindingKinetic_SU2015_DCN",
+        "ToyCaBindingSourceKinetic_SU2015_DCN",
+        "ToyCaBindingIcaSourceKinetic_SU2015_DCN",
+        "ToyDiamFactorKinetic_SU2015_DCN",
+        "ToyCaPumpFactorKinetic_SU2015_DCN",
+    }
+)
 
 
 class IonDocstringTest(DocstringConformanceTests, unittest.TestCase):

--- a/braincell/ion/_docstring_test.py
+++ b/braincell/ion/_docstring_test.py
@@ -3,11 +3,11 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
-from braincell.ion import nonspecific, potassium, sodium
+from braincell.ion import _base, nonspecific, potassium, sodium
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = (nonspecific, potassium, sodium)
+_COVERED_MODULES = (_base, nonspecific, potassium, sodium)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new ion that lands undocumented fails instead of
@@ -21,6 +21,14 @@ _NO_PRIMARY_SOURCE = frozenset({
     "Sodium",
     "SodiumFixed",
     "SodiumInitNernst",
+    "Factor",
+    "Species",
+    "Reaction",
+    "Source",
+    "Conserve",
+    "FixedIon",
+    "InitNernstIon",
+    "DynamicNernstIon",
 })
 
 

--- a/braincell/ion/_docstring_test.py
+++ b/braincell/ion/_docstring_test.py
@@ -3,11 +3,11 @@
 import unittest
 
 from braincell._testing import DocstringConformanceTests
-from braincell.ion import _base, nonspecific, potassium, sodium
+from braincell.ion import _base, calcium, nonspecific, potassium, sodium
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
-_COVERED_MODULES = (_base, nonspecific, potassium, sodium)
+_COVERED_MODULES = (_base, calcium, nonspecific, potassium, sodium)
 
 # Public symbols with no primary literature source. Membership must be a
 # deliberate decision: a new ion that lands undocumented fails instead of
@@ -29,6 +29,15 @@ _NO_PRIMARY_SOURCE = frozenset({
     "FixedIon",
     "InitNernstIon",
     "DynamicNernstIon",
+    "Calcium",
+    "CalciumFixed",
+    "CalciumInitNernst",
+    "CalciumFirstOrder",
+    "ToyCaBindingKinetic_SU2015_DCN",
+    "ToyCaBindingSourceKinetic_SU2015_DCN",
+    "ToyCaBindingIcaSourceKinetic_SU2015_DCN",
+    "ToyDiamFactorKinetic_SU2015_DCN",
+    "ToyCaPumpFactorKinetic_SU2015_DCN",
 })
 
 

--- a/braincell/ion/calcium.py
+++ b/braincell/ion/calcium.py
@@ -1455,11 +1455,149 @@ class ToyDiamFactorKinetic_SU2015_DCN(Calcium, KineticIon):
 
 @register_ion("CdpStC_CAMOnly_MA2020_GoC")
 class CdpStC_CAMOnly_MA2020_GoC(Calcium, KineticIon):
-    r"""Template-based import of ``CdpStC_CAMOnly_MA20_GoC.mod``.
+    r"""Import of the calmodulin-only branch of ``CdpStC_CAMOnly_MA20_GoC.mod``.
 
-    This variant keeps only the calmodulin subnetwork from the imported GoC
-    calcium pool so the CAM-specific semantics can be validated separately
-    from pump and non-CaM buffers.
+    Isolates the calmodulin (CaM) subnetwork of the imported Golgi-cell
+    calcium pool so its binding kinetics can be validated independently
+    of the pump and non-CaM buffers that :class:`CdpStC_MA2020_GoC` also
+    tracks. The scheme is a two-lobe CaM binding model: an independent
+    C-lobe and N-lobe, each with two sequential, reversible
+    calcium-binding steps, reaching the fully-loaded ``CAM4`` state
+    through four distinct binding orders.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 25
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    Nannuli : array-like or callable, optional
+        Radial-shell count inherited from the NEURON multi-shell
+        diffusion template. BrainCell tracks a single well-mixed
+        ``Ci`` pool, so ``Nannuli`` only shapes the effective volume
+        fraction returned by :attr:`vrat` (``dr2 = 0.25 /
+        (Nannuli - 1)``); no shell diffusion is performed. Defaults
+        to ``10.9495``.
+    cainull : array-like or callable, optional
+        Baseline/initial free calcium concentration ``Ci``. Defaults
+        to ``45e-6 mM``.
+    CAM_start : array-like or callable, optional
+        Initial concentration of apo-calmodulin, ``CAM0``. Defaults
+        to ``0.03 mM``.
+    K1Coff, K1Con : array-like or callable, optional
+        Backward and forward rate constants of the first C-lobe
+        binding step. Default ``0.04 /ms`` and ``5.4 /(mM*ms)``.
+    K2Coff, K2Con : array-like or callable, optional
+        Backward and forward rate constants of the second C-lobe
+        binding step. Default ``0.00925 /ms`` and ``15.0 /(mM*ms)``.
+    K1Noff, K1Non : array-like or callable, optional
+        Backward and forward rate constants of the first N-lobe
+        binding step. Default ``2.5 /ms`` and ``142.5 /(mM*ms)``.
+    K2Noff, K2Non : array-like or callable, optional
+        Backward and forward rate constants of the second N-lobe
+        binding step. Default ``0.75 /ms`` and ``175.0 /(mM*ms)``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable or None, optional
+        Initializer for the ``Ci`` species. Defaults to ``None``,
+        which falls back to ``cainull``.
+    species_initializers : dict or None, optional
+        Per-species initializer overrides, keyed by one of this
+        class's ten differential species (``Ci``, ``CAM0``,
+        ``CAM1C``, ``CAM2C``, ``CAM1N2C``, ``CAM1N``, ``CAM2N``,
+        ``CAM2N1C``, ``CAM1C1N``, ``CAM4``). Defaults to ``None``
+        (no overrides).
+    solver : str, optional
+        Integrator name used for the reaction network. Defaults to
+        ``"backward_euler"``, matching
+        :attr:`~braincell.ion._base.KineticIon.default_solver`.
+    substeps : int, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``1``, matching
+        :attr:`~braincell.ion._base.KineticIon.default_substeps`.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged
+        to :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``species_initializers`` names a species outside the ten
+        listed above, or if ``temp`` is explicitly passed as
+        ``None``, or ``substeps`` is less than ``1`` (the latter two
+        raised by :meth:`KineticIon._init_kinetic_ion`).
+    AttributeError
+        Raised during state initialization or reset if this ion's
+        compartment geometry (``diam_arc_mean``) has not been
+        attached yet.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    CdpStC_NoCAM_MA2020_GoC : Sibling decomposition keeping the pump
+        and non-CaM buffers while dropping this class's CaM network.
+    CdpStC_MA2020_GoC : The undivided mechanism, combining this CaM
+        network with the pump and non-CaM buffers.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all ``Cdp*``
+        mechanisms.
+
+    Notes
+    -----
+    Ported from ``GoC/ion/CdpStC_CAMOnly_MA20_GoC.mod``.
+    ``uses_total_current = False`` and ``sources = ()``: this pool has
+    no calcium influx or pump of its own, so ``Ci`` is consumed by the
+    twelve CaM reactions above and never resupplied. It is meant to be
+    exercised in isolation, matching the ``.mod`` file's role of
+    validating the CaM subnetwork rather than serving as a standalone
+    physiological pool.
+
+    The ``cam_unit`` factor scales the nine CaM-state species by a
+    unit-magnitude, ``um**2``-dimensioned array rather than by
+    :attr:`dsqvol` again: the imported NMODL ``COMPARTMENT`` scaling
+    applies once, to the shared cytosolic volume that ``Ci`` occupies,
+    and must not be applied a second time to each CaM row.
+
+    ``CdpStC_NoCAM_MA2020_GoC`` hardcodes ``solver="backward_euler"``
+    and ``substeps=1`` as literal defaults, as this class does,
+    whereas :class:`CdpStC_MA2020_GoC` instead defaults both to
+    ``None`` and lets :meth:`KineticIon._init_kinetic_ion` fall back
+    to the same class-level
+    :attr:`~braincell.ion._base.KineticIon.default_solver` and
+    :attr:`~braincell.ion._base.KineticIon.default_substeps`; the
+    observable defaults are identical either way.
+
+    References
+    ----------
+    .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering in
+           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
+           Eilers, J. (2003). Mutational analysis of dendritic Ca2+
+           kinetics in rodent Purkinje cells: role of parvalbumin and
+           calbindin D28k. The Journal of Physiology, 551(1), 13-32.
+           doi:10.1113/jphysiol.2002.035824
+    .. [3] Maeda, H., Ellis-Davies, G. C. R., Ito, K., Miyashita, Y.,
+           & Kasai, H. (1999). Supralinear Ca2+ signaling by
+           cooperative and mobile Ca2+ buffering in Purkinje neurons.
+           Neuron, 24(4), 989-1002.
+           doi:10.1016/S0896-6273(00)81045-4
+    .. [4] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
     """
 
     __module__ = "braincell.ion"
@@ -1705,10 +1843,194 @@ class CdpStC_CAMOnly_MA2020_GoC(Calcium, KineticIon):
 
 @register_ion("CdpStC_NoCAM_MA2020_GoC")
 class CdpStC_NoCAM_MA2020_GoC(Calcium, KineticIon):
-    r"""Template-based import of ``CdpStC_NoCAM_MA20_GoC.mod``.
+    r"""BrainCell-factored calcium pool: pump, non-CaM buffers, no CaM.
 
-    This variant keeps the pump and non-calmodulin buffer subnetworks from the
-    imported GoC calcium pool while removing the CAM reactions entirely.
+    Keeps the pump and non-calmodulin buffer subnetworks of the
+    imported Golgi-cell ``CdpStC`` calcium pool while dropping the
+    calmodulin (CaM) reactions of :class:`CdpStC_CAMOnly_MA2020_GoC`
+    entirely. Unlike its sibling classes, this one is not itself a
+    direct port of a ``.mod`` file: no
+    ``CdpStC_NoCAM_MA20_GoC.mod`` exists in the imported source tree.
+    It is a BrainCell-factored base whose literal parameter set
+    matches ``BC/ion/CdpStC_MA25_BC.mod`` and
+    ``SC/ion/CdpStC_RI21_SC.mod`` -- both of which are exactly this
+    GoC ``CdpStC`` mechanism with the CaM subnetwork commented out --
+    so it exists to be shared by :class:`CdpStC_MA2025_BC` and
+    :class:`CdpStC_RI2021_SC` rather than to stand for a distinct
+    published mechanism. The CAM reactions were removed, not
+    replaced by different kinetics.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 25
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    Nannuli : array-like or callable, optional
+        Radial-shell count inherited from the NEURON multi-shell
+        diffusion template; only shapes the single effective volume
+        fraction :attr:`vrat`. Defaults to ``10.9495``.
+    cainull : array-like or callable, optional
+        Baseline/initial free calcium concentration ``Ci``. Defaults
+        to ``45e-6 mM``.
+    mginull : array-like or callable, optional
+        Baseline/initial magnesium concentration ``mg``. Defaults to
+        ``0.59 mM``.
+    Buffnull1 : array-like or callable, optional
+        Total concentration of the first generic buffer, ``Buff1 +
+        Buff1_ca``. Defaults to ``0.0 mM``.
+    rf1, rf2 : array-like or callable, optional
+        Forward and backward rate constants of the ``Buff1``
+        binding step. Default ``0.0134329 /(mM*ms)`` and
+        ``0.0397469 /ms``.
+    Buffnull2 : array-like or callable, optional
+        Total concentration of the second generic buffer, ``Buff2 +
+        Buff2_ca``. Defaults to ``60.9091 mM``.
+    rf3, rf4 : array-like or callable, optional
+        Forward and backward rate constants of the ``Buff2``
+        binding step. Default ``0.1435 /(mM*ms)`` and ``0.0014 /ms``.
+    BTCnull : array-like or callable, optional
+        Total concentration of the BTC indicator dye buffer, ``BTC +
+        BTC_ca``. Defaults to ``0.0 mM``.
+    b1, b2 : array-like or callable, optional
+        Forward and backward rate constants of the ``BTC`` binding
+        step. Default ``5.33 /(mM*ms)`` and ``0.08 /ms``.
+    DMNPEnull : array-like or callable, optional
+        Total concentration of the caged-calcium buffer DMNPE,
+        ``DMNPE + DMNPE_ca``. Defaults to ``0.0 mM``.
+    c1, c2 : array-like or callable, optional
+        Forward and backward rate constants of the ``DMNPE`` binding
+        step. Default ``5.63 /(mM*ms)`` and ``0.107e-3 /ms``.
+    PVnull : array-like or callable, optional
+        Total concentration of parvalbumin, ``PV + PV_ca + PV_mg``.
+        Defaults to ``0.08 mM``.
+    m1, m2 : array-like or callable, optional
+        Forward and backward rate constants of the ``PV`` calcium
+        binding step. Default ``1.07e2 /(mM*ms)`` and
+        ``9.5e-4 /ms``.
+    p1, p2 : array-like or callable, optional
+        Forward and backward rate constants of the ``PV``
+        magnesium binding step. Default ``0.8 /(mM*ms)`` and
+        ``2.5e-2 /ms``.
+    kpmp1, kpmp2 : array-like or callable, optional
+        Forward and backward rate constants of the ``pump + Ci ->
+        pumpca`` binding step. Default ``3e-3 /(mM*ms)`` and
+        ``1.75e-5 /ms``.
+    kpmp3 : array-like or callable, optional
+        Rate constant of the irreversible extrusion step,
+        ``pumpca -> pump``. Defaults to ``7.255e-5 /ms``.
+    TotalPump : array-like or callable, optional
+        Areal pump-site density; the conserved sum of ``pump +
+        pumpca`` per unit membrane area. Defaults to
+        ``1e-9 mol/cm2``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable or None, optional
+        Initializer for the ``Ci`` species. Defaults to ``None``,
+        which falls back to ``cainull``.
+    species_initializers : dict or None, optional
+        Per-species initializer overrides, keyed by one of this
+        class's fourteen differential species (``Ci``, ``mg``,
+        ``Buff1``, ``Buff1_ca``, ``Buff2``, ``Buff2_ca``, ``BTC``,
+        ``BTC_ca``, ``DMNPE``, ``DMNPE_ca``, ``PV``, ``PV_ca``,
+        ``PV_mg``, ``pump``). Defaults to ``None`` (no overrides);
+        unset buffer/PV species default to their steady-state
+        occupancy at ``cainull``/``mginull``, and ``pump`` defaults
+        to ``TotalPump``.
+    solver : str, optional
+        Integrator name used for the reaction network. Defaults to
+        ``"backward_euler"``, matching
+        :attr:`~braincell.ion._base.KineticIon.default_solver`.
+    substeps : int, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``1``, matching
+        :attr:`~braincell.ion._base.KineticIon.default_substeps`.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged
+        to :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``species_initializers`` names a species outside the
+        fourteen listed above, or if ``temp`` is explicitly passed
+        as ``None``, or ``substeps`` is less than ``1`` (the latter
+        two raised by :meth:`KineticIon._init_kinetic_ion`).
+    AttributeError
+        Raised during state initialization or reset, or from
+        :attr:`parea`/:attr:`dsq`, if this ion's compartment geometry
+        (``diam_arc_mean``) has not been attached yet.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    CdpStC_CAMOnly_MA2020_GoC : Sibling decomposition keeping only
+        the CaM network this class omits.
+    CdpStC_MA2020_GoC : The undivided mechanism, combining this
+        pump/buffer network with the CaM network.
+    CdpStC_MA2025_BC : Thin basket-cell subclass reusing this class's
+        network unchanged.
+    CdpStC_RI2021_SC : Thin stellate-cell subclass reusing this
+        class's network unchanged.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all ``Cdp*``
+        mechanisms.
+
+    Notes
+    -----
+    This class has no source ``.mod`` file of its own; see the
+    extended summary. ``uses_total_current = True`` and one
+    :class:`~braincell.ion._base.Source` drives ``Ci`` from the
+    channel current supplied at each step:
+    ``_ci_source_flux`` returns zero when no current is supplied, and
+    otherwise ``total_current * pi * diam_arc_mean / (2 *
+    faraday_constant)``. NEURON's raw GoC ``ica`` is efflux-positive,
+    but BrainCell channel currents follow the repo-wide inward-positive
+    convention, so a positive ``total_current`` here increases ``Ci``.
+
+    One :class:`~braincell.ion._base.Conserve` constrains ``pump +
+    pumpca = TotalPump * parea``, with ``pumpca`` recovered
+    algebraically rather than integrated; ``pump`` is the only pump
+    state among the fourteen differential species.
+
+    Buffer- and PV-bound species initialize at the equilibrium
+    occupancy implied by their dissociation constants and
+    ``cainull``/``mginull`` (see ``_ss_buffer_free``,
+    ``_ss_buffer_bound``, ``_ss_pv_free``, ``_ss_pv_ca``,
+    ``_ss_pv_mg``), not at zero, so steady state is reached without a
+    long settling transient.
+
+    References
+    ----------
+    .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering in
+           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
+           Eilers, J. (2003). Mutational analysis of dendritic Ca2+
+           kinetics in rodent Purkinje cells: role of parvalbumin and
+           calbindin D28k. The Journal of Physiology, 551(1), 13-32.
+           doi:10.1113/jphysiol.2002.035824
+    .. [3] Maeda, H., Ellis-Davies, G. C. R., Ito, K., Miyashita, Y.,
+           & Kasai, H. (1999). Supralinear Ca2+ signaling by
+           cooperative and mobile Ca2+ buffering in Purkinje neurons.
+           Neuron, 24(4), 989-1002.
+           doi:10.1016/S0896-6273(00)81045-4
+    .. [4] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
     """
 
     __module__ = "braincell.ion"
@@ -2011,11 +2333,64 @@ class CdpStC_NoCAM_MA2020_GoC(Calcium, KineticIon):
 
 @register_ion("CdpStC_MA2025_BC")
 class CdpStC_MA2025_BC(CdpStC_NoCAM_MA2020_GoC):
-    r"""Thin variant for ``CdpStC_MA25_BC.mod``.
+    r"""Calcium pool for the basket cell, no calmodulin buffering.
 
-    The BC source keeps the same pump, non-CAM buffer, and PV kinetic network
-    as :class:`CdpStC_NoCAM_MA2020_GoC`; the calmodulin block is commented out
-    in the source NMODL.
+    The same pump/non-CaM-buffer/parvalbumin kinetic network
+    documented in :class:`CdpStC_NoCAM_MA2020_GoC`, reused unchanged
+    for the cerebellar basket cell model of Masoli et al. (2025)
+    [4]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Ion state shape. Inherited from :class:`CdpStC_NoCAM_MA2020_GoC`.
+    temp, Nannuli, cainull, mginull, Buffnull1, rf1, rf2, Buffnull2,
+    rf3, rf4, BTCnull, b1, b2, DMNPEnull, c1, c2, PVnull, m1, m2, p1,
+    p2, kpmp1, kpmp2, kpmp3, TotalPump, Co, Ci_initializer,
+    species_initializers, solver, substeps, name, **channels
+        Identical in meaning and default to
+        :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
+
+    See Also
+    --------
+    CdpStC_NoCAM_MA2020_GoC : The base class; full network,
+        parameters and equilibrium initializers are documented
+        there.
+    CdpStC_RI2021_SC : Same kinetics, stellate-cell model citation.
+
+    Notes
+    -----
+    Ported from ``BC/ion/CdpStC_MA25_BC.mod``. This class does not
+    override ``__init__``: the reaction network, the source and the
+    conservation relation are all inherited unchanged from
+    :class:`CdpStC_NoCAM_MA2020_GoC`. Only the ``register_ion`` key
+    and this docstring's model citation differ -- the ``.mod`` file
+    this class ports from is the same GoC ``CdpStC`` mechanism with
+    its calmodulin block commented out, per the imported README's
+    "Ion_dyn inherited variants" table, not a distinct kinetic
+    scheme.
+
+    References
+    ----------
+    .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering in
+           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
+           Eilers, J. (2003). Mutational analysis of dendritic Ca2+
+           kinetics in rodent Purkinje cells: role of parvalbumin and
+           calbindin D28k. The Journal of Physiology, 551(1), 13-32.
+           doi:10.1113/jphysiol.2002.035824
+    .. [3] Maeda, H., Ellis-Davies, G. C. R., Ito, K., Miyashita, Y.,
+           & Kasai, H. (1999). Supralinear Ca2+ signaling by
+           cooperative and mobile Ca2+ buffering in Purkinje neurons.
+           Neuron, 24(4), 989-1002.
+           doi:10.1016/S0896-6273(00)81045-4
+    .. [4] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025). Cerebellar
+           basket cell filtering of Purkinje cell responses elicited
+           by low frequency parallel fibre transmission. Scientific
+           Reports, 15(1), 25192. doi:10.1038/s41598-025-09964-2
     """
 
     __module__ = "braincell.ion"
@@ -2023,11 +2398,63 @@ class CdpStC_MA2025_BC(CdpStC_NoCAM_MA2020_GoC):
 
 @register_ion("CdpStC_RI2021_SC")
 class CdpStC_RI2021_SC(CdpStC_NoCAM_MA2020_GoC):
-    r"""Thin variant for ``CdpStC_RI21_SC.mod``.
+    r"""Calcium pool for the stellate cell, no calmodulin buffering.
 
-    The SC source keeps the same pump, non-CAM buffer, and PV kinetic network
-    as :class:`CdpStC_NoCAM_MA2020_GoC`; the extra ``cao`` read is not used by
-    the kinetic equations.
+    The same pump/non-CaM-buffer/parvalbumin kinetic network
+    documented in :class:`CdpStC_NoCAM_MA2020_GoC`, reused unchanged
+    for the cerebellar stellate cell model of Rizza et al. (2021)
+    [4]_.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Ion state shape. Inherited from :class:`CdpStC_NoCAM_MA2020_GoC`.
+    temp, Nannuli, cainull, mginull, Buffnull1, rf1, rf2, Buffnull2,
+    rf3, rf4, BTCnull, b1, b2, DMNPEnull, c1, c2, PVnull, m1, m2, p1,
+    p2, kpmp1, kpmp2, kpmp3, TotalPump, Co, Ci_initializer,
+    species_initializers, solver, substeps, name, **channels
+        Identical in meaning and default to
+        :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
+
+    See Also
+    --------
+    CdpStC_NoCAM_MA2020_GoC : The base class; full network,
+        parameters and equilibrium initializers are documented
+        there.
+    CdpStC_MA2025_BC : Same kinetics, basket-cell model citation.
+
+    Notes
+    -----
+    Ported from ``SC/ion/CdpStC_RI21_SC.mod``. This class does not
+    override ``__init__``: the reaction network, the source and the
+    conservation relation are all inherited unchanged from
+    :class:`CdpStC_NoCAM_MA2020_GoC`. Only the ``register_ion`` key
+    and this docstring's model citation differ. The source ``.mod``
+    file also reads an extracellular calcium variable ``cao`` that
+    its kinetic equations never use; BrainCell drops that unused
+    read rather than reproducing it.
+
+    References
+    ----------
+    .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering in
+           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
+           Eilers, J. (2003). Mutational analysis of dendritic Ca2+
+           kinetics in rodent Purkinje cells: role of parvalbumin and
+           calbindin D28k. The Journal of Physiology, 551(1), 13-32.
+           doi:10.1113/jphysiol.2002.035824
+    .. [3] Maeda, H., Ellis-Davies, G. C. R., Ito, K., Miyashita, Y.,
+           & Kasai, H. (1999). Supralinear Ca2+ signaling by
+           cooperative and mobile Ca2+ buffering in Purkinje neurons.
+           Neuron, 24(4), 989-1002.
+           doi:10.1016/S0896-6273(00)81045-4
+    .. [4] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+           Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
+           cell computational modeling predicts signal filtering in
+           the molecular layer circuit of cerebellum. Scientific
+           Reports, 11(1), 3873. doi:10.1038/s41598-021-83209-w
     """
 
     __module__ = "braincell.ion"
@@ -2035,11 +2462,215 @@ class CdpStC_RI2021_SC(CdpStC_NoCAM_MA2020_GoC):
 
 @register_ion("CdpStC_MA2020_GoC")
 class CdpStC_MA2020_GoC(Calcium, KineticIon):
-    r"""Template-based import of ``CdpStC_MA20_GoC.mod``.
+    r"""Golgi-cell calcium pool: pump, generic buffers, PV, and CaM.
 
-    ``Ci`` corresponds to the NMODL calcium pool ``ca`` / ``cai``. The
-    reversible kinetic scheme is preserved as 20 explicit reactions, plus the
-    original current-driven source and the single pump conservation relation.
+    Undivided import of the Golgi-cell ``CdpStC`` calcium pool:
+    ``Ci`` (the NMODL ``ca``/``cai`` pool) is buffered by two generic
+    first-order buffers, the indicator dyes BTC and DMNPE, and
+    parvalbumin (PV), extruded by a membrane pump, and additionally
+    binds calmodulin (CaM) through the same four-site cooperative
+    scheme documented in :class:`CdpStC_CAMOnly_MA2020_GoC`. This is
+    the combination that :class:`CdpStC_CAMOnly_MA2020_GoC` (CaM
+    branch only) and :class:`CdpStC_NoCAM_MA2020_GoC` (pump/buffer/PV
+    branch only) each keep half of.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 25
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    Nannuli : array-like or callable, optional
+        Radial-shell count inherited from the NEURON multi-shell
+        diffusion template; only shapes the single effective volume
+        fraction :attr:`vrat`. Defaults to ``10.9495``.
+    cainull : array-like or callable, optional
+        Baseline/initial free calcium concentration ``Ci``. Defaults
+        to ``45e-6 mM``.
+    mginull : array-like or callable, optional
+        Baseline/initial magnesium concentration ``mg``. Defaults to
+        ``0.59 mM``.
+    Buffnull1 : array-like or callable, optional
+        Total concentration of the first generic buffer, ``Buff1 +
+        Buff1_ca``. Defaults to ``0.0 mM``.
+    rf1, rf2 : array-like or callable, optional
+        Forward and backward rate constants of the ``Buff1``
+        binding step. Default ``0.0134329 /(mM*ms)`` and
+        ``0.0397469 /ms``.
+    Buffnull2 : array-like or callable, optional
+        Total concentration of the second generic buffer, ``Buff2 +
+        Buff2_ca``. Defaults to ``60.9091 mM``.
+    rf3, rf4 : array-like or callable, optional
+        Forward and backward rate constants of the ``Buff2``
+        binding step. Default ``0.1435 /(mM*ms)`` and ``0.0014 /ms``.
+    BTCnull : array-like or callable, optional
+        Total concentration of the BTC indicator dye buffer, ``BTC +
+        BTC_ca``. Defaults to ``0.0 mM``.
+    b1, b2 : array-like or callable, optional
+        Forward and backward rate constants of the ``BTC`` binding
+        step. Default ``5.33 /(mM*ms)`` and ``0.08 /ms``.
+    DMNPEnull : array-like or callable, optional
+        Total concentration of the caged-calcium buffer DMNPE,
+        ``DMNPE + DMNPE_ca``. Defaults to ``0.0 mM``.
+    c1, c2 : array-like or callable, optional
+        Forward and backward rate constants of the ``DMNPE`` binding
+        step. Default ``5.63 /(mM*ms)`` and ``0.107e-3 /ms``.
+    PVnull : array-like or callable, optional
+        Total concentration of parvalbumin, ``PV + PV_ca + PV_mg``.
+        Defaults to ``0.08 mM``.
+    m1, m2 : array-like or callable, optional
+        Forward and backward rate constants of the ``PV`` calcium
+        binding step. Default ``1.07e2 /(mM*ms)`` and
+        ``9.5e-4 /ms``.
+    p1, p2 : array-like or callable, optional
+        Forward and backward rate constants of the ``PV``
+        magnesium binding step. Default ``0.8 /(mM*ms)`` and
+        ``2.5e-2 /ms``.
+    CAM_start : array-like or callable, optional
+        Baseline/initial concentration of unbound calmodulin,
+        ``CAM0``. Defaults to ``0.03 mM``.
+    K1Coff, K1Con : array-like or callable, optional
+        Backward and forward rate constants of the first C-lobe
+        calcium-binding step. Default ``0.04 /ms`` and
+        ``5.4 /(mM*ms)``.
+    K2Coff, K2Con : array-like or callable, optional
+        Backward and forward rate constants of the second C-lobe
+        calcium-binding step. Default ``0.00925 /ms`` and
+        ``15.0 /(mM*ms)``.
+    K1Noff, K1Non : array-like or callable, optional
+        Backward and forward rate constants of the first N-lobe
+        calcium-binding step. Default ``2.5 /ms`` and
+        ``142.5 /(mM*ms)``.
+    K2Noff, K2Non : array-like or callable, optional
+        Backward and forward rate constants of the second N-lobe
+        calcium-binding step. Default ``0.75 /ms`` and
+        ``175.0 /(mM*ms)``.
+    kpmp1, kpmp2 : array-like or callable, optional
+        Forward and backward rate constants of the ``pump + Ci ->
+        pumpca`` binding step. Default ``3e-3 /(mM*ms)`` and
+        ``1.75e-5 /ms``.
+    kpmp3 : array-like or callable, optional
+        Rate constant of the irreversible extrusion step,
+        ``pumpca -> pump``. Defaults to ``7.255e-5 /ms``.
+    TotalPump : array-like or callable, optional
+        Areal pump-site density; the conserved sum of ``pump +
+        pumpca`` per unit membrane area. Defaults to
+        ``1e-9 mol/cm2``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable or None, optional
+        Initializer for the ``Ci`` species. Defaults to ``None``,
+        which falls back to ``cainull``.
+    species_initializers : dict or None, optional
+        Per-species initializer overrides, keyed by one of this
+        class's twenty-three differential species (the fourteen of
+        :class:`CdpStC_NoCAM_MA2020_GoC` plus the nine CaM species
+        ``CAM0``, ``CAM1C``, ``CAM2C``, ``CAM1N2C``, ``CAM1N``,
+        ``CAM2N``, ``CAM2N1C``, ``CAM1C1N``, ``CAM4``). Defaults to
+        ``None`` (no overrides); unset buffer/PV species default to
+        their steady-state occupancy at ``cainull``/``mginull``,
+        ``pump`` defaults to ``TotalPump``, ``CAM0`` defaults to
+        ``CAM_start``, and every other CaM species defaults to
+        ``0.0 mM``.
+    solver : str or None, optional
+        Integrator name used for the reaction network. Defaults to
+        ``None``, which falls back to
+        :attr:`~braincell.ion._base.KineticIon.default_solver`
+        (``"backward_euler"``).
+    substeps : int or None, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``None``, which falls back to
+        :attr:`~braincell.ion._base.KineticIon.default_substeps`
+        (``1``).
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged
+        to :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``species_initializers`` names a species outside the
+        twenty-three listed above, or if ``temp`` is explicitly
+        passed as ``None``, or ``substeps`` is less than ``1`` (the
+        latter two raised by :meth:`KineticIon._init_kinetic_ion`).
+    AttributeError
+        Raised during state initialization or reset, or from
+        :attr:`parea`/:attr:`dsq`, if this ion's compartment geometry
+        (``diam_arc_mean``) has not been attached yet.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    CdpStC_CAMOnly_MA2020_GoC : Sibling decomposition keeping only
+        the CaM network this class also includes.
+    CdpStC_NoCAM_MA2020_GoC : Sibling decomposition keeping only the
+        pump/buffer/PV network this class also includes.
+    CdpCAM_MA2024_PC : Purkinje-cell mechanism reusing this class's
+        pump/buffer network unchanged and adding Calbindin.
+    CdpCR_MA2020_GrC : Granule-cell mechanism reusing this class's
+        pump/buffer network unchanged and substituting Calretinin
+        for parvalbumin.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all ``Cdp*``
+        mechanisms.
+
+    Notes
+    -----
+    Ported from ``GoC/ion/CdpStC_MA20_GoC.mod``. ``uses_total_current
+    = True`` and one :class:`~braincell.ion._base.Source` drives
+    ``Ci`` from the channel current supplied at each step:
+    ``_ci_source_flux`` returns zero when no current is supplied, and
+    otherwise ``total_current * pi * diam_arc_mean / (2 *
+    faraday_constant)``. NEURON's raw GoC ``ica`` is efflux-positive,
+    but BrainCell channel currents follow the repo-wide inward-positive
+    convention, so a positive ``total_current`` here increases ``Ci``.
+
+    One :class:`~braincell.ion._base.Conserve` constrains ``pump +
+    pumpca = TotalPump * parea``, with ``pumpca`` recovered
+    algebraically rather than integrated; ``pump`` is the only pump
+    state among the twenty-three differential species.
+
+    Twenty reactions couple the twenty-four species: the two pump
+    steps and the six buffer/PV steps described in
+    :class:`CdpStC_NoCAM_MA2020_GoC`, plus twelve reactions forming
+    the same two-lobe cooperative calmodulin scheme described in
+    :class:`CdpStC_CAMOnly_MA2020_GoC` (``CAM0`` through ``CAM4``,
+    reached via either the C-lobe-first or N-lobe-first binding
+    order). Buffer- and PV-bound species initialize at the
+    equilibrium occupancy implied by their dissociation constants and
+    ``cainull``/``mginull``, not at zero.
+
+    References
+    ----------
+    .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering in
+           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
+           Eilers, J. (2003). Mutational analysis of dendritic Ca2+
+           kinetics in rodent Purkinje cells: role of parvalbumin and
+           calbindin D28k. The Journal of Physiology, 551(1), 13-32.
+           doi:10.1113/jphysiol.2002.035824
+    .. [3] Maeda, H., Ellis-Davies, G. C. R., Ito, K., Miyashita, Y.,
+           & Kasai, H. (1999). Supralinear Ca2+ signaling by
+           cooperative and mobile Ca2+ buffering in Purkinje neurons.
+           Neuron, 24(4), 989-1002.
+           doi:10.1016/S0896-6273(00)81045-4
+    .. [4] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E.
+           (2020). Cerebellar Golgi cell models predict dendritic
+           processing and mechanisms of synaptic plasticity. PLOS
+           Computational Biology, 16(12), e1007937.
+           doi:10.1371/journal.pcbi.1007937
     """
 
     __module__ = "braincell.ion"
@@ -2468,11 +3099,225 @@ class CdpStC_MA2020_GoC(Calcium, KineticIon):
 
 @register_ion("CdpCAM_MA2024_PC")
 class CdpCAM_MA2024_PC(Calcium, KineticIon):
-    r"""Template-based import of ``CdpCAM_MA24_PC.mod``.
+    r"""Purkinje-cell calcium pool: pump, buffers, Calbindin, PV, CaM.
 
-    This PC variant preserves the full pump, non-CAM buffer, Calbindin,
-    Parvalbumin, and Calmodulin kinetic network. Unlike the GoC CdpStC source,
-    the PC file includes CB and CAM species in the cytosolic compartment.
+    Extends the Golgi-cell pump/generic-buffer/parvalbumin/calmodulin
+    network of :class:`CdpStC_MA2020_GoC` with a four-state Calbindin
+    D-28k (CB) cooperative binding scheme. This is the same
+    ``CdpStC`` scaffold with the CB subnetwork enabled and both CB
+    and CaM species placed in the cytosolic compartment, per the
+    imported source tree's "Ion_dyn implementation notes"; the pump,
+    generic-buffer, PV and CaM reactions are otherwise unchanged from
+    :class:`CdpStC_MA2020_GoC`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 25
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    Nannuli : array-like or callable, optional
+        Radial-shell count inherited from the NEURON multi-shell
+        diffusion template; only shapes the single effective volume
+        fraction :attr:`vrat`. Defaults to ``10.9495``.
+    cainull : array-like or callable, optional
+        Baseline/initial free calcium concentration ``Ci``. Defaults
+        to ``45e-6 mM``.
+    mginull : array-like or callable, optional
+        Baseline/initial magnesium concentration ``mg``. Defaults to
+        ``0.59 mM``.
+    Buffnull1 : array-like or callable, optional
+        Total concentration of the first generic buffer, ``Buff1 +
+        Buff1_ca``. Defaults to ``0.0 mM``.
+    rf1, rf2 : array-like or callable, optional
+        Forward and backward rate constants of the ``Buff1``
+        binding step. Default ``0.0134329 /(mM*ms)`` and
+        ``0.0397469 /ms``.
+    Buffnull2 : array-like or callable, optional
+        Total concentration of the second generic buffer, ``Buff2 +
+        Buff2_ca``. Defaults to ``60.9091 mM``.
+    rf3, rf4 : array-like or callable, optional
+        Forward and backward rate constants of the ``Buff2``
+        binding step. Default ``0.1435 /(mM*ms)`` and ``0.0014 /ms``.
+    BTCnull : array-like or callable, optional
+        Total concentration of the BTC indicator dye buffer, ``BTC +
+        BTC_ca``. Defaults to ``0.0 mM``.
+    b1, b2 : array-like or callable, optional
+        Forward and backward rate constants of the ``BTC`` binding
+        step. Default ``5.33 /(mM*ms)`` and ``0.08 /ms``.
+    DMNPEnull : array-like or callable, optional
+        Total concentration of the caged-calcium buffer DMNPE,
+        ``DMNPE + DMNPE_ca``. Defaults to ``0.0 mM``.
+    c1, c2 : array-like or callable, optional
+        Forward and backward rate constants of the ``DMNPE`` binding
+        step. Default ``5.63 /(mM*ms)`` and ``0.107e-3 /ms``.
+    CBnull : array-like or callable, optional
+        Total concentration of Calbindin D-28k, ``CB + CB_f_ca +
+        CB_ca_s + CB_ca_ca``. Defaults to ``0.16 mM``.
+    nf1, nf2 : array-like or callable, optional
+        Forward and backward rate constants of Calbindin's fast
+        binding sites (used for both the ``CB -> CB_ca_s`` and
+        ``CB_f_ca -> CB_ca_ca`` steps). Default ``43.5 /(mM*ms)``
+        and ``3.58e-2 /ms``.
+    ns1, ns2 : array-like or callable, optional
+        Forward and backward rate constants of Calbindin's slow
+        binding sites (used for both the ``CB -> CB_f_ca`` and
+        ``CB_ca_s -> CB_ca_ca`` steps). Default ``5.5 /(mM*ms)``
+        and ``0.26e-2 /ms``.
+    PVnull : array-like or callable, optional
+        Total concentration of parvalbumin, ``PV + PV_ca + PV_mg``.
+        Defaults to ``0.08 mM``.
+    m1, m2 : array-like or callable, optional
+        Forward and backward rate constants of the ``PV`` calcium
+        binding step. Default ``1.07e2 /(mM*ms)`` and
+        ``9.5e-4 /ms``.
+    p1, p2 : array-like or callable, optional
+        Forward and backward rate constants of the ``PV``
+        magnesium binding step. Default ``0.8 /(mM*ms)`` and
+        ``2.5e-2 /ms``.
+    CAM_start : array-like or callable, optional
+        Baseline/initial concentration of unbound calmodulin,
+        ``CAM0``. Defaults to ``0.03 mM``.
+    K1Coff, K1Con : array-like or callable, optional
+        Backward and forward rate constants of the first C-lobe
+        calcium-binding step. Default ``0.04 /ms`` and
+        ``5.4 /(mM*ms)``.
+    K2Coff, K2Con : array-like or callable, optional
+        Backward and forward rate constants of the second C-lobe
+        calcium-binding step. Default ``0.00925 /ms`` and
+        ``15.0 /(mM*ms)``.
+    K1Noff, K1Non : array-like or callable, optional
+        Backward and forward rate constants of the first N-lobe
+        calcium-binding step. Default ``2.5 /ms`` and
+        ``142.5 /(mM*ms)``.
+    K2Noff, K2Non : array-like or callable, optional
+        Backward and forward rate constants of the second N-lobe
+        calcium-binding step. Default ``0.75 /ms`` and
+        ``175.0 /(mM*ms)``.
+    kpmp1, kpmp2 : array-like or callable, optional
+        Forward and backward rate constants of the ``pump + Ci ->
+        pumpca`` binding step. Default ``3e-3 /(mM*ms)`` and
+        ``1.75e-5 /ms``.
+    kpmp3 : array-like or callable, optional
+        Rate constant of the irreversible extrusion step,
+        ``pumpca -> pump``. Defaults to ``7.255e-5 /ms``.
+    TotalPump : array-like or callable, optional
+        Areal pump-site density; the conserved sum of ``pump +
+        pumpca`` per unit membrane area. Defaults to
+        ``1e-9 mol/cm2``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable or None, optional
+        Initializer for the ``Ci`` species. Defaults to ``None``,
+        which falls back to ``cainull``.
+    species_initializers : dict or None, optional
+        Per-species initializer overrides, keyed by one of this
+        class's twenty-seven differential species: the fourteen of
+        :class:`CdpStC_NoCAM_MA2020_GoC`, the four Calbindin species
+        (``CB``, ``CB_f_ca``, ``CB_ca_s``, ``CB_ca_ca``), and the
+        nine CaM species (``CAM0``, ``CAM1C``, ``CAM2C``,
+        ``CAM1N2C``, ``CAM1N``, ``CAM2N``, ``CAM2N1C``, ``CAM1C1N``,
+        ``CAM4``). Defaults to ``None`` (no overrides); unset
+        buffer/Calbindin/PV species default to their steady-state
+        occupancy at ``cainull``/``mginull``, ``pump`` defaults to
+        ``TotalPump``, ``CAM0`` defaults to ``CAM_start``, and every
+        other CaM species defaults to ``0.0 mM``.
+    solver : str or None, optional
+        Integrator name used for the reaction network. Defaults to
+        ``None``, which falls back to
+        :attr:`~braincell.ion._base.KineticIon.default_solver`
+        (``"backward_euler"``).
+    substeps : int or None, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``None``, which falls back to
+        :attr:`~braincell.ion._base.KineticIon.default_substeps`
+        (``1``).
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged
+        to :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``species_initializers`` names a species outside the
+        twenty-seven listed above, or if ``temp`` is explicitly
+        passed as ``None``, or ``substeps`` is less than ``1`` (the
+        latter two raised by :meth:`KineticIon._init_kinetic_ion`).
+    AttributeError
+        Raised during state initialization or reset, or from
+        :attr:`parea`/:attr:`dsq`, if this ion's compartment geometry
+        (``diam_arc_mean``) has not been attached yet.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    CdpStC_MA2020_GoC : Golgi-cell mechanism supplying the pump,
+        generic-buffer, PV and CaM reactions this class reuses
+        (``sources`` and ``conserves`` are the same tuple objects,
+        and several helper methods delegate to it directly).
+    CdpCR_MA2020_GrC : Sibling Purkinje-network variant that
+        substitutes Calretinin for Calbindin.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all ``Cdp*``
+        mechanisms.
+
+    Notes
+    -----
+    Ported from ``PC/ion/CdpCAM_MA24_PC.mod``. ``uses_total_current =
+    True``; ``sources`` and ``conserves`` are the exact tuple objects
+    defined on :class:`CdpStC_MA2020_GoC` (same ``Ci``-driving
+    :class:`~braincell.ion._base.Source` and same ``pump + pumpca =
+    TotalPump * parea`` :class:`~braincell.ion._base.Conserve`), and
+    several geometry/current helpers (:attr:`vrat`, :attr:`parea`,
+    :attr:`dsq`, :attr:`dsqvol`, ``_require_diam_arc_mean``,
+    ``_ci_source_flux``, ``_as_initializer``) explicitly delegate to
+    :class:`CdpStC_MA2020_GoC` rather than redefining the same logic.
+
+    Twenty-four reactions couple the twenty-eight species: the two
+    pump steps and four of the six buffer/PV steps from
+    :class:`CdpStC_NoCAM_MA2020_GoC` (``Buff1``, ``Buff2``, ``BTC``,
+    ``DMNPE``; PV keeps only its two binding steps, unaffected by
+    Calbindin), four Calbindin reactions forming its two-site
+    fast/slow cooperative scheme (``CB -> CB_ca_s`` via the fast
+    rates ``nf1``/``nf2``, ``CB -> CB_f_ca`` via the slow rates
+    ``ns1``/``ns2``, then both intermediates converging on
+    ``CB_ca_ca`` via the complementary rate pair), and the same
+    twelve calmodulin reactions documented in
+    :class:`CdpStC_CAMOnly_MA2020_GoC`.
+
+    References
+    ----------
+    .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering in
+           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
+           Eilers, J. (2003). Mutational analysis of dendritic Ca2+
+           kinetics in rodent Purkinje cells: role of parvalbumin and
+           calbindin D28k. The Journal of Physiology, 551(1), 13-32.
+           doi:10.1113/jphysiol.2002.035824
+    .. [3] Maeda, H., Ellis-Davies, G. C. R., Ito, K., Miyashita, Y.,
+           & Kasai, H. (1999). Supralinear Ca2+ signaling by
+           cooperative and mobile Ca2+ buffering in Purkinje neurons.
+           Neuron, 24(4), 989-1002.
+           doi:10.1016/S0896-6273(00)81045-4
+    .. [4] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz, A.,
+           & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
     """
 
     __module__ = "braincell.ion"
@@ -2929,11 +3774,199 @@ class CdpCAM_MA2024_PC(Calcium, KineticIon):
 
 @register_ion("CdpCR_MA2020_GrC")
 class CdpCR_MA2020_GrC(Calcium, KineticIon):
-    r"""Template-based import of ``CdpCR_MA20_GrC.mod``.
+    r"""Granule-cell calcium pool: pump, generic buffers, Calretinin.
 
-    This GrC variant keeps the pump, non-specific buffer, BTC, DMNPE, and
-    Calretinin kinetic network. The original NMODL removes PV and uses CR as
-    the endogenous calcium buffer.
+    Reuses the pump and generic-buffer (``Buff1``, ``Buff2``, BTC,
+    DMNPE) network of :class:`CdpStC_MA2020_GoC`, but replaces its
+    parvalbumin and calmodulin branches with a two-site-per-lobe
+    cooperative Calretinin (CR) binding scheme plus one separate,
+    uncoupled "vestigial" CR site. Parvalbumin is absent from this
+    mechanism; Calretinin is the endogenous calcium buffer.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 25
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    Nannuli : array-like or callable, optional
+        Radial-shell count inherited from the NEURON multi-shell
+        diffusion template; only shapes the single effective volume
+        fraction :attr:`vrat`. Defaults to ``10.9495``.
+    cainull : array-like or callable, optional
+        Baseline/initial free calcium concentration ``Ci``. Defaults
+        to ``45e-6 mM``.
+    mginull : array-like or callable, optional
+        Baseline/initial magnesium concentration ``mg``. Defaults to
+        ``0.59 mM``.
+    Buffnull1 : array-like or callable, optional
+        Total concentration of the first generic buffer, ``Buff1 +
+        Buff1_ca``. Defaults to ``0.0 mM``.
+    rf1, rf2 : array-like or callable, optional
+        Forward and backward rate constants of the ``Buff1``
+        binding step. Default ``0.0134329 /(mM*ms)`` and
+        ``0.0397469 /ms``.
+    Buffnull2 : array-like or callable, optional
+        Total concentration of the second generic buffer, ``Buff2 +
+        Buff2_ca``. Defaults to ``60.9091 mM``.
+    rf3, rf4 : array-like or callable, optional
+        Forward and backward rate constants of the ``Buff2``
+        binding step. Default ``0.1435 /(mM*ms)`` and ``0.0014 /ms``.
+    BTCnull : array-like or callable, optional
+        Total concentration of the BTC indicator dye buffer, ``BTC +
+        BTC_ca``. Defaults to ``0.0 mM``.
+    b1, b2 : array-like or callable, optional
+        Forward and backward rate constants of the ``BTC`` binding
+        step. Default ``5.33 /(mM*ms)`` and ``0.08 /ms``.
+    DMNPEnull : array-like or callable, optional
+        Total concentration of the caged-calcium buffer DMNPE,
+        ``DMNPE + DMNPE_ca``. Defaults to ``0.0 mM``.
+    c1, c2 : array-like or callable, optional
+        Forward and backward rate constants of the ``DMNPE`` binding
+        step. Default ``5.63 /(mM*ms)`` and ``0.107e-3 /ms``.
+    CRnull : array-like or callable, optional
+        Total concentration of unbound Calretinin, the initializer
+        for ``CR``. Defaults to ``0.9 mM``.
+    nT1, nT2 : array-like or callable, optional
+        Forward and backward rate constants of a Calretinin site's
+        *first* calcium-binding step, on either lobe. Default
+        ``1.8 /(mM*ms)`` and ``0.053 /ms``.
+    nR1, nR2 : array-like or callable, optional
+        Forward and backward rate constants of a Calretinin site's
+        *second*, cooperative calcium-binding step, on either lobe.
+        Default ``310.0 /(mM*ms)`` and ``0.02 /ms``.
+    nV1, nV2 : array-like or callable, optional
+        Forward and backward rate constants of the separate
+        vestigial Calretinin site, ``CR -> CR_1V``. Default
+        ``7.3 /(mM*ms)`` and ``0.24 /ms``.
+    kpmp1, kpmp2 : array-like or callable, optional
+        Forward and backward rate constants of the ``pump + Ci ->
+        pumpca`` binding step. Default ``3e-3 /(mM*ms)`` and
+        ``1.75e-5 /ms``.
+    kpmp3 : array-like or callable, optional
+        Rate constant of the irreversible extrusion step,
+        ``pumpca -> pump``. Defaults to ``7.255e-5 /ms``.
+    TotalPump : array-like or callable, optional
+        Areal pump-site density; the conserved sum of ``pump +
+        pumpca`` per unit membrane area. Defaults to
+        ``1e-9 mol/cm2``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable or None, optional
+        Initializer for the ``Ci`` species. Defaults to ``None``,
+        which falls back to ``cainull``.
+    species_initializers : dict or None, optional
+        Per-species initializer overrides, keyed by one of this
+        class's twenty-one differential species: ``Ci``, ``mg``,
+        the four generic-buffer species (``Buff1``, ``Buff1_ca``,
+        ``Buff2``, ``Buff2_ca``), the BTC and DMNPE pairs, the ten
+        Calretinin species (``CR``, ``CR_1C_0N``, ``CR_2C_0N``,
+        ``CR_2C_1N``, ``CR_1C_1N``, ``CR_0C_1N``, ``CR_0C_2N``,
+        ``CR_1C_2N``, ``CR_2C_2N``, ``CR_1V``), and ``pump``.
+        Defaults to ``None`` (no overrides); unset generic-buffer
+        species default to their steady-state occupancy at
+        ``cainull``, ``CR`` defaults to ``CRnull``, every other
+        Calretinin species defaults to ``0.0 mM``, and ``pump``
+        defaults to ``TotalPump``.
+    solver : str or None, optional
+        Integrator name used for the reaction network. Defaults to
+        ``None``, which falls back to
+        :attr:`~braincell.ion._base.KineticIon.default_solver`
+        (``"backward_euler"``).
+    substeps : int or None, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``None``, which falls back to
+        :attr:`~braincell.ion._base.KineticIon.default_substeps`
+        (``1``).
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged
+        to :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``species_initializers`` names a species outside the
+        twenty-one listed above, or if ``temp`` is explicitly passed
+        as ``None``, or ``substeps`` is less than ``1`` (the latter
+        two raised by :meth:`KineticIon._init_kinetic_ion`).
+    AttributeError
+        Raised during state initialization or reset, or from
+        :attr:`parea`/:attr:`dsq`, if this ion's compartment geometry
+        (``diam_arc_mean``) has not been attached yet.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    CdpStC_MA2020_GoC : Golgi-cell mechanism supplying the pump and
+        generic-buffer reactions this class reuses (``sources`` and
+        ``conserves`` are the same tuple objects, and several helper
+        methods delegate to it directly).
+    CdpCAM_MA2024_PC : Sibling Purkinje-network variant built on the
+        same base but adding Calbindin instead of Calretinin.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all ``Cdp*``
+        mechanisms.
+
+    Notes
+    -----
+    Ported from ``GrC/ion/CdpCR_MA20_GrC.mod``. ``uses_total_current
+    = True``; ``sources`` and ``conserves`` are the exact tuple
+    objects defined on :class:`CdpStC_MA2020_GoC` (same
+    ``Ci``-driving :class:`~braincell.ion._base.Source` and same
+    ``pump + pumpca = TotalPump * parea``
+    :class:`~braincell.ion._base.Conserve`), and several
+    geometry/current helpers (:attr:`vrat`, :attr:`parea`,
+    :attr:`dsq`, :attr:`dsqvol`, ``_require_diam_arc_mean``,
+    ``_ci_source_flux``, ``_as_initializer``) explicitly delegate to
+    :class:`CdpStC_MA2020_GoC` rather than redefining the same logic.
+
+    Nineteen reactions couple the twenty-two species: the two pump
+    steps, four generic-buffer steps (``Buff1``, ``Buff2``, ``BTC``,
+    ``DMNPE``; unlike :class:`CdpStC_MA2020_GoC` there is no PV
+    branch here), thirteen Calretinin reactions, and no calmodulin
+    branch at all. The thirteen Calretinin reactions form a
+    two-site-per-lobe cooperative lattice: nine states index how many
+    of Calretinin's two "C-lobe" sites (0, 1 or 2) and two "N-lobe"
+    sites (0, 1 or 2) are calcium-bound (``CR`` is the (0, 0) state,
+    ``CR_2C_2N`` the fully bound state), every *first*-site binding
+    step on either lobe uses the ``nT1``/``nT2`` rate pair, and every
+    *second*, cooperative-site binding step uses the faster
+    ``nR1``/``nR2`` pair. A tenth, separate Calretinin species,
+    ``CR_1V``, binds calcium directly from ``CR`` via its own
+    ``nV1``/``nV2`` rate pair and does not couple further into the
+    nine-state lattice.
+
+    References
+    ----------
+    .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+           Ca2+-activated K+ channels with models of Ca2+ buffering in
+           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           doi:10.1007/s12311-010-0224-3
+    .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
+           Eilers, J. (2003). Mutational analysis of dendritic Ca2+
+           kinetics in rodent Purkinje cells: role of parvalbumin and
+           calbindin D28k. The Journal of Physiology, 551(1), 13-32.
+           doi:10.1113/jphysiol.2002.035824
+    .. [3] Maeda, H., Ellis-Davies, G. C. R., Ito, K., Miyashita, Y.,
+           & Kasai, H. (1999). Supralinear Ca2+ signaling by
+           cooperative and mobile Ca2+ buffering in Purkinje neurons.
+           Neuron, 24(4), 989-1002.
+           doi:10.1016/S0896-6273(00)81045-4
+    .. [4] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+           D'Angelo, E. (2020). Parameter tuning differentiates
+           granule cell subtypes enriching transmission properties
+           at the cerebellum input stage. Communications Biology,
+           3(1), 222. doi:10.1038/s42003-020-0953-x
     """
 
     __module__ = "braincell.ion"
@@ -3271,16 +4304,119 @@ class CdpCR_MA2020_GrC(Calcium, KineticIon):
 
 @register_ion("CdpHVA_SU2015_DCN")
 class CdpHVA_SU2015_DCN(Calcium, DynamicNernstIon):
-    r"""Template-based import of ``CdpHVA_SU15_DCN.mod``.
+    r"""HVA-current-driven calcium pool for the deep cerebellar nuclei.
 
-    The imported NEURON mechanism evolves intracellular calcium via:
+    First-order relaxation model for the calcium pool associated
+    with high-voltage-activated (HVA) calcium channels in deep
+    cerebellar nucleus (DCN) neurons: the current drive from attached
+    HVA channels pushes ``Ci`` away from a fixed baseline, and a
+    single time constant relaxes it back.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.DynamicNernstIon.E`. Defaults to
+        36 degrees Celsius, converted to kelvin via
+        ``u.celsius2kelvin`` before being stored.
+    kCa : array-like or callable, optional
+        Current-to-concentration scale factor in :meth:`derivative`.
+        Defaults to ``3.45e-7 /coulomb``.
+    tauCa : array-like or callable, optional
+        Relaxation time constant toward ``caiBase`` in
+        :meth:`derivative`. Defaults to ``70.0 ms``.
+    caiBase : array-like or callable, optional
+        Baseline calcium concentration that ``Ci`` relaxes toward,
+        and the default value of ``Ci_initializer`` when none is
+        given. Defaults to ``50e-6 mM``.
+    depth : array-like or callable, optional
+        Shell depth dividing the current-drive term in
+        :meth:`derivative`. Defaults to ``0.2 um``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`DynamicNernstIon._init_dynamic_nernst_ion`.
+    Ci_initializer : array-like or callable or None, optional
+        Initializer for the dynamic ``Ci`` state. Defaults to
+        ``None``, which falls back to a constant initializer at
+        ``caiBase``.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged
+        to :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``.
+        :meth:`DynamicNernstIon._init_dynamic_nernst_ion` requires an
+        explicit temperature and does not fall back to a class
+        default.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class computes a reversal
+        potential for.
+    CdpLVA_SU2015_DCN : Sibling DCN calcium pool with an identical
+        relaxation model driven by low-voltage-activated current.
+    braincell.ion._base.DynamicNernstIon : Mixin this class builds
+        on; documents the ``Ci``/``Co``/``E`` interface shared by
+        all dynamic calcium ions.
+
+    Notes
+    -----
+    This class subclasses :class:`~braincell.ion._base.DynamicNernstIon`,
+    not :class:`~braincell.ion._base.KineticIon`: it defines a single
+    :meth:`derivative` method rather than declarative
+    ``Factor``/``Species``/``Reaction`` tuples, unlike the other
+    ``Cdp*`` mechanisms in this module.
+
+    Ported from ``DCN/ion/CdpHVA_SU15_DCN.mod``. :meth:`derivative`
+    implements
 
     .. math::
 
-       cai' = -\frac{kCa}{depth} \cdot ica \cdot 10^4 - \frac{cai - caiBase}{tauCa}
+        \frac{dCi}{dt} = -\frac{kCa}{depth} \cdot I_{total} \cdot 10^4
+        - \frac{Ci - caiBase}{tauCa}
 
-    In the first comparison notebook we only exercise the zero-``ica`` path,
-    which reduces to pure relaxation toward ``caiBase``.
+    NEURON's raw ``ica`` is efflux-positive; BrainCell channel
+    currents follow the repo-wide inward-positive convention, so the
+    sign of the current-drive term is flipped relative to the
+    original NMODL expression to keep a positive ``total_current``
+    increasing ``Ci``. When no channels are attached,
+    ``total_current`` defaults to zero and :meth:`derivative` reduces
+    to pure relaxation toward ``caiBase``. The current-drive term is
+    computed from unitless decimals (via ``to_decimal``) rather than
+    through ``brainunit`` dimensional arithmetic, matching the
+    imported NMODL's ``* 1e4`` unit-conversion literal rather than
+    deriving it dimensionally.
+
+    The kinetic constants (``kCa``, ``tauCa``, ``caiBase``, ``depth``)
+    are DCN-model parameters; no paper's text can be cited as
+    printing this specific relaxation-model form. The kinetics trace
+    to the deep cerebellar nucleus model of Steuber et al. (2011)
+    [1]_, translated from GENESIS to NEURON by Luthman et al. (2011)
+    and used in the NEURON DCN model of Sudhakar et al. (2015) [2]_,
+    from which this mechanism is imported.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of synaptic
+           integration and heterogeneity in rebound firing explored
+           with data-driven models of deep cerebellar nucleus cells.
+           Journal of Computational Neuroscience, 30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
     """
 
     __module__ = "braincell.ion"
@@ -3335,16 +4471,124 @@ class CdpHVA_SU2015_DCN(Calcium, DynamicNernstIon):
 
 @register_ion("CdpLVA_SU2015_DCN")
 class CdpLVA_SU2015_DCN(Calcium, DynamicNernstIon):
-    r"""Template-based import of ``CdpLVA_SU15_DCN.mod``.
+    r"""LVA-current-driven calcium pool for the deep cerebellar nuclei.
 
-    The imported NEURON mechanism evolves intracellular calcium via:
+    First-order relaxation model for the calcium pool associated
+    with low-voltage-activated (LVA) calcium channels in deep
+    cerebellar nucleus (DCN) neurons: the current drive from attached
+    LVA channels pushes ``Ci`` away from a fixed baseline, and a
+    single time constant relaxes it back. Structurally identical to
+    :class:`CdpHVA_SU2015_DCN`; only the parameter names differ,
+    matching the imported NMODL's separate ``cali``/``cal`` pool.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.DynamicNernstIon.E`. Defaults to
+        36 degrees Celsius, converted to kelvin via
+        ``u.celsius2kelvin`` before being stored.
+    kCal : array-like or callable, optional
+        Current-to-concentration scale factor in :meth:`derivative`.
+        Defaults to ``3.45e-7 /coulomb``.
+    tauCal : array-like or callable, optional
+        Relaxation time constant toward ``caliBase`` in
+        :meth:`derivative`. Defaults to ``70.0 ms``.
+    caliBase : array-like or callable, optional
+        Baseline calcium concentration that ``Ci`` relaxes toward,
+        and the default value of ``Ci_initializer`` when none is
+        given. Defaults to ``50e-6 mM``.
+    depth : array-like or callable, optional
+        Shell depth dividing the current-drive term in
+        :meth:`derivative`. Defaults to ``0.2 um``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`DynamicNernstIon._init_dynamic_nernst_ion`.
+    Ci_initializer : array-like or callable or None, optional
+        Initializer for the dynamic ``Ci`` state. Defaults to
+        ``None``, which falls back to a constant initializer at
+        ``caliBase``.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged
+        to :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``.
+        :meth:`DynamicNernstIon._init_dynamic_nernst_ion` requires an
+        explicit temperature and does not fall back to a class
+        default.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class computes a reversal
+        potential for.
+    CdpHVA_SU2015_DCN : Sibling DCN calcium pool with an identical
+        relaxation model driven by high-voltage-activated current.
+    braincell.ion._base.DynamicNernstIon : Mixin this class builds
+        on; documents the ``Ci``/``Co``/``E`` interface shared by
+        all dynamic calcium ions.
+
+    Notes
+    -----
+    This class subclasses :class:`~braincell.ion._base.DynamicNernstIon`,
+    not :class:`~braincell.ion._base.KineticIon`: it defines a single
+    :meth:`derivative` method rather than declarative
+    ``Factor``/``Species``/``Reaction`` tuples, unlike the other
+    ``Cdp*`` mechanisms in this module. ``Ci`` here corresponds to
+    the NMODL ``cali`` pool (as opposed to ``CdpHVA_SU2015_DCN``'s
+    ``cai``), exposed through the same standard ``Ci``/``Co``/``E``
+    interface.
+
+    Ported from ``DCN/ion/CdpLVA_SU15_DCN.mod``. :meth:`derivative`
+    implements
 
     .. math::
 
-       cali' = -\frac{kCal}{depth} \cdot ical \cdot 10^4 - \frac{cali - caliBase}{tauCal}
+        \frac{dCi}{dt} = -\frac{kCal}{depth} \cdot I_{total} \cdot 10^4
+        - \frac{Ci - caliBase}{tauCal}
 
-    In BrainCell this pool is still exposed through the standard calcium
-    ``Ci/Co/E`` interface, with ``Ci`` corresponding to the NMODL ``cali``.
+    NEURON's raw ``ical`` is efflux-positive; BrainCell channel
+    currents follow the repo-wide inward-positive convention, so the
+    sign of the current-drive term is flipped relative to the
+    original NMODL expression to keep a positive ``total_current``
+    increasing ``Ci``. When no channels are attached,
+    ``total_current`` defaults to zero and :meth:`derivative` reduces
+    to pure relaxation toward ``caliBase``. The current-drive term is
+    computed from unitless decimals (via ``to_decimal``) rather than
+    through ``brainunit`` dimensional arithmetic, matching the
+    imported NMODL's ``* 1e4`` unit-conversion literal rather than
+    deriving it dimensionally.
+
+    The kinetic constants (``kCal``, ``tauCal``, ``caliBase``,
+    ``depth``) are DCN-model parameters; no paper's text can be cited
+    as printing this specific relaxation-model form. The kinetics
+    trace to the deep cerebellar nucleus model of Steuber et al.
+    (2011) [1]_, translated from GENESIS to NEURON by Luthman et al.
+    (2011) and used in the NEURON DCN model of Sudhakar et al. (2015)
+    [2]_, from which this mechanism is imported.
+
+    References
+    ----------
+    .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
+           Schutter, E., & Jaeger, D. (2011). Determinants of synaptic
+           integration and heterogeneity in rebound firing explored
+           with data-driven models of deep cerebellar nucleus cells.
+           Journal of Computational Neuroscience, 30(3), 633-658.
+           doi:10.1007/s10827-010-0282-z
+    .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
+           (2015). Cerebellar nuclear neurons use time and rate
+           coding to transmit Purkinje neuron pauses. PLOS
+           Computational Biology, 11(12), e1004641.
+           doi:10.1371/journal.pcbi.1004641
     """
 
     __module__ = "braincell.ion"

--- a/braincell/ion/calcium.py
+++ b/braincell/ion/calcium.py
@@ -59,15 +59,58 @@ __all__ = [
 
 
 class Calcium(Ion):
-    """
-    Base class for modeling Calcium ion.
+    """Base class for modeling the calcium ion species.
 
-    This class serves as the foundation for all calcium ion models in the braincell library.
-    It inherits from the Ion class and sets the root_type to HHTypedNeuron.
+    ``Calcium`` collects the physiological defaults shared by every
+    concrete calcium ion model in BrainCell and provides the
+    ``Ion``/``IonChannel`` container interface calcium channels
+    attach to. It carries no dynamics of its own.
 
-    Note:
-        This is an abstract base class and should be subclassed to implement specific
-        calcium ion models with their own dynamics and properties.
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Ion`.
+    name : str or None, optional
+        Runtime instance name. Defaults to ``None``, in which case the
+        instance is unnamed. Forwarded unchanged to :class:`Ion`.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Ion`.
+
+    See Also
+    --------
+    CalciumFixed : Fixed-parameter calcium ion built on this base.
+    CalciumInitNernst : Calcium ion with ``E`` initialized from the
+        Nernst equation.
+    CalciumDetailed : Dynamic calcium ion with a first-order
+        concentration model and Nernst-computed ``E``.
+    CalciumFirstOrder : Sibling dynamic calcium ion with a different
+        first-order form.
+
+    Notes
+    -----
+    This is an abstract base class and must be subclassed (for
+    example by :class:`CalciumFixed` or :class:`CalciumDetailed`) to
+    obtain a concrete calcium ion model with defined reversal-
+    potential dynamics. ``default_Ci``, ``default_Co``, and
+    ``default_valence`` below are values conventional in the
+    calcium-modeling literature, not measurements reported by a
+    single paper; no citation is asserted for them.
+
+    Attributes
+    ----------
+    root_type : type
+        Root container type this ion attaches to. Set to
+        :class:`~braincell._base.HHTypedNeuron`.
+    ion_symbol : str
+        Symbol used for runtime family lookup. Set to ``'Ca'``.
+    default_Ci : brainunit.Quantity
+        Default intracellular calcium concentration, ``5e-5 mM``.
+    default_Co : brainunit.Quantity
+        Default extracellular calcium concentration, ``2.0 mM``.
+    default_valence : int
+        Default ionic valence, ``2``.
     """
 
     __module__ = 'braincell.ion'
@@ -81,10 +124,59 @@ class Calcium(Ion):
 
 @register_ion("CalciumFixed")
 class CalciumFixed(Calcium, FixedIon):
-    """Fixed Calcium dynamics.
+    r"""Fixed calcium dynamics.
 
-    This calcium model has no dynamics. It holds fixed reversal
-    potential :math:`E` and concentration :math:`C`.
+    This calcium model has no dynamics. It holds a fixed reversal
+    potential :math:`E` and fixed concentrations :math:`C_i`/:math:`C_o`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    E : array-like or callable or None, optional
+        Fixed reversal potential. Defaults to ``+120 mV``. Passing
+        ``None`` explicitly raises :class:`ValueError`; there is no
+        class-default fallback for this argument.
+    Ci : array-like or callable or None, optional
+        Intracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Ci` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    valence : array-like or callable or None, optional
+        Ionic valence. Defaults to ``None``, which falls back to
+        :attr:`Calcium.default_valence` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``E`` is explicitly passed as ``None``.
+        :meth:`FixedIon._init_fixed_ion` requires an explicit fixed
+        reversal potential and does not fall back to a class default
+        for ``E``.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class fixes.
+    CalciumInitNernst : Sibling calcium model whose ``E`` is computed
+        from the Nernst equation instead of fixed.
+
+    Notes
+    -----
+    With the shipped class defaults (``Co = 2.0 mM``, ``Ci = 5e-5
+    mM``, ``valence = 2``) at 36 degrees Celsius, the Nernst equation
+    gives ``E = +141.15 mV``. ``CalciumFixed`` instead defaults ``E``
+    to ``+120 mV``, so the two sibling classes disagree by about
+    21 mV when both are constructed with no arguments.
     """
 
     __module__ = 'braincell.ion'
@@ -105,7 +197,74 @@ class CalciumFixed(Calcium, FixedIon):
 
 @register_ion("CalciumInitNernst")
 class CalciumInitNernst(Calcium, InitNernstIon):
-    """Fixed ``Ci/Co`` calcium model with ``E`` initialized from Nernst."""
+    r"""Fixed ``Ci``/``Co`` calcium model with ``E`` initialized from Nernst.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation. Defaults to
+        36 degrees Celsius, converted to kelvin via
+        ``u.celsius2kelvin`` before being stored.
+    Ci : array-like or callable or None, optional
+        Intracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Ci` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    valence : array-like or callable or None, optional
+        Ionic valence. Defaults to ``None``, which falls back to
+        :attr:`Calcium.default_valence` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``.
+        :meth:`InitNernstIon._init_nernst_ion` requires an explicit
+        temperature and does not fall back to a class default.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class computes a reversal
+        potential for.
+    CalciumFixed : Sibling calcium model with a fixed reversal
+        potential instead of a Nernst-computed one.
+
+    Notes
+    -----
+    ``E`` is not computed at construction time. ``_init_nernst_ion``
+    sets ``self.E = None`` immediately, and the actual reversal
+    potential is filled in only later by
+    ``InitNernstIon._update_reversal``, which fires from the
+    ``_ion_init_state_hook`` and ``_ion_reset_state_hook`` lifecycle
+    hooks. Between construction and the first state initialization or
+    reset, ``E`` is ``None``.
+
+    The stored formula, transcribed as ``_update_reversal`` writes it,
+    is the Nernst equation
+
+    .. math::
+
+        E = \frac{R \cdot \mathrm{temp}}{\mathrm{valence} \cdot F}
+            \log\!\left(\frac{C_o}{C_i}\right)
+
+    where :math:`R` is the gas constant and :math:`F` is the Faraday
+    constant. The argument to the logarithm is :math:`C_o / C_i`
+    (extracellular over intracellular), and ``valence`` divides inside
+    the prefactor rather than appearing as a separate multiplicative
+    term. House policy treats the Nernst equation as a textbook
+    result, so it is named here without a citation.
+    """
 
     __module__ = 'braincell.ion'
 
@@ -125,11 +284,19 @@ class CalciumInitNernst(Calcium, InitNernstIon):
 
 @register_ion("CalciumDetailed")
 class CalciumDetailed(Calcium, DynamicNernstIon):
-    r"""Dynamical Calcium model proposed.
+    r"""Dynamic calcium concentration model with Nernst-computed reversal potential.
 
-    **1. The dynamics of intracellular** :math:`Ca^{2+}`
+    :meth:`derivative` implements only the first-order relaxation
+    model of section 2 below. Section 1 reproduces, for background
+    only, the fuller ATP-pump model this family of models is drawn
+    from: **the pump kinetics in section 1 are NOT implemented by
+    this class.** ``derivative`` is three lines long and contains no
+    Michaelis-Menten term and no pump parameter.
 
-    The dynamics of intracellular :math:`Ca^{2+}` were determined by two contributions [1]_ :
+    **1. Background: the dynamics of intracellular** :math:`Ca^{2+}`
+    **(not implemented)**
+
+    The dynamics of intracellular :math:`Ca^{2+}` were determined by two contributions [3]_ :
 
     *(i) Influx of* :math:`Ca^{2+}` *due to Calcium currents*
 
@@ -174,12 +341,14 @@ class CalciumDetailed(Calcium, DynamicNernstIon):
     with the total concentration of :math:`P` and :math:`K_{d}=c_{2} / c_{1}=10^{-4}\, \mathrm{mM}`
     is the dissociation constant, which can be interpreted here as the value of
     :math:`[Ca]_{i}` at which the pump is half activated (if :math:`[Ca]_{i} \ll K_{d}`
-    then the efflux is negligible).
+    then the efflux is negligible). None of this pump exists in :meth:`derivative`
+    below -- no saturating term and no pump parameter appear anywhere in this class.
 
-    **2.A simple first-order model**
+    **2. The implemented model: a simple first-order relaxation**
 
-    While, in (Bazhenov, et al., 1998) [2]_, the :math:`Ca^{2+}` dynamics is
-    described by a simple first-order model,
+    What :meth:`derivative` actually computes is the first-order model of
+    (Bazhenov, et al., 1998) [2]_, which that paper's own Appendix credits
+    to (Destexhe et al., 1994) [1]_:
 
     .. math::
 
@@ -187,10 +356,13 @@ class CalciumDetailed(Calcium, DynamicNernstIon):
 
     where :math:`I_{Ca}` is the summation of all :math:`Ca ^{2+}` currents, :math:`d`
     is the thickness of the perimembrane "shell" in which calcium is able to affect
-    membrane properties :math:`(1.\, \mathrm{\mu M})`, :math:`z=2` is the valence of the
+    membrane properties :math:`(1.\, \mathrm{\mu m})`, :math:`z=2` is the valence of the
     :math:`Ca ^{2+}` ion, :math:`F` is the Faraday constant, and :math:`\tau_{C a}` is
     the :math:`Ca ^{2+}` removal rate. The resting :math:`Ca ^{2+}` concentration was
-    set to be :math:`\left[ Ca ^{2+}\right]_{\text {rest}}=.05\, \mathrm{\mu M}` .
+    set to be :math:`\left[ Ca ^{2+}\right]_{\text {rest}}=2.4\times 10^{-4}\, \mathrm{mM}`
+    (:math:`0.24\, \mathrm{\mu M}`), matching the default ``C_rest`` below exactly.
+    BrainCell additionally clamps the influx term at zero before adding it (see
+    Notes), which neither paper does.
 
     **3. The reversal potential**
 
@@ -208,30 +380,91 @@ class CalciumDetailed(Calcium, DynamicNernstIon):
 
     Parameters
     ----------
-    d : float
-      The thickness of the peri-membrane "shell".
-    F : float
-      The Faraday constant. (:math:`C*mmol^{-1}`)
-    tau : float
-      The time constant of the :math:`Ca ^{2+}` removal rate. (ms)
-    C_rest : float
-      The resting :math:`Ca ^{2+}` concentration.
-    Co : float
-      The :math:`Ca ^{2+}` concentration outside of the membrane.
-    R : float
-      The gas constant. (:math:` J*mol^{-1}*K^{-1}`)
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.DynamicNernstIon.E`. Defaults to
+        36 degrees Celsius, converted to kelvin via
+        ``u.celsius2kelvin`` before being stored.
+    d : array-like or callable, optional
+        Thickness :math:`d` of the peri-membrane calcium shell.
+        Defaults to ``1.0 um``.
+    tau : array-like or callable, optional
+        Time constant :math:`\tau_{Ca}` of the calcium removal rate.
+        Defaults to ``5.0 ms``.
+    C_rest : array-like or callable, optional
+        Resting intracellular calcium concentration
+        :math:`[Ca^{2+}]_{rest}` that ``Ci`` relaxes toward. Defaults
+        to ``2.4e-4 mM`` (``0.24 uM``).
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`DynamicNernstIon._init_dynamic_nernst_ion`.
+    Ci_initializer : array-like or callable, optional
+        Initializer for the dynamic ``Ci`` state. Defaults to a
+        constant ``2.4e-4 mM`` initializer, matching ``C_rest``.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``.
+        :meth:`DynamicNernstIon._init_dynamic_nernst_ion` requires an
+        explicit temperature and does not fall back to a class
+        default.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class computes a reversal
+        potential for.
+    CalciumFirstOrder : Sibling dynamic calcium ion with a different
+        first-order form.
+
+    Notes
+    -----
+    ``derivative`` rectifies the influx term with
+    ``u.math.maximum(drive, 0)`` so that only inward calcium current
+    raises ``Ci``; no such clamp appears in either Destexhe et al.
+    (1994) [1]_ or Bazhenov et al. (1998) [2]_, and it is a BrainCell
+    addition.
+
+    Bazhenov's Appendix writes the influx term with one lumped
+    constant, :math:`A = 5.18 \times 10^{-5}\, \mathrm{mM\, cm^2 /
+    (ms\, \mu A)}`. BrainCell instead writes it out as
+    :math:`1/(zFd)`, with :math:`z=2` hard-coded and ``d`` exposed as
+    a constructor parameter. The two are the same term parameterized
+    differently, not a divergence -- it is why ``d`` is a BrainCell
+    parameter and not one of Bazhenov's.
+
+    Section 1's Faraday and gas constants, :math:`F = 96489\,
+    \mathrm{C/mol}` and :math:`R = 8.31441\, \mathrm{J/(mol\, K)}`,
+    are the paper's own literal values, quoted above for reference
+    only. The code instead uses the CODATA constants
+    ``u.faraday_constant`` and ``u.gas_constant`` (via
+    :attr:`~braincell.ion._base.DynamicNernstIon.E`), neither of
+    which is a constructor parameter.
 
     References
     ----------
-
-    .. [1] Destexhe, Alain, Agnessa Babloyantz, and Terrence J. Sejnowski.
-           "Ionic mechanisms for intrinsic slow oscillations in thalamic
-           relay neuron." Biophysical journal 65, no. 4 (1993): 1538-1552.
-    .. [2] Bazhenov, Maxim, Igor Timofeev, Mircea Steriade, and Terrence J.
-           Sejnowski. "Cellular and network models for intrathalamic augmenting
-           responses during 10-Hz stimulation." Journal of neurophysiology 79,
-           no. 5 (1998): 2730-2748.
-
+    .. [1] Destexhe, A., Contreras, D., Sejnowski, T. J., & Steriade, M.
+           (1994). A model of spindle rhythmicity in the isolated thalamic
+           reticular nucleus. Journal of Neurophysiology, 72(2), 803-818.
+           doi:10.1152/jn.1994.72.2.803
+    .. [2] Bazhenov, M., Timofeev, I., Steriade, M., & Sejnowski, T. J.
+           (1998). Cellular and network models for intrathalamic
+           augmenting responses during 10-Hz stimulation. Journal of
+           Neurophysiology, 79(5), 2730-2748.
+           doi:10.1152/jn.1998.79.5.2730
+    .. [3] Destexhe, A., Babloyantz, A., & Sejnowski, T. J. (1993). Ionic
+           mechanisms for intrinsic slow oscillations in thalamic relay
+           neurons. Biophysical Journal, 65(4), 1538-1552.
+           doi:10.1016/S0006-3495(93)81190-1
     """
 
     __module__ = 'braincell.ion'
@@ -271,13 +504,86 @@ class CalciumDetailed(Calcium, DynamicNernstIon):
 
 @register_ion("CalciumFirstOrder")
 class CalciumFirstOrder(Calcium, DynamicNernstIon):
-    r"""
-    The first-order calcium concentration model.
+    r"""First-order calcium concentration model with rectified current drive.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.DynamicNernstIon.E`. Defaults to
+        36 degrees Celsius, converted to kelvin via
+        ``u.celsius2kelvin`` before being stored.
+    alpha : array-like or callable, optional
+        Scale factor applied to the rectified current-drive term in
+        :meth:`derivative`. Defaults to ``0.13`` (a bare, unitless
+        number).
+    beta : array-like or callable, optional
+        First-order decay rate applied to ``Ci`` in :meth:`derivative`.
+        Defaults to ``0.075`` (a bare, unitless number).
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`DynamicNernstIon._init_dynamic_nernst_ion`.
+    Ci_initializer : array-like or callable, optional
+        Initializer for the dynamic ``Ci`` state. Defaults to a
+        constant ``2.4e-4 mM`` initializer.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``.
+        :meth:`DynamicNernstIon._init_dynamic_nernst_ion` requires an
+        explicit temperature and does not fall back to a class
+        default.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class computes a reversal
+        potential for.
+    CalciumDetailed : Sibling dynamic calcium ion with a first-order
+        relaxation model driven by a unit-converted current term.
+
+    Notes
+    -----
+    :meth:`derivative` computes
 
     .. math::
 
-       Ca' = -\alpha I_{Ca} + -\beta Ca
+        \frac{dCi}{dt} = \max(\alpha \cdot I_{Ca},\ 0) - \beta \cdot Ci
 
+    i.e. a *rectified*, positively-scaled current drive minus a
+    first-order decay -- not a symmetric ``-alpha*I_Ca - beta*Ca``
+    form. ``alpha`` and ``beta`` are generic first-order-model
+    coefficients with no identified literature source; they are not
+    traceable to a specific paper from the code alone, so none is
+    cited here.
+
+    ``alpha`` and ``beta`` are stored as bare, unitless numbers, while
+    ``total_current`` (the calcium current summed over attached
+    channels) carries current-density units such as
+    :math:`\mathrm{\mu A/cm^2}`. Because :meth:`derivative` compares
+    ``self.alpha * total_current`` directly against ``0.0 * u.mM`` in
+    ``u.math.maximum``, calling ``derivative`` with any real,
+    unit-typed ``total_current`` raises
+    ``brainunit.UnitMismatchError``; calling it with no channels
+    attached instead raises ``TypeError``, because ``current()``
+    returns ``None`` rather than a zero quantity when there are no
+    channels to sum. Unlike :class:`CalciumDetailed`, which divides
+    its current term by :math:`2Fd` before clamping (so the clamped
+    quantity and the zero it is compared against share the same
+    derived unit), this class performs no such conversion, so
+    ``derivative`` is not currently callable with a real
+    ``total_current`` in either configuration. This is an existing
+    implementation defect, not a documentation issue; it is recorded
+    here rather than fixed, since this change is documentation-only.
     """
 
     __module__ = 'braincell.ion'
@@ -316,7 +622,10 @@ class CalciumFirstOrder(Calcium, DynamicNernstIon):
 class ToyCaBindingKinetic_SU2015_DCN(Calcium, KineticIon):
     r"""Minimal reversible calcium-binding toy for ``KineticIon`` validation.
 
-    The mechanism models one reversible buffering step:
+    This is a BrainCell import-path validation fixture, not a model of
+    a published mechanism -- the ``SU2015_DCN`` suffix follows
+    BrainCell's naming convention only. The mechanism models one
+    reversible buffering step:
 
     .. math::
 
@@ -330,6 +639,72 @@ class ToyCaBindingKinetic_SU2015_DCN(Calcium, KineticIon):
 
     ``B`` is solved algebraically from the conservation rule while ``Ci`` and
     ``BC`` are integrated as differential species.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 36
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    kf : array-like or callable, optional
+        Forward rate constant of the ``Ci + B -> BC`` reaction.
+        Defaults to ``2.0 / (mM * ms)``.
+    kb : array-like or callable, optional
+        Backward rate constant of the ``BC -> Ci + B`` reaction.
+        Defaults to ``0.5 / ms``.
+    Btot : array-like or callable, optional
+        Total conserved concentration of ``B + BC``. Defaults to
+        ``1.0 mM``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable, optional
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
+    BC_initializer : array-like or callable, optional
+        Initializer for the ``BC`` species. Defaults to ``0.00 mM``.
+    solver : str, optional
+        Integrator name used for the reaction network. Defaults to
+        ``"rk4"``.
+    substeps : int, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``5``.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``, or if
+        ``substeps`` is less than ``1``. Both come from
+        :meth:`KineticIon._init_kinetic_ion`.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    ToyCaBindingSourceKinetic_SU2015_DCN : Same reaction network plus
+        a constant source on ``Ci``.
+    ToyCaBindingIcaSourceKinetic_SU2015_DCN : Same reaction network
+        plus a current-driven source on ``Ci``.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all five toy
+        fixtures.
+
+    Notes
+    -----
+    ``B`` is not a differential species: it is declared in
+    :attr:`species` for readability, but :attr:`conserves` marks it as
+    the ``algebraic`` member of the ``B + BC = Btot`` conservation
+    relation, so its value is recovered from ``BC`` rather than
+    integrated.
     """
 
     __module__ = "braincell.ion"
@@ -394,8 +769,10 @@ class ToyCaBindingKinetic_SU2015_DCN(Calcium, KineticIon):
 class ToyCaBindingSourceKinetic_SU2015_DCN(Calcium, KineticIon):
     r"""Minimal reversible calcium-binding toy with a constant ``Ci`` source.
 
-    The mechanism keeps the same reversible binding network as
-    :class:`ToyCaBindingKinetic_SU2015_DCN`:
+    This is a BrainCell import-path validation fixture, not a model of
+    a published mechanism -- the ``SU2015_DCN`` suffix follows
+    BrainCell's naming convention only. The mechanism keeps the same
+    reversible binding network as :class:`ToyCaBindingKinetic_SU2015_DCN`:
 
     .. math::
 
@@ -406,6 +783,74 @@ class ToyCaBindingSourceKinetic_SU2015_DCN(Calcium, KineticIon):
     .. math::
 
        \frac{d Ca_i}{dt}\Big|_{\text{source}} = s_{Ca}
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 36
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    kf : array-like or callable, optional
+        Forward rate constant of the ``Ci + B -> BC`` reaction.
+        Defaults to ``2.0 / (mM * ms)``.
+    kb : array-like or callable, optional
+        Backward rate constant of the ``BC -> Ci + B`` reaction.
+        Defaults to ``0.5 / ms``.
+    Btot : array-like or callable, optional
+        Total conserved concentration of ``B + BC``. Defaults to
+        ``1.0 mM``.
+    ci_source : array-like or callable, optional
+        Constant source rate :math:`s_{Ca}` added to ``dCi/dt``.
+        Defaults to ``0.002 mM / ms``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable, optional
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
+    BC_initializer : array-like or callable, optional
+        Initializer for the ``BC`` species. Defaults to ``0.00 mM``.
+    solver : str, optional
+        Integrator name used for the reaction network. Defaults to
+        ``"rk4"``.
+    substeps : int, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``5``.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``, or if
+        ``substeps`` is less than ``1``. Both come from
+        :meth:`KineticIon._init_kinetic_ion`.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    ToyCaBindingKinetic_SU2015_DCN : Same reaction network without the
+        constant source.
+    ToyCaBindingIcaSourceKinetic_SU2015_DCN : Sibling fixture whose
+        source is driven by current instead of a constant rate.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all five toy
+        fixtures.
+
+    Notes
+    -----
+    ``B`` is not a differential species: :attr:`conserves` marks it as
+    the ``algebraic`` member of the ``B + BC = Btot`` conservation
+    relation, so its value is recovered from ``BC`` rather than
+    integrated, exactly as in :class:`ToyCaBindingKinetic_SU2015_DCN`.
     """
 
     __module__ = "braincell.ion"
@@ -460,8 +905,88 @@ class ToyCaBindingSourceKinetic_SU2015_DCN(Calcium, KineticIon):
 class ToyCaBindingIcaSourceKinetic_SU2015_DCN(Calcium, KineticIon):
     r"""Minimal reversible calcium-binding toy with current-driven ``Ci`` source.
 
-    The mechanism keeps the same reversible binding network as the earlier
-    toy kinetic ions and drives ``Ci`` with inward-positive calcium current.
+    This is a BrainCell import-path validation fixture, not a model of
+    a published mechanism -- the ``SU2015_DCN`` suffix follows
+    BrainCell's naming convention only. The mechanism keeps the same
+    reversible binding network as the earlier toy kinetic ions and
+    drives ``Ci`` with inward-positive calcium current.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 36
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    kf : array-like or callable, optional
+        Forward rate constant of the ``Ci + B -> BC`` reaction.
+        Defaults to ``2.0 / (mM * ms)``.
+    kb : array-like or callable, optional
+        Backward rate constant of the ``BC -> Ci + B`` reaction.
+        Defaults to ``0.5 / ms``.
+    Btot : array-like or callable, optional
+        Total conserved concentration of ``B + BC``. Defaults to
+        ``1.0 mM``.
+    kCa : array-like or callable, optional
+        Current-to-flux scale factor used by the ``Ci`` source.
+        Defaults to ``3.45e-7 / coulomb``.
+    depth : array-like or callable, optional
+        Shell depth used by the ``Ci`` source's unit conversion.
+        Defaults to ``0.2 um``.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable, optional
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
+    BC_initializer : array-like or callable, optional
+        Initializer for the ``BC`` species. Defaults to ``0.00 mM``.
+    solver : str, optional
+        Integrator name used for the reaction network. Defaults to
+        ``"rk4"``.
+    substeps : int, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``5``.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``, or if
+        ``substeps`` is less than ``1``. Both come from
+        :meth:`KineticIon._init_kinetic_ion`.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    ToyCaBindingKinetic_SU2015_DCN : Same reaction network without any
+        source term.
+    ToyCaBindingSourceKinetic_SU2015_DCN : Sibling fixture with a
+        constant, rather than current-driven, source.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all five toy
+        fixtures.
+
+    Notes
+    -----
+    The ``Ci`` source evaluates to zero when ``total_current`` is
+    ``None`` (no channels attached), and otherwise to
+    ``(kCa / depth) * total_current * 1e4``, with ``total_current``
+    read in ``mA/cm**2`` and the ``1e4`` factor converting that
+    current density into the ``mM/ms`` units the source needs -- the
+    standard cross-sectional-area conversion used across BrainCell's
+    current-driven calcium sources. This class sets
+    ``uses_total_current = True``, so :meth:`KineticIon`'s derivative
+    hook always supplies a real ``total_current`` once at least one
+    channel is attached, unlike :class:`CalciumFirstOrder`.
     """
 
     __module__ = "braincell.ion"
@@ -529,9 +1054,114 @@ class ToyCaBindingIcaSourceKinetic_SU2015_DCN(Calcium, KineticIon):
 class ToyCaPumpFactorKinetic_SU2015_DCN(Calcium, KineticIon):
     r"""Minimal factor-crossing toy with cytosolic and pump-area compartments.
 
-    ``Ci`` lives in a cytosolic volume factor while pump states live in an
-    area-like factor. The toy keeps the state count minimal while exercising
-    mixed-factor reaction, conservation, and current-driven source paths.
+    This is a BrainCell import-path validation fixture, not a model of
+    a published mechanism -- the ``SU2015_DCN`` suffix follows
+    BrainCell's naming convention only. ``Ci`` lives in a cytosolic
+    volume factor while pump states live in an area-like factor. The
+    toy keeps the state count minimal while exercising mixed-factor
+    reaction, conservation, and current-driven source paths, plus an
+    irreversible (one-way) release reaction.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 36
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    kf : array-like or callable, optional
+        Forward rate constant of the ``Ci + PumpFree -> PumpBound``
+        binding reaction. Defaults to ``2.0 / (mM * ms)``.
+    kb : array-like or callable, optional
+        Backward rate constant of the ``PumpBound -> Ci + PumpFree``
+        unbinding reaction. Defaults to ``0.5 / ms``.
+    k_rel : array-like or callable, optional
+        Rate constant of the irreversible ``PumpBound -> PumpFree``
+        release reaction (no back-reaction; ``backward=None``).
+        Defaults to ``0.05 / ms``.
+    PumpTot : array-like or callable, optional
+        Per-area total pump concentration used by the conserved pool
+        ``PumpFree + PumpBound = PumpTot * pump_area``. Defaults to
+        ``1.0 mM * um``.
+    kCa : array-like or callable, optional
+        Current-to-flux scale factor used by the ``Ci`` source.
+        Defaults to ``3.45e-7 / coulomb``.
+    depth : array-like or callable, optional
+        Shell depth used by the ``Ci`` source's unit conversion.
+        Defaults to ``0.2 um``.
+    cyt_volume : array-like or callable, optional
+        Constant cytosolic volume backing the ``cyto`` factor that
+        ``Ci`` lives in. Defaults to ``3.0 um**3``. Unlike
+        :class:`ToyDiamFactorKinetic_SU2015_DCN`, this value is a
+        plain constructor constant, not derived from compartment
+        geometry.
+    pump_area : array-like or callable, optional
+        Constant membrane area backing the ``pump_area`` factor that
+        ``PumpFree``/``PumpBound`` live in. Defaults to ``3.0 um**2``.
+        Also a plain constructor constant, not geometry-derived.
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable, optional
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
+    PumpBound_initializer : array-like or callable, optional
+        Initializer for the ``PumpBound`` species. Defaults to
+        ``0.00 mM * um``.
+    solver : str, optional
+        Integrator name used for the reaction network. Defaults to
+        ``"rk4"``.
+    substeps : int, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``5``.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``, or if
+        ``substeps`` is less than ``1``. Both come from
+        :meth:`KineticIon._init_kinetic_ion`.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    ToyCaBindingIcaSourceKinetic_SU2015_DCN : Sibling fixture with the
+        same current-driven ``Ci`` source but a single, non-factor
+        binding partner.
+    ToyDiamFactorKinetic_SU2015_DCN : Sibling fixture whose factors
+        are derived from runtime compartment geometry instead of
+        fixed constructor constants.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all five toy
+        fixtures, including the ``Factor`` mechanism.
+
+    Notes
+    -----
+    ``PumpFree`` is the algebraic member of the conserved pool
+    ``PumpFree + PumpBound = PumpTot * pump_area``; it is recovered
+    from ``PumpBound`` by subtraction rather than integrated directly.
+    The second reaction, ``PumpBound -> PumpFree``, has
+    ``backward=None`` and is therefore irreversible: it drains
+    ``PumpBound`` at rate ``k_rel * pump_area`` with no corresponding
+    forward-binding contribution of its own.
+
+    The ``Ci`` source evaluates to zero when ``total_current`` is
+    ``None`` (no channels attached), and otherwise to
+    ``cyt_volume * (kCa / depth) * total_current * 1e4``, with
+    ``total_current`` read in ``mA/cm**2``. This mirrors
+    :class:`ToyCaBindingIcaSourceKinetic_SU2015_DCN`'s source formula,
+    additionally scaled by ``cyt_volume`` because ``Ci`` here lives in
+    a volume factor rather than being unfactored. This class sets
+    ``uses_total_current = True``.
     """
 
     __module__ = "braincell.ion"
@@ -635,9 +1265,11 @@ class ToyCaPumpFactorKinetic_SU2015_DCN(Calcium, KineticIon):
 class ToyDiamFactorKinetic_SU2015_DCN(Calcium, KineticIon):
     r"""Minimal geometry-factor toy with runtime-derived cytosolic strip factors.
 
-    ``Ci`` lives in a thin strip volume derived from the runtime midpoint
-    diameter, while ``PumpFree`` and ``PumpBound`` live on a line-like
-    membrane factor:
+    This is a BrainCell import-path validation fixture, not a model of
+    a published mechanism -- the ``SU2015_DCN`` suffix follows
+    BrainCell's naming convention only. ``Ci`` lives in a thin strip
+    volume derived from the runtime midpoint diameter, while
+    ``PumpFree`` and ``PumpBound`` live on a line-like membrane factor:
 
     .. math::
 
@@ -656,6 +1288,105 @@ class ToyDiamFactorKinetic_SU2015_DCN(Calcium, KineticIon):
     .. math::
 
        PumpFree + PumpBound = PumpTot \cdot pump\_area
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Calcium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation in
+        :attr:`~braincell.ion._base.KineticIon.E`. Defaults to 36
+        degrees Celsius, converted to kelvin via ``u.celsius2kelvin``
+        before being stored.
+    kf : array-like or callable, optional
+        Forward rate constant of the ``Ci + PumpFree -> PumpBound``
+        reaction, applied per unit ``pi * diam_mid``. Defaults to
+        ``2.0 / (mM * ms)``.
+    kb : array-like or callable, optional
+        Backward rate constant of the ``PumpBound -> Ci + PumpFree``
+        reaction, applied per unit ``pi * diam_mid``. Defaults to
+        ``0.5 / ms``.
+    PumpTot : array-like or callable, optional
+        Per-area total pump concentration used by the conserved pool
+        ``PumpFree + PumpBound = PumpTot * pi * diam_mid``. Defaults
+        to ``1.0 mM * um``.
+    depth : array-like or callable, optional
+        Strip depth multiplying ``pi * diam_mid`` to form the
+        ``cyto`` factor that ``Ci`` lives in. Defaults to ``1.0 um``,
+        which differs from every other toy fixture in this module
+        (they default ``depth`` to ``0.2 um``).
+    Co : array-like or callable or None, optional
+        Extracellular calcium concentration. Defaults to ``None``,
+        which falls back to :attr:`Calcium.default_Co` inside
+        :meth:`KineticIon._init_kinetic_ion`.
+    Ci_initializer : array-like or callable, optional
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
+    PumpBound_initializer : array-like or callable, optional
+        Initializer for the ``PumpBound`` species. Defaults to
+        ``0.00 mM * um``.
+    solver : str, optional
+        Integrator name used for the reaction network. Defaults to
+        ``"backward_euler"``, unlike every other toy fixture in this
+        module (they default to ``"rk4"``).
+    substeps : int, optional
+        Number of solver substeps run inside one parent update.
+        Defaults to ``1``, unlike every other toy fixture in this
+        module (they default to ``5``).
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Calcium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``, or if
+        ``substeps`` is less than ``1``. Both come from
+        :meth:`KineticIon._init_kinetic_ion`.
+
+    See Also
+    --------
+    Calcium : Base calcium ion family this class attaches the
+        reaction network to.
+    ToyCaPumpFactorKinetic_SU2015_DCN : Sibling fixture with the same
+        binding/pump topology, but whose ``cyto``/``pump_area``
+        factors are fixed constructor constants instead of
+        geometry-derived quantities.
+    braincell.ion._base.KineticIon : Template this class instantiates;
+        documents the NMODL-style semantics shared by all five toy
+        fixtures, including the ``Factor`` mechanism.
+
+    Notes
+    -----
+    ``diam_mid`` is **not** a constructor parameter of this class. It
+    is a compartment-geometry attribute injected at runtime onto every
+    ion instance from the enclosing compartment's context (see
+    ``braincell.mech._context``, populated from
+    ``braincell._discretization``), documented there as the diameter
+    at the control-volume midpoint. The ``cyto`` and ``pump_area``
+    factors, and the reaction/conservation coefficients above, read
+    ``self.diam_mid`` directly and so are only well-defined once this
+    ion is attached to a compartment that supplies that context.
+
+    This class has no ``sources``: ``Ci`` is driven only by the
+    binding reaction, with no current-driven or constant influx term.
+
+    ``PumpFree`` is the algebraic member of the conserved pool; it is
+    recovered from ``PumpBound`` by subtraction rather than integrated
+    directly.
+
+    The corresponding ``.mod`` fixture's ``pump_area``/``cyto``
+    constants are compiled by NEURON to the fixed decimal
+    ``62.8319``, a rounding of the exact value
+    ``pi * diam_mid * depth`` (``62.83185307179586`` for the
+    fixture's reference geometry) would produce. BrainCell does not
+    substitute that compiled decimal: both factors are recomputed at
+    runtime from ``self.diam_mid``, so results track the live geometry
+    exactly rather than reproducing NEURON's rounded constant. No
+    other toy or ``Cdp*`` mechanism in this module carries this
+    exception.
     """
 
     __module__ = "braincell.ion"

--- a/braincell/ion/calcium.py
+++ b/braincell/ion/calcium.py
@@ -1581,8 +1581,8 @@ class CdpStC_CAMOnly_MA2020_GoC(Calcium, KineticIon):
     References
     ----------
     .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
-           Ca2+-activated K+ channels with models of Ca2+ buffering in
-           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
            doi:10.1007/s12311-010-0224-3
     .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
            Eilers, J. (2003). Mutational analysis of dendritic Ca2+
@@ -2014,8 +2014,8 @@ class CdpStC_NoCAM_MA2020_GoC(Calcium, KineticIon):
     References
     ----------
     .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
-           Ca2+-activated K+ channels with models of Ca2+ buffering in
-           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
            doi:10.1007/s12311-010-0224-3
     .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
            Eilers, J. (2003). Mutational analysis of dendritic Ca2+
@@ -2374,8 +2374,8 @@ class CdpStC_MA2025_BC(CdpStC_NoCAM_MA2020_GoC):
     References
     ----------
     .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
-           Ca2+-activated K+ channels with models of Ca2+ buffering in
-           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
            doi:10.1007/s12311-010-0224-3
     .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
            Eilers, J. (2003). Mutational analysis of dendritic Ca2+
@@ -2388,10 +2388,10 @@ class CdpStC_MA2025_BC(CdpStC_NoCAM_MA2020_GoC):
            Neuron, 24(4), 989-1002.
            doi:10.1016/S0896-6273(00)81045-4
     .. [4] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D.,
-           Munoz, A., Prestori, F., & D'Angelo, E. (2025). Cerebellar
-           basket cell filtering of Purkinje cell responses elicited
-           by low frequency parallel fibre transmission. Scientific
-           Reports, 15(1), 25192.
+           Munoz, A., Prestori, F., & D'Angelo, E. (2025).
+           Cerebellar basket cell filtering of Purkinje cell
+           responses elicited by low frequency parallel fibre
+           transmission. Scientific Reports, 15(1), 25192.
            doi:10.1038/s41598-025-09964-2
     """
 
@@ -2439,8 +2439,8 @@ class CdpStC_RI2021_SC(CdpStC_NoCAM_MA2020_GoC):
     References
     ----------
     .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
-           Ca2+-activated K+ channels with models of Ca2+ buffering in
-           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
            doi:10.1007/s12311-010-0224-3
     .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
            Eilers, J. (2003). Mutational analysis of dendritic Ca2+
@@ -2656,8 +2656,8 @@ class CdpStC_MA2020_GoC(Calcium, KineticIon):
     References
     ----------
     .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
-           Ca2+-activated K+ channels with models of Ca2+ buffering in
-           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
            doi:10.1007/s12311-010-0224-3
     .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
            Eilers, J. (2003). Mutational analysis of dendritic Ca2+
@@ -3301,8 +3301,8 @@ class CdpCAM_MA2024_PC(Calcium, KineticIon):
     References
     ----------
     .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
-           Ca2+-activated K+ channels with models of Ca2+ buffering in
-           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
            doi:10.1007/s12311-010-0224-3
     .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
            Eilers, J. (2003). Mutational analysis of dendritic Ca2+
@@ -3316,8 +3316,8 @@ class CdpCAM_MA2024_PC(Calcium, KineticIon):
            doi:10.1016/S0896-6273(00)81045-4
     .. [4] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
            Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
-           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz, A.,
-           & D'Angelo, E. (2024). Human Purkinje cells outperform
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
            mouse Purkinje cells in dendritic complexity and
            computational capacity. Communications Biology, 7(1), 5.
            doi:10.1038/s42003-023-05689-y
@@ -3952,8 +3952,8 @@ class CdpCR_MA2020_GrC(Calcium, KineticIon):
     References
     ----------
     .. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
-           Ca2+-activated K+ channels with models of Ca2+ buffering in
-           Purkinje cells. The Cerebellum, 11(3), 681-693.
+           Ca2+-activated K+ channels with models of Ca2+ buffering
+           in Purkinje cells. The Cerebellum, 11(3), 681-693.
            doi:10.1007/s12311-010-0224-3
     .. [2] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
            Eilers, J. (2003). Mutational analysis of dendritic Ca2+
@@ -4411,10 +4411,11 @@ class CdpHVA_SU2015_DCN(Calcium, DynamicNernstIon):
     References
     ----------
     .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
-           Schutter, E., & Jaeger, D. (2011). Determinants of synaptic
-           integration and heterogeneity in rebound firing explored
-           with data-driven models of deep cerebellar nucleus cells.
-           Journal of Computational Neuroscience, 30(3), 633-658.
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
            doi:10.1007/s10827-010-0282-z
     .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
            (2015). Cerebellar nuclear neurons use time and rate
@@ -4583,10 +4584,11 @@ class CdpLVA_SU2015_DCN(Calcium, DynamicNernstIon):
     References
     ----------
     .. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De
-           Schutter, E., & Jaeger, D. (2011). Determinants of synaptic
-           integration and heterogeneity in rebound firing explored
-           with data-driven models of deep cerebellar nucleus cells.
-           Journal of Computational Neuroscience, 30(3), 633-658.
+           Schutter, E., & Jaeger, D. (2011). Determinants of
+           synaptic integration and heterogeneity in rebound firing
+           explored with data-driven models of deep cerebellar
+           nucleus cells. Journal of Computational Neuroscience,
+           30(3), 633-658.
            doi:10.1007/s10827-010-0282-z
     .. [2] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E.
            (2015). Cerebellar nuclear neurons use time and rate

--- a/braincell/ion/calcium.py
+++ b/braincell/ion/calcium.py
@@ -1555,7 +1555,13 @@ class CdpStC_CAMOnly_MA2020_GoC(Calcium, KineticIon):
 
     Notes
     -----
-    Ported from ``GoC/ion/CdpStC_CAMOnly_MA20_GoC.mod``.
+    Ported from ``GoC/ion/CdpStC_CAMOnly_MA20_GoC.mod``, part of the
+    cerebellar Golgi cell model of (Masoli et al., 2020) [4]_. That
+    file carries a title only, no credit block; the CaM subnetwork it
+    isolates belongs to the ``CdpStC`` mechanism of Anwar, Hong & De
+    Schutter [1]_, whose extended buffer parameters come from Schmidt
+    et al. (2003) [2]_ and whose pump rate was tuned to data from
+    Maeda et al. (1999) [3]_.
     ``uses_total_current = False`` and ``sources = ()``: this pool has
     no calcium influx or pump of its own, so ``Ci`` is consumed by the
     twelve CaM reactions above and never resupplied. It is meant to be
@@ -1990,7 +1996,12 @@ class CdpStC_NoCAM_MA2020_GoC(Calcium, KineticIon):
     Notes
     -----
     This class has no source ``.mod`` file of its own; see the
-    extended summary. ``uses_total_current = True`` and one
+    extended summary. Its credits are those of the GoC ``CdpStC``
+    mechanism it factors, part of the cerebellar Golgi cell model of
+    (Masoli et al., 2020) [4]_: Anwar, Hong & De Schutter [1]_ as the
+    reference for the mechanism, the extended buffer parameters from
+    Schmidt et al. (2003) [2]_, and the pump rate tuned to data from
+    Maeda et al. (1999) [3]_. ``uses_total_current = True`` and one
     :class:`~braincell.ion._base.Source` drives ``Ci`` from the
     channel current supplied at each step:
     ``_ci_source_flux`` returns zero when no current is supplied, and
@@ -2345,9 +2356,15 @@ class CdpStC_MA2025_BC(CdpStC_NoCAM_MA2020_GoC):
     ----------
     size : brainstate.typing.Size
         Ion state shape. Inherited from :class:`CdpStC_NoCAM_MA2020_GoC`.
-    temp, Nannuli, cainull, mginull, Buffnull1, rf1, rf2, Buffnull2,
-    rf3, rf4, BTCnull, b1, b2, DMNPEnull, c1, c2, PVnull, m1, m2, p1,
-    p2, kpmp1, kpmp2, kpmp3, TotalPump, Co, Ci_initializer,
+    temp, Nannuli, cainull, mginull, Buffnull1, rf1, rf2, Buffnull2
+        Identical in meaning and default to
+        :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
+    rf3, rf4, BTCnull, b1, b2, DMNPEnull, c1, c2, PVnull, m1, m2
+        Identical in meaning and default to
+        :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
+    p1, p2, kpmp1, kpmp2, kpmp3, TotalPump, Co, Ci_initializer
+        Identical in meaning and default to
+        :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
     species_initializers, solver, substeps, name, **channels
         Identical in meaning and default to
         :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
@@ -2361,7 +2378,11 @@ class CdpStC_MA2025_BC(CdpStC_NoCAM_MA2020_GoC):
 
     Notes
     -----
-    Ported from ``BC/ion/CdpStC_MA25_BC.mod``. This class does not
+    Ported from ``BC/ion/CdpStC_MA25_BC.mod``, whose header names
+    Anwar, Hong & De Schutter [1]_ as the reference for the
+    mechanism, credits the extended buffer parameters to Schmidt
+    et al. (2003) [2]_, and records the pump rate as tuned to data
+    from Maeda et al. (1999) [3]_. This class does not
     override ``__init__``: the reaction network, the source and the
     conservation relation are all inherited unchanged from
     :class:`CdpStC_NoCAM_MA2020_GoC`. Only the ``register_ion`` key
@@ -2411,9 +2432,15 @@ class CdpStC_RI2021_SC(CdpStC_NoCAM_MA2020_GoC):
     ----------
     size : brainstate.typing.Size
         Ion state shape. Inherited from :class:`CdpStC_NoCAM_MA2020_GoC`.
-    temp, Nannuli, cainull, mginull, Buffnull1, rf1, rf2, Buffnull2,
-    rf3, rf4, BTCnull, b1, b2, DMNPEnull, c1, c2, PVnull, m1, m2, p1,
-    p2, kpmp1, kpmp2, kpmp3, TotalPump, Co, Ci_initializer,
+    temp, Nannuli, cainull, mginull, Buffnull1, rf1, rf2, Buffnull2
+        Identical in meaning and default to
+        :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
+    rf3, rf4, BTCnull, b1, b2, DMNPEnull, c1, c2, PVnull, m1, m2
+        Identical in meaning and default to
+        :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
+    p1, p2, kpmp1, kpmp2, kpmp3, TotalPump, Co, Ci_initializer
+        Identical in meaning and default to
+        :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
     species_initializers, solver, substeps, name, **channels
         Identical in meaning and default to
         :class:`CdpStC_NoCAM_MA2020_GoC`; not restated here.
@@ -2427,7 +2454,11 @@ class CdpStC_RI2021_SC(CdpStC_NoCAM_MA2020_GoC):
 
     Notes
     -----
-    Ported from ``SC/ion/CdpStC_RI21_SC.mod``. This class does not
+    Ported from ``SC/ion/CdpStC_RI21_SC.mod``, whose header names
+    Anwar, Hong & De Schutter [1]_ as the reference for the
+    mechanism, credits the extended buffer parameters to Schmidt
+    et al. (2003) [2]_, and records the pump rate as tuned to data
+    from Maeda et al. (1999) [3]_. This class does not
     override ``__init__``: the reaction network, the source and the
     conservation relation are all inherited unchanged from
     :class:`CdpStC_NoCAM_MA2020_GoC`. Only the ``register_ion`` key
@@ -2629,7 +2660,12 @@ class CdpStC_MA2020_GoC(Calcium, KineticIon):
 
     Notes
     -----
-    Ported from ``GoC/ion/CdpStC_MA20_GoC.mod``. ``uses_total_current
+    Ported from ``GoC/ion/CdpStC_MA20_GoC.mod``, part of the
+    cerebellar Golgi cell model of (Masoli et al., 2020) [4]_; its
+    header names Anwar, Hong & De Schutter [1]_ as the reference for
+    the mechanism, credits the extended buffer parameters to Schmidt
+    et al. (2003) [2]_, and records the pump rate as tuned to data
+    from Maeda et al. (1999) [3]_. ``uses_total_current
     = True`` and one :class:`~braincell.ion._base.Source` drives
     ``Ci`` from the channel current supplied at each step:
     ``_ci_source_flux`` returns zero when no current is supplied, and
@@ -3276,7 +3312,12 @@ class CdpCAM_MA2024_PC(Calcium, KineticIon):
 
     Notes
     -----
-    Ported from ``PC/ion/CdpCAM_MA24_PC.mod``. ``uses_total_current =
+    Ported from ``PC/ion/CdpCAM_MA24_PC.mod``, part of the human
+    Purkinje cell model of (Masoli et al., 2024) [4]_; its header
+    names Anwar, Hong & De Schutter [1]_ as the reference for the
+    mechanism, credits the extended buffer parameters to Schmidt
+    et al. (2003) [2]_, and records the pump rate as tuned to data
+    from Maeda et al. (1999) [3]_. ``uses_total_current =
     True``; ``sources`` and ``conserves`` are the exact tuple objects
     defined on :class:`CdpStC_MA2020_GoC` (same ``Ci``-driving
     :class:`~braincell.ion._base.Source` and same ``pump + pumpca =
@@ -3922,7 +3963,12 @@ class CdpCR_MA2020_GrC(Calcium, KineticIon):
 
     Notes
     -----
-    Ported from ``GrC/ion/CdpCR_MA20_GrC.mod``. ``uses_total_current
+    Ported from ``GrC/ion/CdpCR_MA20_GrC.mod``, part of the granule
+    cell subtype model of (Masoli et al., 2020) [4]_; its header
+    names Anwar, Hong & De Schutter [1]_ as the reference for the
+    mechanism, credits the extended buffer parameters to Schmidt
+    et al. (2003) [2]_, and records the pump rate as tuned to data
+    from Maeda et al. (1999) [3]_. ``uses_total_current
     = True``; ``sources`` and ``conserves`` are the exact tuple
     objects defined on :class:`CdpStC_MA2020_GoC` (same
     ``Ci``-driving :class:`~braincell.ion._base.Source` and same

--- a/braincell/ion/calcium.py
+++ b/braincell/ion/calcium.py
@@ -284,7 +284,7 @@ class CalciumInitNernst(Calcium, InitNernstIon):
 
 @register_ion("CalciumDetailed")
 class CalciumDetailed(Calcium, DynamicNernstIon):
-    r"""Dynamic calcium concentration model with Nernst-computed reversal potential.
+    r"""Dynamic calcium concentration with a Nernst-computed reversal.
 
     :meth:`derivative` implements only the first-order relaxation
     model of section 2 below. Section 1 reproduces, for background
@@ -341,8 +341,9 @@ class CalciumDetailed(Calcium, DynamicNernstIon):
     with the total concentration of :math:`P` and :math:`K_{d}=c_{2} / c_{1}=10^{-4}\, \mathrm{mM}`
     is the dissociation constant, which can be interpreted here as the value of
     :math:`[Ca]_{i}` at which the pump is half activated (if :math:`[Ca]_{i} \ll K_{d}`
-    then the efflux is negligible). None of this pump exists in :meth:`derivative`
-    below -- no saturating term and no pump parameter appear anywhere in this class.
+    then the efflux is negligible). None of this pump exists in
+    :meth:`derivative` below -- no saturating term and no pump parameter
+    appears anywhere in this class.
 
     **2. The implemented model: a simple first-order relaxation**
 
@@ -1455,7 +1456,7 @@ class ToyDiamFactorKinetic_SU2015_DCN(Calcium, KineticIon):
 
 @register_ion("CdpStC_CAMOnly_MA2020_GoC")
 class CdpStC_CAMOnly_MA2020_GoC(Calcium, KineticIon):
-    r"""Import of the calmodulin-only branch of ``CdpStC_CAMOnly_MA20_GoC.mod``.
+    r"""Import of the calmodulin-only ``CdpStC_CAMOnly_MA20_GoC.mod``.
 
     Isolates the calmodulin (CaM) subnetwork of the imported Golgi-cell
     calcium pool so its binding kinetics can be validated independently
@@ -2390,7 +2391,8 @@ class CdpStC_MA2025_BC(CdpStC_NoCAM_MA2020_GoC):
            Munoz, A., Prestori, F., & D'Angelo, E. (2025). Cerebellar
            basket cell filtering of Purkinje cell responses elicited
            by low frequency parallel fibre transmission. Scientific
-           Reports, 15(1), 25192. doi:10.1038/s41598-025-09964-2
+           Reports, 15(1), 25192.
+           doi:10.1038/s41598-025-09964-2
     """
 
     __module__ = "braincell.ion"
@@ -2454,7 +2456,8 @@ class CdpStC_RI2021_SC(CdpStC_NoCAM_MA2020_GoC):
            Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate
            cell computational modeling predicts signal filtering in
            the molecular layer circuit of cerebellum. Scientific
-           Reports, 11(1), 3873. doi:10.1038/s41598-021-83209-w
+           Reports, 11(1), 3873.
+           doi:10.1038/s41598-021-83209-w
     """
 
     __module__ = "braincell.ion"
@@ -3966,7 +3969,8 @@ class CdpCR_MA2020_GrC(Calcium, KineticIon):
            D'Angelo, E. (2020). Parameter tuning differentiates
            granule cell subtypes enriching transmission properties
            at the cerebellum input stage. Communications Biology,
-           3(1), 222. doi:10.1038/s42003-020-0953-x
+           3(1), 222.
+           doi:10.1038/s42003-020-0953-x
     """
 
     __module__ = "braincell.ion"

--- a/braincell/ion/nonspecific.py
+++ b/braincell/ion/nonspecific.py
@@ -119,6 +119,14 @@ class NonSpecificFixed(NonSpecific, FixedIon):
     **channels
         Optional channels added directly to the placeholder ion.
 
+    Raises
+    ------
+    ValueError
+        If ``E`` is explicitly passed as ``None``.
+        :meth:`FixedIon._init_fixed_ion` requires an explicit fixed
+        reversal potential and does not fall back to a class default
+        for ``E``.
+
     See Also
     --------
     NonSpecific : Base placeholder ion family this class fixes.

--- a/braincell/ion/nonspecific.py
+++ b/braincell/ion/nonspecific.py
@@ -39,12 +39,38 @@ class NonSpecific(Ion):
     ordinary ionic currents while preserving the usual ion/current
     container interfaces.
 
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Ion`.
+    name : str or None, optional
+        Runtime instance name. Defaults to ``None``, in which case the
+        instance is unnamed. Forwarded unchanged to :class:`Ion`.
+    **channels
+        Channel instances to attach to this placeholder ion, forwarded
+        unchanged to :class:`Ion`.
+
+    See Also
+    --------
+    NonSpecificFixed : Fixed-parameter placeholder ion built on this
+        base.
+    braincell.channel.Kv1p5_MA2020_GrC : Shipped channel that declares a
+        nonspecific current owner via ``current_owner_types``.
+
     Notes
     -----
     This class does not represent a real chemical species and does not
     define concentration dynamics. It is intended for mechanisms such as
     NEURON ``USEION no WRITE ino`` declarations, where ``no`` is a
     current owner name rather than a physiologically conserved ion pool.
+
+    ``default_Ci``, ``default_Co``, and ``default_valence`` are arbitrary
+    placeholder values, chosen only so that the ordinary ``Ion``
+    interfaces (concentration lookups, Nernst-derived reversal
+    potentials, etc.) resolve without error. They are not measured or
+    physiological values, and no Nernst potential computed from them is
+    biologically meaningful.
 
     Attributes
     ----------
@@ -77,18 +103,25 @@ class NonSpecificFixed(NonSpecific, FixedIon):
         Fixed reversal potential used only by channels that choose to
         read ``No.E``. Defaults to ``0 mV``.
     Ci : array-like or callable or None, optional
-        Placeholder intracellular concentration. Defaults to
-        :attr:`NonSpecific.default_Ci`.
+        Placeholder intracellular concentration. Defaults to ``None``,
+        which falls back to :attr:`NonSpecific.default_Ci` inside
+        :meth:`FixedIon._init_fixed_ion`.
     Co : array-like or callable or None, optional
-        Placeholder extracellular concentration. Defaults to
-        :attr:`NonSpecific.default_Co`.
+        Placeholder extracellular concentration. Defaults to ``None``,
+        which falls back to :attr:`NonSpecific.default_Co` inside
+        :meth:`FixedIon._init_fixed_ion`.
     valence : array-like or callable or None, optional
-        Placeholder valence. Defaults to
-        :attr:`NonSpecific.default_valence`.
+        Placeholder valence. Defaults to ``None``, which falls back to
+        :attr:`NonSpecific.default_valence` inside
+        :meth:`FixedIon._init_fixed_ion`.
     name : str or None, optional
         Runtime ion instance name.
     **channels
         Optional channels added directly to the placeholder ion.
+
+    See Also
+    --------
+    NonSpecific : Base placeholder ion family this class fixes.
 
     Notes
     -----

--- a/braincell/ion/potassium.py
+++ b/braincell/ion/potassium.py
@@ -161,7 +161,7 @@ class PotassiumFixed(Potassium, FixedIon):
 
 @register_ion("PotassiumInitNernst")
 class PotassiumInitNernst(Potassium, InitNernstIon):
-    r"""Fixed ``Ci``/``Co`` potassium model with ``E`` initialized from Nernst.
+    r"""Fixed ``Ci``/``Co`` potassium model with Nernst-initialized ``E``.
 
     Parameters
     ----------
@@ -200,7 +200,8 @@ class PotassiumInitNernst(Potassium, InitNernstIon):
 
     See Also
     --------
-    Potassium : Base potassium ion family this class fixes.
+    Potassium : Base potassium ion family this class computes a
+        reversal potential for.
     PotassiumFixed : Sibling potassium model with a fixed reversal
         potential instead of a Nernst-computed one.
 

--- a/braincell/ion/potassium.py
+++ b/braincell/ion/potassium.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 
 
+"""Potassium ion species, plus fixed and Nernst-derived reversal models."""
+
 from typing import Union, Callable, Optional
 
 import brainstate
@@ -32,16 +34,48 @@ __all__ = [
 
 
 class Potassium(Ion):
-    """
-    Base class for modeling Potassium ion.
+    """Base class for modeling the potassium ion species.
 
-    This class serves as a foundation for implementing various Potassium ion models
-    in neuronal simulations. It inherits from the Ion base class and provides a
-    structure for defining Potassium-specific properties and behaviors.
+    ``Potassium`` collects the physiological defaults shared by every
+    concrete potassium ion model in BrainCell and provides the
+    ``Ion``/``IonChannel`` container interface potassium channels attach
+    to. It carries no dynamics of its own.
 
-    Note:
-        This is an abstract base class and should be subclassed to create specific
-        Potassium ion models with defined dynamics and properties.
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Ion`.
+    name : str or None, optional
+        Runtime instance name. Defaults to ``None``, in which case the
+        instance is unnamed. Forwarded unchanged to :class:`Ion`.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Ion`.
+
+    See Also
+    --------
+    PotassiumFixed : Fixed-parameter potassium ion built on this base.
+    PotassiumInitNernst : Potassium ion with ``E`` initialized from the
+        Nernst equation.
+
+    Notes
+    -----
+    This is an abstract base class and must be subclassed (for example
+    by :class:`PotassiumFixed` or :class:`PotassiumInitNernst`) to
+    obtain a concrete potassium ion model with defined reversal-
+    potential dynamics.
+
+    Attributes
+    ----------
+    ion_symbol : str
+        Symbol used for runtime family lookup. Set to ``'K'``.
+    default_Ci : brainunit.Quantity
+        Default intracellular potassium concentration, ``54.4 mM``.
+    default_Co : brainunit.Quantity
+        Default extracellular potassium concentration, ``2.5 mM``.
+    default_valence : int
+        Default ionic valence, ``1``.
     """
 
     __module__ = 'braincell.ion'
@@ -53,10 +87,60 @@ class Potassium(Ion):
 
 @register_ion("PotassiumFixed")
 class PotassiumFixed(Potassium, FixedIon):
-    """Fixed Sodium dynamics.
+    r"""Fixed potassium dynamics.
 
-    This calcium model has no dynamics. It holds fixed reversal
-    potential :math:`E` and concentration :math:`C`.
+    This potassium model has no dynamics. It holds a fixed reversal
+    potential :math:`E` and fixed concentrations :math:`C_i`/:math:`C_o`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Potassium`.
+    E : array-like or callable or None, optional
+        Fixed reversal potential. Defaults to ``-95 mV``. Passing
+        ``None`` explicitly raises :class:`ValueError`; there is no
+        class-default fallback for this argument.
+    Ci : array-like or callable or None, optional
+        Intracellular potassium concentration. Defaults to ``None``,
+        which falls back to :attr:`Potassium.default_Ci` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    Co : array-like or callable or None, optional
+        Extracellular potassium concentration. Defaults to ``None``,
+        which falls back to :attr:`Potassium.default_Co` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    valence : array-like or callable or None, optional
+        Ionic valence. Defaults to ``None``, which falls back to
+        :attr:`Potassium.default_valence` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Potassium`.
+
+    Raises
+    ------
+    ValueError
+        If ``E`` is explicitly passed as ``None``.
+        :meth:`FixedIon._init_fixed_ion` requires an explicit fixed
+        reversal potential and does not fall back to a class default
+        for ``E``.
+
+    See Also
+    --------
+    Potassium : Base potassium ion family this class fixes.
+    PotassiumInitNernst : Sibling potassium model whose ``E`` is
+        computed from the Nernst equation instead of fixed.
+
+    Notes
+    -----
+    With the shipped class defaults (``Co = 2.5 mM``, ``Ci = 54.4 mM``,
+    ``valence = 1``) at 36 degrees Celsius, the Nernst equation gives
+    ``E = -82.05 mV``. ``PotassiumFixed`` instead defaults ``E`` to
+    ``-95 mV``, so the two sibling classes disagree by about 13 mV when
+    both are constructed with no arguments.
     """
 
     __module__ = 'braincell.ion'
@@ -77,7 +161,73 @@ class PotassiumFixed(Potassium, FixedIon):
 
 @register_ion("PotassiumInitNernst")
 class PotassiumInitNernst(Potassium, InitNernstIon):
-    """Fixed ``Ci/Co`` potassium model with ``E`` initialized from Nernst."""
+    r"""Fixed ``Ci``/``Co`` potassium model with ``E`` initialized from Nernst.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to
+        :class:`Potassium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation. Defaults to
+        36 degrees Celsius, converted to kelvin via
+        ``u.celsius2kelvin`` before being stored.
+    Ci : array-like or callable or None, optional
+        Intracellular potassium concentration. Defaults to ``None``,
+        which falls back to :attr:`Potassium.default_Ci` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    Co : array-like or callable or None, optional
+        Extracellular potassium concentration. Defaults to ``None``,
+        which falls back to :attr:`Potassium.default_Co` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    valence : array-like or callable or None, optional
+        Ionic valence. Defaults to ``None``, which falls back to
+        :attr:`Potassium.default_valence` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Potassium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``.
+        :meth:`InitNernstIon._init_nernst_ion` requires an explicit
+        temperature and does not fall back to a class default.
+
+    See Also
+    --------
+    Potassium : Base potassium ion family this class fixes.
+    PotassiumFixed : Sibling potassium model with a fixed reversal
+        potential instead of a Nernst-computed one.
+
+    Notes
+    -----
+    ``E`` is not computed at construction time. ``_init_nernst_ion``
+    sets ``self.E = None`` immediately, and the actual reversal
+    potential is filled in only later by
+    ``InitNernstIon._update_reversal``, which fires from the
+    ``_ion_init_state_hook`` and ``_ion_reset_state_hook`` lifecycle
+    hooks. Between construction and the first state initialization or
+    reset, ``E`` is ``None``.
+
+    The stored formula, transcribed as ``_update_reversal`` writes it,
+    is
+
+    .. math::
+
+        E = \frac{R \cdot \mathrm{temp}}{\mathrm{valence} \cdot F}
+            \log\!\left(\frac{C_o}{C_i}\right)
+
+    where :math:`R` is the gas constant and :math:`F` is the Faraday
+    constant. The argument to the logarithm is :math:`C_o / C_i`
+    (extracellular over intracellular), and ``valence`` divides inside
+    the prefactor rather than appearing as a separate multiplicative
+    term.
+    """
 
     __module__ = 'braincell.ion'
 

--- a/braincell/ion/sodium.py
+++ b/braincell/ion/sodium.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
+
+"""Sodium ion species, plus fixed and Nernst-derived reversal models."""
+
 from typing import Union, Callable, Optional
 
 import brainstate
@@ -31,16 +34,47 @@ __all__ = [
 
 
 class Sodium(Ion):
-    """
-    Base class for modeling Sodium ion.
+    """Base class for modeling the sodium ion species.
 
-    This class serves as a foundation for creating specific sodium ion models
-    in neuronal simulations. It inherits from the Ion base class and provides
-    a starting point for implementing various sodium dynamics.
+    ``Sodium`` collects the physiological defaults shared by every
+    concrete sodium ion model in BrainCell and provides the
+    ``Ion``/``IonChannel`` container interface sodium channels attach
+    to. It carries no dynamics of its own.
 
-    Note:
-        This is an abstract base class and should be subclassed to implement
-        specific sodium ion models with defined dynamics and properties.
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Ion`.
+    name : str or None, optional
+        Runtime instance name. Defaults to ``None``, in which case the
+        instance is unnamed. Forwarded unchanged to :class:`Ion`.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Ion`.
+
+    See Also
+    --------
+    SodiumFixed : Fixed-parameter sodium ion built on this base.
+    SodiumInitNernst : Sodium ion with ``E`` initialized from the
+        Nernst equation.
+
+    Notes
+    -----
+    This is an abstract base class and must be subclassed (for example
+    by :class:`SodiumFixed` or :class:`SodiumInitNernst`) to obtain a
+    concrete sodium ion model with defined reversal-potential dynamics.
+
+    Attributes
+    ----------
+    ion_symbol : str
+        Symbol used for runtime family lookup. Set to ``'Na'``.
+    default_Ci : brainunit.Quantity
+        Default intracellular sodium concentration, ``10.0 mM``.
+    default_Co : brainunit.Quantity
+        Default extracellular sodium concentration, ``140.0 mM``.
+    default_valence : int
+        Default ionic valence, ``1``.
     """
 
     __module__ = 'braincell.ion'
@@ -52,11 +86,59 @@ class Sodium(Ion):
 
 @register_ion("SodiumFixed")
 class SodiumFixed(Sodium, FixedIon):
-    """
-    Fixed Sodium dynamics.
+    r"""Fixed Sodium dynamics.
 
-    This calcium model has no dynamics. It holds fixed reversal
-    potential :math:`E` and concentration :math:`C`.
+    This sodium model has no dynamics. It holds a fixed reversal
+    potential :math:`E` and fixed concentrations :math:`C_i`/:math:`C_o`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Sodium`.
+    E : array-like or callable or None, optional
+        Fixed reversal potential. Defaults to ``+50 mV``. Passing
+        ``None`` explicitly raises :class:`ValueError`; there is no
+        class-default fallback for this argument.
+    Ci : array-like or callable or None, optional
+        Intracellular sodium concentration. Defaults to ``None``,
+        which falls back to :attr:`Sodium.default_Ci` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    Co : array-like or callable or None, optional
+        Extracellular sodium concentration. Defaults to ``None``,
+        which falls back to :attr:`Sodium.default_Co` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    valence : array-like or callable or None, optional
+        Ionic valence. Defaults to ``None``, which falls back to
+        :attr:`Sodium.default_valence` inside
+        :meth:`FixedIon._init_fixed_ion`.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Sodium`.
+
+    Raises
+    ------
+    ValueError
+        If ``E`` is explicitly passed as ``None``.
+        :meth:`FixedIon._init_fixed_ion` requires an explicit fixed
+        reversal potential and does not fall back to a class default
+        for ``E``.
+
+    See Also
+    --------
+    Sodium : Base sodium ion family this class fixes.
+    SodiumInitNernst : Sibling sodium model whose ``E`` is computed
+        from the Nernst equation instead of fixed.
+
+    Notes
+    -----
+    With the shipped class defaults (``Co = 140.0 mM``, ``Ci = 10.0
+    mM``, ``valence = 1``) at 36 degrees Celsius, the Nernst equation
+    gives ``E = +70.31 mV``. ``SodiumFixed`` instead defaults ``E`` to
+    ``+50 mV``, so the two sibling classes disagree by about 20 mV
+    when both are constructed with no arguments.
     """
 
     __module__ = 'braincell.ion'
@@ -77,7 +159,73 @@ class SodiumFixed(Sodium, FixedIon):
 
 @register_ion("SodiumInitNernst")
 class SodiumInitNernst(Sodium, InitNernstIon):
-    """Fixed ``Ci/Co`` sodium model with ``E`` initialized from Nernst."""
+    r"""Fixed ``Ci``/``Co`` sodium model with ``E`` initialized from Nernst.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        The size of the simulation target, typically the number of
+        neurons or compartments. Forwarded unchanged to :class:`Sodium`.
+    temp : array-like or callable, optional
+        Absolute temperature used by the Nernst equation. Defaults to
+        36 degrees Celsius, converted to kelvin via
+        ``u.celsius2kelvin`` before being stored.
+    Ci : array-like or callable or None, optional
+        Intracellular sodium concentration. Defaults to ``None``,
+        which falls back to :attr:`Sodium.default_Ci` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    Co : array-like or callable or None, optional
+        Extracellular sodium concentration. Defaults to ``None``,
+        which falls back to :attr:`Sodium.default_Co` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    valence : array-like or callable or None, optional
+        Ionic valence. Defaults to ``None``, which falls back to
+        :attr:`Sodium.default_valence` inside
+        :meth:`InitNernstIon._init_nernst_ion`.
+    name : str or None, optional
+        Runtime ion instance name. Defaults to ``None``.
+    **channels
+        Channel instances to attach to this ion, forwarded unchanged to
+        :class:`Sodium`.
+
+    Raises
+    ------
+    ValueError
+        If ``temp`` is explicitly passed as ``None``.
+        :meth:`InitNernstIon._init_nernst_ion` requires an explicit
+        temperature and does not fall back to a class default.
+
+    See Also
+    --------
+    Sodium : Base sodium ion family this class computes a reversal
+        potential for.
+    SodiumFixed : Sibling sodium model with a fixed reversal
+        potential instead of a Nernst-computed one.
+
+    Notes
+    -----
+    ``E`` is not computed at construction time. ``_init_nernst_ion``
+    sets ``self.E = None`` immediately, and the actual reversal
+    potential is filled in only later by
+    ``InitNernstIon._update_reversal``, which fires from the
+    ``_ion_init_state_hook`` and ``_ion_reset_state_hook`` lifecycle
+    hooks. Between construction and the first state initialization or
+    reset, ``E`` is ``None``.
+
+    The stored formula, transcribed as ``_update_reversal`` writes it,
+    is
+
+    .. math::
+
+        E = \frac{R \cdot \mathrm{temp}}{\mathrm{valence} \cdot F}
+            \log\!\left(\frac{C_o}{C_i}\right)
+
+    where :math:`R` is the gas constant and :math:`F` is the Faraday
+    constant. The argument to the logarithm is :math:`C_o / C_i`
+    (extracellular over intracellular), and ``valence`` divides inside
+    the prefactor rather than appearing as a separate multiplicative
+    term.
+    """
 
     __module__ = 'braincell.ion'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -157,7 +157,16 @@ napoleon_use_ivar = True
 
 import re as _re
 
-_FIELD_LINE = _re.compile(r'^:[^:]+:')
+# A field-list line such as ``:param foo: text`` or ``:rtype: int``.
+# The negative lookahead excludes interpreted-text *roles* -- a wrapped
+# prose or math line may legitimately begin with ``:class:`X``` or
+# ``:math:`y```, and treating one as a field line injects a blank line
+# into the middle of a paragraph. That tears the paragraph in two and,
+# when the split falls inside an inline literal or an inline role that
+# spans the line break, makes docutils emit "Inline literal/interpreted
+# text start-string without end-string". A role is always followed
+# immediately by a backtick; a real field line never is.
+_FIELD_LINE = _re.compile(r'^:[^:]+:(?!`)')
 
 
 def _restore_field_list_blank_line(app, what, name, obj, options, lines):

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -3361,11 +3361,28 @@ somatic Na parameterisation, matching `Na_ZH19_IO.mod` term for term.
 BrainCell and so is absent from the class, as expected.
 
 **Caveat for the module task -- a real numerical deviation, not a
-citation issue.** `Na_ZH19_IO.mod` and `Kdr_ZH19_IO.mod` guard the
-removable singularities in `alpha_m` and `beta_h` with explicit
-`if (fabs(v + 41.0) < 1e-6)` / `if (fabs(v + 50.0) < 1e-6)` branches
-that substitute the perturbed literals `41.000001` and `50.000001`.
-BrainCell replaces both with a numerically stable
+citation issue.** `Na_ZH19_IO.mod` and `Kdr_ZH19_IO.mod` each guard a
+removable singularity with an explicit
+`if (fabs(v + X) < 1e-6) { ... } else { ... }` branch whose taken side
+substitutes a perturbed offset literal. **The three guards are not
+identical**, and an earlier revision of this paragraph merged them --
+corrected here after Task 17a's review, from the sources line by line:
+
+| File | Function | Guard | Perturbed literal | Line |
+|---|---|---|---|---|
+| `Na_ZH19_IO.mod` | `a_m` | `fabs(v+41.0) < 1e-6` | `41.000001` | 64 |
+| `Na_ZH19_IO.mod` | `b_h` | `fabs(v+50.0) < 1e-6` | `50.000001` | 73 |
+| `Kdr_ZH19_IO.mod` | `a_n` | `fabs(v+41.0) < 1e-6` | `41.00001` | 59 |
+
+Two things to carry into a docstring. First, `Kdr`'s guarded function
+is `a_n`, not `alpha_m` or `beta_h`, and its perturbation is `41.00001`
+-- one fewer zero than `Na`'s `41.000001`. A docstring must use its own
+mechanism's literal. Second, `Kdr`'s perturbation (1e-5) is ten times
+*larger* than the guard window (1e-6) that selects it, so on the taken
+branch the substituted offset always lands outside the interval the
+branch was testing for; `Na`'s two guards are matched to their windows.
+
+BrainCell replaces all three with a numerically stable
 `x/(1 - exp(-x))` helper (`_x_over_one_minus_exp_neg_stable` in
 `braincell/channel/sodium.py`), so the perturbed literals do not
 appear in the class. The README explicitly excludes those literals

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -75,9 +75,11 @@ Entries are written in the reST form that goes straight into a NumPy-doc
 - Title: sentence case, ending in a period. Most of the journals cited
   here (The Journal of Neuroscience, Journal of Neurophysiology) print
   their titles in title case, so down-casing is the normal operation,
-  not an exception -- all eight Task 2 entries do it. Preserve proper
-  nouns, species names, ion and chemical symbols (Ca2+, K+, GABAergic)
-  and capitalised acronyms as published. What must never change is the
+  not an exception -- five of the eight Task 2 entries required it;
+  ``HH1952``, ``Re1993`` and ``De1994`` arrived from Crossref already
+  in sentence case and needed none. Preserve proper nouns, species
+  names, ion and chemical symbols (Ca2+, K+, GABAergic) and
+  capitalised acronyms as published. What must never change is the
   *wording*: do not silently correct a publisher's singular/plural,
   spelling or hyphenation oddity -- reproduce it verbatim and record
   the discrepancy in the surrounding prose.
@@ -163,11 +165,11 @@ draws on it.
 
 ### Verified record
 
-_TODO (Task 2 / Task 3): not yet verified._
+_TODO (Task 3): not yet verified._
 
 ### Attribution
 
-_TODO (Task 2 / Task 3): not yet filled in._
+_TODO (Task 3): not yet filled in._
 
 ---
 
@@ -1116,8 +1118,7 @@ presented the two mod files as interchangeable. They are not:
 
 - Its header reads "Model based **on the data of** Huguenard &
   McCormick, J Neurophysiol 68: 1373-1383, 1992 **and Huguenard &
-  Prince, J Neurosci. 12: 3804-3817, 1992**" -- not "Model of", and
-  it draws on two papers, not one.
+  Prince, J Neurosci. 12: 3804-3817, 1992**" -- not "Model of".
 - It shares only ``m_inf`` and ``h_inf`` with ``ITGHK.mod``.
 - It has **no ``tau_m`` at all**. Activation is taken at steady state
   ("activation considered at steady-state"); ``tau_m`` appears in the
@@ -1311,7 +1312,11 @@ Two independent confirmations:
 Algebraically, ``KDR_Ba2002`` and ``Na_Ba2002`` are the same
 Traub-Miles rate functions as ``K_TM1991`` / ``Na_TM1991`` (see the
 ``TM1991`` attribution block) written in the mirrored sign convention,
-with ``V_sh = -50 mV`` instead of -63 mV and ``q10 = 3`` instead of 1.
+both shipping ``V_sh = -50 mV`` and ``q10 = 3`` instead of 1. The -50
+mV value replaces -63 mV for the sodium pair only (``Na_Ba2002`` vs.
+``Na_TM1991``); the potassium pair's own ``TM1991`` counterpart,
+``K_TM1991``, ships -60 mV, not -63 mV -- see the ``TM1991``
+attribution block below for the verified values.
 
 **Caveat for the module task:** the paper does *not* print the rate
 equations. It defers them: "The expressions for voltage- and
@@ -1381,15 +1386,29 @@ BrainCell, all six rate functions match term for term:
 An earlier revision of this block said the mod file and BrainCell share
 a -63 mV default. They do not. ``HH2.mod``'s own ``PARAMETER`` block
 ships ``vtraub = -55 (mV)`` (re-read from the ModelDB 3670 GitHub
-mirror, 2026-08-15). BrainCell's ``V_sh = -63 mV``
-(``braincell/channel/sodium.py:121``, and the matching default in
-``potassium.py``) is nevertheless the correct value to ship: -63 mV is
-what Destexhe's network ``.hoc`` code assigns to ``vtraub`` when it
+mirror, 2026-08-15).
+
+**MODULE-TASK WARNING -- BrainCell's two ``TM1991`` classes do not
+even agree with each other.** There is no "matching default in
+potassium.py"; an earlier revision of this block wrongly claimed one.
+Verified 2026-08-15 by reading both constructors directly:
+``Na_TM1991`` ships ``V_sh = -63 mV``
+(``braincell/channel/sodium.py:121``); ``K_TM1991`` ships
+``V_sh = -60 mV`` (``braincell/channel/potassium.py:143``), not
+-63 mV. Both classes derive from the same ``HH2.mod`` mechanism (see
+"Attribution check" above), so this 3 mV divergence is a BrainCell
+choice, not something inherited from the source. **Any docstring
+sentence about "the Traub & Miles -63 mV shift" is wrong for
+``K_TM1991``** -- write ``K_TM1991``'s default as -60 mV, and
+``Na_TM1991``'s as -63 mV.
+
+-63 mV is nevertheless the correct value to ship for ``Na_TM1991``: it
+is what Destexhe's network ``.hoc`` code assigns to ``vtraub`` when it
 uses this mechanism, and it is the offset associated with the
 Traub-Miles hippocampal pyramidal cell. Only the mod file's *own*
-default differs; the six rate equations above are confirmed to match
-term for term either way, since the shift enters only through
-``v2``/``V'``.
+default (-55 mV) differs from BrainCell's sodium value; the six rate
+equations above are confirmed to match term for term either way, since
+the shift enters only through ``v2``/``V'``.
 
 Gating m^3 h and n^4 also match. The mod file's ``tadj = 3^((celsius -
 36)/10)`` corresponds to BrainCell's ``q10 = 1.0`` at ``temp_ref = 36

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -51,14 +51,32 @@ name alone; read the harvested header text.
   carry a published `.. [N]` entry; `IS2008` is recorded as NOT FILLED
   because its attribution did not close (see `## Unresolved
   attributions` item 6), and one symbol of the otherwise-verified
-  `HM1992` key is carved out the same way (item 7). Every remaining
-  key still shows `_TODO (Task 3)` and is owned by Task 3
-  (cerebellar-model keys).
+  `HM1992` key is carved out the same way (item 7).
+- Task 3 (2026-08-15) completed the seven cerebellar-model keys --
+  `MA2020`, `MA2024`, `MA2025`, `RI2021`, `SU2015`, `ZH2019` and
+  `PC24`, covering **104** public symbols (not 103; see the note in
+  `## Unresolved attributions` item 11). All seven model papers
+  verified. Because the key names a *porter*, not an author, Task 3
+  also verified 38 **origin-of-kinetics** papers, collected in
+  `## Origin-of-kinetics records` below. **99 of the 104 symbols need
+  a two-level citation**; the other 5 (the `SU2015` `Toy*` family) get
+  no citation at all because they are BrainCell's own test fixtures.
+  `NO_KEY` remains open.
 - Nothing in this file's `### Provenance evidence` blocks is a citation.
   It is raw, unedited text copied from `.mod` file headers (typos,
   inconsistent spacing, and missing apostrophes preserved verbatim) plus
   structural notes about what was and was not found. Do not treat any of
-  it as verified.
+  it as verified. **Task 1's harvest read only the first 25 lines of
+  each `.mod` file and therefore missed real provenance text in five
+  places** -- see `## Unresolved attributions` item 8. The raw blocks
+  are left exactly as harvested; the corrections live in the
+  `### Verified record` blocks.
+- Task 3 added one structural block per key, `### Import deviations`,
+  carrying the NEURON-to-BrainCell port deviations transcribed from
+  `examples/neuron_compare/Cerebellum_mod/README.md`. This is not a
+  second citation format -- it holds no citations. It exists so a
+  module task can write a docstring `Notes` section without
+  re-reading that file.
 
 ## Citation house style
 
@@ -110,6 +128,657 @@ Entries are written in the reST form that goes straight into a NumPy-doc
   `### Verified record` block says NOT FILLED and points at the
   numbered item in `## Unresolved attributions` that carries the
   evidence.
+
+## How to assemble a two-level citation
+
+Established by Task 3 for the cerebellar half of this file. **This is
+not a second citation format** -- the `.. [N]` entries below are
+written in exactly the house style above. What is new is only *which
+two* entries a docstring needs.
+
+A cerebellar key names the group that assembled the multi-compartment
+cell model BrainCell imported the mechanism from. It almost never names
+whoever wrote the mechanism's equations. So a cerebellar docstring's
+`References` section normally takes two entries, in this order:
+
+- `.. [1]` -- the **origin of the kinetics**: the paper the mechanism's
+  equations actually come from. Copy it verbatim from
+  `## Origin-of-kinetics records` below, using the label given in the
+  key's `### Attribution` mapping table.
+- `.. [2]` -- the **model BrainCell imported from**: the key's own
+  paper. Copy it verbatim from that key's `### Verified record`.
+
+Renumber only the bracket digits when a docstring needs a different
+order; never retype the entry text. Where origin and model genuinely
+coincide, one entry is correct -- but across all 104 cerebellar
+symbols this never happens, so treat a single-entry cerebellar
+`References` block as a bug unless the mapping table says otherwise.
+
+**One deliberate exception to the 79-column rule.** The per-key
+mapping tables and `### Import deviations` tables are Markdown table
+rows, which cannot be wrapped without breaking the table, and some
+exceed 79 columns. The rule continues to bind without exception for
+every `.. [N]` entry and its 7-space continuation lines, which is
+where it matters -- those are the strings that get copied into
+docstrings. No table row is ever copied into a docstring.
+
+---
+
+## Origin-of-kinetics records
+
+Thirty-eight papers, each the source of the equations in one or more
+cerebellar mechanisms. Each carries a stable label (`O-XXNNNN`) used by
+the per-key `### Attribution` mapping tables. **Labels are internal to
+this file and must never appear in a docstring** -- copy the `.. [N]`
+entry text, not the label.
+
+All thirty-eight were confirmed 2026-08-15 against at least two
+independent sources: NCBI E-utilities (`efetch`, `db=pubmed`), the
+Crossref REST API (`api.crossref.org/works/<doi>`), publisher-deposited
+JATS XML via `efetch db=pmc`, live DOI resolution, and -- where the
+mechanism file itself had to be inspected -- the ModelDB REST API and
+the `github.com/ModelDBRepository` mirrors. Per-record deviations from
+that baseline are noted inline.
+
+### O-DA2001 -- cerebellar granule cell model (Pavia)
+
+Source of the `CaHVA`, `Kv4p3`, `KM` and `Kir2p3` mechanisms.
+
+.. [1] D'Angelo, E., Nieus, T., Maffei, A., Armano, S., Rossi, P.,
+       Taglietti, V., Fontana, A., & Naldi, G. (2001). Theta-frequency
+       bursting and resonance in cerebellar granule cells: experimental
+       evidence and modeling of a slow K+-dependent mechanism. The
+       Journal of Neuroscience, 21(3), 759-770.
+       doi:10.1523/JNEUROSCI.21-03-00759.2001
+
+PMID 11157062, PMCID PMC6762330. **Two corrections to the `.mod`
+headers.** The credit "E.D'Angelo, T.Nieus, A. Fontana" names authors
+1, 2 and 7 of an eight-author paper; Maffei, Armano, Rossi, Taglietti
+and Naldi are omitted. The `Kir2p3` header's reference string
+"Theta-Frequency Bursting and Resonance in Cerebellar Granule
+Cells:Experimental" is the published title truncated mid-subtitle.
+PubMed renders "k+" lowercase; Crossref and the publisher's own PMC
+deposit both give capital "K+", which is used above.
+
+### O-SO2007a -- cerebellar Golgi cell model, part I
+
+.. [1] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De Schutter,
+       E., & D'Angelo, E. (2007). Computational reconstruction of
+       pacemaking and intrinsic electroresponsiveness in cerebellar
+       Golgi cells. Frontiers in Cellular Neuroscience, 1, 2.
+       doi:10.3389/neuro.03.002.2007
+
+PMID 18946520, PMCID PMC2525930. Article number 2; no issue number and
+**no page range** -- the article number goes in the page slot.
+**Discrepancy with the `.mod` header, resolved.** `Kca2p2_*.mod` cites
+this paper as "(2008) ... Frontiers in Cellular Neuroscience 2:2".
+Both fields are wrong: the year of record is 2007 and the volume is 1,
+confirmed by PubMed, the PMC JATS deposit and the live publisher page.
+The publisher's site also advertises a legacy slash-form DOI
+(`10.3389/neuro.03/002.2007`) and a spurious `citation_firstpage` of
+91; neither is canonical. Use the dot-form DOI and the article number.
+
+### O-SO2007b -- cerebellar Golgi cell model, part II
+
+.. [1] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De Schutter,
+       E., & D'Angelo, E. (2007). Fast-reset of pacemaking and
+       theta-frequency resonance patterns in cerebellar Golgi cells:
+       Simulations of their impact in vivo. Frontiers in Cellular
+       Neuroscience, 1, 4.
+       doi:10.3389/neuro.03.004.2007
+
+PMID 18946522, PMCID PMC2525929. Article number 4; same no-page-range
+and legacy-DOI caveats as O-SO2007a (its spurious `citation_firstpage`
+is 166). The post-colon "Simulations" is capitalised in the publisher
+deposit and is reproduced as published.
+
+### O-FO2006 -- Golgi cell autorhythmicity, experimental
+
+.. [1] Forti, L., Cesana, E., Mapelli, J., & D'Angelo, E. (2006).
+       Ionic mechanisms of autorhythmic firing in rat cerebellar Golgi
+       cells. The Journal of Physiology, 574(3), 711-729.
+       doi:10.1113/jphysiol.2006.110858
+
+PMID 16690702, PMCID PMC1817727. **Both machine-readable deposits are
+corrupt for this record**: Crossref and the PMC JATS both merge the
+first two authors into one contributor (`given: "Lia Forti", family:
+"Elisabetta Cesana"`), yielding three authors. PubMed is authoritative
+and gives the four above, in that order. PubMed prints the issue as
+"Pt 3"; Crossref as "3", which is used.
+
+### O-SA2000 -- HCN subunit data
+
+Cited by `HCN1_MA20_GoC.mod` / `HCN2_MA20_GoC.mod` as "Data from".
+
+.. [1] Santoro, B., Chen, S., Luthi, A., Pavlidis, P., Shumyatsky,
+       G. P., Tibbs, G. R., & Siegelbaum, S. A. (2000). Molecular and
+       functional heterogeneity of hyperpolarization-activated
+       pacemaker channels in the mouse CNS. The Journal of
+       Neuroscience, 20(14), 5264-5275.
+       doi:10.1523/JNEUROSCI.20-14-05264.2000
+
+PMID 10884310, PMCID PMC6772310. The third author is published as
+**Lüthi**; the ASCII form is used above because the rest of this file
+is ASCII. If the docstring pipeline is UTF-8-safe, write "Lüthi, A.".
+
+### O-HI1998 -- SK2 gating data
+
+.. [1] Hirschberg, B., Maylie, J., Adelman, J. P., & Marrion, N. V.
+       (1998). Gating of recombinant small-conductance Ca-activated K+
+       channels by calcium. The Journal of General Physiology, 111(4),
+       565-581.
+       doi:10.1085/jgp.111.4.565
+
+PMID 9524139, PMCID PMC2217120. **Verbatim-wording flag:** the title
+reads "**Ca**-activated", not "Ca2+-activated", even though the "K+"
+in the same title is superscripted. That is a publisher inconsistency
+in the original, identical in Crossref and the JGP PMC deposit, and it
+is reproduced rather than corrected. Do not confuse this with the same
+authors' 1999 Biophysical Journal 77(4), 1905-1913 SK paper.
+
+### O-MG2006 -- granule cell sodium currents
+
+.. [1] Magistretti, J., Castelli, L., Forti, L., & D'Angelo, E.
+       (2006). Kinetic and functional analysis of transient, persistent
+       and resurgent sodium currents in rat cerebellar granule cells in
+       situ: an electrophysiological and modelling study. The Journal
+       of Physiology, 573(1), 83-106.
+       doi:10.1113/jphysiol.2006.106682
+
+PMID 16527854, PMCID PMC1779707. Keep the British "modelling" and the
+Latin "in situ" verbatim.
+
+### O-RB2001 -- the 13-state Purkinje Na scheme
+
+.. [1] Raman, I. M., & Bean, B. P. (2001). Inactivation and recovery
+       of sodium currents in cerebellar Purkinje neurons: evidence for
+       two mechanisms. Biophysical Journal, 80(2), 729-737.
+       doi:10.1016/S0006-3495(01)76052-3
+
+PMID 11159440, PMCID PMC1301271. The `.mod` headers' "Based om" is a
+typo for "Based on", and their bare "80 (2001) 729" omits the closing
+page 737 and the issue. Full given names come from Crossref only;
+PubMed and PMC carry initials for this record.
+
+### O-AN2012 -- OIST Purkinje Ca-buffering model
+
+The "Current Model Reference" of the `Cav3p1`, `Cav2p1`, `Kca1p1` and
+`Cdp*` mechanisms. ModelDB accession 138382.
+
+.. [1] Anwar, H., Hong, S., & De Schutter, E. (2012). Controlling
+       Ca2+-activated K+ channels with models of Ca2+ buffering in
+       Purkinje cells. The Cerebellum, 11(3), 681-693.
+       doi:10.1007/s12311-010-0224-3
+
+PMID 20981513, PMCID PMC3411306. **Two corrections to the `.mod`
+headers.** (1) The published title ends "Purkinje **cells**" (plural);
+every header in this repository has the singular. (2) The headers date
+it 2010; that is the online-first date, which is also why the DOI
+carries `-010-`. The citable record is **2012**, 11(3), 681-693, per
+both PubMed and Crossref, and ModelDB itself labels the entry
+"(Anwar et al. 2012)". The journal's title of record is "The
+Cerebellum" (Crossref journal record for ISSN 1473-4222); NLM indexes
+it as "Cerebellum (London, England)".
+
+### O-CX1997 -- BK/mslo allosteric gating parameters
+
+.. [1] Cox, D. H., Cui, J., & Aldrich, R. W. (1997). Allosteric gating
+       of a large conductance Ca-activated K+ channel. The Journal of
+       General Physiology, 110(3), 257-281.
+       doi:10.1085/jgp.110.3.257
+
+PMID 9276753, PMCID PMC2229366. **The `.mod` headers' "Cox et al.
+(1987)" is a typo for 1997** -- stated explicitly because the wrong
+year is copy-pasted into five files in this repository. J Gen Physiol
+volume 110 is September 1997, and pages 257-281 of that volume are
+exactly this paper. The headers' "(patch 1)" points at a specific
+recorded patch inside the paper, not a bibliographic field. Title
+reads "Ca-activated", as published.
+
+### O-SW2005 -- P-type (Cav2.1) recordings
+
+.. [1] Swensen, A. M., & Bean, B. P. (2005). Robustness of burst
+       firing in dissociated Purkinje neurons with acute or long-term
+       reductions in sodium conductance. The Journal of Neuroscience,
+       25(14), 3509-3520.
+       doi:10.1523/JNEUROSCI.3929-04.2005
+
+PMID 15814781, PMCID PMC6725377. The `.mod` headers write "purkinje"
+lowercase, inherited from PubMed's own lowercasing; the publisher's
+`<article-title>` in PMC6725377 capitalises it, and "Purkinje" is a
+proper noun that survives sentence-casing. Headers also omit issue 14
+and truncate the page range to 3509-20.
+
+### O-IF2006 -- Cav3.1 temperature dependence
+
+.. [1] Iftinca, M., McKay, B. E., Snutch, T. P., McRory, J. E.,
+       Turner, R. W., & Zamponi, G. W. (2006). Temperature dependence
+       of T-type calcium channel gating. Neuroscience, 142(4),
+       1031-1042.
+       doi:10.1016/j.neuroscience.2006.07.010
+
+PMID 16935432; **no PMCID** (NCBI ID Converter returns an explicit
+"not found in PMC", i.e. confirmed absent, not merely unfound). The
+`.mod` headers capitalise "Calcium"; the published title is lowercase.
+*Neuroscience* publishes initials only, so no source of record carries
+full given names for these six authors.
+
+### O-SC2003 -- Purkinje dendritic Ca buffering parameters
+
+.. [1] Schmidt, H., Stiefel, K. M., Racay, P., Schwaller, B., &
+       Eilers, J. (2003). Mutational analysis of dendritic Ca2+
+       kinetics in rodent Purkinje cells: role of parvalbumin and
+       calbindin D28k. The Journal of Physiology, 551(1), 13-32.
+       doi:10.1113/jphysiol.2002.035824
+
+PMID 12813159, PMCID PMC2343131. PubMed records the issue as "Pt 1",
+Crossref as "1", which is used. Crossref's `given: "K. M"` is a
+deposit artefact; PubMed's `ForeName=Klaus M` is authoritative.
+
+### O-MD1999 -- Ca decay data used to tune the pump rate
+
+.. [1] Maeda, H., Ellis-Davies, G. C. R., Ito, K., Miyashita, Y., &
+       Kasai, H. (1999). Supralinear Ca2+ signaling by cooperative and
+       mobile Ca2+ buffering in Purkinje neurons. Neuron, 24(4),
+       989-1002.
+       doi:10.1016/S0896-6273(00)81045-4
+
+PMID 10624961; **no PMCID** (confirmed absent). Identified by
+derivation, not guesswork: the `Cdp*` headers cite O-AN2012 as their
+model reference, and the reference list of O-AN2012 as returned by
+`efetch` contains exactly one Maeda-1999 entry, which is this one; it
+was then re-verified independently against PubMed and Crossref.
+**Caveat for the module task:** this is *not* a Ca2+-ATPase/PMCA
+paper. It is a caged-Ca2+ uncaging study of endogenous buffering. The
+headers' "pump rate was tuned according to data from Maeda et al.
+1999" means the pump was tuned so the model reproduces Maeda's
+measured Ca2+ decay -- do not write that Maeda characterised a pump.
+Crossref gives "Graham C. R. Ellis-Davies"; PubMed truncates to "G C".
+
+### O-XC2008 -- Cav3.3
+
+.. [1] Xu, J., & Clancy, C. E. (2008). Ionic mechanisms of endogenous
+       bursting in CA3 hippocampal pyramidal neurons: A model study.
+       PLoS ONE, 3(4), e2056.
+       doi:10.1371/journal.pone.0002056
+
+PMID 18446231, PMCID PMC2323611. `e2056` is the article number and
+occupies the page slot. Issue 4 is the only field the `.mod` headers
+omit; their "3:e2056" is otherwise correct.
+
+### O-VI2005 -- Cav3.2 recordings
+
+.. [1] Vitko, I., Chen, Y., Arias, J. M., Shen, Y., Wu, X.-R., &
+       Perez-Reyes, E. (2005). Functional characterization and
+       neuronal modeling of the effects of childhood absence epilepsy
+       variants of CACNA1H, a T-type calcium channel. The Journal of
+       Neuroscience, 25(19), 4844-4855.
+       doi:10.1523/JNEUROSCI.0847-05.2005
+
+PMID 15888660, PMCID PMC6724770. The `.mod` header's "25(19)
+:4844-4855, 2005" is correct in every field. Independently confirmed
+by two separate verification passes in this task.
+
+### O-CO1989 -- Q10 source for the low-threshold Ca current
+
+.. [1] Coulter, D. A., Huguenard, J. R., & Prince, D. A. (1989).
+       Calcium currents in rat thalamocortical relay neurones: kinetic
+       properties of the transient, low-threshold current. The Journal
+       of Physiology, 414(1), 587-604.
+       doi:10.1113/jphysiol.1989.sp017705
+
+PMID 2607443, PMCID PMC1189159. British "neurones" as published. The
+issue number is uncertain in provenance -- PubMed records none,
+Crossref supplies 1, and the classic in-print form is "414: 587-604"
+with no issue; drop the `(1)` if matching the majority convention.
+**Do not write that the paper prints "Q10 = 5 for m and 3 for h".** Its
+abstract states only that all kinetic properties were temperature
+sensitive "with Q10 ... values of greater than 2.5"; the specific 5/3
+split is Destexhe's parameterisation derived from that data.
+
+### O-AK2009 -- Kv1.1, Kv3.3 and Nav1.1 reference
+
+.. [1] Akemann, W., Lundby, A., Mutoh, H., & Knopfel, T. (2009).
+       Effect of voltage sensitive fluorescent proteins on neuronal
+       excitability. Biophysical Journal, 96(10), 3959-3976.
+       doi:10.1016/j.bpj.2009.02.046
+
+PMID 19450468, PMCID PMC2712148. Published as **Knöpfel**; ASCII form
+used here for file consistency. The title is printed "Voltage
+Sensitive" with no hyphen -- non-standard, confirmed identically in
+Crossref, PMC JATS and MEDLINE, and reproduced rather than corrected.
+The `.mod` headers' "96: 3959-3976" is correct; only issue 10 is
+missing.
+
+### O-AK2006 -- resurgent Na (Nav1.6) reference
+
+.. [1] Akemann, W., & Knopfel, T. (2006). Interaction of Kv3
+       potassium channels and resurgent sodium current influences the
+       rate of spontaneous firing of Purkinje neurons. The Journal of
+       Neuroscience, 26(17), 4602-4612.
+       doi:10.1523/JNEUROSCI.5204-05.2006
+
+PMID 16641240, PMCID PMC6674064. The `.mod` headers' "Knoepfel" is an
+ASCII transliteration of **Knöpfel**, and their "26 (2006) 4602" gives
+only the first page; the range is 4602-4612, issue 17.
+
+### O-KH2003 -- Purkinje resurgent Na and TEA-sensitive K
+
+Origin of both the `Nav1p6` family (via O-AK2006) and, directly, the
+`Kv3p4` family. ModelDB accession 48332.
+
+.. [1] Khaliq, Z. M., Gouwens, N. W., & Raman, I. M. (2003). The
+       contribution of resurgent sodium current to high-frequency
+       firing in Purkinje neurons: an experimental and modeling study.
+       The Journal of Neuroscience, 23(12), 4899-4912.
+       doi:10.1523/JNEUROSCI.23-12-04899.2003
+
+PMID 12832512, PMCID PMC6741194. The `.mod` headers' "23(2003)4899"
+compresses volume, year and first page; the full locator is 23(12),
+4899-4912.
+
+**Verified against the deposited source, not just the citation.** The
+`Kv3p4_*` files in this repository are ModelDB 48332's `kpkj.mod`
+renamed. The deposited `kpkj.mod` opens with exactly the two lines
+this repository's files carry -- ": HH TEA-sensitive Purkinje
+potassium current" / ": Created 8/5/02 - nwg" -- and its parameters
+`mivh = -24 mV`, `mik = 15.4`, `hiy0 = 0.31` reproduce the paper's
+Table 1 row for **K fast** (m^3 h, V-half -24 mV, k 15.4 mV,
+y0 = 0.31). "nwg" is Nathan W. Gouwens, the paper's second author. The
+": Suffix from kpkj to Kv3_4" line is a BrainCell-local addition and is
+not in the deposit. Sibling mechanisms in the same
+accession are `kpkj2.mod` (low TEA-sensitive) and `kpkjslow.mod`
+(TEA-insensitive); neither is imported here.
+
+**Caveat that must reach the `Kv3p4` docstrings.** The paper calls
+this current **K fast**, never a Kv subunit. Its only mention of Kv3 is
+one Discussion sentence noting that the positive activation range is
+"typical of the K_V3 family". The strings "Kv3.4", "Kv3.3" and "Kv3.1"
+appear nowhere in it. **The ".4" in BrainCell's `Kv3p4` name is an
+interpolation with no support in the cited paper.** A docstring may say
+the kinetics are those of the TEA-sensitive fast K current of Khaliq
+et al. (2003), which those authors associate with the Kv3 family; it
+must not say the paper identifies a Kv3.4 subunit.
+
+### O-ZE1998 -- human Kv1.1
+
+.. [1] Zerr, P., Adelman, J. P., & Maylie, J. (1998). Episodic ataxia
+       mutations in Kv1.1 alter potassium channel function by dominant
+       negative effects or haploinsufficiency. The Journal of
+       Neuroscience, 18(8), 2842-2848.
+       doi:10.1523/JNEUROSCI.18-08-02842.1998
+
+PMID 9526001, PMCID PMC6792579. The `.mod` headers' "18, 2842, 2848,
+1998" is not garbled but mis-punctuated: volume 18, pages 2842**-**2848,
+issue 8. **Disambiguation trap:** the same three authors published a
+second 1998 paper on the same subject, FEBS Letters 431(3), 461-464
+(PMID 9714564, doi:10.1016/s0014-5793(98)00814-x). The header's
+volume/page pin the J Neurosci paper, but its descriptive gloss
+("Human Kv1.1 expressed in xenopus oocytes") fits both.
+
+### O-MT2007 -- Kv3.3 fitting data
+
+.. [1] Martina, M., Metz, A. E., & Bean, B. P. (2007).
+       Voltage-dependent potassium currents during fast spikes of rat
+       cerebellar Purkinje neurons: inhibition by BDS-I toxin. Journal
+       of Neurophysiology, 97(1), 563-571.
+       doi:10.1152/jn.00269.2006
+
+PMID 17065256; **no PMCID** (not deposited in PMC). **The `.mod`
+header is wrong twice**: its page range "563-671" should be
+**563-571**, and its unbalanced "(" before 563 is stray. The header
+also omits the published subtitle ": inhibition by BDS-I toxin".
+
+### O-AG2007 -- HCN1 (I_h) distribution
+
+.. [1] Angelo, K., London, M., Christensen, S. R., & Hausser, M.
+       (2007). Local and global effects of Ih distribution in
+       dendrites of mammalian neurons. The Journal of Neuroscience,
+       27(32), 8643-8653.
+       doi:10.1523/JNEUROSCI.5284-06.2007
+
+PMID 17687042, PMCID PMC6672943. Published as **Häusser**; ASCII form
+used here. The published title sets I_h as an italic capital I with
+subscript h -- PubMed's "I(h)" is an ASCII-flattening artefact and the
+parentheses must not be copied. Christensen is published "Soren R."
+with a plain o, despite the author's canonical "Søren". The `.mod`
+`TITLE` line carries the author names but no volume, issue or pages.
+
+### O-PO2003a -- CA1 pyramidal model, part I
+
+Origin of `Cav2p3` (the `car.mod` mechanism). ModelDB accession 20212.
+
+.. [1] Poirazi, P., Brannon, T., & Mel, B. W. (2003). Arithmetic of
+       subthreshold synaptic summation in a model CA1 pyramidal cell.
+       Neuron, 37(6), 977-987.
+       doi:10.1016/S0896-6273(03)00148-X
+
+PMID 12670426; no PMCID (Cell Press does not deposit in PMC).
+
+### O-PO2003b -- CA1 pyramidal model, part II
+
+.. [1] Poirazi, P., Brannon, T., & Mel, B. W. (2003). Pyramidal neuron
+       as two-layer neural network. Neuron, 37(6), 989-999.
+       doi:10.1016/S0896-6273(03)00149-1
+
+PMID 12670427; no PMCID. **Verbatim-wording flag:** the title has no
+article before either noun phrase ("as two-layer neural network"),
+which is the publisher's wording and is reproduced unaltered.
+
+**Which of the pair to cite.** ModelDB 20212 is one shared model
+serving both companion papers plus their joint online supplement, and
+its `readme.txt` and `model_paper` field list both. `car.mod` belongs
+to the shared biophysics and cannot be assigned to one. Citing both is
+the accurate choice; if only one is wanted, cite O-PO2003a, which is
+listed first in both places and is the paper describing the model's
+construction. The deposited `car.mod` header matches this repository's
+file exactly apart from the BrainCell-local ": From car to Cav2_3"
+line, and `calH.mod`, which the header references, is a sibling in the
+same deposit.
+
+### O-RC2006 -- Kca3.1 implementation
+
+.. [1] Rubin, D. B., & Cleland, T. A. (2006). Dynamical mechanisms of
+       odor processing in olfactory bulb mitral cells. Journal of
+       Neurophysiology, 96(2), 555-568.
+       doi:10.1152/jn.00264.2006
+
+PMID 16707721; no PMCID (confirmed absent). The `.mod` header line
+"Implemented in Rubin and Cleland (2006) J Neurophysiology" is correct.
+
+### O-BB1993 -- Kca3.1 parameters
+
+.. [1] Bhalla, U. S., & Bower, J. M. (1993). Exploring parameter space
+       in detailed single neuron models: simulations of the mitral and
+       granule cells of the olfactory bulb. Journal of
+       Neurophysiology, 69(6), 1948-1965.
+       doi:10.1152/jn.1993.69.6.1948
+
+PMID 7688798; no PMCID. Header line correct; this is indeed the
+parameter-fitting paper the header points at.
+
+### O-DV2000 -- Kca3.1 mod-file author
+
+.. [1] Davison, A. P., Feng, J., & Brown, D. (2000). A reduced
+       compartmental model of the mitral cell for use in network
+       models of the olfactory bulb. Brain Research Bulletin, 51(5),
+       393-399.
+       doi:10.1016/S0361-9230(99)00256-7
+
+PMID 10715559; no PMCID. The header's affiliation claim is also
+confirmed: PubMed's affiliation field reads "Laboratory of
+Computational Neuroscience, The Babraham Institute, Babraham,
+Cambridge, UK".
+
+### O-FE1998 -- IKur data behind Kv1.5
+
+.. [1] Feng, J., Xu, D., Wang, Z., & Nattel, S. (1998). Ultrarapid
+       delayed rectifier current inactivation in human atrial
+       myocytes: properties and consequences. American Journal of
+       Physiology-Heart and Circulatory Physiology, 275(5),
+       H1717-H1725.
+       doi:10.1152/ajpheart.1998.275.5.H1717
+
+PMID 9815079; no PMCID. Every field in the `.mod` header, including
+the page range, is correct. In 1998 this appeared under the omnibus
+title *American Journal of Physiology*, which is what PubMed indexes;
+the sectioned title above is the publisher's own and matches the
+`ajpheart` DOI namespace.
+
+### O-SZ1998 -- Kv2.2 identification
+
+.. [1] Schmalz, F., Kinsella, J., Koh, S. D., Vogalis, F., Schneider,
+       A., Flynn, E. R. M., Kenyon, J. L., & Horowitz, B. (1998).
+       Molecular identification of a component of delayed rectifier
+       current in gastrointestinal smooth muscles. American Journal of
+       Physiology-Gastrointestinal and Liver Physiology, 274(5),
+       G901-G911.
+       doi:10.1152/ajpgi.1998.274.5.G901
+
+PMID 9612272; no PMCID. Every field of the `.mod` header's
+":Reference :" line is correct; it merely abbreviates the end page.
+PubMed gives the sixth author as "Flynn E R"; the publisher deposit in
+Crossref gives "Elaine R. M. Flynn", which is used. This is the only
+field in the record where two authoritative sources disagree.
+
+### O-RA2011 -- the toolchain that generated the Kv2.2 file
+
+.. [1] Ranjan, R., Khazen, G., Gambazzi, L., Ramaswamy, S., Hill,
+       S. L., Schurmann, F., & Markram, H. (2011). Channelpedia: an
+       integrative and interactive database for ion channels.
+       Frontiers in Neuroinformatics, 5, 36.
+       doi:10.3389/fninf.2011.00036
+
+PMID 22232598, PMCID PMC3248699. Published as **Schürmann**; ASCII
+form used here. Article number 36, no page range.
+
+**Why this record exists.** `Kv2p2_0010_MA20_GrC.mod` is not
+hand-written. Its SVN keywords name the generator
+(`.../IonChannel/xmlTomod/CreateMOD.c`, EPFL Blue Brain) and its
+`BBiD = 10` is the Channelpedia ion-channel ID for Kv2.2 (gene
+*KCNB2*), HH model 24. The Open Source Brain NeuroML2 re-derivation of
+Channelpedia model 10/24 carries the identical reference string and
+annotates `identifiers.org/pubmed/9612272`, and its gating equations
+match constant for constant -- so O-SZ1998 is the actual parameter
+source, not merely a bibliography line. The `.mod` header's
+"$Author: rajnish $" is SVN noise, but it does identify Rajnish
+Ranjan, first author above. There is **no standalone ModelDB accession**
+for this mechanism; it is redistributed inside larger cell models,
+here ModelDB 265584 (see the `MA2020` record).
+
+### O-EV2013 -- Cav1.2 / Cav1.3 GENESIS kinetics
+
+.. [1] Evans, R. C., Maniar, Y. M., & Blackwell, K. T. (2013).
+       Dynamic modulation of spike timing-dependent calcium influx
+       during corticostriatal upstates. Journal of Neurophysiology,
+       110(7), 1631-1645.
+       doi:10.1152/jn.00232.2013
+
+PMID 23843436, PMCID PMC4042418. ModelDB accession 150912 (GENESIS).
+This is a **striatal medium spiny neuron** paper, not a dentate
+granule cell paper -- the `.mod` header's phrasing invites that
+misreading. Identification is certain, not merely likely: O-BE2017's
+Methods state verbatim that "The Cav1.2 and Cav1.3 (L-type) Ca2+
+channel models were taken from (Evans et al., 2013) and transferred
+from GENESIS to NEURON", with this exact DOI as its `bib62`, and the
+GENESIS sources `CaL12CDI.g` / `CaL13CDI.g` match the ported `.mod`
+files parameter for parameter.
+
+### O-BE2017 -- the GENESIS-to-NEURON transfer
+
+.. [1] Beining, M., Mongiat, L. A., Schwarzacher, S. W., Cuntz, H., &
+       Jedlicka, P. (2017). T2N as a new tool for robust
+       electrophysiological modeling demonstrated for mature and
+       adult-born dentate granule cells. eLife, 6, e26517.
+       doi:10.7554/eLife.26517
+
+PMID 29165247, PMCID PMC5737656. **The `.mod` header is wrong on both
+of the fields it gives.** (1) Year: it says 2016; the paper was
+published 22 November 2017. (2) Title: its "A novel comprehensive and
+consistent electrophysiologcal model of dentate granule cells" (typo
+in the original) corresponds to **no published paper or preprint** --
+bioRxiv author search, Crossref preprint search, OpenAlex and Europe
+PMC exact-phrase search all return nothing, and the eLife article
+declares no preprint relation. Best reading: a pre-publication working
+title that was never posted. A withdrawn posting cannot be formally
+excluded. The discrepancy is internal to the upstream deposit --
+Beining's own repository README attributes the code to the 2017 eLife
+paper while still shipping the stale "(2016)" header.
+
+**Explicitly ruled out:** this is *not* the group's Brain Structure
+and Function paper (Beining et al., 2017, 222(3), 1427-1446,
+doi:10.1007/s00429-016-1285-y, PMID 27514866), which is a
+developmental morphology paper containing no channel kinetics. Its
+`-016-` DOI suffix is online-first dating and is a likely source of
+the year confusion.
+
+### O-ST2011 -- the GENESIS DCN model
+
+Origin of every DCN channel and calcium pool. ModelDB accession 136175.
+
+.. [1] Steuber, V., Schultheiss, N. W., Silver, R. A., De Schutter,
+       E., & Jaeger, D. (2011). Determinants of synaptic integration
+       and heterogeneity in rebound firing explored with data-driven
+       models of deep cerebellar nucleus cells. Journal of
+       Computational Neuroscience, 30(3), 633-658.
+       doi:10.1007/s10827-010-0282-z
+
+PMID 21052805, PMCID PMC3108018.
+
+### O-LU2011 -- the NEURON translation of that model
+
+.. [1] Luthman, J., Hoebeek, F. E., Maex, R., Davey, N., Adams, R.,
+       De Zeeuw, C. I., & Steuber, V. (2011). STD-dependent and
+       independent encoding of input irregularity as spike rate in a
+       computational model of a cerebellar nucleus neuron. The
+       Cerebellum, 10(4), 667-682.
+       doi:10.1007/s12311-011-0295-9
+
+PMID 21761198, PMCID PMC3215884. **Note the author list**: the last
+author is Steuber and **De Schutter is not on this paper at all** -- a
+natural but wrong assumption given the surrounding lineage. Its
+Methods state verbatim that the model, "originally implemented in
+GENESIS", "was translated to NEURON", citing O-ST2011.
+
+### O-SW1999 -- inferior olive compartmental model
+
+Origin of the IO `Na`, `Kdr` and `HCN` mechanisms.
+
+.. [1] Schweighofer, N., Doya, K., & Kawato, M. (1999).
+       Electrophysiological properties of inferior olive neurons: A
+       compartmental model. Journal of Neurophysiology, 82(2),
+       804-817.
+       doi:10.1152/jn.1999.82.2.804
+
+PMID 10444678; **no PMCID**. Free readability was **not** verified --
+there is no PMC copy and the publisher paywall was not tested.
+
+### O-MN1997 -- inferior olive low-amplitude oscillations
+
+Origin of the IO `Ca` mechanism.
+
+.. [1] Manor, Y., Rinzel, J., Segev, I., & Yarom, Y. (1997).
+       Low-amplitude oscillations in the inferior olive: A model based
+       on electrical coupling of neurons with heterogeneous channel
+       densities. Journal of Neurophysiology, 77(5), 2736-2752.
+       doi:10.1152/jn.1997.77.5.2736
+
+PMID 9163389; **no PMCID**. Free readability not verified, same
+reason. The `.mod` header's "Manor (Rinzel, Segev, Yarom) 1997"
+parenthesises the co-authors; all four are authors of record.
+
+### O-TN2012 -- the NEURON port of the IO channels
+
+.. [1] Torben-Nielsen, B., Segev, I., & Yarom, Y. (2012). The
+       generation of phase differences and frequency changes in a
+       network model of inferior olive subthreshold oscillations. PLOS
+       Computational Biology, 8(7), e1002580.
+       doi:10.1371/journal.pcbi.1002580
+
+PMID 22792054, PMCID PMC3390386. ModelDB accession 144502. This is the
+"B. Torben-Nielsen @ HUJI, 2010" credit in the IO `.mod` headers --
+the deposit from which the `Ca`, `Kdr` and `Na` files were ported
+before the `ZH2019` model reused them.
 
 ---
 
@@ -449,11 +1118,221 @@ repository-tooling artifact, not a scientific author).
 
 ### Verified record
 
-_TODO (Task 3): not yet verified._
+Confirmed 2026-08-15 against PubMed (`efetch`, `db=pubmed`), the
+Crossref REST API, the PMC article HTML for each paper, and the ModelDB
+REST API for the accessions. **`MA2020` requires two papers, not one.**
+The Task 1 hypothesis of a single Masoli et al. (2020) covering both
+cell types is wrong: the Golgi and granule models were published
+separately, in different journals, with different co-author sets.
+Neither paper covers the other's cell type.
+
+Golgi cell (`GoC` symbols), ModelDB accession 266806:
+
+.. [1] Masoli, S., Ottaviani, A., Casali, S., & D'Angelo, E. (2020).
+       Cerebellar Golgi cell models predict dendritic processing and
+       mechanisms of synaptic plasticity. PLOS Computational Biology,
+       16(12), e1007937.
+       doi:10.1371/journal.pcbi.1007937
+
+PMID 33378395, PMCID PMC7837495, fully open access. The accession
+appears both in the ModelDB API record and in the paper's own Data
+Availability statement.
+
+Granule cell (`GrC` symbols), ModelDB accession 265584:
+
+.. [2] Masoli, S., Tognolina, M., Laforenza, U., Moccia, F., &
+       D'Angelo, E. (2020). Parameter tuning differentiates granule
+       cell subtypes enriching transmission properties at the
+       cerebellum input stage. Communications Biology, 3(1), 222.
+       doi:10.1038/s42003-020-0953-x
+
+PMID 32385389, PMCID PMC7210112, fully open access. `222` is the
+article number and occupies the page slot; *Communications Biology*
+places every article of a volume-year in issue 1, so `3(1)` is
+nominal. **Provenance caveat:** unlike the Golgi paper, this one's
+Data Availability statement cites only the EBRAINS Knowledge Graph and
+an HBP live paper, not ModelDB. Accession 265584 is confirmed from the
+ModelDB API record, which names this paper, not from the article.
+
+**Which paper a given symbol takes.** Split strictly on the cell-type
+suffix: every `*_MA2020_GoC` symbol takes entry [1], every
+`*_MA2020_GrC` symbol takes entry [2]. Seven mechanisms
+(`CaHVA`, `KM`, `Kv1p1`, `Kv3p4`, `Kv4p3`, `Kca1p1`, `Kca2p2`) exist in
+both buckets with identical kinetics; they still take different model
+papers, because they were imported from different deposits.
 
 ### Attribution
 
-_TODO (Task 3): not yet filled in._
+**Attribution check: PASSED for all 32 symbols**, with three caveats
+recorded below that must reach the docstrings.
+
+**Method, applied uniformly across all seven Task 3 keys.** Every
+symbol's `.mod` counterpart is present in this repository, so the
+`code -> .mod` half of the check was done exhaustively rather than by
+sampling: every numeric literal in each BrainCell class was extracted
+and set-differenced against every numeric literal in the corresponding
+`.mod` file, with NMODL comments and `COMMENT` blocks stripped. Every
+rate-function constant matches. The only literals that appear in a
+`.mod` file and not in its BrainCell class fall into seven benign
+classes, verified individually: (a) GHK/unit-conversion constants
+(`8.3145`, `96485`, `1e-6`, `1e3`) handled by `braincell.channel.
+_base.ghk_flux`; (b) Kelvin offsets (`273.15`/`273.19`/`273.14`)
+handled by `u.celsius2kelvin`; (c) reversal potentials (`ek = -84.69`,
+`eca = 140`) supplied by the ion object, not the channel; (d) the Q10
+exponent divisor `10` absorbed into `Gate(q10=, temp_ref=)`; (e) NMODL
+range annotations such as `<0,1e9>`; (f) `gbar` in `mho/cm2` or
+`S/cm2` against BrainCell's `mS/cm2` -- e.g. `KM_MA20_GoC.mod`'s
+`gkbar = 0.00025 mho/cm2` is BrainCell's `g_max = 0.25 mS/cm2`
+exactly; and (g) the documented NMODL default-precision rewrites (see
+`### Import deviations`). The `.mod -> paper` half was done per
+mechanism family, against the origin records cited in the mapping
+table.
+
+Classes that report a zero literal overlap in that scan are BrainCell
+subclasses whose constants live in a base class (e.g.
+`Kca1p1_MA2020_GrC(Kca1p1_MA2020_GoC)`); this was confirmed by reading
+each `class` line and is a scan artefact, not a mismatch.
+
+**Mapping table.** `.. [1]` is the origin record; `.. [2]` is the
+`MA2020` model paper above ([1] for `GoC`, [2] for `GrC`).
+
+| Symbols | Origin `.. [1]` |
+|---|---|
+| `CaHVA_MA2020_GoC`, `CaHVA_MA2020_GrC`, `Kv4p3_MA2020_GoC`, `Kv4p3_MA2020_GrC`, `KM_MA2020_GoC`, `KM_MA2020_GrC`, `Kir2p3_MA2020_GrC` | O-DA2001 |
+| `HCN1_MA2020_GoC`, `HCN2_MA2020_GoC` | O-SO2007a (kinetics), O-SA2000 (data) |
+| `Kca2p2_MA2020_GoC`, `Kca2p2_MA2020_GrC` | O-HI1998 (data), O-SO2007a (model) |
+| `Kca1p1_MA2020_GoC`, `Kca1p1_MA2020_GrC` | O-CX1997 (parameters), O-AN2012 (model) |
+| `Kca3p1_MA2020_GoC` | O-RC2006, O-BB1993, O-DV2000 |
+| `Cav1p2_MA2020_GoC`, `Cav1p3_MA2020_GoC` | O-EV2013 (kinetics), O-BE2017 (port) |
+| `Cav3p1_MA2020_GoC`, `Cav3p1_MA2020_GoC_Frozen` | O-IF2006 (kinetics), O-AN2012 (model) |
+| `Cav2p3_MA2020_GoC` | O-PO2003a (and O-PO2003b) |
+| `Kv1p1_MA2020_GoC`, `Kv1p1_MA2020_GrC` | O-ZE1998 (data), O-AK2009 (model) |
+| `Kv3p4_MA2020_GoC`, `Kv3p4_MA2020_GrC` | O-KH2003 |
+| `Kv1p5_MA2020_GrC` | O-FE1998 |
+| `Kv2p2_0010_MA2020_GrC` | O-SZ1998 (data), O-RA2011 (toolchain) |
+| `Nav1p6_MA2020_GoC` | O-RB2001 (kinetics), O-KH2003, O-AK2006 |
+| `Nav_MA2020_GrC`, `NaFHF_MA2020_GrC` | O-MG2006 (kinetics), O-RB2001 (scheme) |
+| `CdpStC_MA2020_GoC`, `CdpStC_CAMOnly_MA2020_GoC`, `CdpStC_NoCAM_MA2020_GoC`, `CdpCR_MA2020_GrC` | O-AN2012 (model), O-SC2003 (buffer parameters), O-MD1999 (pump tuning) |
+
+**Fingerprints checked beyond the literal scan.**
+
+- `Kca1p1_*` (`braincell/channel/potassium_calcium.py`) carries the
+  Horrigan-Aldrich allosteric parameter set `Qo = 0.73`,
+  `Qc = -0.67`, `L0 = 1806`, `Kc = 11.0e-3 mM`, `Ko = 1.1e-3 mM`,
+  `k1 = 1.0e3 /mM`, and the `pf0..pf4` / `pb0..pb4` opening and
+  closing rate ladders. These are the BK/mslo parameters of O-CX1997
+  patch 1, as the header states -- with the year corrected from 1987
+  to 1997.
+- `Kca2p2_*` implements the six-state SK2 scheme of O-HI1998 with
+  `invc1 = invc2 = 80e-3`, `invc3 = 200e-3`, `invo1 = 1`,
+  `invo2 = 100e-3`, `diro1 = 160e-3`, `diro2 = 1.2` (Ca-independent)
+  and `dirc2 = 200`, `dirc3 = 160`, `dirc4 = 80` /ms-mM
+  (Ca-dependent), plus `diff = 3`.
+- `Nav_MA2020_GrC` and `NaFHF_MA2020_GrC` are the same 13-state
+  Raman-style Markov scheme with `ACon = 0.025`, `ACoff = 0.5`,
+  `AOon = 0.75`, `AOoff = 0.002` /ms and the derived
+  `a = (Oon/Con)^0.25`, `b = (Ooff/Coff)^0.25`. `NaFHF` adds the
+  `Lon`/`Loff` blocked-state ladder (`L3..L6`) on top of the same
+  `C1..C5`/`I1..I6`/`O` topology -- it is the same mechanism with the
+  slow-blocked branch enabled, not an independent model. This is why
+  `NaFHF_MA20_GrC.mod`'s empty `COMMENT` block is not a provenance
+  gap: it inherits `Nav_MA20_GrC.mod`'s "Based on Raman 13 state
+  model. Adapted from Magistretti et al, 2006."
+
+**Caveat 1 -- `Kv3p4` is not established as a Kv3.4.** See the
+paragraph in O-KH2003. The cited paper calls this current "K fast" and
+never names a Kv3 subunit. Do not write a docstring sentence claiming
+the paper identifies Kv3.4. This caveat applies identically to
+`Kv3p4_MA2024_PC`, `Kv3p4_MA2025_BC` and `Kv3p4_RI2021_SC`.
+
+**Caveat 2 -- `Cav1p2` / `Cav1p3` may carry a unit-scale defect
+inherited from upstream.** The GENESIS originals (`CaL12CDI.g`,
+`CaL13CDI.g`) evaluate the `mTau` linoid in volts and return seconds,
+whereas the NEURON ports apply the same numeric coefficients in mV and
+declare `mTau (ms)`. Worked at V = 0 mV for Cav1.3, GENESIS gives
+tau ~ 0.283 ms and the `.mod` file gives tau ~ 2.9e-5 ms -- about
+1e4 times smaller, i.e. effectively instantaneous activation. Cav1.2
+shows the same pattern and O-BE2017's Methods mention no intentional
+rescaling. **This is derived arithmetic, not a fetched claim, and it
+was not confirmed against a NEURON run.** It is not a citation error:
+BrainCell faithfully reproduces the `.mod` file. Record it as an open
+question for the module task rather than asserting either reading.
+Applies identically to `Cav1p2_MA2025_BC` and `Cav1p3_MA2025_BC`.
+
+**Caveat 3 -- `CdpStC_NoCAM_MA2020_GoC` has no `.mod` file of its own,
+and this is deliberate.** Task 1 flagged the missing
+`CdpStC_NoCAM_MA20_GoC.mod` as unresolved (`## Unresolved
+attributions` item 1). It is now resolved: the class is a
+BrainCell-factored base, not a port of a file that went missing. Its
+literal set matches `BC/ion/CdpStC_MA25_BC.mod` and
+`SC/ion/CdpStC_RI21_SC.mod` (21 of 26 literals; the five unmatched are
+unit conversions and NMODL range annotations), which are exactly the
+GoC `CdpStC` mechanism with the CAM subnetwork commented out -- as
+`examples/neuron_compare/Cerebellum_mod/README.md` states in its
+"Ion_dyn inherited variants" table. Its citation is therefore
+O-AN2012 / O-SC2003 / O-MD1999 plus the `MA2020` GoC paper, the same
+as `CdpStC_MA2020_GoC`, and a docstring should say the CAM reactions
+were removed rather than implying a distinct published mechanism.
+
+**Parameter-default caveats (not citation errors).** BrainCell's
+`g_max` defaults were read against each `.mod` file's `gbar`/`gkbar`
+and agree after the `mho/cm2` -> `mS/cm2` conversion wherever both
+exist. Where a docstring wants to state a conductance as "the
+published value", it must not: these are the *cell-model* deposit's
+tuned values, not values from the origin paper.
+
+### Import deviations
+
+Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`
+(tables "TABLE status summary", "Integration method status", "Rate
+update placement status", "NMODL numeric default precision"). Put
+these in the docstring `Notes` section; do not re-read that file.
+
+**`TABLE` removed, replaced by per-call evaluation of the continuous
+formula.** The former interpolation range is given because NEURON
+clamps to the boundary value outside it, so any recorded BrainCell/
+NEURON divergence outside the range is expected.
+
+| Symbol | Former `TABLE` range | Tabulated |
+|---|---|---|
+| `Kv4p3_MA2020_GoC`, `Kv4p3_MA2020_GrC` | `[-100, 30]` (clamped) | `a_inf`, `tau_a`, `b_inf`, `tau_b` |
+| `KM_MA2020_GoC`, `KM_MA2020_GrC` | `[-100, 30]` (clamped) | `n_inf`, `tau_n` |
+| `CaHVA_MA2020_GoC`, `CaHVA_MA2020_GrC` | `[-100, 30]` (clamped) | `s_inf`, `tau_s`, `u_inf`, `tau_u` |
+| `HCN1_MA2020_GoC`, `HCN2_MA2020_GoC` | `[-100, 30]` (clamped) | `o_fast_inf`, `o_slow_inf`, `tau_f`, `tau_s` |
+| `Kir2p3_MA2020_GrC` | `[-100, 100]` | `d_inf`, `tau_d` |
+| `Cav2p3_MA2020_GoC` | `[-100, 100]` | indexed `inf`/`tau` |
+| `Kca3p1_MA2020_GoC` | V `[-100, 100]`; `cai` `[0, 0.01]` (clamped) | `Yvdep`, `Yconcdep` |
+
+The `Kca3p1` concentration table is the one to watch: `cai` above
+0.01 mM was previously clamped to the boundary value.
+
+**`derivimplicit` -> `cnexp`.** `KM_MA2020_GoC`, `KM_MA2020_GrC`,
+`Kir2p3_MA2020_GrC`, `Kv1p5_MA2020_GrC`, `Kv4p3_MA2020_GoC`,
+`Kv4p3_MA2020_GrC`, `CaHVA_MA2020_GrC`. Each gate ODE is independent,
+so the substitution is exact. `CaHVA_MA2020_GoC` was already `cnexp`
+upstream and is **not** a substitution.
+
+**Rate-refresh relocation.** `Cav1p2_MA2020_GoC` and
+`Cav1p3_MA2020_GoC`: the `rates()` call moved from `BREAKPOINT` into
+`DERIVATIVE state`, so `inf`/`tau` are refreshed before the `cnexp`
+state update rather than after.
+
+**NMODL default-precision rewrites.** NEURON's generated C writes some
+`PARAMETER`/global defaults to about six significant figures, and
+BrainCell aligns with the compiled values rather than the `.mod`
+source text:
+
+| Symbol | Name | `.mod` source | BrainCell |
+|---|---|---|---|
+| `Kv4p3_MA2020_GoC`, `Kv4p3_MA2020_GrC` | `Kalpha_a` | `-23.32708` | `-23.3271` |
+| " | `Kbeta_a` | `19.47175` | `19.4718` |
+| " | `V0beta_a` | `-18.27914` | `-18.2791` |
+| " | `V0alpha_b` | `-111.33209` | `-111.332` |
+| `HCN1_MA2020_GoC` | `tEf`, `tEs` | `2.302585092` | `2.30259` |
+| `CaHVA_MA2020_GoC`, `CaHVA_MA2020_GrC` | `Kalpha_s` | `15.87301587302` | `15.873` |
+
+Ordinary in-formula literals are **not** subject to this rewrite and
+keep their source values.
 
 ---
 
@@ -614,11 +1493,116 @@ across all cell-type ports).
 
 ### Verified record
 
-_TODO (Task 3): not yet verified._
+Confirmed 2026-08-15 against PubMed (`efetch`), the Crossref REST API,
+the PMC article HTML (PMC10761885, 299 KB retrieved), and the ModelDB
+REST API. The Task 1 hypothesis is confirmed unchanged. ModelDB
+accession 267694, which the paper's own Code Availability statement
+gives as `https://modeldb.science/267694`.
+
+.. [1] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+       Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+       Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz, A., &
+       D'Angelo, E. (2024). Human Purkinje cells outperform mouse
+       Purkinje cells in dendritic complexity and computational
+       capacity. Communications Biology, 7(1), 5.
+       doi:10.1038/s42003-023-05689-y
+
+PMID 38168772, PMCID PMC10761885, fully open access. All thirteen
+authors are listed in the published order, confirmed identically by
+PubMed and Crossref. `5` is the article number and occupies the page
+slot; *Communications Biology* assigns every article of a volume-year
+to issue 1, so `7(1)` is nominal, not a real issue.
+
+**Name-form note.** In this paper the second author is published
+"Sanchez-Ponce" and the twelfth "Munoz", without accents, in both
+PubMed and Crossref -- whereas the *same two people* appear as
+"Sanchez-Ponce"/"Munoz" here but with accents in the `RI2021` record.
+That inconsistency is real and inter-paper, not a transcription error;
+each record reproduces its own publisher's form.
 
 ### Attribution
 
-_TODO (Task 3): not yet filled in._
+**Attribution check: PASSED for all 19 symbols**, with the `Kv3p4`
+caveat from the `MA2020` block carried over.
+
+Method as documented in the `MA2020` `### Attribution` block: the
+exhaustive literal set-difference of every BrainCell class against its
+`PC/channel/*_MA24_PC.mod` or `PC/ion/*_MA24_PC.mod` counterpart, with
+the same seven benign-difference classes. All 19 map 1:1 onto a `.mod`
+file and every rate-function constant matches. The zero-overlap
+classes in that scan (`Cav2p1_MA2024_PC`, `Cav3p1_MA2024_PC`,
+`Cav3p2_MA2024_PC`, `Cav3p3_MA2024_PC`, `Kca1p1_MA2024_PC`,
+`Kca2p2_MA2024_PC`, `Kca3p1_MA2024_PC`, `Nav1p6_MA2024_PC`) are
+subclasses that inherit their constants -- e.g. `Cav2p1_MA2024_PC`
+derives from `Cav2p1_RI2021_SC`, `Kca3p1_MA2024_PC` from
+`Kca3p1_MA2020_GoC` -- confirmed by reading each `class` line.
+
+**Mapping table.** `.. [1]` is the origin record; `.. [2]` is the
+`MA2024` entry above.
+
+| Symbols | Origin `.. [1]` |
+|---|---|
+| `Cav2p1_MA2024_PC`, `Cav2p1_MA2024_PC_Frozen` | O-SW2005 (recordings), O-AN2012 (model) |
+| `Cav3p1_MA2024_PC`, `Cav3p1_MA2024_PC_Frozen` | O-IF2006 (kinetics), O-AN2012 (model) |
+| `Cav3p2_MA2024_PC` | Huguenard & McCormick (1992) -- see the `HM1992` Verified record -- plus O-VI2005 and O-CO1989 (Q10) |
+| `Cav3p3_MA2024_PC`, `Cav3p3_MA2024_PC_Frozen` | O-XC2008 |
+| `HCN1_MA2024_PC` | O-AG2007 (kinetics), O-SA2000 (subunit identity) |
+| `Kir2p3_MA2024_PC`, `Kv4p3_MA2024_PC` | O-DA2001 |
+| `Kv1p1_MA2024_PC` | O-ZE1998 (data), O-AK2009 (model) |
+| `Kv1p5_MA2024_PC` | O-FE1998 |
+| `Kv3p3_MA2024_PC` | O-MT2007 (fits), O-AK2009 (model) |
+| `Kv3p4_MA2024_PC` | O-KH2003 |
+| `Kca1p1_MA2024_PC` | O-CX1997 (parameters), O-AN2012 (model) |
+| `Kca2p2_MA2024_PC` | O-HI1998 (data), O-SO2007a (model) |
+| `Kca3p1_MA2024_PC` | O-RC2006, O-BB1993, O-DV2000 |
+| `Nav1p6_MA2024_PC` | O-RB2001 (kinetics), O-KH2003, O-AK2006 |
+| `CdpCAM_MA2024_PC` | O-AN2012 (model), O-SC2003 (buffers), O-MD1999 (pump tuning) |
+
+**Fingerprints checked beyond the literal scan.** `Cav3p1_MA24_PC.mod`
+carries the named Boltzmann/tau parameter block
+`v0_m_inf = -52 mV`, `v0_h_inf = -72 mV`, `k_m_inf = -5 mV`,
+`k_h_inf = 7 mV`, `C_tau_m = 1`, `v0_tau_m1 = -40 mV`,
+`v0_tau_m2 = -102 mV`, `k_tau_m1 = 9 mV`, `k_tau_m2 = -18 mV`,
+`C_tau_h = 15`, `v0_tau_h1 = -32 mV`, `k_tau_h1 = 7 mV`, with
+`qt = 3^((celsius - 37)/10)` -- Anwar's `CaT3_1.mod` from ModelDB
+138382, whose header names O-IF2006 as the kinetic fit. The
+`Kca1p1`/`Kca2p2` fingerprints are the same as in the `MA2020` block
+(identical mechanism, different port). `CdpCAM_MA24_PC.mod` is the
+`CdpStC` scaffold with the CB subnetwork enabled and both CB and CAM
+states placed in the cytosolic compartment, per the README's
+"Ion_dyn implementation notes" table.
+
+**Caveats.** The `Kv3p4` subunit-naming caveat (see O-KH2003) applies
+to `Kv3p4_MA2024_PC`. `Kv1p5_MA2024_PC` is the one PC mechanism whose
+`.mod` file computes `ino` as a RANGE variable with its
+`USEION no WRITE ino` line commented out; BrainCell converts only the
+default `ik` path. `Cav3p2_MA2024_PC` shares Destexhe's 1992
+implementation of the Huguenard & McCormick low-threshold current;
+that key is already verified in this file and must be cited from the
+`HM1992` `### Verified record` block, not retyped.
+
+### Import deviations
+
+Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
+
+**`TABLE` removed, replaced by per-call evaluation.**
+
+| Symbol | Former `TABLE` range | Tabulated |
+|---|---|---|
+| `Kv4p3_MA2024_PC` | `[-100, 30]` (clamped) | `a_inf`, `tau_a`, `b_inf`, `tau_b` |
+| `Kir2p3_MA2024_PC` | `[-100, 100]` | `d_inf`, `tau_d` |
+| `Kca3p1_MA2024_PC` | V `[-100, 100]`; `cai` `[0, 0.01]` (clamped) | `Yvdep`, `Yconcdep` |
+
+**`derivimplicit` -> `cnexp`.** `Kir2p3_MA2024_PC`,
+`Kv1p5_MA2024_PC`, `Kv4p3_MA2024_PC`.
+
+**Rate-refresh relocation.** None for `PC`.
+
+**NMODL default-precision rewrites.** `Kv4p3_MA2024_PC` only, same
+four parameters and values as in the `MA2020` table:
+`Kalpha_a` `-23.32708` -> `-23.3271`; `Kbeta_a` `19.47175` ->
+`19.4718`; `V0beta_a` `-18.27914` -> `-18.2791`; `V0alpha_b`
+`-111.33209` -> `-111.332`.
 
 ---
 
@@ -651,6 +1635,29 @@ the 11 `DCN` `.mod` files harvested here carry an `Author:`/`Ref:` line at
 all — their headers are bare `TITLE ... (DCN) neuron` / empty `COMMENT`
 blocks, so this bucket has essentially no in-repo textual provenance
 beyond the mechanism name and species (DCN neuron).
+
+> **TWO CORRECTIONS TO THE PARAGRAPH ABOVE (Task 3, 2026-08-15).** It is
+> left unedited because `### Provenance evidence` blocks are raw harvest
+> output, but both of its factual claims are wrong.
+>
+> 1. **The file count is 17, not 11.** `DCN/channel/` holds 9 `.mod`
+>    files and `DCN/ion/` holds 8, verified by `find`. Sixteen are
+>    claimed by `SU2015` symbols and one
+>    (`ToyStoich3ABtoCKinetic_SU15_DCN.mod`) is unclaimed. The count 11
+>    is Task 1's harvest window, not the directory. (The 11 in the
+>    README's "Cell totals" table is a different, correct number: it
+>    counts only the shipped DCN mechanisms and excludes the six `Toy*`
+>    fixtures.) `DCN/` also holds `other/` and `synapse/`
+>    subdirectories with 6 further `.mod` files, outside this bucket's
+>    scope.
+> 2. **These files are NOT provenance-free.** Every one of the 11
+>    shipped DCN mechanisms carries, inside its `COMMENT` block below
+>    the harvest's 25-line window, the line:
+>
+>        Translated from GENESIS by Johannes Luthman and Volker Steuber.
+>
+>    That is a complete provenance lead, and it resolves the bucket. See
+>    the `### Verified record` block below.
 
 ### Provenance evidence
 
@@ -741,11 +1748,185 @@ in "Unresolved attributions" below.
 
 ### Verified record
 
-_TODO (Task 3): not yet verified._
+Confirmed 2026-08-15 against PubMed (`efetch`), the Crossref REST API,
+the PMC article HTML (PMC4668013, 231 KB retrieved and searched), the
+ModelDB REST API, and the `github.com/ModelDBRepository/185513` file
+tree. ModelDB accession 185513, which the paper's own Data
+Availability statement gives.
+
+.. [1] Sudhakar, S. K., Torben-Nielsen, B., & De Schutter, E. (2015).
+       Cerebellar nuclear neurons use time and rate coding to transmit
+       Purkinje neuron pauses. PLOS Computational Biology, 11(12),
+       e1004641.
+       doi:10.1371/journal.pcbi.1004641
+
+PMID 26630202, PMCID PMC4668013, fully open access. `e1004641` is the
+article number and occupies the page slot.
+
+**Author-list correction to the Task 1 brief.** The hypothesised
+"Sudhakar, Hong, Raikov, ... De Schutter" is a *different* paper --
+Sudhakar, Hong, Raikov, Publio, Lang, Close, Guo, Negrello & De
+Schutter (2017), *Spatiotemporal network coding of physiological mossy
+fiber inputs by the cerebellar granular layer*, PLOS Computational
+Biology 13(9), e1005754, PMID 28934196 (record independently confirmed
+here, and **not** the source of anything in this bucket). The 2015 DCN
+paper has three authors.
+
+**The origin of the DCN kinetics is Steuber et al. (2011), reached
+through Luthman et al. (2011).** Task 1 recorded this bucket as having
+no in-repo provenance; that was an artefact of its 25-line harvest
+window. Every shipped DCN `.mod` file carries "Translated from GENESIS
+by Johannes Luthman and Volker Steuber." inside its `COMMENT` block.
+Three steps, each verified:
+
+1. **O-ST2011** is the original GENESIS DCN model (ModelDB 136175) and
+   the origin of the channel kinetics. `SU2015`'s own Methods cite it
+   verbatim: "The CN neuron model used in our study is based on a
+   previously published model [21]", where [21] is Steuber et al.
+   2011, repeated throughout (its m1/m2/m3 reproduce "Neuron 1/2/3 of
+   [21]").
+2. **O-LU2011** is the GENESIS-to-NEURON translation. Its Methods say
+   verbatim that the model, "originally implemented in GENESIS", "was
+   translated to NEURON to simplify the modelling of STD", citing
+   Steuber et al. 2011. Corroborating detail: `GammaStim.mod`, which
+   Luthman et al. describe as their custom `NetStim` variant, is
+   present in the `SU2015` deposit -- so this file set demonstrably
+   passed through that translation.
+3. **`SU2015`** reused the NEURON translation but cites only step 1.
+   **"Luthman" appears zero times in the Sudhakar et al. (2015) full
+   text, reference list included.** The `.mod` files are the only
+   evidence of step 2, which is why it must be recorded here rather
+   than inferred from the paper.
+
+No GENESIS ancestor earlier than O-ST2011 is cited by either paper.
+
+**One further correction, recorded because a docstring could easily
+get it wrong.** Six of the mechanism names in this bucket appear only
+in the deposited code, never in the article. Searching the PMC full
+text, only `CaLVA`, `NaP`, `HCN` and `SK` occur as strings; `CaHVA`,
+`CaL`, `NaF`, `fKdr`, `sKdr` and the phrase "calcium pool" occur zero
+times. A docstring may say the mechanism is part of the model
+published as `SU2015`; it must not say the paper names or describes
+that mechanism.
 
 ### Attribution
 
-_TODO (Task 3): not yet filled in._
+**Attribution check: PASSED for 11 of 16 symbols. The other 5 get NO
+CITATION -- they are not literature-derived at all.**
+
+**The five `Toy*` symbols are BrainCell's own test fixtures.**
+`ToyCaBindingKinetic_SU2015_DCN`,
+`ToyCaBindingSourceKinetic_SU2015_DCN`,
+`ToyCaBindingIcaSourceKinetic_SU2015_DCN`,
+`ToyCaPumpFactorKinetic_SU2015_DCN` and
+`ToyDiamFactorKinetic_SU2015_DCN` carry the `SU15_DCN` suffix by naming
+convention only. Their `.mod` files say so explicitly -- e.g.
+`ToyCaBindingKinetic_SU15_DCN.mod`: "This deliberately minimal
+mechanism exists only to validate the BrainCell `KineticIon` import
+path against a small NMODL `KINETIC` example before attempting larger
+DCN or GoC calcium-pool mechanisms." They model one reversible
+buffering step (`cai + b <-> bc` with `CONSERVE b + bc = Btot`,
+`kf = 2 /ms mM`, `kb = 0.5 /ms`, `Btot = 1 mM`) and its variants with
+a constant source, an `ica`-driven source, an explicit pump
+compartment, and geometry-derived factors. **They must ship no
+`References` section.** Their docstrings should state that they are
+import-path fixtures, not models of a published mechanism. The
+unclaimed sixth file, `ToyStoich3ABtoCKinetic_SU15_DCN.mod` (`3a + b
+<-> c`, "exists to validate higher-order stoichiometry handling"), is
+the same thing left unported -- closing `## Unresolved attributions`
+item 4.
+
+**Mapping table for the 11 real symbols.** `.. [1]` is O-ST2011
+(origin of the kinetics), `.. [2]` is the `SU2015` entry above.
+O-LU2011 is the NEURON translation and belongs in `Notes`, not in
+`References`, unless the docstring discusses the port itself.
+
+| Symbols | Origin `.. [1]` |
+|---|---|
+| `CaHVA_SU2015_DCN`, `CaL_SU2015_DCN`, `CaLVA_SU2015_DCN`, `HCN_SU2015_DCN`, `fKdr_SU2015_DCN`, `sKdr_SU2015_DCN`, `SK_SU2015_DCN`, `NaF_SU2015_DCN`, `NaP_SU2015_DCN`, `CdpHVA_SU2015_DCN`, `CdpLVA_SU2015_DCN` | O-ST2011 (via O-LU2011) |
+
+**Code-versus-mod check.** Method as documented in the `MA2020`
+`### Attribution` block. All 11 match exhaustively; the unmatched
+literals are `gbar = 1e-5 siemens/cm2` (BrainCell `g_max =
+0.01 mS/cm2`, an exact match after conversion) and the GHK Kelvin
+offset `273.15`. Equations confirmed term for term against the `.mod`
+files, for example:
+
+- `NaF_SU2015_DCN` (`braincell/channel/sodium.py:194`):
+  `m_inf = 1/(1 + exp((V+45)/-7.3))`,
+  `tau_m = 5.83/(exp((V-6.4)/-9) + exp((V+97)/17)) + 0.025`,
+  `h_inf = 1/(1 + exp((V+42)/5.9))`,
+  `tau_h = 16.67/(exp((V-8.3)/-29) + exp((V+66)/9)) + 0.2`, gating
+  `m^3 h`, all divided by `qdeltat`.
+- `NaP_SU2015_DCN`: `m_inf = 1/(1 + exp((V+70)/-4.1))`, `tau_m = 50`,
+  `h_inf = 1/(1 + exp((V+80)/4))`,
+  `tau_h = 1750/(1 + exp((V+65)/-8)) + 250`.
+- `fKdr_SU2015_DCN`: `m_inf = 1/(1 + exp((V+40)/-7.8))`,
+  `tau_m = 13.9/(exp((V+40)/12) + exp((V+40)/-13)) + 0.1`.
+- `sKdr_SU2015_DCN`: `m_inf = 1/(1 + exp((V+50)/-9.1))`,
+  `tau_m = 14.95/(exp((V+50)/21.74) + exp((V+50)/-13.91)) + 0.05`,
+  gating `m^4`.
+- `HCN_SU2015_DCN`: `m_inf = 1/(1 + exp((V+80)/5))`, no tau.
+- `SK_SU2015_DCN`: `z_inf = cai^4/(cai^4 + 8.1e-15)` (i.e. a Hill
+  coefficient of 4 at `[Ca] = 3e-4 mM`), with the piecewise
+  `tau_z = 1 - 186.67 cai` below `cai = 0.005 mM` and `0.0667` above.
+- `CaHVA_SU2015_DCN` and `CaLVA_SU2015_DCN` are the only two DCN
+  channels using GHK; both carry the `4.47814e6` and
+  `-23.20764929` GHK constants, and `CaLVA` reads a separate `cal`
+  ion so that `CdpLVA` can track it independently of the `CaHVA` pool
+  that gates `SK`.
+
+**What could NOT be established, and must not be papered over.** The
+individual DCN mechanisms have no per-mechanism attribution anywhere
+in this chain. O-ST2011 is the origin of the *set*, established from
+the `.mod` translation credit plus `SU2015`'s own "based on a
+previously published model" sentence -- **not** from a per-mechanism
+statement in any paper, and **not** by comparing these constants
+against numbers printed in O-ST2011, whose parameter tables were not
+read. Six of the nine channel names do not appear in the `SU2015` text
+at all (above). So a docstring may say: "kinetics from the deep
+cerebellar nucleus model of Steuber et al. (2011), translated from
+GENESIS to NEURON by Luthman et al. (2011) and used in Sudhakar et
+al. (2015)". It may **not** say that any of these papers prints the
+Boltzmann constants quoted above. Recorded as `## Unresolved
+attributions` item 9.
+
+### Import deviations
+
+Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
+
+**`TABLE` removed, replaced by per-call evaluation.** The DCN files
+used a wider voltage window than the other cell types, so boundary
+clamping was much less likely to bite; the concentration table in
+`SK` is the exception.
+
+| Symbol | Former `TABLE` range | Tabulated |
+|---|---|---|
+| `CaHVA_SU2015_DCN` | `[-150, 100]` | `minf`, `taum`, plus a `DEPEND T` table |
+| `CaLVA_SU2015_DCN` | `[-150, 100]` | `minf`, `taum`, `hinf`, `tauh`, plus a `DEPEND T` table |
+| `CaL_SU2015_DCN` | `[-150, 100]` | `minf`, `taum`, `hinf`, `tauh` |
+| `HCN_SU2015_DCN` | `[-150, 100]` | `minf` |
+| `NaF_SU2015_DCN` | `[-150, 100]` | `minf`, `taum`, `hinf`, `tauh` |
+| `NaP_SU2015_DCN` | `[-150, 100]` | `minf`, `hinf`, `tauh` |
+| `fKdr_SU2015_DCN` | `[-150, 100]` | `minf`, `taum` |
+| `sKdr_SU2015_DCN` | `[-150, 100]` | `minf`, `taum` |
+| `SK_SU2015_DCN` | `cai` `[0, 0.01]` (clamped) | `zinf`, `tauz` |
+
+**`derivimplicit` -> `cnexp`.** None. `DCN` does not appear in the
+README's integration-method table; these mechanisms were already
+`cnexp` (or `sparse`, for the kinetic pools) upstream.
+
+**Rate-refresh relocation.** None for `DCN`.
+
+**NMODL default-precision rewrites -- one documented EXCEPTION.**
+`ToyDiamFactorKinetic_SU2015_DCN`'s `pump_area` and `cyto` are
+`62.83185307179586` in the `.mod` source and `62.8319` in NEURON's
+compiled output. BrainCell does **not** substitute the compiled
+constant: it derives both at runtime from geometry, as
+`pi * diam_mid` and `pi * diam_mid * depth`. The README marks this
+`例外` (exception). No other DCN mechanism is affected. (This entry is
+recorded for completeness; the symbol it concerns is one of the five
+citation-less `Toy*` fixtures.)
 
 ---
 
@@ -884,11 +2065,100 @@ unrelated to the `MA2025` search target.
 
 ### Verified record
 
-_TODO (Task 3): not yet verified._
+Confirmed 2026-08-15 against PubMed (`efetch`), the Crossref REST API,
+the PMC article HTML (PMC12255734, 275 KB retrieved), and the ModelDB
+REST API. ModelDB accession 2018018, given in the paper's own Data
+Availability statement. **It is not a preprint** -- the Task 1 brief
+allowed for that possibility; the paper is peer-reviewed and appeared
+12 July 2025.
+
+.. [1] Masoli, S., Rizza, M. F., Soda, T., Sanchez-Ponce, D., Munoz,
+       A., Prestori, F., & D'Angelo, E. (2025). Cerebellar basket cell
+       filtering of Purkinje cell responses elicited by low frequency
+       parallel fibre transmission. Scientific Reports, 15(1), 25192.
+       doi:10.1038/s41598-025-09964-2
+
+PMID 40652073, PMCID PMC12255734, fully open access. `25192` is the
+article number and occupies the page slot; *Scientific Reports*
+assigns every article of a volume-year to issue 1, so `15(1)` is
+nominal. Keep the British spelling **"fibre"** as published. As in the
+`MA2024` record, "Sanchez-Ponce" and "Munoz" are published here
+without accents in both PubMed and Crossref.
 
 ### Attribution
 
-_TODO (Task 3): not yet filled in._
+**Attribution check: PASSED for all 16 symbols**, with the `Kv3p4` and
+`Cav1p2`/`Cav1p3` caveats from the `MA2020` block carried over.
+
+Method as documented in the `MA2020` `### Attribution` block. All 16
+map 1:1 onto a `BC/channel/*_MA25_BC.mod` or `BC/ion/*_MA25_BC.mod`
+file and every rate-function constant matches. The zero-overlap
+classes in that scan (`Cav1p2_MA2025_BC`, `Cav1p3_MA2025_BC`,
+`Cav2p1_MA2025_BC`, `Cav2p1_MA2025_BC_Frozen`, `Cav3p2_MA2025_BC`,
+`Kca1p1_MA2025_BC`, `Kca2p2_MA2025_BC`, `Kca3p1_MA2025_BC`,
+`Nav1p6_MA2025_BC`, `CdpStC_MA2025_BC`) are subclasses inheriting
+their constants from a `MA2020`, `MA2024` or `RI2021` base --
+confirmed by reading each `class` line. `CdpStC_MA2025_BC` derives
+from `CdpStC_NoCAM_MA2020_GoC`, and that base's literal set was
+re-checked directly against `BC/ion/CdpStC_MA25_BC.mod`: 21 of 26
+literals match, the five unmatched being unit conversions and NMODL
+range annotations.
+
+**Mapping table.** `.. [1]` is the origin record; `.. [2]` is the
+`MA2025` entry above.
+
+| Symbols | Origin `.. [1]` |
+|---|---|
+| `Cav1p2_MA2025_BC`, `Cav1p3_MA2025_BC` | O-EV2013 (kinetics), O-BE2017 (port) |
+| `Cav2p1_MA2025_BC`, `Cav2p1_MA2025_BC_Frozen` | O-SW2005 (recordings), O-AN2012 (model) |
+| `Cav3p2_MA2025_BC` | Huguenard & McCormick (1992) -- see the `HM1992` Verified record -- plus O-VI2005 and O-CO1989 (Q10) |
+| `HCN1_MA2025_BC` | O-AG2007 (kinetics), O-SA2000 (subunit identity) |
+| `Kir2p3_MA2025_BC`, `Kv4p3_MA2025_BC` | O-DA2001 |
+| `Kv1p1_MA2025_BC` | O-ZE1998 (data), O-AK2009 (model) |
+| `Kv3p4_MA2025_BC` | O-KH2003 |
+| `Kca1p1_MA2025_BC` | O-CX1997 (parameters), O-AN2012 (model) |
+| `Kca2p2_MA2025_BC` | O-HI1998 (data), O-SO2007a (model) |
+| `Kca3p1_MA2025_BC` | O-RC2006, O-BB1993, O-DV2000 |
+| `Nav1p1_MA2025_BC` | O-KH2003 (`Narsg` derivation), O-AK2009 |
+| `Nav1p6_MA2025_BC` | O-RB2001 (kinetics), O-KH2003, O-AK2006 |
+| `CdpStC_MA2025_BC` | O-AN2012 (model), O-SC2003 (buffers), O-MD1999 (pump tuning) |
+
+**Caveat specific to this bucket.** `HCN1_MA25_BC.mod` inherits the
+Purkinje-cell comment "We call it HCN1 as PC express only HCN1 Santoro
+et al. 2000" verbatim from the `MA2024` port, and sets
+`rec_temp = 23 (deg)` with the header note that Angelo et al. "forogot
+tp mention the recording temperature" (typos in the original). A
+basket-cell docstring must not repeat the Purkinje-only claim as
+though it were about basket cells; the 23 degC is the porter's
+assumption, not a value from O-AG2007. This applies equally to
+`HCN1_MA2024_PC` and `HCN1_RI2021_SC`.
+
+`CdpStC_MA25_BC.mod` is the GoC `CdpStC` mechanism with its CAM block
+commented out, per the README's "Ion_dyn inherited variants" table --
+the same non-CAM pump/PV network as `CdpStC_RI2021_SC`.
+
+### Import deviations
+
+Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
+
+**`TABLE` removed, replaced by per-call evaluation.**
+
+| Symbol | Former `TABLE` range | Tabulated |
+|---|---|---|
+| `Kv4p3_MA2025_BC` | `[-100, 30]` (clamped) | `a_inf`, `tau_a`, `b_inf`, `tau_b` |
+| `Kir2p3_MA2025_BC` | `[-100, 100]` | `d_inf`, `tau_d` |
+| `Kca3p1_MA2025_BC` | V `[-100, 100]`; `cai` `[0, 0.01]` (clamped) | `Yvdep`, `Yconcdep` |
+
+**`derivimplicit` -> `cnexp`.** `Kir2p3_MA2025_BC`,
+`Kv4p3_MA2025_BC`.
+
+**Rate-refresh relocation.** `Cav1p2_MA2025_BC` and
+`Cav1p3_MA2025_BC`: `rates()` moved from `BREAKPOINT` into
+`DERIVATIVE state`, so `inf`/`tau` are refreshed before the `cnexp`
+state update.
+
+**NMODL default-precision rewrites.** `Kv4p3_MA2025_BC` only, same
+four parameters and values as in the `MA2020` table.
 
 ---
 
@@ -1028,11 +2298,103 @@ the other cerebellar buckets.
 
 ### Verified record
 
-_TODO (Task 3): not yet verified._
+Confirmed 2026-08-15 against PubMed (`efetch`), the Crossref REST API,
+the PMC article HTML (PMC7886897, 279 KB retrieved), and the ModelDB
+REST API. The Task 1 hypothesis is confirmed as to authorship but
+**not** as to journal: this is *Scientific Reports*, not
+*Communications Biology*.
+
+.. [1] Rizza, M. F., Locatelli, F., Masoli, S., Sanchez-Ponce, D.,
+       Munoz, A., Prestori, F., & D'Angelo, E. (2021). Stellate cell
+       computational modeling predicts signal filtering in the
+       molecular layer circuit of cerebellum. Scientific Reports,
+       11(1), 3873.
+       doi:10.1038/s41598-021-83209-w
+
+PMID 33594118, PMCID PMC7886897, fully open access. `3873` is the
+article number and occupies the page slot; `11(1)` is nominal.
+
+**Name-form note.** In *this* paper the fourth and fifth authors are
+published **with** accents -- Sánchez-Ponce and Muñoz -- in both
+PubMed and Crossref, whereas the same two appear unaccented in the
+`MA2024` and `MA2025` records. The ASCII forms are used above for
+consistency with the rest of this file; if the docstring pipeline is
+UTF-8-safe, prefer the accented forms here and the plain forms there,
+because that is how each publisher printed them.
+
+**ModelDB provenance quirk, recorded rather than smoothed over.**
+Accession **2018019**. The 2021 paper itself gives no accession -- it
+says only that the models "will also be uploaded on ModelDB". The
+accession is established from two other places: the ModelDB API
+record, and the `MA2025` paper's Data Availability statement, which
+states "SC model is available on ModelDB
+(https://modeldb.science/2018019)". ModelDB shows it created
+2024-11-18, i.e. deposited three years after publication. **It is
+therefore not established that this repository's `RI21_SC` `.mod`
+files came from accession 2018019 specifically**; an earlier copy
+could have circulated via the HBP Brain Simulation Platform. This does
+not affect the citation, only any claim about the download source.
 
 ### Attribution
 
-_TODO (Task 3): not yet filled in._
+**Attribution check: PASSED for all 15 symbols**, with the `Kv3p4` and
+`HCN1` caveats carried over from the `MA2020` and `MA2025` blocks.
+
+Method as documented in the `MA2020` `### Attribution` block. All 15
+map 1:1 onto an `SC/channel/*_RI21_SC.mod` or `SC/ion/*_RI21_SC.mod`
+file and every rate-function constant matches. `Cav2p1_RI2021_SC` and
+`Cav3p2_RI2021_SC` and `Cav3p3_RI2021_SC` are the *base* classes that
+`MA2024` and `MA2025` inherit from, so their literal overlap with the
+`.mod` files is direct and high (14/23, 21/25 and 20/27 respectively;
+the remainder are GHK and Kelvin constants). The zero-overlap classes
+(`Cav2p1_RI2021_SC_Frozen`, `Kca1p1_RI2021_SC`, `Kca2p2_RI2021_SC`,
+`Nav1p1_RI2021_SC`, `Nav1p6_RI2021_SC`, `CdpStC_RI2021_SC`) are
+subclasses inheriting their constants; `CdpStC_RI2021_SC` derives from
+`CdpStC_NoCAM_MA2020_GoC`, whose literals were re-checked directly
+against `SC/ion/CdpStC_RI21_SC.mod` (21 of 26).
+
+**Mapping table.** `.. [1]` is the origin record; `.. [2]` is the
+`RI2021` entry above.
+
+| Symbols | Origin `.. [1]` |
+|---|---|
+| `Cav2p1_RI2021_SC`, `Cav2p1_RI2021_SC_Frozen` | O-SW2005 (recordings), O-AN2012 (model) |
+| `Cav3p2_RI2021_SC` | Huguenard & McCormick (1992) -- see the `HM1992` Verified record -- plus O-VI2005 and O-CO1989 (Q10) |
+| `Cav3p3_RI2021_SC` | O-XC2008 |
+| `HCN1_RI2021_SC` | O-AG2007 (kinetics), O-SA2000 (subunit identity) |
+| `KM_RI2021_SC`, `Kir2p3_RI2021_SC`, `Kv4p3_RI2021_SC` | O-DA2001 |
+| `Kv1p1_RI2021_SC` | O-ZE1998 (data), O-AK2009 (model) |
+| `Kv3p4_RI2021_SC` | O-KH2003 |
+| `Kca1p1_RI2021_SC` | O-CX1997 (parameters), O-AN2012 (model) |
+| `Kca2p2_RI2021_SC` | O-HI1998 (data), O-SO2007a (model) |
+| `Nav1p1_RI2021_SC` | O-KH2003 (`Narsg` derivation), O-AK2009 |
+| `Nav1p6_RI2021_SC` | O-RB2001 (kinetics), O-KH2003, O-AK2006 |
+| `CdpStC_RI2021_SC` | O-AN2012 (model), O-SC2003 (buffers), O-MD1999 (pump tuning) |
+
+**Caveat specific to this bucket.** `SC/ion/CdpStC_RI21_SC.mod` reads
+`cao` but never uses it in its equations, per the README's "Ion_dyn
+inherited variants" table; BrainCell drops the unused read. Also note
+that `SC` has no `Kca3p1` mechanism, unlike `BC`, `GoC` and `PC`.
+
+### Import deviations
+
+Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
+
+**`TABLE` removed, replaced by per-call evaluation.**
+
+| Symbol | Former `TABLE` range | Tabulated |
+|---|---|---|
+| `Kv4p3_RI2021_SC` | `[-100, 30]` (clamped) | `a_inf`, `tau_a`, `b_inf`, `tau_b` |
+| `KM_RI2021_SC` | `[-100, 30]` (clamped) | `n_inf`, `tau_n` |
+| `Kir2p3_RI2021_SC` | `[-100, 100]` | `d_inf`, `tau_d` |
+
+**`derivimplicit` -> `cnexp`.** `KM_RI2021_SC`, `Kir2p3_RI2021_SC`,
+`Kv4p3_RI2021_SC`.
+
+**Rate-refresh relocation.** None for `SC`.
+
+**NMODL default-precision rewrites.** `Kv4p3_RI2021_SC` only, same
+four parameters and values as in the `MA2020` table.
 
 ---
 
@@ -1222,11 +2584,142 @@ Task 3 as a possible (not yet verified) partial match.
 
 ### Verified record
 
-_TODO (Task 3): not yet verified._
+**Task 1's flag was right: `ZH` is Xu Zhang, the porter named in
+`HCN_ZH19_IO.mod`.** The key resolves to **Zhang**, not Zang.
+Confirmed 2026-08-15 against the Crossref REST API, PubMed (`efetch`),
+the PMC article HTML (PMC6612915), the ModelDB REST API, and the
+`github.com/ModelDBRepository/257028` file tree.
+
+.. [1] Zhang, X., & Santaniello, S. (2019). Role of cerebellar
+       GABAergic dysfunctions in the origins of essential tremor.
+       Proceedings of the National Academy of Sciences of the United
+       States of America, 116(27), 13592-13601.
+       doi:10.1073/pnas.1817689116
+
+PMID 31209041, PMCID PMC6612915. Published online 17 June 2019, print
+issue 2 July 2019. ModelDB accession **257028**, "A
+cortico-cerebello-thalamo-cortical loop model under essential tremor
+(Zhang & Santaniello 2019)", created 2019-06-04.
+
+**Identification evidence, four independent strands.**
+
+1. The `.mod` headers in ModelDB 257028 are an **exact string match**
+   to this repository's: `modfiles/io_h.mod` carries "Somatic h
+   channel from Schweighofer et al., 1999" / "Xu Zhang @ UConn,
+   6-22-2018"; `io_na.mod` and `io_kdr.mod` carry the Schweighofer
+   credit with "B. Torben-Nielsen @ HUJI, 21-10-2010"; `io_ca.mod`
+   carries "Ca channel from Manor (Rinzel, Segev, Yarom) 1997" with
+   "B. Torben-Nielsen @ HUJI, 7-10-2010".
+2. ModelDB's `public_submitter_name` for 257028 is literally
+   "Xu Zhang", and its indexed neuron list includes "Inferior olive
+   neuron".
+3. Crossref gives the first author's affiliation as UConn Biomedical
+   Engineering, matching the "@ UConn" porter credit and the June-2018
+   porting date against a 2019 publication.
+4. The repository's own `<Mechanism>_<Initials><YY>_<Cell>` naming
+   convention decodes `ZH19_IO` as Zhang 2019, inferior olive --
+   consistent with `SU15_DCN` decoding to Sudhakar 2015, deep
+   cerebellar nuclei, which is independently confirmed.
+
+**Yunliang Zang is ruled out**: no 2019 inferior olive paper, and no
+UConn affiliation at any point.
+
+**Two caveats that must be recorded.**
+
+- **A 2021 deposit contains byte-identical `io_*.mod` files.** ModelDB
+  **266842** (Schreglmann et al. 2021, a phase-locked tACS model, on
+  which Xu Zhang is a middle author) ships the same files with the
+  same headers -- `io_h.mod` is byte-identical (md5 `66e12eb6...`) in
+  both. The header text alone therefore **cannot** discriminate 257028
+  from 266842. Strand 4 above resolves it -- a 2021 provenance would
+  have been tagged `SC21`/`SR21`, not `ZH19` -- but that is a
+  naming-convention inference, a weaker grade of evidence than the
+  exact header match. Recorded as `## Unresolved attributions` item 10.
+- **The inferior olive neurons in Zhang & Santaniello (2019) are
+  single-compartment.** `CCTC_model/cell_ION.hoc` creates
+  `IONcell[8]` with `nseg = 1`, `L = diam = 20`, mechanisms
+  `ioNa`/`ioKdr`/`ioCa`/`ioh`/`pas`, coupled as an eight-node
+  gap-junction lattice; its own header says "Modified from
+  Schweighofer et al., 1999 and Torben-Nielson et al., 2012". The
+  multi-compartment part of that paper is the Purkinje population, not
+  the olive. A docstring must not describe these as multi-compartment
+  inferior olive mechanisms.
+
+`IO` has no `ion/` subdirectory under `Cerebellum_mod`, so this key
+has no ion-state symbol.
 
 ### Attribution
 
-_TODO (Task 3): not yet filled in._
+**Attribution check: PASSED for all 5 symbols.**
+
+Method as documented in the `MA2020` `### Attribution` block. All 5
+map 1:1 onto an `IO/channel/*_ZH19_IO.mod` file and every
+rate-function constant matches. `Ca_ZH2019_IO_Frozen` reports zero
+overlap in that scan because it subclasses `Ca_ZH2019_IO`.
+
+**Mapping table.** `.. [1]` is the origin record; `.. [2]` is the
+`ZH2019` entry above. O-TN2012 is the intermediate NEURON port and
+belongs in `Notes`, not `References`, unless the docstring discusses
+the port itself.
+
+| Symbols | Origin `.. [1]` |
+|---|---|
+| `Na_ZH2019_IO`, `Kdr_ZH2019_IO`, `HCN_ZH2019_IO` | O-SW1999 (via O-TN2012) |
+| `Ca_ZH2019_IO`, `Ca_ZH2019_IO_Frozen` | O-MN1997 (via O-TN2012) |
+
+**Fingerprint checked beyond the literal scan.** `Na_ZH2019_IO`
+(`braincell/channel/sodium.py:269`) implements
+`alpha_m = 0.1 (V+41)/(1 - exp(-(V+41)/10))`,
+`beta_m = 9 exp(-(V+66)/20)`, `alpha_h = 5 exp(-(V+60)/15)`,
+`beta_h = 10 (V+50)/(1 - exp(-(V+50)/10))` with
+`tau_h = 250/(alpha_h + beta_h)` and an instantaneous `m`
+(`tau_m = 0.001 ms`) -- the Schweighofer et al. (1999) inferior olive
+somatic Na parameterisation, matching `Na_ZH19_IO.mod` term for term.
+`Kdr_ZH19_IO.mod`'s `ek = -75 mV` is supplied by the ion object in
+BrainCell and so is absent from the class, as expected.
+
+**Caveat for the module task -- a real numerical deviation, not a
+citation issue.** `Na_ZH19_IO.mod` and `Kdr_ZH19_IO.mod` guard the
+removable singularities in `alpha_m` and `beta_h` with explicit
+`if (fabs(v + 41.0) < 1e-6)` / `if (fabs(v + 50.0) < 1e-6)` branches
+that substitute the perturbed literals `41.000001` and `50.000001`.
+BrainCell replaces both with a numerically stable
+`x/(1 - exp(-x))` helper (`_x_over_one_minus_exp_neg_stable` in
+`braincell/channel/sodium.py`), so the perturbed literals do not
+appear in the class. The README explicitly excludes those literals
+from its NMODL default-precision rewrite table -- they are ordinary
+in-formula constants that "keep their original value" -- so the
+stable-helper substitution is a separate, undocumented BrainCell
+choice. It is exact away from the singularity and better-behaved at
+it, but a docstring should say the guard was replaced rather than
+imply the mod file's branch was reproduced.
+
+### Import deviations
+
+Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
+
+**`TABLE` removed.** None. No `IO` mechanism used a `TABLE`.
+
+**`derivimplicit` -> `cnexp`.** None. `IO` does not appear in the
+README's integration-method table.
+
+**Rate-refresh relocation -- this is the `IO` bucket's characteristic
+deviation, and it applies to all four mechanisms.** For
+`Ca_ZH2019_IO`, `HCN_ZH2019_IO`, `Kdr_ZH2019_IO` and `Na_ZH2019_IO`,
+the `rates(v)` call moved from `BREAKPOINT` into `DERIVATIVE states`,
+so `inf`/`tau` are refreshed before the `cnexp` state update rather
+than after it. Independently confirmed against ModelDB 257028: the
+upstream `io_h.mod` has `rates(v)` in `BREAKPOINT`, and this
+repository's `HCN_ZH19_IO.mod` has it in `DERIVATIVE states`. That is
+a semantic change, not a cosmetic one -- the only other difference
+from upstream is the `SUFFIX ioh` -> `SUFFIX HCN_ZH19_IO` rename, and
+the `COMMENT` header is untouched, which is why the attribution string
+survived intact.
+
+**NMODL default-precision rewrites.** None. The README states
+explicitly that `IO`'s in-formula literal `41.000001` keeps its
+original value and is **not** part of the default-precision rewrite.
+See the singularity-guard caveat above for what BrainCell did instead.
 
 ---
 
@@ -1646,11 +3139,88 @@ family (see the docstring already in the source), but nothing in the
 
 ### Verified record
 
-_TODO (Task 3): not yet verified._
+**Task 1's "genuine zero-provenance case" verdict is superseded.** The
+`.mod` file is anonymous, but it is not unidentifiable: its kinetics
+are `Cav3p1_MA24_PC.mod`'s, character for character, so `PC24` inherits
+that mechanism's whole attribution chain. `PC24` is therefore the same
+model paper as `MA2024`, as the Task 1 brief hypothesised, and the
+hypothesis is now confirmed by code comparison rather than assumed
+from the `PC` fragment in the class name.
+
+The model-paper entry to copy is the `MA2024` `### Verified record`
+block above (Masoli et al., 2024, Communications Biology 7(1), 5,
+doi:10.1038/s42003-023-05689-y); the origin-of-kinetics entry is
+O-IF2006 with O-AN2012. **Do not retype either.**
+
+**How the identification was made.** `Cav3_1_test.mod` and
+`Cav3p1_MA24_PC.mod` declare the identical named parameter block --
+`v0_m_inf = -52 mV`, `v0_h_inf = -72 mV`, `k_m_inf = -5 mV`,
+`k_h_inf = 7 mV`, `C_tau_m = 1`, `A_tau_m = 1.0`,
+`v0_tau_m1 = -40 mV`, `v0_tau_m2 = -102 mV`, `k_tau_m1 = 9 mV`,
+`k_tau_m2 = -18 mV`, `C_tau_h = 15`, `A_tau_h = 1.0`,
+`v0_tau_h1 = -32 mV`, `k_tau_h1 = 7 mV`, `pcabar = 2.5e-4`,
+`q10 = 3` -- and the identical four rate expressions, including
+`qt = q10^((celsius - 37)/10)`:
+
+    minf = 1/(1 + exp((v - v0_m_inf)/k_m_inf))
+    hinf = 1/(1 + exp((v - v0_h_inf)/k_h_inf))
+    taum = (C_tau_m + A_tau_m/(exp((v - v0_tau_m1)/k_tau_m1)
+           + exp((v - v0_tau_m2)/k_tau_m2)))/qt
+    tauh = (C_tau_h + A_tau_h/exp((v - v0_tau_h1)/k_tau_h1))/qt
+
+**The single difference is the current law**, and it is exactly what
+the existing class docstring already says. `Cav3p1_MA24_PC.mod`
+computes `ica = (1e3) * pcabar * m*m*h * g` with `g` from GHK and
+`pcabar` in `cm/s` (a permeability). `Cav3_1_test.mod` drops the GHK
+drive entirely, redeclares `pcabar = 2.5e-4 (S/cm2)` as a conductance
+density, and computes `ica = pcabar * m*m*h`. So `Cav3p1Test_PC24` is
+the `MA2024` Cav3.1 mechanism with an ohmic current law substituted
+for the GHK one -- a variant of a published mechanism, not an
+unattributable orphan.
+
+The sibling `Cav3_1_test2.mod` remains unclaimed by any BrainCell
+symbol and was not analysed further.
 
 ### Attribution
 
-_TODO (Task 3): not yet filled in._
+**Symbol:** `Cav3p1Test_PC24`
+(`braincell/channel/calcium.py:881`).
+
+**Attribution check: PASSED, with one mandatory caveat.**
+
+The class's own constructor was read and carries `v0_m_inf = -52 mV`,
+`v0_h_inf = -72 mV`, `k_m_inf = -5 mV`, `k_h_inf = 7 mV`,
+`C_tau_m = 1.0`, `A_tau_m = 1.0`, `v0_tau_m1 = -40 mV`,
+`v0_tau_m2 = -102 mV`, `k_tau_m1 = 9 mV`, `k_tau_m2 = -18 mV`,
+`g_max = 2.5e-4 S/cm^2`, `q10 = 3.0`, `temp_ref = 37 degC`,
+`temp = 22 degC`, with `Gate("p", power=2)` and `Gate("q")` -- i.e. it
+reproduces `Cav3_1_test.mod` exactly, and through it the O-IF2006
+Cav3.1 kinetics as fitted in Anwar's `CaT3_1.mod` (ModelDB 138382).
+
+**Two-level citation:** `.. [1]` O-IF2006 (with O-AN2012 as the model
+the fit was published in), `.. [2]` the `MA2024` model paper.
+
+**Mandatory caveat.** The current law is *not* the published one. The
+mechanism as published is a GHK-driven permeability; this variant is
+ohmic, and `g_max = 2.5e-4` carries `S/cm^2` here against `cm/s` in
+the published mechanism -- the same number in a different dimension.
+A docstring must say that the kinetics are those of the Cav3.1
+mechanism of the cited model with the GHK drive replaced by a direct
+conductance-density current law, and must not present the ohmic form
+as the published one. The class name's "Test" is accurate: nothing in
+the `.mod` file or the deposit indicates this variant was used to
+produce any published result.
+
+### Import deviations
+
+None recorded. `Cav3_1_test.mod` does not appear in any table of
+`examples/neuron_compare/Cerebellum_mod/README.md` -- that file covers
+only the shipped `channel/ion` mechanisms, and this is a test variant.
+It carries no `TABLE`, no `derivimplicit`, and no rate-refresh
+relocation, confirmed by reading the file. For the deviations that
+apply to the mechanism it is derived from, see the `MA2024`
+`### Import deviations` block (`Cav3p1` is not listed there either --
+the `MA2024` deviations affect `Kv4p3`, `Kir2p3` and `Kca3p1` only).
 
 ---
 
@@ -1881,21 +3451,27 @@ Items below need explicit attention in Task 2/3 beyond the default
 literature search, because Step 1/Step 2 of this harvest could not
 resolve them cleanly:
 
-1. **`CdpStC_NoCAM_MA2020_GoC`** (`braincell/ion/calcium.py`) — no
-   `CdpStC_NoCAM_MA20_GoC.mod` file exists anywhere under
-   `examples/neuron_compare/Cerebellum_mod`. Only the `CAMOnly` and
-   plain `CdpStC` variants have `.mod` counterparts in `GoC/ion/`. The
-   `NoCAM` variant's provenance (is it a hand-derived complement of the
-   other two, or ported from elsewhere?) must be established directly
-   from the BrainCell source/tests, not from a `.mod` header.
+1. ~~**`CdpStC_NoCAM_MA2020_GoC`**~~ — **CLOSED by Task 3
+   (2026-08-15).** The absent `CdpStC_NoCAM_MA20_GoC.mod` is not a
+   missing file: the class is a BrainCell-factored base, and its
+   literal set matches `BC/ion/CdpStC_MA25_BC.mod` and
+   `SC/ion/CdpStC_RI21_SC.mod` (21 of 26 literals; the five unmatched
+   are unit conversions and NMODL range annotations), which are the GoC
+   `CdpStC` mechanism with the CAM subnetwork commented out. This is
+   what the README's "Ion_dyn inherited variants" table says. Full
+   detail and the resulting citation are in the `MA2020`
+   `### Attribution` block, Caveat 3.
 
-2. **`SU2015` bucket (all 16 symbols)** — none of the 11 `.mod` files
-   under `DCN/channel/` and `DCN/ion/` carry any `Author:`/`Ref:`/
-   `Written by` line. Headers are bare `TITLE ... (DCN) neuron` with an
-   empty `COMMENT` block. Task 3 has zero in-repo textual lead for this
-   entire cell type and must resolve purely from the `SU2015` key
-   (presumably a "Su" or similarly-initialed 2015 DCN modeling paper)
-   and cross-checking with published deep cerebellar nuclei models.
+2. ~~**`SU2015` bucket (all 16 symbols)**~~ — **CLOSED by Task 3
+   (2026-08-15), and the premise of the item was wrong twice.** The
+   count is 17 `.mod` files (9 in `DCN/channel/`, 8 in `DCN/ion/`), not
+   11; and they are not attribution-free. Every shipped DCN mechanism
+   carries "Translated from GENESIS by Johannes Luthman and Volker
+   Steuber." inside its `COMMENT` block, below Task 1's 25-line harvest
+   window. That resolves the bucket to Steuber et al. (2011) via
+   Luthman et al. (2011). See the `SU2015` `### Verified record` and
+   `### Attribution` blocks. A residual, narrower gap remains and is
+   recorded as item 9 below.
 
 3. **`HM1992`, `IS2008`, `Ba2002`, `TM1991`, `HH1952`, `HP1992`,
    `Re1993`, `Ya1989`, `De1994`, `PC24`** — no `.mod` file evidence at
@@ -1908,11 +3484,14 @@ resolve them cleanly:
    Hodgkin & Huxley 1952 — but that identification is Task 2's job to
    make and verify, not this task's).
 
-4. **Unclaimed `.mod` file**: `examples/neuron_compare/Cerebellum_mod/DCN/ion/ToyStoich3ABtoCKinetic_SU15_DCN.mod`
-   has no corresponding BrainCell symbol in the `SU2015` bucket (or
-   anywhere else in `braincell/ion/` or `braincell/channel/`). Flagged in
-   case a future task needs to know it was intentionally left unported,
-   not missed.
+4. ~~**Unclaimed `.mod` file**~~ — **CLOSED by Task 3 (2026-08-15).**
+   `.../DCN/ion/ToyStoich3ABtoCKinetic_SU15_DCN.mod` was intentionally
+   left unported. Its own `COMMENT` says it "exists to validate
+   higher-order stoichiometry handling in the BrainCell `KineticIon`
+   path against a minimal NMODL `KINETIC` example" (`3a + b <-> c`). It
+   is a BrainCell test fixture, not a model of anything published, and
+   the same is true of the five `Toy*` files that *were* ported. See
+   the `SU2015` `### Attribution` block.
 
 5. **Systemic author mismatch** — every one of the 18 cerebellar `.mod`
    files that carries an explicit `Author:`/`CoAuthor:` line (across the
@@ -1926,6 +3505,15 @@ resolve them cleanly:
    an author line at all. Treat the key name as a "ported by" label, not
    an "authored by" label, for the entire cerebellar half of this
    bibliography.
+
+   **Task 3 confirms and widens this.** It is not only the 18
+   author-line files: it holds for every one of the 104 cerebellar
+   symbols. Not a single mechanism in any of the seven keys originates
+   with the group the key names. That is why `## Origin-of-kinetics
+   records` exists and why 99 of the 104 symbols take a two-level
+   citation. The five exceptions take no citation at all, and they are
+   exceptions in the opposite direction: BrainCell's own `Toy*` test
+   fixtures, which originate with no publication whatsoever.
 
 6. **`IS2008` (both symbols: `CaN_IS2008`, `CaL_IS2008`)** -- *record
    resolves; attribution NOT CONFIRMED. Do not cite yet.*
@@ -2115,3 +3703,96 @@ resolve them cleanly:
    shift is a BrainCell/BrainPy convention with no source in that paper.
    If a genuine high-threshold thalamic Ca current is wanted, the
    provenance of the +25 mV shift needs to be traced separately.
+
+8. **Task 1's harvest window hid provenance in five places.** Step 2
+   read only the first 25 lines of each `.mod` file. Five real
+   attribution leads sit below that line and were therefore recorded
+   in this file as absent. All five are now resolved, but the pattern
+   matters for anyone re-auditing: **a "no provenance found" note in a
+   `### Provenance evidence` block is evidence about the harvest, not
+   about the file.**
+
+   - All 11 shipped `DCN` mechanisms: "Translated from GENESIS by
+     Johannes Luthman and Volker Steuber." -> O-ST2011 / O-LU2011.
+   - `Kca2p2_*.mod` (all five cell types): a full citation to
+     "Sergio M. Solinas, Lia Forti, Elisabetta Cesana, Jonathan
+     Mapelli, Erik De Schutter and Egidio D`Angelo (2008) /
+     Computational reconstruction of pacemaking and intrinsic
+     electroresponsiveness in cerebellar golgi cells / Frontiers in
+     Cellular Neuroscience 2:2" at lines 10-14 -> O-SO2007a (with the
+     header's year and volume both corrected).
+   - `Kv3p4_*.mod` (all five cell types), recorded as having no
+     header lines at all: it has two, ": HH TEA-sensitive Purkinje
+     potassium current" / ": Created 8/5/02 - nwg", which identify
+     ModelDB 48332's `kpkj.mod` -> O-KH2003.
+   - `Cav2p3_MA20_GoC.mod`, recorded as `TITLE`-only: it also carries
+     ": written by Yiota Poirazi on 11/13/00 poirazi@LNC.usc.edu" and
+     ": From car to Cav2_3" -> O-PO2003a.
+   - `Cav3p2_*.mod`: ": (as in Coulter et al., J Physiol 414: 587,
+     1989)" at line ~85 -> O-CO1989.
+
+   `NaFHF_MA20_GrC.mod`'s empty `COMMENT` is a genuine absence, but it
+   is not a gap: the file is `Nav_MA20_GrC.mod`'s 13-state scheme with
+   the blocked-state ladder enabled, so it inherits that file's
+   Magistretti/Raman credit. See the `MA2020` `### Attribution` block.
+
+9. **`SU2015`: the per-mechanism attribution is not closed, only the
+   per-model one.** The bucket's 11 real symbols are safe to cite as
+   the DCN model of Steuber et al. (2011) used by Sudhakar et al.
+   (2015), because the translation credit in the `.mod` files and the
+   "based on a previously published model [21]" sentence in
+   Sudhakar et al. together establish that chain. What could **not** be
+   established:
+
+   - No paper in the chain was shown to print the Boltzmann and tau
+     constants these classes carry. O-ST2011's parameter tables were
+     **not** read; the code-side check was `.mod` -> BrainCell only.
+   - Six of the nine channel names (`CaHVA`, `CaL`, `NaF`, `fKdr`,
+     `sKdr`, and the phrase "calcium pool") appear **zero** times in
+     the Sudhakar et al. (2015) full text.
+   - Sudhakar et al. (2015) does not cite Luthman et al. (2011) at
+     all; the NEURON-translation step rests solely on the `.mod`
+     header line and on Luthman et al.'s own Methods.
+
+   Consequence for the module task: cite as described in the `SU2015`
+   `### Attribution` block, and do **not** write that any of these
+   papers reports the specific constants. Closing this would need
+   O-ST2011's parameter tables read and compared.
+
+10. **`ZH2019`: the exact upstream deposit is inferred, not proved.**
+    The `.mod` headers match ModelDB 257028 exactly, but they match
+    ModelDB 266842 (Schreglmann et al. 2021) equally exactly --
+    `io_h.mod` is byte-identical in both, md5 `66e12eb6...`. The
+    identification of 257028 rests on the repository's own
+    `<Mechanism>_<Initials><YY>_<Cell>` naming convention decoding
+    `ZH19` as Zhang 2019, which is a weaker grade of evidence than the
+    header match itself. **This does not affect the citation** --
+    Zhang & Santaniello (2019) is the paper either way, since 266842
+    is downstream of it and Xu Zhang is an author of both. It affects
+    only any claim about which accession the files were downloaded
+    from, which no docstring should make.
+
+11. **Symbol count: 104, not 103.** The Task 3 brief and the project
+    plan both say the seven cerebellar keys cover 103 public symbols.
+    Counting `__all__` across `braincell/channel/*.py` and
+    `braincell/ion/*.py` gives 155 public symbols in total, of which
+    `MA2020` 32 + `MA2024` 19 + `MA2025` 16 + `RI2021` 15 + `SU2015`
+    16 + `ZH2019` 5 + `PC24` 1 = **104**. The per-key counts in this
+    file's own section headings are correct and sum to 104; the 103 is
+    an arithmetic slip upstream. Note also that the `*Test` classes
+    visible in the source (`Cav1p2_MA2020_GoCTest`,
+    `CaHVA_SU2015_DCNTest`, and about twenty others) are **not** in
+    any `__all__` and are correctly excluded from the 155. There are 24
+    of them across the six affected modules, one per templated
+    mechanism family.
+
+12. **`NO_KEY` (32 symbols) is still open and belongs to no task yet.**
+    Its `### Verified record` and `### Attribution` blocks are still
+    marked `_TODO (Task 3)`, but the Task 3 brief scopes that task to
+    the seven cerebellar keys only and Task 3 did not touch `NO_KEY`.
+    The marker is therefore stale, not an omission. Two sub-items
+    inherited from Task 2 sit inside it and must be picked up by
+    whichever task claims it: the `CalciumDetailed` pump constants
+    (see `## Corrections to pre-existing in-code citations`, items 1
+    and 2, where the record checks passed but the attribution checks
+    were explicitly not performed).

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -208,15 +208,28 @@ Two failure modes, both bugs:
   symbols, origin and model never coincide, so treat a single-entry
   cerebellar `References` block as a bug unless the mapping table says
   otherwise.
-- **Two entries where a three-origin row requires four.** The eleven
-  three-origin rows are the `Kca3p1` family (`O-RC2006`, `O-BB1993`,
-  `O-DV2000`), the `Kv3p4`/`Kv3p3` family (`O-RB2001`, `O-KH2003`,
-  `O-AK2006`) and the `Cav3p1`/`Cav3p2`/`Cav3p3` family (`O-AN2012`,
-  `O-SC2003`, `O-MD1999`), each recurring across several keys.
-  Dropping one of the three because "two-level" was read as a literal
-  cap is the same class of bug as dropping the model paper, and it is
-  easier to make. **Count the labels in the row; the entry count is
-  labels + 1.**
+- **Two entries where a three-origin row requires four.** Eleven rows
+  name three origins as `O-` keys: the `Kca3p1` family (`O-RC2006`,
+  `O-BB1993`, `O-DV2000`, 3 rows), the `Nav1p6` family (`O-RB2001`
+  kinetics, `O-KH2003`, `O-AK2006`, 4 rows) and the calcium
+  buffer/pump family -- `CdpStC*`, `CdpCR*`, `CdpCAM*` -- (`O-AN2012`
+  model, `O-SC2003` buffers, `O-MD1999` pump tuning, 4 rows). Three
+  further rows reach three sources without three `O-` keys: the
+  `Cav3p2_*` rows spell their first source as prose (Huguenard &
+  McCormick 1992, see the `HM1992` Verified record) alongside
+  `O-VI2005` and `O-CO1989`, so they need four entries as well.
+  Fourteen rows in total, not eleven -- do not audit this by grepping
+  for three `O-` keys. Dropping one of the three because "two-level"
+  was read as a literal cap is the same class of bug as dropping the
+  model paper, and it is easier to make. **Count the sources in the
+  row, however they are spelled; the entry count is sources + 1.**
+
+  The `Kv3p4_*` rows carry a single origin (`O-KH2003`) and
+  `Kv3p3_MA2024_PC` carries two (`O-MT2007` fits, `O-AK2009` model);
+  an earlier revision of this paragraph mislabelled the `Nav1p6`
+  triple as a "`Kv3p4`/`Kv3p3` family" and the `Cdp*` triple as a
+  "`Cav3p1`/`Cav3p2`/`Cav3p3` family". The per-key mapping tables
+  were correct throughout and remain authoritative.
 
 Renumber only the bracket digits when a docstring needs a different
 order; never retype the entry text.

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -197,7 +197,7 @@ whoever wrote the mechanism's equations. So a cerebellar docstring's
 
 **"Two" is the minimum, not the norm.** Of the 58 mapping rows in this
 file, only **12 carry a single origin** (giving a two-entry
-docstring). **35 carry two origins** (three entries) and **11 carry
+docstring). **32 carry two origins** (three entries) and **14 carry
 three** (four entries). So 46 of 58 rows -- the clear majority --
 need more than the two-entry shape, and a reader who skims this
 section and writes two entries everywhere will truncate most of them.
@@ -1390,7 +1390,7 @@ is written out symbol by symbol.
 | 18 | `braincell/ion/calcium.py::Calcium` | Species container. Holds `default_Co = 2.0 mM`, `default_valence = 2`. |
 | 19 | `braincell/ion/calcium.py::CalciumFixed` | Container + `FixedIon`. |
 | 20 | `braincell/ion/calcium.py::CalciumInitNernst` | Container + `InitNernstIon`. |
-| 21 | `braincell/ion/calcium.py::CalciumFirstOrder` | `Ca' = -alpha*I_Ca - beta*Ca` with `alpha = 0.13`, `beta = 0.075`. Generic first-order form; no paper identified. See below. |
+| 21 | `braincell/ion/calcium.py::CalciumFirstOrder` | `Ca' = max(alpha*I_Ca, 0) - beta*Ca` with `alpha = 0.13`, `beta = 0.075`. Generic first-order form; no paper identified. See below. |
 | 22 | `braincell/ion/nonspecific.py::NonSpecific` | Container. `default_Ci = default_Co = 1.0 mM`, `valence = 1` -- placeholders, not measurements. |
 | 23 | `braincell/ion/nonspecific.py::NonSpecificFixed` | Container + `FixedIon`. |
 | 24 | `braincell/ion/potassium.py::Potassium` | Container. `default_Ci = 54.4 mM`, `default_Co = 2.5 mM`. |

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -1913,6 +1913,13 @@ Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`
 update placement status", "NMODL numeric default precision"). Put
 these in the docstring `Notes` section; do not re-read that file.
 
+**These deviations are already applied to the `.mod` files in this
+repository.** The README's status column reads `已连续化` ("now
+continuous") with the former range under `原` ("formerly"), so opening
+a shipped `.mod` file shows `cnexp` and no `TABLE`. That is the
+deviation having been made, not evidence against it. Do not read the
+shipped file as refuting a row below.
+
 **`TABLE` removed, replaced by per-call evaluation of the continuous
 formula.** The former interpolation range is given because NEURON
 clamps to the boundary value outside it, so any recorded BrainCell/
@@ -2209,6 +2216,13 @@ that key is already verified in this file and must be cited from the
 ### Import deviations
 
 Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
+
+**These deviations are already applied to the `.mod` files in this
+repository.** The README's status column reads `已连续化` ("now
+continuous") with the former range under `原` ("formerly"), so opening
+a shipped `.mod` file shows `cnexp` and no `TABLE`. That is the
+deviation having been made, not evidence against it. Do not read the
+shipped file as refuting a row below.
 
 **`TABLE` removed, replaced by per-call evaluation.**
 
@@ -2546,6 +2560,13 @@ attributions` item 9.
 
 Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
 
+**These deviations are already applied to the `.mod` files in this
+repository.** The README's status column reads `已连续化` ("now
+continuous") with the former range under `原` ("formerly"), so opening
+a shipped `.mod` file shows `cnexp` and no `TABLE`. That is the
+deviation having been made, not evidence against it. Do not read the
+shipped file as refuting a row below.
+
 **`TABLE` removed, replaced by per-call evaluation.** The DCN files
 used a wider voltage window than the other cell types, so boundary
 clamping was much less likely to bite; the concentration table in
@@ -2805,6 +2826,13 @@ the same non-CAM pump/PV network as `CdpStC_RI2021_SC`.
 
 Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
 
+**These deviations are already applied to the `.mod` files in this
+repository.** The README's status column reads `已连续化` ("now
+continuous") with the former range under `原` ("formerly"), so opening
+a shipped `.mod` file shows `cnexp` and no `TABLE`. That is the
+deviation having been made, not evidence against it. Do not read the
+shipped file as refuting a row below.
+
 **`TABLE` removed, replaced by per-call evaluation.**
 
 | Symbol | Former `TABLE` range | Tabulated |
@@ -3061,6 +3089,13 @@ that `SC` has no `Kca3p1` mechanism, unlike `BC`, `GoC` and `PC`.
 ### Import deviations
 
 Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
+
+**These deviations are already applied to the `.mod` files in this
+repository.** The README's status column reads `已连续化` ("now
+continuous") with the former range under `原` ("formerly"), so opening
+a shipped `.mod` file shows `cnexp` and no `TABLE`. That is the
+deviation having been made, not evidence against it. Do not read the
+shipped file as refuting a row below.
 
 **`TABLE` removed, replaced by per-call evaluation.**
 
@@ -3396,6 +3431,13 @@ imply the mod file's branch was reproduced.
 ### Import deviations
 
 Transcribed from `examples/neuron_compare/Cerebellum_mod/README.md`.
+
+**These deviations are already applied to the `.mod` files in this
+repository.** The README's status column reads `已连续化` ("now
+continuous") with the former range under `原` ("formerly"), so opening
+a shipped `.mod` file shows `cnexp` and no `TABLE`. That is the
+deviation having been made, not evidence against it. Do not read the
+shipped file as refuting a row below.
 
 **`TABLE` removed.** None. No `IO` mechanism used a `TABLE`.
 

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -15,6 +15,22 @@ verification steps (Tasks 2 and 3).
   citation-key fragment embedded in its name (`[A-Za-z]{2}(?:19|20)\d{2}` or
   `[A-Z]{2}\d{2}`, e.g. `HM1992`, `MA2020`, `PC24`). Symbols whose name
   carries no such fragment are bucketed as `NO_KEY`.
+- **Scope exclusion: package `__init__.py` files.** Step 1 scanned the
+  *module* files `braincell/channel/*.py` and `braincell/ion/*.py`.
+  Symbols defined in `braincell/channel/__init__.py` and
+  `braincell/ion/__init__.py` are **outside this project's scope** and
+  are deliberately absent from this file. Exactly one public symbol
+  falls in that gap today:
+  **`braincell/ion/__init__.py::build_placeholder_ions`**, which is in
+  that module's `__all__` and is documented with an
+  `.. autofunction::` directive in `docs/apis/braincell.ion.rst`. It
+  is therefore a 156th public symbol by any whole-package count.
+  **This is an exclusion, not an omission.** The figure **155** used
+  throughout this file -- including in `## Unresolved attributions`
+  item 11 and by any coverage check built from it -- counts module
+  files only and does not include it. A later task that widens scope
+  to `__init__.py` should add it deliberately and restate the count;
+  until then, nobody should read 155 versus 156 as a missing record.
 - **Step 2 (provenance harvest).** Every `.mod` file under
   `examples/neuron_compare/Cerebellum_mod/*/{channel,ion}/` was scanned for
   its `TITLE`/`COMMENT`/`Author`/`Ref`/`revis`/4-digit-year lines (first 25
@@ -59,22 +75,29 @@ name alone; read the harvested header text.
   verified. Because the key names a *porter*, not an author, Task 3
   also verified 38 **origin-of-kinetics** papers, collected in
   `## Origin-of-kinetics records` below. **99 of the 104 symbols need
-  a two-level citation**; the other 5 (the `SU2015` `Toy*` family) get
-  no citation at all because they are BrainCell's own test fixtures.
+  a two-or-more-level citation** -- most of them more than two
+  entries, not exactly two; see `## How to assemble a
+  two-or-more-level citation`. The other 5 (the `SU2015` `Toy*`
+  family) get no citation at all because they are BrainCell's own
+  test fixtures.
 - Task 3 follow-up (2026-08-15) closed the `NO_KEY` bucket, which had
   been assigned to no task. Three of its 32 symbols carry a real
   primary source and are now verified -- `ghk_flux` (Goldman 1943 /
   Hodgkin & Katz 1949), `KineticIon` (Hines & Carnevale 2000 / The
-  NEURON book 2006) and `CalciumDetailed` (Destexhe 1993 / Bazhenov
-  1998, whose deferred attribution checks are closed at the same
-  time). The other **29 are recorded, symbol by symbol, as having no
+  NEURON book 2006) and `CalciumDetailed` (Destexhe 1994 / Bazhenov
+  1998, plus Destexhe 1993 for its expository prose only; the
+  deferred attribution checks are closed at the same time). The
+  other **29 are recorded, symbol by symbol, as having no
   primary literature source** and are expected to ship without a
   `References` section; that list is in the bucket's
   `### Symbols with no primary literature source` block and is the
   source of truth for any later allowlist.
 - **The symbol count, reconciled.** `__all__` across
   `braincell/channel/*.py` and `braincell/ion/*.py` holds **155**
-  public symbols: 154 classes and one function (`ghk_flux`). They
+  public symbols: 154 classes and one function (`ghk_flux`). The
+  package `__init__.py` files are out of scope and their symbols are
+  excluded -- see the scope exclusion under `## How this file was
+  built`, which names the one symbol affected. They
   split as **32 `NO_KEY` + 123 keyed**, and the keyed half splits as
   **19 across Task 2's nine keys + 104 across Task 3's seven**. Every
   per-key heading in this file already carries the right number and
@@ -150,30 +173,53 @@ Entries are written in the reST form that goes straight into a NumPy-doc
   numbered item in `## Unresolved attributions` that carries the
   evidence.
 
-## How to assemble a two-level citation
+## How to assemble a two-or-more-level citation
 
 Established by Task 3 for the cerebellar half of this file. **This is
 not a second citation format** -- the `.. [N]` entries below are
-written in exactly the house style above. What is new is only *which
-two* entries a docstring needs.
+written in exactly the house style above. What is new is only *which*
+entries a docstring needs, and *how many*.
 
 A cerebellar key names the group that assembled the multi-compartment
 cell model BrainCell imported the mechanism from. It almost never names
 whoever wrote the mechanism's equations. So a cerebellar docstring's
-`References` section normally takes two entries, in this order:
+`References` section takes **two or more** entries, in this order:
 
-- `.. [1]` -- the **origin of the kinetics**: the paper the mechanism's
-  equations actually come from. Copy it verbatim from
-  `## Origin-of-kinetics records` below, using the label given in the
-  key's `### Attribution` mapping table.
-- `.. [2]` -- the **model BrainCell imported from**: the key's own
-  paper. Copy it verbatim from that key's `### Verified record`.
+- `.. [1]` (and `.. [2]`, `.. [3]` where the mapping row lists more
+  than one) -- the **origin of the kinetics**: the paper or papers the
+  mechanism's equations actually come from. Copy each verbatim from
+  `## Origin-of-kinetics records` below, using the label(s) given in
+  the key's `### Attribution` mapping table, **in the order the row
+  lists them**.
+- the **last** entry -- the **model BrainCell imported from**: the
+  key's own paper. Copy it verbatim from that key's
+  `### Verified record`.
+
+**"Two" is the minimum, not the norm.** Of the 58 mapping rows in this
+file, only **12 carry a single origin** (giving a two-entry
+docstring). **35 carry two origins** (three entries) and **11 carry
+three** (four entries). So 46 of 58 rows -- the clear majority --
+need more than the two-entry shape, and a reader who skims this
+section and writes two entries everywhere will truncate most of them.
+
+Two failure modes, both bugs:
+
+- **One entry where two are required.** Across all 104 cerebellar
+  symbols, origin and model never coincide, so treat a single-entry
+  cerebellar `References` block as a bug unless the mapping table says
+  otherwise.
+- **Two entries where a three-origin row requires four.** The eleven
+  three-origin rows are the `Kca3p1` family (`O-RC2006`, `O-BB1993`,
+  `O-DV2000`), the `Kv3p4`/`Kv3p3` family (`O-RB2001`, `O-KH2003`,
+  `O-AK2006`) and the `Cav3p1`/`Cav3p2`/`Cav3p3` family (`O-AN2012`,
+  `O-SC2003`, `O-MD1999`), each recurring across several keys.
+  Dropping one of the three because "two-level" was read as a literal
+  cap is the same class of bug as dropping the model paper, and it is
+  easier to make. **Count the labels in the row; the entry count is
+  labels + 1.**
 
 Renumber only the bracket digits when a docstring needs a different
-order; never retype the entry text. Where origin and model genuinely
-coincide, one entry is correct -- but across all 104 cerebellar
-symbols this never happens, so treat a single-entry cerebellar
-`References` block as a bug unless the mapping table says otherwise.
+order; never retype the entry text.
 
 **One deliberate exception to the 79-column rule.** The per-key
 mapping tables and `### Import deviations` tables are Markdown table
@@ -187,9 +233,16 @@ docstrings. No table row is ever copied into a docstring.
 
 ## Origin-of-kinetics records
 
-Thirty-eight papers, each the source of the equations in one or more
-cerebellar mechanisms. Each carries a stable label (`O-XXNNNN`) used by
-the per-key `### Attribution` mapping tables. **Labels are internal to
+Thirty-eight papers. **Thirty-six of them are the source of the
+equations in one or more cerebellar mechanisms**; the remaining two --
+`O-FO2006` and `O-SO2007b` -- are verified records that no mapping
+table assigns to any symbol, and each is marked
+**VERIFIED BUT UNASSIGNED** at its own heading below. Do not read
+either as a gap in the mapping tables: they were verified because the
+harvest surfaced them, and they are recorded so that a later task
+neither re-verifies them nor assumes an assignment that was never
+established. Each carries a stable label (`O-XXNNNN`) used by the
+per-key `### Attribution` mapping tables. **Labels are internal to
 this file and must never appear in a docstring** -- copy the `.. [N]`
 entry text, not the label.
 
@@ -241,6 +294,13 @@ The publisher's site also advertises a legacy slash-form DOI
 
 ### O-SO2007b -- cerebellar Golgi cell model, part II
 
+**VERIFIED BUT UNASSIGNED.** No mapping table row cites this label and
+no symbol takes it. The record below is correct and re-usable, but
+nothing in this file establishes which mechanism, if any, draws its
+equations from part II rather than part I (`O-SO2007a`, which *is*
+assigned, to the `HCN1`/`HCN2` and `Kca2p2` rows). A module task must
+not reach for this entry on the strength of the label's existence.
+
 .. [1] Solinas, S., Forti, L., Cesana, E., Mapelli, J., De Schutter,
        E., & D'Angelo, E. (2007). Fast-reset of pacemaking and
        theta-frequency resonance patterns in cerebellar Golgi cells:
@@ -266,6 +326,22 @@ first two authors into one contributor (`given: "Lia Forti", family:
 "Elisabetta Cesana"`), yielding three authors. PubMed is authoritative
 and gives the four above, in that order. PubMed prints the issue as
 "Pt 3"; Crossref as "3", which is used.
+
+**VERIFIED BUT UNASSIGNED.** No mapping table row cites this label and
+no symbol takes it. The lead that produced it is real but stops short
+of an assignment: `GoC/channel/HCN1_MA20_GoC.mod` and
+`HCN2_MA20_GoC.mod` carry `Author:L. Forti & S. Solinas` and
+`Last revised: April 2006`, and Lia Forti is the first author here.
+That places the mod files' author and this paper in the same year and
+the same subject, which is why the record was verified. It does
+**not** show that the HCN rate expressions were taken from this paper:
+those files' own header credits their data to `Santoro et al. J
+Neurosci. 2000` (`O-SA2000`), and the `HCN1`/`HCN2` mapping row
+already assigns `O-SO2007a` for the kinetics and `O-SA2000` for the
+data on the strength of direct constant comparison. This is an
+experimental paper, not a modelling one, so a kinetics assignment
+would need equation-level evidence that was not found. **Do not add it
+to the `HCN1`/`HCN2` row without that evidence.**
 
 ### O-SA2000 -- HCN subunit data
 
@@ -951,39 +1027,94 @@ itself returned HTTP 403, so the chapter page range rests on the
 Crossref chapter deposit.
 
 **Why the 1997 paper is not the citation here, and would be wrong.**
-The obvious candidate -- Hines & Carnevale (1997), "The NEURON
+The obvious candidate is Hines & Carnevale (1997), "The NEURON
 simulation environment", Neural Computation 9(6), 1179-1209,
-doi:10.1162/neco.1997.9.6.1179 -- contains **zero** occurrences of
-`KINETIC`, `COMPARTMENT` or `CONSERVE` in the authors' own extended
-preprint, and says so in as many words: "An extensive discussion of
-NMODL is beyond the scope of this article." The 2000 paper opens by
-drawing exactly that boundary against its predecessor. Citing the 1997
-paper for `KINETIC`/`COMPARTMENT` points the reader at a paper that
-disclaims the topic. It remains the right citation for NEURON the
-simulator in general; it is the wrong one for this class. Also ruled
-out, by full-text search returning zero hits for all three keywords:
-Hines & Carnevale (2001) in *The Neuroscientist*, and Awile et al.
-(2022), doi:10.3389/fninf.2022.884046, which covers the build system
-and transpiler rather than language semantics.
+doi:10.1162/neco.1997.9.6.1179. Three independent findings rule it
+out, all from a full-text search of the authors' own extended preprint
+(re-run 2026-08-15):
 
-**N-CAD -- `braincell/ion/calcium.py::CalciumDetailed`.** Two entries.
-These supersede the two that the source tree already carries at
-`braincell/ion/calcium.py:227-233`; the existing pair has a title
-error and no DOIs. See `## Corrections to pre-existing in-code
-citations` items 1 and 2, whose *record* checks these confirm
-independently, and whose deferred *attribution* checks are closed
-below.
+1. **It contains no NMODL block keyword of any kind.** Not just
+   `KINETIC`, `COMPARTMENT` and `CONSERVE`: the count is **zero** for
+   every one of `SOLVE`, `BREAKPOINT`, `DERIVATIVE`, `PARAMETER`,
+   `SUFFIX`, `USEION`, `NONLINEAR`, `LINEAR` and `PROCEDURE` as well.
+   The paper does not exhibit the language it would be cited for.
+2. **It contains no `.mod` listing.** The string `.mod` occurs zero
+   times; there is no mechanism source anywhere in the paper.
+3. **It explicitly forward-references its successor.** Verbatim: *"In
+   a future publication we will examine how the NMODL translator is
+   used to define new membrane channels and calculate ionic
+   concentration changes."* The 2000 paper is that future publication.
 
-.. [1] Destexhe, A., Babloyantz, A., & Sejnowski, T. J. (1993). Ionic
-       mechanisms for intrinsic slow oscillations in thalamic relay
-       neurons. Biophysical Journal, 65(4), 1538-1552.
-       doi:10.1016/S0006-3495(93)81190-1
+The paper also says as much in passing -- *"An extensive discussion of
+NMODL is beyond the scope of this article, but its major advantages
+can be listed succinctly."* -- but finding 3 is the decisive one,
+because it names the successor rather than merely declining the topic.
+Citing the 1997 paper for `KINETIC`/`COMPARTMENT` points the reader at
+a paper that defers the subject to another. It remains the right
+citation for NEURON the simulator in general; it is the wrong one for
+this class.
+
+**A precision the earlier revision got wrong.** The keyword counts
+above are for the **uppercase NMODL block keywords** as they appear in
+mechanism source. Lowercase prose *does* discuss the concept: the
+phrase "kinetic schemes" occurs three times in the 1997 preprint
+(e.g. "allows the expression of models in terms of kinetic schemes",
+"Mechanisms described by kinetic schemes are written with a syntax in
+which the reactions are clearly apparent"). A claim of "zero
+occurrences of `KINETIC`" is therefore only true case-sensitively, and
+must be stated that way. **The verdict is unaffected** -- naming the
+concept in one clause is not documenting the language construct -- but
+a case-insensitive re-audit would otherwise appear to refute this
+block.
+
+Also ruled out, by full-text search returning zero hits for the
+uppercase keywords: Hines & Carnevale (2001) in *The Neuroscientist*,
+and Awile et al. (2022), doi:10.3389/fninf.2022.884046, which covers
+the build system and transpiler rather than language semantics.
+
+**N-CAD -- `braincell/ion/calcium.py::CalciumDetailed`.** Three
+entries, ordered by the file's own `.. [1]` = origin-of-kinetics /
+`.. [2]` = model-imported-from rule (see `## How to assemble a
+two-or-more-level citation`). Entries [2] and [3] supersede the two that the
+source tree already carries at `braincell/ion/calcium.py:227-233`; the
+existing pair has a title error and no DOIs. See `## Corrections to
+pre-existing in-code citations` items 1 and 2, whose *record* checks
+these confirm independently, and whose deferred *attribution* checks
+are closed below.
+
+.. [1] Destexhe, A., Contreras, D., Sejnowski, T. J., & Steriade, M.
+       (1994). A model of spindle rhythmicity in the isolated thalamic
+       reticular nucleus. Journal of Neurophysiology, 72(2), 803-818.
+       doi:10.1152/jn.1994.72.2.803
 
 .. [2] Bazhenov, M., Timofeev, I., Steriade, M., & Sejnowski, T. J.
        (1998). Cellular and network models for intrathalamic
        augmenting responses during 10-Hz stimulation. Journal of
        Neurophysiology, 79(5), 2730-2748.
        doi:10.1152/jn.1998.79.5.2730
+
+.. [3] Destexhe, A., Babloyantz, A., & Sejnowski, T. J. (1993). Ionic
+       mechanisms for intrinsic slow oscillations in thalamic relay
+       neurons. Biophysical Journal, 65(4), 1538-1552.
+       doi:10.1016/S0006-3495(93)81190-1
+
+**Why entry [1] exists: Bazhenov is not the origin of this model.**
+An earlier revision of this block treated Bazhenov et al. (1998) as
+the origin of the first-order calcium model and gave `CalciumDetailed`
+only a two-entry block that did not follow this file's `[1]` = origin
+/ `[2]` = model rule. Bazhenov's own Appendix credits it: equation
+(A5) is introduced with the words "the Ca 2+ dynamics is described by
+a simple first-order model (Destexhe et al. 1994a)", and the paper's
+reference list resolves `1994a` to "DESTEXHE, A., CONTRERAS, D.,
+SEJNOWSKI, T. J., AND STERIADE, M. A model of spindle rhythmicity in
+the isolated thalamic reticular nucleus. J. Neurophysiol. 72:
+803-818, 1994a." Read directly from the author-hosted PDF of the
+Bazhenov paper, 2026-08-15. That is **the same paper already verified
+in this file under the `De1994` key** (`## De1994`, PMID 7527077); the
+entry above is copied verbatim from that key's `### Verified record`
+and is not a fresh citation. Entry [2] remains the right *model*
+citation -- it is the deposit BrainCell's parameter defaults come
+from, and it is what the class's existing docstring names.
 
 Destexhe: PMID 8274647, PMCID PMC1225880. Re-confirmed here by direct
 `efetch db=pubmed`, which returns the title ending in "thalamic relay
@@ -1122,14 +1253,22 @@ drive = u.math.maximum(drive, u.math.zeros_like(drive))
 return drive + (self.C_rest - Ci) / self.tau
 ```
 
-*Entry [2], Bazhenov et al. 1998: attribution PASSED.* That expression
-is term for term the first-order model the docstring's own section 2
-attributes to Bazhenov -- influx `I_Ca/(zFd)` with `z = 2` hard-coded
-as the literal `2`, plus relaxation `([Ca]_rest - [Ca])/tau`. The
-constructor exposes exactly and only that model's three parameters:
-`d`, `tau`, `C_rest`.
+*Entries [1] and [2], Destexhe et al. 1994 / Bazhenov et al. 1998:
+attribution PASSED.* That expression is term for term the first-order
+model the docstring's own section 2 attributes to Bazhenov -- influx
+`I_Ca/(zFd)` with `z = 2` hard-coded as the literal `2`, plus
+relaxation `([Ca]_rest - [Ca])/tau`. The constructor exposes exactly
+and only that model's three parameters: `d`, `tau`, `C_rest`. Entry
+[1] is the model's origin and entry [2] the deposit the defaults come
+from; a module task should carry both, in that order. One shape
+difference worth knowing and not worth flagging as a divergence:
+Bazhenov writes the influx term with a single lumped constant,
+`A = 5.18e-5 mM cm2/(ms uA)`, where BrainCell (like the docstring's
+own section 2) writes it out as `1/(zFd)`. The two are the same term
+parameterised differently, which is why `d` is a BrainCell parameter
+and not a Bazhenov one.
 
-*Entry [1], Destexhe et al. 1993: the paper is correctly identified
+*Entry [3], Destexhe et al. 1993: the paper is correctly identified
 and correctly recorded, but the class does not implement it.* The
 docstring's section 1 sets out the ATP-driven pump, its kinetic scheme
 `Ca_i + P <-> CaP -> P + Ca_o`, and its Michaelis-Menten reduction
@@ -1143,23 +1282,52 @@ assumption that the abstract's "included Ca2+ diffusion" was
 "consistent with the Michaelis-Menten Ca pump the class implements";
 **that assumption is wrong and is corrected here.**
 
-The consequence for the module task is narrow and specific: keep both
-entries only for as long as the docstring keeps its expository section
-1. `.. [1]` is a correct citation *for the text it supports*. It must
-not be presented as the source of `CalciumDetailed.derivative`, and if
-the docstring is ever trimmed to what the class computes, `.. [1]`
-goes with the prose it belongs to and Bazhenov becomes the sole
-reference.
+The consequence for the module task is narrow and specific: keep
+entry `.. [3]` only for as long as the docstring keeps its expository
+section 1. `.. [3]` is a correct citation *for the text it supports*.
+It must not be presented as the source of
+`CalciumDetailed.derivative`, and if the docstring is ever trimmed to
+what the class computes, `.. [3]` goes with the prose it belongs to
+and entries [1] and [2] -- Destexhe et al. 1994 and Bazhenov et al.
+1998 -- become the whole reference block.
 
 *Parameter caveats, none of them citation errors.* `d = 1.0 um` and
 the `Calcium` base's `default_Co = 2.0 mM` and `default_valence = 2`
-match the docstring's stated values. `C_rest` defaults to
-`2.4e-4 mM`, i.e. 0.24 uM, where the docstring's section 2 reports
-Bazhenov's resting concentration as 0.05 uM -- a factor of about five,
-and a default divergence that must be described as BrainCell's choice
-rather than the paper's value. `tau` defaults to `5.0 ms`; the paper's
-own value was not independently confirmed (see item 14 below). The
-docstring quotes `F = 96489 C/mol` and `R = 8.31441 J/(mol K)` from
+match the docstring's stated values.
+
+**`C_rest` and `tau` are Bazhenov's own values, and the docstring's
+"0.05 uM" is the error.** An earlier revision of this block had this
+exactly backwards -- it recorded `C_rest = 2.4e-4 mM` as "BrainCell's
+choice rather than the paper's value" and `tau = 5.0 ms` as
+unconfirmed. Both statements were false, and shipping either into a
+docstring would have published a false claim about the paper.
+Bazhenov et al. (1998), Appendix, equation (A5) reads verbatim:
+
+```
+For both the RE and TC cells, the Ca 2+ dynamics is described
+by a simple first-order model (Destexhe et al. 1994a)
+  d[Ca]/dt = -A I_T - ([Ca] - [Ca]_inf)/tau            (A5)
+where [Ca]_inf = 2.4e-4 mM is equilibrium Ca 2+ concentration,
+A = 5.18e-5 mM cm2/(ms uA) and tau = 5 ms.
+```
+
+Read from the author-hosted PDF of the paper, 2026-08-15. The code at
+`braincell/ion/calcium.py:245-246` defaults `tau = 5.0 * u.ms` and
+`C_rest = 2.4e-4 * u.mM` (and `Ci_initializer` to the same
+`2.4e-4 mM`). **Both are verbatim the paper's values and may be
+presented as such.** Neither is a divergence and neither needs a
+caveat.
+
+*What the module task must fix instead.* The error is in the existing
+docstring **prose**, not in the defaults. `braincell/ion/calcium.py:193`
+states the resting concentration as `.05 uM`, which is neither the
+paper's `2.4e-4 mM` (= 0.24 uM) nor the code's default. That number is
+wrong and must be **corrected to 2.4e-4 mM (0.24 uM), or removed**, by
+whichever module task rewrites this docstring. Do not preserve it, and
+do not "reconcile" it by relabelling the correct defaults as
+BrainCell's own -- that is the inversion this paragraph replaces.
+
+The docstring quotes `F = 96489 C/mol` and `R = 8.31441 J/(mol K)` from
 the paper while the code uses `u.faraday_constant` and, through
 `DynamicNernstIon`, `u.gas_constant` -- the CODATA values. The default
 temperature `u.celsius2kelvin(36.0)` is 309.15 K, matching the
@@ -1528,6 +1696,36 @@ repository-tooling artifact, not a scientific author).
 
 ### Verified record
 
+> ## !!! STOP -- `[1]` AND `[2]` DO NOT MEAN WHAT THEY MEAN ELSEWHERE
+>
+> **In this `MA2020` block only, `.. [1]` = the Golgi paper and
+> `.. [2]` = the granule paper. They are two alternatives, and a
+> given symbol takes exactly ONE of them.**
+>
+> Everywhere else in this file -- and in every docstring produced
+> from it -- `.. [1]` means *origin of the kinetics* and `.. [2]`
+> means *the model BrainCell imported from*, and a docstring carries
+> **both**.
+>
+> **Never copy this block's `[1]` and `[2]` into a docstring as a
+> pair.** Doing so would cite the granule-cell paper on a Golgi-cell
+> class, or vice versa, and would drop the origin entry entirely.
+>
+> The correct docstring shape for an `MA2020` symbol is: the
+> origin entry or entries from the mapping table as `.. [1]`
+> (`.. [2]`, `.. [3]` ...), then **whichever one** of the two papers
+> below matches the symbol's cell-type suffix as the final entry,
+> renumbered.
+>
+> - `*_MA2020_GoC` -> the Golgi paper (labelled `[1]` below)
+> - `*_MA2020_GrC` -> the granule paper (labelled `[2]` below)
+>
+> **This hazard is live across all 32 `MA2020` symbols.** It is the
+> only place in this file where the bracket digits carry a local
+> meaning, and the two labels are not distinguishable by eye once
+> copied out of context. Re-read this box before touching any
+> `MA2020` docstring.
+
 Confirmed 2026-08-15 against PubMed (`efetch`, `db=pubmed`), the
 Crossref REST API, the PMC article HTML for each paper, and the ModelDB
 REST API for the accessions. **`MA2020` requires two papers, not one.**
@@ -1603,8 +1801,18 @@ subclasses whose constants live in a base class (e.g.
 `Kca1p1_MA2020_GrC(Kca1p1_MA2020_GoC)`); this was confirmed by reading
 each `class` line and is a scan artefact, not a mismatch.
 
-**Mapping table.** `.. [1]` is the origin record; `.. [2]` is the
-`MA2020` model paper above ([1] for `GoC`, [2] for `GrC`).
+**Mapping table.** The `Origin` column gives the origin record(s),
+which become `.. [1]` (and `.. [2]`, `.. [3]` where the row lists
+more than one). The **final** entry is the `MA2020` model paper.
+
+> **Reminder -- the labels above are local.** The model entry is
+> **one** of the two papers in the `### Verified record` block, not
+> both: the Golgi paper (labelled `[1]` there) for every `*_GoC`
+> symbol, the granule paper (labelled `[2]` there) for every `*_GrC`
+> symbol. In the finished docstring it is renumbered to whatever
+> follows the origin entries. Copying "`[1]` and `[2]`" out of that
+> block as a pair is the specific mistake this warning exists to
+> prevent.
 
 | Symbols | Origin `.. [1]` |
 |---|---|
@@ -2173,6 +2381,18 @@ Availability statement gives.
 PMID 26630202, PMCID PMC4668013, fully open access. `e1004641` is the
 article number and occupies the page slot.
 
+**Title case: down-cased deliberately -- do not "fix" it back.**
+*PLOS Computational Biology* prints this title in title case, and both
+Crossref and PubMed return it that way: "Cerebellar Nuclear Neurons
+Use Time and Rate Coding to Transmit Purkinje Neuron Pauses". The
+entry above is in sentence case because that is the house rule (see
+`## Citation house style`, "Title: sentence case"), under which
+down-casing a title-case journal is the normal operation, not an
+exception. "Cerebellar" and "Purkinje" are kept capitalised as a
+sentence opener and a proper noun respectively. **The wording is
+untouched.** Anyone re-auditing this record against Crossref will see
+a case mismatch; it is intentional and is not a transcription error.
+
 **Author-list correction to the Task 1 brief.** The hypothesised
 "Sudhakar, Hong, Raikov, ... De Schutter" is a *different* paper --
 Sudhakar, Hong, Raikov, Publio, Lang, Close, Guo, Negrello & De
@@ -2184,10 +2404,17 @@ paper has three authors.
 
 **The origin of the DCN kinetics is Steuber et al. (2011), reached
 through Luthman et al. (2011).** Task 1 recorded this bucket as having
-no in-repo provenance; that was an artefact of its 25-line harvest
-window. Every shipped DCN `.mod` file carries "Translated from GENESIS
-by Johannes Luthman and Volker Steuber." inside its `COMMENT` block.
-Three steps, each verified:
+no in-repo provenance; that was an artefact of its harvest pattern,
+which matched on `Author`/`Ref`-style keywords and so never saw a
+credit phrased as free text (see `## Unresolved attributions` item 8).
+**9 of the 11 shipped DCN `.mod` files carry "Translated from GENESIS
+by Johannes Luthman and Volker Steuber." inside their `COMMENT`
+block** -- every `DCN/channel/` file except `CaLVA_SU15_DCN.mod`, plus
+`DCN/ion/CdpHVA_SU15_DCN.mod`. The two that do not,
+`CaLVA_SU15_DCN.mod` and `CdpLVA_SU15_DCN.mod`, carry a `COMMENT`
+about their shared GHK coupling and name no author at all; they are
+part of the same deposit and the chain below is unaffected by their
+silence. Three steps, each verified:
 
 1. **O-ST2011** is the original GENESIS DCN model (ModelDB 136175) and
    the origin of the channel kinetics. `SU2015`'s own Methods cite it
@@ -2491,9 +2718,22 @@ allowed for that possibility; the paper is peer-reviewed and appeared
 PMID 40652073, PMCID PMC12255734, fully open access. `25192` is the
 article number and occupies the page slot; *Scientific Reports*
 assigns every article of a volume-year to issue 1, so `15(1)` is
-nominal. Keep the British spelling **"fibre"** as published. As in the
-`MA2024` record, "Sanchez-Ponce" and "Munoz" are published here
-without accents in both PubMed and Crossref.
+nominal. Keep the British spelling **"fibre"** as published.
+
+**Name-form note, corrected.** An earlier revision of this record
+claimed that, as in `MA2024`, both "Sanchez-Ponce" and "Munoz" are
+published here without accents. That is **half wrong**, and the wrong
+half is the fourth author. Re-checked 2026-08-15 against both sources:
+Crossref returns `family: "Sánchez-Ponce"` and PubMed's `efetch`
+returns `<LastName>S&#xe1;nchez-Ponce</LastName>` -- i.e. **this paper
+prints Sánchez-Ponce with the accent.** Only the fifth author, Munoz,
+is unaccented here (both sources agree). The `.. [1]` entry above uses
+the ASCII form for both, deliberately and for the same reason as
+`Lüthi`, `Knöpfel`, `Häusser` and `Schürmann` elsewhere in this file:
+the entry text is kept ASCII. **The ASCII "Sanchez-Ponce" above is a
+transliteration, not a reproduction of the publisher's form.** If the
+docstring pipeline is UTF-8-safe, write "Sánchez-Ponce, D." here and
+leave "Munoz, A." plain.
 
 ### Attribution
 
@@ -2726,11 +2966,29 @@ article number and occupies the page slot; `11(1)` is nominal.
 
 **Name-form note.** In *this* paper the fourth and fifth authors are
 published **with** accents -- Sánchez-Ponce and Muñoz -- in both
-PubMed and Crossref, whereas the same two appear unaccented in the
-`MA2024` and `MA2025` records. The ASCII forms are used above for
-consistency with the rest of this file; if the docstring pipeline is
-UTF-8-safe, prefer the accented forms here and the plain forms there,
-because that is how each publisher printed them.
+PubMed and Crossref. The ASCII forms are used above for consistency
+with the rest of this file; if the docstring pipeline is UTF-8-safe,
+prefer the accented forms here.
+
+**The cross-record picture, corrected.** An earlier revision of this
+note told later tasks that "the same two appear unaccented in the
+`MA2024` and `MA2025` records" and to prefer the plain forms there.
+That is wrong for `MA2025`. All three were re-checked against Crossref
+and PubMed on 2026-08-15 and they genuinely differ paper by paper:
+
+| Record | Fourth/second author | Muñoz |
+|---|---|---|
+| `RI2021` (this record) | **Sánchez-Ponce** (accented) | **Muñoz** (accented) |
+| `MA2025` | **Sánchez-Ponce** (accented) | Munoz (plain) |
+| `MA2024` | Sanchez-Ponce (plain) | Munoz (plain) |
+
+So only `MA2024` prints both plain. Every `.. [N]` entry in this file
+uses the ASCII form throughout, so no entry text changes; what changes
+is the instruction to a UTF-8-safe pipeline. **Sánchez-Ponce takes the
+accent in `RI2021` *and* `MA2025`, and only Muñoz varies between
+`RI2021` and the other two.** The inter-paper inconsistency is real
+and each record reproduces its own publisher's form -- see also the
+`MA2024` name-form note, which is correct as written.
 
 **ModelDB provenance quirk, recorded rather than smoothed over.**
 Accession **2018019**. The 2021 paper itself gives no accession -- it
@@ -3858,10 +4116,17 @@ findings below are for whichever module task rewrites those docstrings.
    1).~~ **CLOSED: PASSED.** The Task 3 follow-up compared the paper's
    first-order model against `CalciumDetailed.derivative` term by
    term; they agree, and this entry -- not item 1's -- is the source of
-   what the class computes. Two default divergences are recorded as
-   caveats in that block (`C_rest` 0.24 uM against the docstring's
-   stated 0.05 uM; `maximum(drive, 0)` rectification present in neither
-   paper). Note that this same paper is where Bazhenov et al. (2002)
+   what the class computes. **Its parameter defaults are not
+   divergences.** `C_rest = 2.4e-4 mM` and `tau = 5.0 ms` are verbatim
+   the values in the paper's equation (A5), read from the paper itself;
+   the "0.05 uM" in the *existing docstring prose* at
+   `braincell/ion/calcium.py:193` is the error and must be corrected or
+   removed. The one real BrainCell addition is the `maximum(drive, 0)`
+   rectification, which is in neither paper. A further correction
+   applies here too: Bazhenov's (A5) credits the model to Destexhe et
+   al. (1994a), so the block now carries that paper as `.. [1]`. All of
+   this is set out in the `NO_KEY` `### Attribution` block. Note that
+   this same paper is where Bazhenov et al. (2002)
    says its INa/IK rate expressions live -- see the `Ba2002`
    attribution block.
 
@@ -3879,7 +4144,7 @@ Items below need explicit attention in Task 2/3 beyond the default
 literature search, because Step 1/Step 2 of this harvest could not
 resolve them cleanly:
 
-1. ~~**`CdpStC_NoCAM_MA2020_GoC`**~~ — **CLOSED by Task 3
+1. ~~**`CdpStC_NoCAM_MA2020_GoC`**~~ -- **CLOSED by Task 3
    (2026-08-15).** The absent `CdpStC_NoCAM_MA20_GoC.mod` is not a
    missing file: the class is a BrainCell-factored base, and its
    literal set matches `BC/ion/CdpStC_MA25_BC.mod` and
@@ -3890,14 +4155,18 @@ resolve them cleanly:
    detail and the resulting citation are in the `MA2020`
    `### Attribution` block, Caveat 3.
 
-2. ~~**`SU2015` bucket (all 16 symbols)**~~ — **CLOSED by Task 3
+2. ~~**`SU2015` bucket (all 16 symbols)**~~ -- **CLOSED by Task 3
    (2026-08-15), and the premise of the item was wrong twice.** The
    count is 17 `.mod` files (9 in `DCN/channel/`, 8 in `DCN/ion/`), not
-   11; and they are not attribution-free. Every shipped DCN mechanism
-   carries "Translated from GENESIS by Johannes Luthman and Volker
-   Steuber." inside its `COMMENT` block, below Task 1's 25-line harvest
-   window. That resolves the bucket to Steuber et al. (2011) via
-   Luthman et al. (2011). See the `SU2015` `### Verified record` and
+   11; and they are not attribution-free. **9 of the 11 shipped DCN
+   mechanisms** carry "Translated from GENESIS by Johannes Luthman and
+   Volker Steuber." inside their `COMMENT` block, phrased so that Task
+   1's `Author`/`Ref` keyword pattern never matched it;
+   `CaLVA_SU15_DCN.mod` and `CdpLVA_SU15_DCN.mod` are the two without
+   it, and their absence does not change the outcome (item 8 below has
+   the file-by-file count). That resolves the bucket to Steuber et al.
+   (2011) via Luthman et al. (2011). See the `SU2015`
+   `### Verified record` and
    `### Attribution` blocks. A residual, narrower gap remains and is
    recorded as item 9 below.
 
@@ -3912,7 +4181,7 @@ resolve them cleanly:
    Hodgkin & Huxley 1952 — but that identification is Task 2's job to
    make and verify, not this task's).
 
-4. ~~**Unclaimed `.mod` file**~~ — **CLOSED by Task 3 (2026-08-15).**
+4. ~~**Unclaimed `.mod` file**~~ -- **CLOSED by Task 3 (2026-08-15).**
    `.../DCN/ion/ToyStoich3ABtoCKinetic_SU15_DCN.mod` was intentionally
    left unported. Its own `COMMENT` says it "exists to validate
    higher-order stoichiometry handling in the BrainCell `KineticIon`
@@ -3938,10 +4207,11 @@ resolve them cleanly:
    author-line files: it holds for every one of the 104 cerebellar
    symbols. Not a single mechanism in any of the seven keys originates
    with the group the key names. That is why `## Origin-of-kinetics
-   records` exists and why 99 of the 104 symbols take a two-level
-   citation. The five exceptions take no citation at all, and they are
-   exceptions in the opposite direction: BrainCell's own `Toy*` test
-   fixtures, which originate with no publication whatsoever.
+   records` exists and why 99 of the 104 symbols take a
+   two-or-more-level citation. The five exceptions take no citation
+   at all, and they are exceptions in the opposite direction:
+   BrainCell's own `Toy*` test fixtures, which originate with no
+   publication whatsoever.
 
 6. **`IS2008` (both symbols: `CaN_IS2008`, `CaL_IS2008`)** -- *record
    resolves; attribution NOT CONFIRMED. Do not cite yet.*
@@ -4132,16 +4402,45 @@ resolve them cleanly:
    If a genuine high-threshold thalamic Ca current is wanted, the
    provenance of the +25 mV shift needs to be traced separately.
 
-8. **Task 1's harvest window hid provenance in five places.** Step 2
-   read only the first 25 lines of each `.mod` file. Five real
-   attribution leads sit below that line and were therefore recorded
-   in this file as absent. All five are now resolved, but the pattern
-   matters for anyone re-auditing: **a "no provenance found" note in a
-   `### Provenance evidence` block is evidence about the harvest, not
-   about the file.**
+8. **Task 1's harvest missed provenance in five places, and the cause
+   was the keyword pattern, not the line window.** Five real
+   attribution leads were recorded in this file as absent. All five
+   are now resolved, but the pattern matters for anyone re-auditing:
+   **a "no provenance found" note in a `### Provenance evidence`
+   block is evidence about the harvest, not about the file.**
 
-   - All 11 shipped `DCN` mechanisms: "Translated from GENESIS by
+   **Corrected diagnosis.** An earlier revision of this item blamed
+   Step 2's "25-line harvest window". That explanation does not
+   survive its own examples: four of the five leads listed below sit
+   at lines 1-2, 3-8, 5-6 and 10-14 of their files -- well inside a
+   25-line window, and in two cases on the very first lines. Only the
+   `Cav3p2_*` lead (line ~85) was actually out of range.
+
+   The real cause is the **keyword pattern**. Step 2 harvested only
+   lines matching `TITLE`/`COMMENT`/`Author`/`Ref`/`revis`/4-digit
+   year. Every missed lead is phrased so that none of those tokens
+   appears on the line carrying the credit:
+
+   - "Translated from GENESIS by Johannes Luthman and Volker
+     Steuber." -- names the translators with no `Author`/`Ref` token.
+   - ": HH TEA-sensitive Purkinje potassium current" /
+     ": Created 8/5/02 - nwg" -- a two-digit year, not four.
+   - ": written by Yiota Poirazi on 11/13/00 poirazi@LNC.usc.edu" --
+     "written by", not `Author`; again a two-digit year.
+
+   A `COMMENT` block's *opening* line matches the pattern and so was
+   captured, while the attribution text **inside** the block did not
+   and was dropped -- which is why several files were recorded as
+   "`TITLE`-only" or "empty `COMMENT`" despite carrying a credit two
+   lines further down. **Widening the line window alone would not
+   have found four of these five.** A re-audit should harvest whole
+   `COMMENT` blocks verbatim and match on free text ("written by",
+   "translated from", "based on", "adapted from", "from ... et al.",
+   two-digit dates), not on a fixed keyword list.
+
+   - 9 of the 11 shipped `DCN` mechanisms: "Translated from GENESIS by
      Johannes Luthman and Volker Steuber." -> O-ST2011 / O-LU2011.
+     (Not all 11 -- see the count note below.)
    - `Kca2p2_*.mod` (all five cell types): a full citation to
      "Sergio M. Solinas, Lia Forti, Elisabetta Cesana, Jonathan
      Mapelli, Erik De Schutter and Egidio D`Angelo (2008) /
@@ -4158,6 +4457,23 @@ resolve them cleanly:
      ": From car to Cav2_3" -> O-PO2003a.
    - `Cav3p2_*.mod`: ": (as in Coulter et al., J Physiol 414: 587,
      1989)" at line ~85 -> O-CO1989.
+
+   **Count note: 9 of the 11, not all 11.** The Luthman/Steuber
+   translation line was re-checked file by file on 2026-08-15
+   (`grep -rl Luthman DCN/`). Of the 11 real (non-`Toy*`) DCN
+   mechanisms it appears in 9: all eight `DCN/channel/` files other
+   than `CaLVA_SU15_DCN.mod`, plus `DCN/ion/CdpHVA_SU15_DCN.mod`.
+   **`CaLVA_SU15_DCN.mod` and `CdpLVA_SU15_DCN.mod` do not carry it.**
+   Both instead open with a `COMMENT` describing the GHK coupling
+   between the two of them ("This mechanism and the other calcium
+   channel (CaHVA.mod) are the only channel mechanisms of the DCN
+   model that use the GHK mechanism...") and name no author. **The
+   conclusion is unaffected**: the two files are part of the same
+   deposit as the other nine, the pair is internally cross-referenced
+   by that `COMMENT`, and the O-ST2011 / O-LU2011 chain established in
+   the `SU2015` `### Attribution` block rests on the deposit, not on a
+   per-file header. It is recorded only so that a re-audit grepping
+   for "Luthman" does not read two misses as a discrepancy.
 
    `NaFHF_MA20_GrC.mod`'s empty `COMMENT` is a genuine absence, but it
    is not a gap: the file is `Nav_MA20_GrC.mod`'s 13-state scheme with
@@ -4222,6 +4538,19 @@ resolve them cleanly:
     `__all__`, and none is listed twice. **155 is therefore the figure
     a coverage check should use**, and 123 the keyed figure.
 
+    **What 155 excludes, stated so the number is unambiguous.** The
+    parse above reads the *module* files under `braincell/channel/`
+    and `braincell/ion/` and does not read either package's
+    `__init__.py`. One public symbol lives only there --
+    `braincell/ion/__init__.py::build_placeholder_ions`, present in
+    that module's `__all__` and documented with `.. autofunction::` in
+    `docs/apis/braincell.ion.rst`. A whole-package count would
+    therefore return 156, not 155. That symbol is **out of scope by
+    the project's own definition** (see the scope exclusion under
+    `## How this file was built`) and its absence from this file is
+    not a gap. Do not "fix" the count to 156 without also widening the
+    scope and adding a record for it.
+
     *Is `ghk_flux` counted consistently? Yes, and it is the only case
     that could go either way.* It is a module-level **function**; the
     other 154 entries are classes. It is exported in
@@ -4273,10 +4602,7 @@ resolve them cleanly:
     0.1 um used by the widely circulated `cad.mod` implementation of
     it; (c) the individual values of the pump rate constants `c1`,
     `c2`, `c3`, which the paper gives only through the lumped
-    `K_T` and `K_d`. Independently, the value of `tau` in Bazhenov et
-    al. (1998) was not confirmed against the paper, so BrainCell's
-    `tau = 5.0 ms` default is recorded as a default, not as the
-    paper's value. **None of these affects any verdict** -- the
+    `K_T` and `K_d`. **None of these affects any verdict** -- the
     `CalciumDetailed` finding rests on the implementation containing
     no pump term at all, which is settled from the code. They are
     recorded so nobody re-derives them.
@@ -4304,3 +4630,36 @@ resolve them cleanly:
     source for either, it is an addition to the allowlist's
     exceptions, not a contradiction of a verified record -- no
     `.. [N]` entry was written for either.
+
+    **UNVERIFIED LEAD for `CalciumFirstOrder`, to be checked before
+    shipping.** One candidate was *not* pursued and should be, because
+    it is the best-known source of a bare `Ca' = -alpha*I_Ca -
+    beta*Ca` with numeric `alpha`/`beta` and no shell-depth term:
+
+    ```
+    Pinsky, P. F., & Rinzel, J. (1994). Intrinsic and network
+    rhythmogenesis in a reduced Traub model for CA3 neurons. Journal
+    of Computational Neuroscience, 1(1-2), 39-60.
+    ```
+
+    **This is a lead, not a verified record.** The bibliographic
+    fields above were read from Crossref (doi:10.1007/BF00962717) and
+    are given only so the paper can be found; **the attribution was
+    not checked at all.** Specifically, nobody has confirmed that the
+    paper's calcium equation prints `alpha = 0.13` and `beta = 0.075`,
+    or that its calcium variable is scaled the way
+    `CalciumFirstOrder`'s is. Do **not** cite it, do not copy the
+    block above into a `.. [N]` entry, and do not treat its presence
+    here as weakening the no-source determination, which stands until
+    the check is done.
+
+    *What closing it would take.* Read the paper's model equations,
+    compare the two constants and the sign convention against
+    `braincell/ion/calcium.py::CalciumFirstOrder.derivative`, and be
+    aware that the reduced-Traub calcium variable is conventionally
+    dimensionless -- if BrainCell's is in `mM`, the constants will not
+    match numerically even if the model is the right one, and that
+    mismatch would need explaining rather than waving through. If the
+    check passes, this becomes a verified record and the symbol leaves
+    the no-source list; if it fails, strike this lead so nobody
+    re-derives it.

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -1847,8 +1847,15 @@ more than one). The **final** entry is the `MA2020` model paper.
   and `dirc2 = 200`, `dirc3 = 160`, `dirc4 = 80` /ms-mM
   (Ca-dependent), plus `diff = 3`.
 - `Nav_MA2020_GrC` and `NaFHF_MA2020_GrC` are the same 13-state
-  Raman-style Markov scheme with `ACon = 0.025`, `ACoff = 0.5`,
-  `AOon = 0.75`, `AOoff = 0.002` /ms and the derived
+  Raman-style Markov scheme. **Correction (Task 13):** an earlier
+  revision of this bullet gave one shared constant set for both. That
+  is wrong. `ACon` and `AOoff` differ between them, verified by
+  reading both constructors:
+  `NaFHF_MA2020_GrC` ships `ACon = 0.025` and `AOoff = 0.002`
+  (`braincell/channel/sodium.py:1818,1821`), while `Nav_MA2020_GrC`
+  ships `ACon = 0.005` and `AOoff = 0.005`
+  (`braincell/channel/sodium.py:1592,1595`). `ACoff = 0.5` and
+  `AOon = 0.75` /ms are shared, as are the derived
   `a = (Oon/Con)^0.25`, `b = (Ooff/Coff)^0.25`. `NaFHF` adds the
   `Lon`/`Loff` blocked-state ladder (`L3..L6`) on top of the same
   `C1..C5`/`I1..I6`/`O` topology -- it is the same mechanism with the

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -2503,7 +2503,14 @@ files, for example:
 - `sKdr_SU2015_DCN`: `m_inf = 1/(1 + exp((V+50)/-9.1))`,
   `tau_m = 14.95/(exp((V+50)/21.74) + exp((V+50)/-13.91)) + 0.05`,
   gating `m^4`.
-- `HCN_SU2015_DCN`: `m_inf = 1/(1 + exp((V+80)/5))`, no tau.
+- `HCN_SU2015_DCN`: `m_inf = 1/(1 + exp((V+80)/5))`, and a **constant**
+  `tau_m = 400/qdeltat` ms. Earlier drafts of this line read "no tau",
+  meaning only that no *voltage-dependent* tau expression appears (the
+  `.mod` file's `TABLE` directive tabulates `minf` alone, because
+  `taum` does not depend on `V`). That wording misled a module task
+  into briefing the gate as instantaneous, which it is not:
+  `braincell/channel/hyperpolarization_activated.py::HCN_SU2015_DCN.f_m_tau`
+  returns a real, finite `400.0 / self.qdeltat`.
 - `SK_SU2015_DCN`: `z_inf = cai^4/(cai^4 + 8.1e-15)` (i.e. a Hill
   coefficient of 4 at `[Ca] = 3e-4 mM`), with the piecewise
   `tau_z = 1 - 186.67 cai` below `cai = 0.005 mM` and `0.0667` above.

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -61,7 +61,28 @@ name alone; read the harvested header text.
   `## Origin-of-kinetics records` below. **99 of the 104 symbols need
   a two-level citation**; the other 5 (the `SU2015` `Toy*` family) get
   no citation at all because they are BrainCell's own test fixtures.
-  `NO_KEY` remains open.
+- Task 3 follow-up (2026-08-15) closed the `NO_KEY` bucket, which had
+  been assigned to no task. Three of its 32 symbols carry a real
+  primary source and are now verified -- `ghk_flux` (Goldman 1943 /
+  Hodgkin & Katz 1949), `KineticIon` (Hines & Carnevale 2000 / The
+  NEURON book 2006) and `CalciumDetailed` (Destexhe 1993 / Bazhenov
+  1998, whose deferred attribution checks are closed at the same
+  time). The other **29 are recorded, symbol by symbol, as having no
+  primary literature source** and are expected to ship without a
+  `References` section; that list is in the bucket's
+  `### Symbols with no primary literature source` block and is the
+  source of truth for any later allowlist.
+- **The symbol count, reconciled.** `__all__` across
+  `braincell/channel/*.py` and `braincell/ion/*.py` holds **155**
+  public symbols: 154 classes and one function (`ghk_flux`). They
+  split as **32 `NO_KEY` + 123 keyed**, and the keyed half splits as
+  **19 across Task 2's nine keys + 104 across Task 3's seven**. Every
+  per-key heading in this file already carries the right number and
+  they sum to 155 with no symbol listed twice and none missing -- this
+  was checked mechanically, by parsing `__all__` and diffing it
+  against this file's own bullet lists. The plan's figures of 103 and
+  122 are each one short of 104 and 123; see `## Unresolved
+  attributions` item 11.
 - Nothing in this file's `### Provenance evidence` blocks is a citation.
   It is raw, unedited text copied from `.mod` file headers (typos,
   inconsistent spacing, and missing apostrophes preserved verbatim) plus
@@ -832,13 +853,402 @@ math should cite the standard HH (1952) formalism or the relevant ion
 model paper only where the *implementation* (not the class scaffolding)
 draws on it.
 
+> **Correction (Task 3 follow-up, 2026-08-15).** "Nothing further to
+> verify for most of these" is right about 29 of the 32 symbols and
+> wrong about three. `ghk_flux` implements a named published equation,
+> `KineticIon` reproduces a documented NEURON language feature by name,
+> and `CalciumDetailed` already ships a `References` section in the
+> source tree. Those three are verified below. The remaining 29 are
+> confirmed as having no primary literature source, and that
+> confirmation is now written out symbol by symbol rather than left
+> implicit -- see `### Symbols with no primary literature source`.
+
 ### Verified record
 
-_TODO (Task 3): not yet verified._
+**Three of the 32 symbols carry a real primary source; 29 do not.**
+The three are verified here. The 29 are enumerated, with reasons, in
+`### Symbols with no primary literature source` below -- that list is
+the complete determination, not a summary of one, and a later task
+builds its allowlist from it.
+
+All records below were confirmed 2026-08-15 against at least two
+independent sources: the Crossref REST API, NCBI E-utilities
+(`efetch`, `db=pubmed` and `db=pmc`), Europe PMC, dblp, Semantic
+Scholar, OpenLibrary, and -- where a rendered publisher page was
+unreachable -- the publisher-deposited JATS XML or the authors' own
+extended preprints. Sources are named per record.
+
+**N-GHK -- `braincell/channel/_base.py::ghk_flux`.** Two entries, in
+this order:
+
+.. [1] Goldman, D. E. (1943). Potential, impedance, and rectification
+       in membranes. The Journal of General Physiology, 27(1), 37-60.
+       doi:10.1085/jgp.27.1.37
+
+.. [2] Hodgkin, A. L., & Katz, B. (1949). The effect of sodium ions on
+       the electrical activity of the giant axon of the squid. The
+       Journal of Physiology, 108(1), 37-77.
+       doi:10.1113/jphysiol.1949.sp004310
+
+Goldman: PMID 19873371, PMCID PMC2142582; Crossref, PubMed, Europe PMC
+and the RUPress JATS deposit all agree on 27(1), 37-60. **The printed
+title is set in full capitals** (`POTENTIAL, IMPEDANCE, AND
+RECTIFICATION IN MEMBRANES`) -- that is the journal's 1943 house style
+for every article, so down-casing it to sentence case is the house
+rule's normal operation, not a silent edit to a publisher's wording.
+
+Hodgkin & Katz: PMID 18128147, PMCID PMC1392331. **One source
+disagreement, resolved.** PubMed and Europe PMC print "... electrical
+activity of giant axon of the squid", dropping the definite article;
+Crossref and the Physiological Society's own JATS deposit both print
+"... of **the** giant axon of the squid". Two publisher-sourced
+records outweigh one cataloguer-sourced one, so "the giant axon" is
+used above. The article is free-to-read but not open access, and its
+PMC deposit is a scanned PDF with no text layer.
+
+**Ordering is not cosmetic here.** Goldman 1943 and Hodgkin & Katz
+1949 are the two halves of the name "GHK", but they are the primary
+sources for two *different* equations, and `ghk_flux` computes only
+one of them -- see the attribution check below. Goldman is the primary
+source for the constant-field current/flux equation and therefore
+takes `.. [1]`. A docstring that cites Hodgkin & Katz alone, or that
+puts it first, is citing the constant-field *voltage* equation, which
+this function does not compute.
+
+**N-NRN -- `braincell/ion/_base.py::KineticIon`.** Two entries:
+
+.. [1] Hines, M. L., & Carnevale, N. T. (2000). Expanding NEURON's
+       repertoire of mechanisms with NMODL. Neural Computation, 12(5),
+       995-1007.
+       doi:10.1162/089976600300015475
+
+.. [2] Carnevale, N. T., & Hines, M. L. (2006). The NEURON book.
+       Cambridge University Press.
+       doi:10.1017/CBO9780511541612
+
+Hines & Carnevale 2000: PMID 10905805, MIT Press, ISSN 0899-7667.
+Confirmed against Crossref, PubMed, dblp, Semantic Scholar, the
+official NEURON "Publications about NEURON" list and the authors' own
+Yale page -- six sources, all agreeing on 12(5), 995-1007. **One
+disagreement, resolved.** The authors' extended preprint
+(`nmodl400.pdf`) carries "Neural Computation 12:839-851, 2000" on its
+own cover page; that is a stale pre-publication estimate contradicted
+by all six sources above, and third-party summaries still propagate
+it. Use 995-1007. The published title is set in title case by MIT
+Press (`Expanding NEURON's Repertoire of Mechanisms with NMODL`);
+down-casing to sentence case is the house rule, and `NEURON` and
+`NMODL` are preserved as capitalised acronyms.
+
+The NEURON book: ISBN-13 9780521843218 (hardback, ISBN-10
+0521843219), 9780521115636 (paperback), 9780511541612 (online); 478
+pages; LCCN 2006277066. Per the house style, the ISBN is recorded here
+and not in the `.. [N]` entry, and no place of publication is given.
+Chapter 9, "How to expand NEURON's library of mechanisms", pp.
+207-264, is the relevant chapter (chapter DOI
+10.1017/CBO9780511541612.010). Confirmed against Crossref (book record
+plus all sixteen chapter records) and OpenLibrary. Cambridge Core
+itself returned HTTP 403, so the chapter page range rests on the
+Crossref chapter deposit.
+
+**Why the 1997 paper is not the citation here, and would be wrong.**
+The obvious candidate -- Hines & Carnevale (1997), "The NEURON
+simulation environment", Neural Computation 9(6), 1179-1209,
+doi:10.1162/neco.1997.9.6.1179 -- contains **zero** occurrences of
+`KINETIC`, `COMPARTMENT` or `CONSERVE` in the authors' own extended
+preprint, and says so in as many words: "An extensive discussion of
+NMODL is beyond the scope of this article." The 2000 paper opens by
+drawing exactly that boundary against its predecessor. Citing the 1997
+paper for `KINETIC`/`COMPARTMENT` points the reader at a paper that
+disclaims the topic. It remains the right citation for NEURON the
+simulator in general; it is the wrong one for this class. Also ruled
+out, by full-text search returning zero hits for all three keywords:
+Hines & Carnevale (2001) in *The Neuroscientist*, and Awile et al.
+(2022), doi:10.3389/fninf.2022.884046, which covers the build system
+and transpiler rather than language semantics.
+
+**N-CAD -- `braincell/ion/calcium.py::CalciumDetailed`.** Two entries.
+These supersede the two that the source tree already carries at
+`braincell/ion/calcium.py:227-233`; the existing pair has a title
+error and no DOIs. See `## Corrections to pre-existing in-code
+citations` items 1 and 2, whose *record* checks these confirm
+independently, and whose deferred *attribution* checks are closed
+below.
+
+.. [1] Destexhe, A., Babloyantz, A., & Sejnowski, T. J. (1993). Ionic
+       mechanisms for intrinsic slow oscillations in thalamic relay
+       neurons. Biophysical Journal, 65(4), 1538-1552.
+       doi:10.1016/S0006-3495(93)81190-1
+
+.. [2] Bazhenov, M., Timofeev, I., Steriade, M., & Sejnowski, T. J.
+       (1998). Cellular and network models for intrathalamic
+       augmenting responses during 10-Hz stimulation. Journal of
+       Neurophysiology, 79(5), 2730-2748.
+       doi:10.1152/jn.1998.79.5.2730
+
+Destexhe: PMID 8274647, PMCID PMC1225880. Re-confirmed here by direct
+`efetch db=pubmed`, which returns the title ending in "thalamic relay
+**neurons**" -- plural, as Task 2 found; the in-code entry's "neuron"
+is wrong. Bazhenov: PMID 9582241; the same `efetch` call returns
+79(5), 2730-2748, and the publisher-typeset PDF's embedded metadata
+(`Subject: J. Neurophysiol. 79: 2730-2748, 1998`) independently
+confirms the same range across 19 pages. Both records agree with the
+corrected forms Task 2 published, from a separate query.
+
+**Caveat on open-access status, for anyone re-auditing.** OpenAlex,
+Unpaywall and Semantic Scholar all report the Bazhenov paper as closed
+with zero open-access locations, while an author-hosted copy is in
+fact reachable. That is a simultaneous false negative in three
+aggregators; do not use them to decide whether a reference here is
+obtainable. The companion paper -- Bazhenov, Timofeev, Steriade &
+Sejnowski (1998), "Computational models of thalamocortical augmenting
+responses", *The Journal of Neuroscience* 18(16), 6444-6465, PMID
+9698334 -- *is* in PMC as PMC6793176, if a docstring ever needs it.
 
 ### Attribution
 
-_TODO (Task 3): not yet filled in._
+**Attribution check: PASSED for `ghk_flux` and `KineticIon`. PASSED
+with a correction for `CalciumDetailed`, whose two entries are both
+verified but are not both descriptions of what the class computes.**
+
+**`ghk_flux` -- checked against the implementation, not the name.**
+Code read: `braincell/channel/_base.py:33-40`. The function is five
+lines and computes, with `zeta = z*F*V/(R*T)`:
+
+```
+regular_branch = z * zeta * F * (ci - co*exp(-zeta)) / (1 - exp(-zeta))
+```
+
+Substituting `zeta` gives `z^2 F^2 V / (R T) * (ci - co e^{-zeta}) /
+(1 - e^{-zeta})`, which is the Goldman constant-field **current**
+equation divided through by the permeability. The permeability is
+supplied by the caller: `braincell/channel/calcium.py:1002-1013`
+(`Cav2p1_RI2021_SC.current`) returns `-g_max * conductance_factor(V,
+Ca) * drive`, so `g_max` occupies the `P_s` slot. The function takes
+`V` as an *input* and returns a flux; the constant-field **voltage**
+equation takes concentrations and permeabilities and returns a
+potential. The two cannot be confused once the signature is read, and
+this is the check the coordinator asked for: **`ghk_flux` computes the
+flux/current equation, so Goldman 1943 is its primary source.**
+
+That Goldman 1943 is the source of the current equation is verified
+from the paper's own OCR'd full text in the PMC deposit, which gives
+it as equation (11), `J_i = (u_i F / a) dV (n_i^0 e^{-z_i theta dV} -
+n_i)/(e^{-z_i theta dV} - 1)`, generalised at equation (17). That
+Hodgkin & Katz 1949 is the source of the voltage equation is verified
+from a peer-reviewed secondary source rather than the primary text,
+which is not retrievable: Alvarez, R., & Latorre, R. (2017), "The
+enduring legacy of the 'constant-field equation' in membrane ion
+transport", *The Journal of General Physiology* 149(10), 911,
+PMC5688357. **Recorded as a limitation:** the Hodgkin & Katz half of
+this attribution rests on that review, not on the 1949 paper's text.
+The review is a JGP centenary tribute written about the Goldman paper
+by domain experts, and it cross-checks against the primary Goldman
+text (its claim that the voltage equation is "formally equivalent to
+Eq. 18 in Goldman's 1943 paper" matches Goldman's equation (18) as
+read directly), so the limitation is narrow. It is nevertheless not a
+primary-source confirmation and must not be presented as one.
+
+*Caveat, and it belongs in the docstring.* The `small_branch` return
+value, `z*F*(ci - co*e^{-zeta})*(1 + zeta/2)`, is **not** from either
+paper. It is the first-order Taylor truncation of `zeta/(1 -
+e^{-zeta}) = 1 + zeta/2 + zeta^2/12 + ...`, selected by
+`where(|1 - exp(-zeta)| <= 1e-6, ...)` to keep the removable
+singularity at `V = 0` finite and differentiable under JAX. It is a
+BrainCell numerical-stability addition. The same applies to the two
+private variants in `braincell/channel/calcium.py:78-96`,
+`_cav3p1_nmodl_ghk_flux` and `_cav3p3_nmodl_ghk_flux`, which differ
+from the public helper only in substituting the Faraday, gas-constant
+and Kelvin-offset literals that the corresponding NMODL sources use in
+place of the `brainunit` constants; their expansions
+(`1 + zeta/2` and `1 - w/2` respectively) were both checked and are
+correct to first order. Those two are private and not in `__all__`, so
+they need no `References` section of their own.
+
+**`KineticIon` -- checked against the NMODL constructs it names.**
+Code read: `braincell/ion/_base.py:335-351` (the class and its
+`Notes`, which state the semantics "matching NEURON's
+``KINETIC``/``COMPARTMENT`` behavior") and `43-147` (the five frozen
+declaration dataclasses it consumes). The mapping is one-for-one, and
+each element was matched against verbatim text in the 2000 paper's
+extended preprint and in the public draft of NEURON Book chapter 9:
+
+| BrainCell declaration | NMODL construct | Evidence |
+|---|---|---|
+| `Reaction(lhs, rhs, forward, backward)` | `~ A + B <-> C (kf, kb)` | "The first character of a reaction statement is the tilde `~`"; worked example `~ cai + pump <-> capump (k1,k2)` |
+| `Factor(name, value)` + `Species(..., factor=)` | `COMPARTMENT vol {states}` | "where the STATEs named in the braces have the same compartment volume given by the volume expression after the COMPARTMENT keyword. The volume merely multiplies the dSTATE/dt left hand side" |
+| `Conserve(species, algebraic, total)` | `CONSERVE` | "the user is allowed to explicitly specify conservation equations with the CONSERVE statement" |
+| `Species(name, init, factor)` | `STATE` | kinetic-scheme unknowns: "The NMODL translator converts the kinetic scheme into a family of ODEs whose unknowns are the STATEs" |
+
+The `COMPARTMENT` semantics quoted above is exactly what
+`KineticIon`'s `Notes` describes: the factor multiplies the derivative
+side only, which is why the class stores species in visible units and
+converts only temporarily inside conservation and derivative mapping.
+Corroboration that this is still current NEURON semantics and not a
+2000-vintage description: the live official NMODL language reference
+at `nrn.readthedocs.io` carries the `COMPARTMENT` and `CONSERVE`
+paragraphs **word for word** identical to the 2000 text. *Caveat:*
+that documentation page carries no citation of its own -- zero
+occurrences of "Hines", "Carnevale" or "Neural Comput" -- so it
+corroborates the semantics, not the attribution.
+
+Two limitations, both recorded rather than papered over. First, the
+published 13-page article could not be read (MIT Press and the ACM
+Digital Library both returned HTTP 403); the `KINETIC`/`COMPARTMENT`
+text was verified in the authors' own much longer extended preprint of
+it, and the published abstract calls itself "a summary". That is why
+the book is cited alongside as `.. [2]` rather than optionally: NEURON
+Book chapter 9 was verified directly from the authors' public draft
+and carries the same `COMPARTMENT` passage and the same worked
+examples, including `COMPARTMENT (1e10)*parea {pump pumpca}` -- the
+very idiom `braincell/ion/calcium.py:1317-1318` describes when
+explaining an imported mechanism. Second, do not quote a numbered
+section such as "9.10.1" from the book; the draft uses example
+numbering and Cambridge Core was unreachable.
+
+*Scope caveat.* This reference belongs on `KineticIon`, the template
+that implements the semantics. The five declaration dataclasses are
+inert records with no behaviour, so they ship without a `References`
+section and point at `KineticIon` through `See Also` instead. That is
+a judgement call, not a finding -- flagged as item 15 below.
+
+**`CalciumDetailed` -- the correction.** Code read:
+`braincell/ion/calcium.py:127-269` (the 106-line docstring, the
+constructor and `derivative`) and `61-81` (the `Calcium` base). The
+class's entire dynamics is four lines:
+
+```
+drive = total_current / (2 * u.faraday_constant * self.d)
+drive = u.math.maximum(drive, u.math.zeros_like(drive))
+return drive + (self.C_rest - Ci) / self.tau
+```
+
+*Entry [2], Bazhenov et al. 1998: attribution PASSED.* That expression
+is term for term the first-order model the docstring's own section 2
+attributes to Bazhenov -- influx `I_Ca/(zFd)` with `z = 2` hard-coded
+as the literal `2`, plus relaxation `([Ca]_rest - [Ca])/tau`. The
+constructor exposes exactly and only that model's three parameters:
+`d`, `tau`, `C_rest`.
+
+*Entry [1], Destexhe et al. 1993: the paper is correctly identified
+and correctly recorded, but the class does not implement it.* The
+docstring's section 1 sets out the ATP-driven pump, its kinetic scheme
+`Ca_i + P <-> CaP -> P + Ca_o`, and its Michaelis-Menten reduction
+`d[Ca]_i/dt = -K_T [Ca]_i/([Ca]_i + K_d)` with `K_T = 1e-4 mM/ms` and
+`K_d = 1e-4 mM`. **None of it is implemented.** A grep of the whole
+module for `K_T`, `Kd`, `1e-4` and `Michaelis` returns exactly one hit
+-- the word "Michaelis-Menten" in that docstring's prose. There is no
+saturating term anywhere in `derivative`, and no pump parameter in the
+constructor. Task 2 deferred this check and, in doing so, recorded the
+assumption that the abstract's "included Ca2+ diffusion" was
+"consistent with the Michaelis-Menten Ca pump the class implements";
+**that assumption is wrong and is corrected here.**
+
+The consequence for the module task is narrow and specific: keep both
+entries only for as long as the docstring keeps its expository section
+1. `.. [1]` is a correct citation *for the text it supports*. It must
+not be presented as the source of `CalciumDetailed.derivative`, and if
+the docstring is ever trimmed to what the class computes, `.. [1]`
+goes with the prose it belongs to and Bazhenov becomes the sole
+reference.
+
+*Parameter caveats, none of them citation errors.* `d = 1.0 um` and
+the `Calcium` base's `default_Co = 2.0 mM` and `default_valence = 2`
+match the docstring's stated values. `C_rest` defaults to
+`2.4e-4 mM`, i.e. 0.24 uM, where the docstring's section 2 reports
+Bazhenov's resting concentration as 0.05 uM -- a factor of about five,
+and a default divergence that must be described as BrainCell's choice
+rather than the paper's value. `tau` defaults to `5.0 ms`; the paper's
+own value was not independently confirmed (see item 14 below). The
+docstring quotes `F = 96489 C/mol` and `R = 8.31441 J/(mol K)` from
+the paper while the code uses `u.faraday_constant` and, through
+`DynamicNernstIon`, `u.gas_constant` -- the CODATA values. The default
+temperature `u.celsius2kelvin(36.0)` is 309.15 K, matching the
+docstring. Finally, `maximum(drive, 0)` rectifies the influx term so
+that only inward calcium current raises `Ci`; no such clamp appears in
+either paper, and it is a BrainCell addition on the same footing as
+the `ghk_flux` small-`zeta` branch.
+
+*What was not closed on the paper side.* Three items about the
+Destexhe paper's own numbers were sought and not resolved: an apparent
+factor-of-100 inconsistency between `k = 0.1` and `k = 10` in its
+equation (7); a disagreement between the 1 um shell depth stated in
+the paper and the 0.1 um used by the widely circulated `cad.mod`
+implementation of it; and the absence of individual values for the
+rate constants `c1`, `c2`, `c3`, which the paper gives only through
+the lumped `K_T` and `K_d`. **None of the three affects the verdict**,
+which rests on the implementation containing no pump at all, but they
+are recorded as item 14 below so nobody re-derives them.
+
+### Symbols with no primary literature source
+
+**The remaining 29 symbols have no primary literature source and are
+expected to ship without a `References` section.** This is a
+determination, not an omission: each was inspected and the reason is
+given. A later task builds its allowlist from exactly this list, so it
+is written out symbol by symbol.
+
+| # | Symbol | Why no reference |
+|---|---|---|
+| 1 | `braincell/channel/_base.py::Gate` | Declaration dataclass for one HH gate (name, power, q10, temp_ref). No equations, no constants. |
+| 2 | `braincell/channel/_base.py::Transition` | Declaration dataclass for one Markov transition. Same. |
+| 3 | `braincell/channel/_base.py::HH` | Generic gate-template base. Carries no rate expressions and no parameters; subclasses supply both. |
+| 4 | `braincell/channel/_base.py::OhmicHH` | `HH` plus the ohmic current law `g_max * f * (E - V)`. Textbook, parameterless. |
+| 5 | `braincell/channel/_base.py::Markov` | Generic state-transition template. No scheme of its own. |
+| 6 | `braincell/channel/leaky.py::LeakageChannel` | Abstract base; every method is `pass` or `NotImplementedError`. |
+| 7 | `braincell/channel/leaky.py::IL` | `g_max * (E - V)` with conventional defaults `0.1 mS/cm2`, `-70 mV`. No source model. |
+| 8 | `braincell/channel/potassium.py::K_Leak` | Same, `0.005 mS/cm2`, reversal taken from the ion object. |
+| 9 | `braincell/channel/potassium.py::K_Kv_test` | Scratch/template fixture: `g_max` defaults to zero, `Q10_n` to 1.0. See the caveat below. |
+| 10 | `braincell/ion/_base.py::Factor` | Frozen declaration dataclass. See `KineticIon`. |
+| 11 | `braincell/ion/_base.py::Species` | Frozen declaration dataclass. See `KineticIon`. |
+| 12 | `braincell/ion/_base.py::Reaction` | Frozen declaration dataclass. See `KineticIon`. |
+| 13 | `braincell/ion/_base.py::Source` | Frozen declaration dataclass. See `KineticIon`. |
+| 14 | `braincell/ion/_base.py::Conserve` | Frozen declaration dataclass. See `KineticIon`. |
+| 15 | `braincell/ion/_base.py::FixedIon` | Mixin: stores `Ci`/`Co`/`E` as constants. No model. |
+| 16 | `braincell/ion/_base.py::InitNernstIon` | Mixin: computes `E` once from the Nernst equation. See the Nernst note below. |
+| 17 | `braincell/ion/_base.py::DynamicNernstIon` | Mixin: recomputes `E` from a dynamic `Ci`. Same note. |
+| 18 | `braincell/ion/calcium.py::Calcium` | Species container. Holds `default_Co = 2.0 mM`, `default_valence = 2`. |
+| 19 | `braincell/ion/calcium.py::CalciumFixed` | Container + `FixedIon`. |
+| 20 | `braincell/ion/calcium.py::CalciumInitNernst` | Container + `InitNernstIon`. |
+| 21 | `braincell/ion/calcium.py::CalciumFirstOrder` | `Ca' = -alpha*I_Ca - beta*Ca` with `alpha = 0.13`, `beta = 0.075`. Generic first-order form; no paper identified. See below. |
+| 22 | `braincell/ion/nonspecific.py::NonSpecific` | Container. `default_Ci = default_Co = 1.0 mM`, `valence = 1` -- placeholders, not measurements. |
+| 23 | `braincell/ion/nonspecific.py::NonSpecificFixed` | Container + `FixedIon`. |
+| 24 | `braincell/ion/potassium.py::Potassium` | Container. `default_Ci = 54.4 mM`, `default_Co = 2.5 mM`. |
+| 25 | `braincell/ion/potassium.py::PotassiumFixed` | Container + `FixedIon`. |
+| 26 | `braincell/ion/potassium.py::PotassiumInitNernst` | Container + `InitNernstIon`. |
+| 27 | `braincell/ion/sodium.py::Sodium` | Container. `default_Ci = 10.0 mM`, `default_Co = 140.0 mM`. |
+| 28 | `braincell/ion/sodium.py::SodiumFixed` | Container + `FixedIon`. |
+| 29 | `braincell/ion/sodium.py::SodiumInitNernst` | Container + `InitNernstIon`. |
+
+Four notes, so that the list is unambiguous rather than merely short:
+
+1. **`HH` and `OhmicHH` do not take `HH1952`.** The temptation is
+   obvious and should be resisted. These are parameterless templates,
+   not the squid-axon model; the squid-axon model is already covered
+   by the `HH1952` key, which owns `K_HH1952` and `Na_HH1952`. A
+   module task may name the Hodgkin-Huxley formalism in `Notes` prose,
+   but the `References` section stays absent.
+2. **The Nernst equation is not cited.** `InitNernstIon`,
+   `DynamicNernstIon` and `KineticIon.E` all evaluate
+   `E = (RT/zF) ln(Co/Ci)`. It is a nineteenth-century textbook
+   result; house policy for textbook results is no citation, and
+   applying it here keeps `KineticIon`'s `References` section about
+   the NMODL semantics that are actually distinctive.
+3. **The default concentrations are conventions, not data.** `54.4 /
+   2.5 mM` for potassium, `10 / 140 mM` for sodium and `2.0 mM`
+   external calcium are the values conventional in this literature
+   -- potassium's pair yields `E_K` near -82 mV at 36 C -- but no
+   single paper is their source, and they are constructor defaults
+   that any caller overrides. Recorded explicitly so that no later
+   task asserts a source for them.
+4. **Two symbols are judgement calls rather than clean determinations,
+   and are flagged as such.** `K_Kv_test`'s rate form,
+   `Ra*(V - V12)/(1 - exp(-(V - V12)/q))`, is the generic `vtrap`
+   alpha/beta idiom that recurs across dozens of unrelated NEURON
+   `kv.mod` files; its name, its zero default conductance and its unit
+   `Q10` mark it as a fixture, and no specific source was pursued.
+   `CalciumFirstOrder`'s `alpha = 0.13`, `beta = 0.075` are likewise
+   not traceable to a paper from the code alone. Both are recorded as
+   no-source; see item 16 below.
 
 ---
 
@@ -3408,11 +3818,22 @@ findings below are for whichever module task rewrites those docstrings.
           doi:10.1016/S0006-3495(93)81190-1
    ```
 
-   *Attribution check: not performed here.* `CalciumDetailed` is in the
-   `NO_KEY` bucket, which Task 3 owns. The abstract does confirm the
-   paper's model "included Ca2+ diffusion", which is consistent with the
-   Michaelis-Menten Ca pump the class implements, but the pump constants
-   were not compared. Task 3 must finish this.
+   ~~*Attribution check: not performed here.* `CalciumDetailed` is in
+   the `NO_KEY` bucket, which Task 3 owns. The abstract does confirm
+   the paper's model "included Ca2+ diffusion", which is consistent
+   with the Michaelis-Menten Ca pump the class implements, but the pump
+   constants were not compared. Task 3 must finish this.~~
+
+   **CLOSED, and the deferred assumption was wrong.** The Task 3
+   follow-up performed the check; see `## NO_KEY` -> `### Attribution`
+   -> **`CalciumDetailed` -- the correction**. `CalciumDetailed` does
+   **not** implement a Michaelis-Menten Ca pump. Its `derivative` is
+   the Bazhenov first-order model of item 2 below and nothing else;
+   the pump appears only in the docstring's expository prose. The
+   record check above stands unchanged and was re-confirmed
+   independently. The corrected entry is correct **for the text it
+   supports**, and must not be presented as the source of
+   `CalciumDetailed.derivative`.
 
 2. **`braincell/ion/calcium.py:230-233`** (in `CalciumDetailed`) --
    "Bazhenov, Maxim, Igor Timofeev, Mircea Steriade, and Terrence J.
@@ -3433,9 +3854,16 @@ findings below are for whichever module task rewrites those docstrings.
           doi:10.1152/jn.1998.79.5.2730
    ```
 
-   *Attribution check: not performed here* (same reason as item 1). Note
-   that this same paper is where Bazhenov et al. (2002) says its INa/IK
-   rate expressions live -- see the `Ba2002` attribution block.
+   ~~*Attribution check: not performed here* (same reason as item
+   1).~~ **CLOSED: PASSED.** The Task 3 follow-up compared the paper's
+   first-order model against `CalciumDetailed.derivative` term by
+   term; they agree, and this entry -- not item 1's -- is the source of
+   what the class computes. Two default divergences are recorded as
+   caveats in that block (`C_rest` 0.24 uM against the docstring's
+   stated 0.05 uM; `maximum(drive, 0)` rectification present in neither
+   paper). Note that this same paper is where Bazhenov et al. (2002)
+   says its INa/IK rate expressions live -- see the `Ba2002`
+   attribution block.
 
 3. **`braincell/channel/hyperpolarization_activated.py:78-80`** (in
    `HCN_HM1992`) -- same singular/plural title error ("thalamic relay
@@ -3772,27 +4200,107 @@ resolve them cleanly:
     only any claim about which accession the files were downloaded
     from, which no docstring should make.
 
-11. **Symbol count: 104, not 103.** The Task 3 brief and the project
-    plan both say the seven cerebellar keys cover 103 public symbols.
-    Counting `__all__` across `braincell/channel/*.py` and
-    `braincell/ion/*.py` gives 155 public symbols in total, of which
-    `MA2020` 32 + `MA2024` 19 + `MA2025` 16 + `RI2021` 15 + `SU2015`
-    16 + `ZH2019` 5 + `PC24` 1 = **104**. The per-key counts in this
-    file's own section headings are correct and sum to 104; the 103 is
-    an arithmetic slip upstream. Note also that the `*Test` classes
-    visible in the source (`Cav1p2_MA2020_GoCTest`,
-    `CaHVA_SU2015_DCNTest`, and about twenty others) are **not** in
-    any `__all__` and are correctly excluded from the 155. There are 24
-    of them across the six affected modules, one per templated
-    mechanism family.
+11. **Symbol count: 104, not 103; 123 keyed, not 122. RESOLVED --
+    recorded here as the reconciliation, not as an open question.**
+    The Task 3 brief and the project plan say the seven cerebellar
+    keys cover 103 public symbols and that the keyed total is 122.
+    Both are one short. The figures were re-derived mechanically, by
+    parsing `__all__` out of every module under
+    `braincell/channel/` and `braincell/ion/` with `ast` and diffing
+    the result against this file's own `### Symbols` bullet lists:
 
-12. **`NO_KEY` (32 symbols) is still open and belongs to no task yet.**
-    Its `### Verified record` and `### Attribution` blocks are still
-    marked `_TODO (Task 3)`, but the Task 3 brief scopes that task to
-    the seven cerebellar keys only and Task 3 did not touch `NO_KEY`.
-    The marker is therefore stale, not an omission. Two sub-items
-    inherited from Task 2 sit inside it and must be picked up by
-    whichever task claims it: the `CalciumDetailed` pump constants
-    (see `## Corrections to pre-existing in-code citations`, items 1
-    and 2, where the record checks passed but the attribution checks
-    were explicitly not performed).
+    | Bucket | Symbols |
+    |---|---|
+    | Task 2's nine keys (`HM1992` 7, `IS2008` 2, `Ba2002` 2, `TM1991` 2, `HH1952` 2, `HP1992` 1, `Re1993` 1, `Ya1989` 1, `De1994` 1) | 19 |
+    | Task 3's seven keys (`MA2020` 32, `MA2024` 19, `MA2025` 16, `RI2021` 15, `SU2015` 16, `ZH2019` 5, `PC24` 1) | 104 |
+    | **Keyed subtotal** | **123** |
+    | `NO_KEY` | 32 |
+    | **Total** | **155** |
+
+    The diff is empty in both directions: no symbol is in `__all__`
+    but missing from this file, none is listed here but absent from
+    `__all__`, and none is listed twice. **155 is therefore the figure
+    a coverage check should use**, and 123 the keyed figure.
+
+    *Is `ghk_flux` counted consistently? Yes, and it is the only case
+    that could go either way.* It is a module-level **function**; the
+    other 154 entries are classes. It is exported in
+    `braincell/channel/_base.py::__all__` exactly like the classes,
+    it is listed in the `NO_KEY` bucket above, and it is one of the
+    155. Nothing in this file counts symbols by "classes only". The
+    likeliest origin of the upstream 103/122 is a key-extraction
+    pattern requiring a four-digit year, which `PC24` does not match;
+    that would drop `Cav3p1Test_PC24` from the keyed side and give
+    exactly 103 and 122.
+
+    Note also that the `*Test` classes visible in the source
+    (`Cav1p2_MA2020_GoCTest`, `CaHVA_SU2015_DCNTest`, and others) are
+    **not** in any `__all__` and are correctly excluded from the 155.
+    There are 24 of them across the six affected modules, one per
+    templated mechanism family.
+
+12. ~~**`NO_KEY` (32 symbols) is still open and belongs to no task
+    yet.** Its `### Verified record` and `### Attribution` blocks are
+    still marked `_TODO (Task 3)`, but the Task 3 brief scopes that
+    task to the seven cerebellar keys only and Task 3 did not touch
+    `NO_KEY`. The marker is therefore stale, not an omission.~~
+    **CLOSED** by the Task 3 follow-up. The stale markers are gone,
+    three symbols are verified, 29 are recorded as having no primary
+    literature source, and the two `CalciumDetailed` sub-items
+    inherited from Task 2 are closed in
+    `## Corrections to pre-existing in-code citations` items 1 and 2
+    -- item 1 with a correction, because the assumption Task 2
+    recorded while deferring it turned out to be false.
+
+13. **The Hodgkin & Katz 1949 attribution rests on a secondary
+    source.** The record is verified from publisher-deposited metadata
+    (Crossref and the Physiological Society's JATS), but the paper's
+    *text* is not retrievable: it is free-to-read rather than open
+    access, and its PMC deposit is a scan with no text layer. That
+    Hodgkin & Katz derive the constant-field **voltage** equation --
+    the fact that establishes which of the two GHK papers `ghk_flux`
+    should cite first -- is confirmed from Alvarez & Latorre (2017),
+    a peer-reviewed JGP centenary review, and not from the 1949 paper
+    itself. The Goldman half *is* primary-verified from the OCR'd PMC
+    full text. Anyone able to reach the 1949 text should confirm and
+    strike this item.
+
+14. **Three numbers inside Destexhe et al. (1993) were not resolved.**
+    Sought while checking `CalciumDetailed` and not closed: (a) an
+    apparent factor-of-100 inconsistency between `k = 0.1` and
+    `k = 10` in the paper's equation (7); (b) a disagreement between
+    the 1 um submembrane shell depth stated in the paper and the
+    0.1 um used by the widely circulated `cad.mod` implementation of
+    it; (c) the individual values of the pump rate constants `c1`,
+    `c2`, `c3`, which the paper gives only through the lumped
+    `K_T` and `K_d`. Independently, the value of `tau` in Bazhenov et
+    al. (1998) was not confirmed against the paper, so BrainCell's
+    `tau = 5.0 ms` default is recorded as a default, not as the
+    paper's value. **None of these affects any verdict** -- the
+    `CalciumDetailed` finding rests on the implementation containing
+    no pump term at all, which is settled from the code. They are
+    recorded so nobody re-derives them.
+
+15. **Where the NEURON reference sits is a judgement call.**
+    `Factor`, `Species`, `Reaction`, `Source` and `Conserve` are the
+    surface that maps onto `COMPARTMENT`, `STATE`, `~ A <-> B (kf,
+    kb)` and `CONSERVE`, so an argument exists for citing Hines &
+    Carnevale on each of them. The determination taken here is that
+    the reference belongs on `KineticIon`, which implements the
+    semantics, and that the five dataclasses -- inert frozen records
+    with no behaviour -- ship without a `References` section and point
+    at `KineticIon` through `See Also`. A later task may revisit this;
+    it should do so deliberately, not by accident.
+
+16. **Two no-source determinations are weaker than the other 27.**
+    `K_Kv_test` uses the generic `vtrap` alpha/beta idiom found in
+    dozens of unrelated NEURON `kv.mod` files, and
+    `CalciumFirstOrder` hard-codes `alpha = 0.13`, `beta = 0.075`.
+    Neither is traceable to a paper from the code alone, and neither
+    was pursued further: `K_Kv_test` is marked a fixture by its name,
+    its zero default conductance and its unit `Q10`, and
+    `CalciumFirstOrder` states no more than the generic first-order
+    form. Both are recorded as no-source. If a later task finds a
+    source for either, it is an addition to the allowlist's
+    exceptions, not a contradiction of a verified record -- no
+    `.. [N]` entry was written for either.

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -1,0 +1,1360 @@
+# Ion and channel bibliography
+
+This file is the single source of truth for the `References` entries that
+will appear in the NumPy-doc docstrings of the 155 public symbols under
+`braincell/ion/` and `braincell/channel/`. Docstring `References` sections
+in later tasks are copied **verbatim** from the `### Attribution` block of
+the relevant key section below — no citation is typed fresh at docstring
+time, and no citation is typed here without having been through the
+verification steps (Tasks 2 and 3).
+
+## How this file was built
+
+- **Step 1 (key -> symbol inventory).** Every public class/function in
+  `braincell/channel/*.py` and `braincell/ion/*.py` was scanned for a
+  citation-key fragment embedded in its name (`[A-Za-z]{2}(?:19|20)\d{2}` or
+  `[A-Z]{2}\d{2}`, e.g. `HM1992`, `MA2020`, `PC24`). Symbols whose name
+  carries no such fragment are bucketed as `NO_KEY`.
+- **Step 2 (provenance harvest).** Every `.mod` file under
+  `examples/neuron_compare/Cerebellum_mod/*/{channel,ion}/` was scanned for
+  its `TITLE`/`COMMENT`/`Author`/`Ref`/`revis`/4-digit-year lines (first 25
+  lines only). This is the NEURON source BrainCell's cerebellar channel
+  suite was ported from. The mod-file "year code" in filenames
+  (`MA20`, `MA24`, `MA25`, `RI21`, `SU15`, `ZH19`) is a 2-digit form of the
+  same key used in the BrainCell class name.
+- **Cell-type suffixes** (fixed by
+  `examples/neuron_compare/Cerebellum_mod/README.md` and confirmed against
+  directory layout): `BC` = basket cell, `DCN` = deep cerebellar nuclei,
+  `GoC` = Golgi cell, `GrC` = granule cell, `IO` = inferior olive, `PC` =
+  Purkinje cell, `SC` = stellate cell.
+
+## READ BEFORE TRUSTING A `.mod` HEADER
+
+The key embedded in a BrainCell class name is the name of the person(s)
+BrainCell's `.mod` source file was imported *from* (i.e. whoever assembled
+the multi-compartment cell model this channel was extracted from), **not**
+necessarily the origin of the channel's equations or the author of the
+paper that should be cited. Every cerebellar `.mod` file that carries an
+explicit `Author:`/`CoAuthor:` line in this harvest names an author
+*different* from the key's own literature-search target (e.g. Masoli et
+al., Solinas/Forti/Rizza, etc.) — see the per-key `### Provenance evidence`
+blocks below, and the summary table in
+`.superpowers/sdd/task-1-report.md`. Do not resolve a citation from the key
+name alone; read the harvested header text.
+
+## Status of this file
+
+- `### Verified record` and `### Attribution` blocks are intentionally
+  **empty** in this task. They are filled in by Task 2 (classical/thalamic
+  keys) and Task 3 (cerebellar-model keys) after literature verification.
+- Nothing in this file's `### Provenance evidence` blocks is a citation.
+  It is raw, unedited text copied from `.mod` file headers (typos,
+  inconsistent spacing, and missing apostrophes preserved verbatim) plus
+  structural notes about what was and was not found. Do not treat any of
+  it as verified.
+
+---
+
+## NO_KEY  (32 symbols)
+
+### Symbols
+
+- `braincell/channel/_base.py::ghk_flux`
+- `braincell/channel/_base.py::Gate`
+- `braincell/channel/_base.py::Transition`
+- `braincell/channel/_base.py::HH`
+- `braincell/channel/_base.py::OhmicHH`
+- `braincell/channel/_base.py::Markov`
+- `braincell/channel/leaky.py::LeakageChannel`
+- `braincell/channel/leaky.py::IL`
+- `braincell/channel/potassium.py::K_Leak`
+- `braincell/channel/potassium.py::K_Kv_test`
+- `braincell/ion/_base.py::Factor`
+- `braincell/ion/_base.py::Species`
+- `braincell/ion/_base.py::Reaction`
+- `braincell/ion/_base.py::Source`
+- `braincell/ion/_base.py::Conserve`
+- `braincell/ion/_base.py::FixedIon`
+- `braincell/ion/_base.py::InitNernstIon`
+- `braincell/ion/_base.py::DynamicNernstIon`
+- `braincell/ion/_base.py::KineticIon`
+- `braincell/ion/calcium.py::Calcium`
+- `braincell/ion/calcium.py::CalciumFixed`
+- `braincell/ion/calcium.py::CalciumInitNernst`
+- `braincell/ion/calcium.py::CalciumDetailed`
+- `braincell/ion/calcium.py::CalciumFirstOrder`
+- `braincell/ion/nonspecific.py::NonSpecific`
+- `braincell/ion/nonspecific.py::NonSpecificFixed`
+- `braincell/ion/potassium.py::Potassium`
+- `braincell/ion/potassium.py::PotassiumFixed`
+- `braincell/ion/potassium.py::PotassiumInitNernst`
+- `braincell/ion/sodium.py::Sodium`
+- `braincell/ion/sodium.py::SodiumFixed`
+- `braincell/ion/sodium.py::SodiumInitNernst`
+
+### Provenance evidence
+
+No `.mod` file provenance applies to this bucket. These are BrainCell's own
+template/base classes (`Gate`, `Transition`, `HH`, `OhmicHH`, `Markov`,
+GHK helper), a generic leak channel, a test-only stub (`K_Kv_test`), and
+the abstract ion-state container hierarchy (`Factor`, `Species`,
+`Reaction`, `Source`, `Conserve`, fixed/Nernst/kinetic ion mixins). They are
+not literature-derived channel models and carry no citation key by
+construction. Nothing further to verify for most of these; any docstring
+math should cite the standard HH (1952) formalism or the relevant ion
+model paper only where the *implementation* (not the class scaffolding)
+draws on it.
+
+### Verified record
+
+_TODO (Task 2 / Task 3): not yet verified._
+
+### Attribution
+
+_TODO (Task 2 / Task 3): not yet filled in._
+
+---
+
+## MA2020  (32 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::Cav1p2_MA2020_GoC`
+- `braincell/channel/calcium.py::Cav1p3_MA2020_GoC`
+- `braincell/channel/calcium.py::Cav3p1_MA2020_GoC`
+- `braincell/channel/calcium.py::Cav3p1_MA2020_GoC_Frozen`
+- `braincell/channel/calcium.py::CaHVA_MA2020_GoC`
+- `braincell/channel/calcium.py::CaHVA_MA2020_GrC`
+- `braincell/channel/calcium.py::Cav2p3_MA2020_GoC`
+- `braincell/channel/hyperpolarization_activated.py::HCN1_MA2020_GoC`
+- `braincell/channel/hyperpolarization_activated.py::HCN2_MA2020_GoC`
+- `braincell/channel/potassium.py::KM_MA2020_GoC`
+- `braincell/channel/potassium.py::Kv1p1_MA2020_GoC`
+- `braincell/channel/potassium.py::Kv3p4_MA2020_GoC`
+- `braincell/channel/potassium.py::Kv4p3_MA2020_GoC`
+- `braincell/channel/potassium.py::KM_MA2020_GrC`
+- `braincell/channel/potassium.py::Kir2p3_MA2020_GrC`
+- `braincell/channel/potassium.py::Kv1p1_MA2020_GrC`
+- `braincell/channel/potassium.py::Kv2p2_0010_MA2020_GrC`
+- `braincell/channel/potassium.py::Kv3p4_MA2020_GrC`
+- `braincell/channel/potassium.py::Kv4p3_MA2020_GrC`
+- `braincell/channel/potassium_calcium.py::Kca3p1_MA2020_GoC`
+- `braincell/channel/potassium_calcium.py::Kca2p2_MA2020_GoC`
+- `braincell/channel/potassium_calcium.py::Kca2p2_MA2020_GrC`
+- `braincell/channel/potassium_calcium.py::Kca1p1_MA2020_GoC`
+- `braincell/channel/potassium_calcium.py::Kca1p1_MA2020_GrC`
+- `braincell/channel/potassium_sodium.py::Kv1p5_MA2020_GrC`
+- `braincell/channel/sodium.py::Nav1p6_MA2020_GoC`
+- `braincell/channel/sodium.py::Nav_MA2020_GrC`
+- `braincell/channel/sodium.py::NaFHF_MA2020_GrC`
+- `braincell/ion/calcium.py::CdpStC_CAMOnly_MA2020_GoC`
+- `braincell/ion/calcium.py::CdpStC_NoCAM_MA2020_GoC`
+- `braincell/ion/calcium.py::CdpStC_MA2020_GoC`
+- `braincell/ion/calcium.py::CdpCR_MA2020_GrC`
+
+Mod-file year code: `MA20`. Cell types: `GoC` (Golgi cell), `GrC` (granule
+cell). Every symbol above maps 1:1 onto a `<mechanism>_MA20_<GoC|GrC>.mod`
+file **except** `CdpStC_NoCAM_MA2020_GoC`, for which no matching `.mod`
+file (`CdpStC_NoCAM_MA20_GoC.mod`) exists anywhere under
+`examples/neuron_compare/Cerebellum_mod` — see "no provenance evidence"
+note below. There is also an unclaimed mod file with no BrainCell symbol:
+`GoC/ion/CdpStC_CAMOnly_MA20_GoC.mod` *is* claimed
+(`CdpStC_CAMOnly_MA2020_GoC`); no extra unclaimed files were found in this
+bucket.
+
+### Provenance evidence
+
+Raw header text (first 25 lines, filtered to
+`TITLE|COMMENT|Author|Ref|revis|[0-9]{4}` lines), verbatim, one block per
+`.mod` file:
+
+```
+=== GoC/channel/CaHVA_MA20_GoC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: E.D'Angelo, T.Nieus, A. Fontana
+	Last revised: 8.5.2000
+ENDCOMMENT
+
+=== GoC/channel/Cav1p2_MA20_GoC.mod
+: model from Evans et al 2013, transferred from GENESIS to NEURON by Beining et al (2016), "A novel comprehensive and consistent electrophysiologcal model of dentate granule cells"
+
+=== GoC/channel/Cav1p3_MA20_GoC.mod
+: model from Evans et al 2013, transferred from GENESIS to NEURON by Beining et al (2016), "A novel comprehensive and consistent electrophysiologcal model of dentate granule cells"
+
+=== GoC/channel/Cav2p3_MA20_GoC.mod
+TITLE Ca R-type channel with medium threshold for activation
+(no further TITLE/COMMENT/Author/Ref/revis/year lines in first 25 lines)
+
+=== GoC/channel/Cav3p1_MA20_GoC.mod
+TITLE Low threshold calcium current Cerebellum Purkinje Cell Model
+COMMENT
+Kinetics adapted to fit the Cav3.1 Iftinca et al 2006, Temperature dependence of T-type Calcium channel gating, NEUROSCIENCE
+Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Haroon Anwar, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2010.
+ENDCOMMENT
+
+=== GoC/channel/HCN1_MA20_GoC.mod
+TITLE Cerebellum Golgi Cell Model
+COMMENT
+Author:L. Forti & S. Solinas
+Data from: Santoro et al. J Neurosci. 2000
+Last revised: April 2006
+ENDCOMMENT
+
+=== GoC/channel/HCN2_MA20_GoC.mod
+TITLE Cerebellum Golgi Cell Model
+COMMENT
+Author:L. Forti & S. Solinas
+Data from: Santoro et al. J Neurosci. 2000
+Last revised: April 2006
+ENDCOMMENT
+
+=== GoC/channel/Kca1p1_MA20_GoC.mod
+TITLE Large conductance Ca2+ activated K+ channel mslo
+COMMENT
+Parameters from Cox et al. (1987) J Gen Physiol 110:257-81 (patch 1).
+Current Model Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Sungho Hong, Okinawa Institute of Science and Technology, March 2009.
+ENDCOMMENT
+
+=== GoC/channel/Kca2p2_MA20_GoC.mod
+TITLE SK2 multi-state model Cerebellum Golgi Cell Model
+COMMENT
+Author:Sergio Solinas, Lia Forti, Egidio DAngelo
+Based on data from: Hirschberg, Maylie, Adelman, Marrion J Gen Physiol 1998
+Last revised: May 2007
+             Jonathan Mapelli, Erik De Schutter and Egidio D`Angelo (2008)
+ENDCOMMENT
+
+=== GoC/channel/Kca3p1_MA20_GoC.mod
+TITLE Calcium dependent potassium channel
+: Implemented in Rubin and Cleland (2006) J Neurophysiology
+: Parameters from Bhalla and Bower (1993) J Neurophysiology
+:   by Andrew Davison, The Babraham Institute  [Brain Res Bulletin, 2000]
+
+=== GoC/channel/KM_MA20_GoC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: A. Fontana
+	CoAuthor: T.Nieus Last revised: 20.11.99
+ENDCOMMENT
+
+=== GoC/channel/Kv1p1_MA20_GoC.mod
+TITLE Voltage-gated low threshold potassium current from Kv1 subunits
+COMMENT
+Human Kv1.1 expressed in xenopus oocytes: Zerr et al., J Neurosci 18, 2842, 2848, 1998
+Reference: Akemann et al., Biophys. J. (2009) 96: 3959-3976
+
+=== GoC/channel/Kv3p4_MA20_GoC.mod
+(no TITLE/COMMENT/Author/Ref/revis/year lines in first 25 lines)
+
+=== GoC/channel/Kv4p3_MA20_GoC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: E.D'Angelo, T.Nieus, A. Fontana
+	Last revised: Egidio 3.12.2003
+ENDCOMMENT
+
+=== GoC/channel/Nav1p6_MA20_GoC.mod
+TITLE resurgent sodium channel
+COMMENT
+Based om updated kinetic parameters from Raman and Bean, Biophys.J. 80 (2001) 729
+Modified from Khaliq et al., J.Neurosci. 23(2003)4899
+Reference: Akemann and Knoepfel, J.Neurosci. 26 (2006) 4602
+Date of Implementation: May 2005
+ENDCOMMENT
+
+=== GoC/ion/CdpStC_CAMOnly_MA20_GoC.mod
+TITLE Calcium accumulation with calmodulin-only subnetwork in Golgi cell model
+    Nannuli = 10.9495 (1)
+
+=== GoC/ion/CdpStC_MA20_GoC.mod
+COMMENT
+1) Extended using parameters from Schmidt et al. 2003.
+2) Pump rate was tuned according to data from Maeda et al. 1999
+Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Haroon Anwar, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2010.
+ENDCOMMENT
+
+=== GrC/channel/CaHVA_MA20_GrC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: E.D'Angelo, T.Nieus, A. Fontana
+	Last revised: 8.5.2000
+ENDCOMMENT
+
+=== GrC/channel/Kca1p1_MA20_GrC.mod
+TITLE Large conductance Ca2+ activated K+ channel mslo
+COMMENT
+Parameters from Cox et al. (1987) J Gen Physiol 110:257-81 (patch 1).
+Current Model Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Sungho Hong, Okinawa Institute of Science and Technology, March 2009.
+ENDCOMMENT
+
+=== GrC/channel/Kca2p2_MA20_GrC.mod
+TITLE SK2 multi-state model Cerebellum Golgi Cell Model
+COMMENT
+Author:Sergio Solinas, Lia Forti, Egidio DAngelo
+Based on data from: Hirschberg, Maylie, Adelman, Marrion J Gen Physiol 1998
+Last revised: May 2007
+             Jonathan Mapelli, Erik De Schutter and Egidio D`Angelo (2008)
+ENDCOMMENT
+
+=== GrC/channel/Kir2p3_MA20_GrC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Reference: Theta-Frequency Bursting and Resonance in Cerebellar Granule Cells:Experimental
+ENDCOMMENT
+
+=== GrC/channel/KM_MA20_GrC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: A. Fontana
+	CoAuthor: T.Nieus Last revised: 20.11.99
+ENDCOMMENT
+
+=== GrC/channel/Kv1p1_MA20_GrC.mod
+TITLE Voltage-gated low threshold potassium current from Kv1 subunits
+COMMENT
+Human Kv1.1 expressed in xenopus oocytes: Zerr et al., J Neurosci 18, 2842, 2848, 1998
+Reference: Akemann et al., Biophys. J. (2009) 96: 3959-3976
+
+=== GrC/channel/Kv1p5_MA20_GrC.mod
+TITLE Cardiac IKur  current & nonspec cation current with identical kinetics
+: Hodgkin - Huxley type channels, modified to fit IKur data from Feng et al Am J Physiol 1998 275:H1717 - H 1725
+	 gKur=0.13195e-3 (S/cm2) <0,1e9>
+
+=== GrC/channel/Kv2p2_0010_MA20_GrC.mod
+:[$Revision: 1367 $]
+:[$Date: 2010-03-26 15:17:59 +0200 (Fri, 26 Mar 2010) $]
+:[$Author: rajnish $]
+:Comment :
+:Reference :Molecular identification of a component of delayed rectifier current in gastrointestinal smooth muscles. Am. J. Physiol., 1998, 274, G901-11
+	SUFFIX Kv2p2_0010_MA20_GrC
+	gKv2_2bar = 0.00001 (S/cm2)
+
+=== GrC/channel/Kv3p4_MA20_GrC.mod
+(no TITLE/COMMENT/Author/Ref/revis/year lines in first 25 lines)
+
+=== GrC/channel/Kv4p3_MA20_GrC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: E.D'Angelo, T.Nieus, A. Fontana
+	Last revised: Egidio 3.12.2003
+ENDCOMMENT
+
+=== GrC/channel/NaFHF_MA20_GrC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+ENDCOMMENT
+
+=== GrC/channel/Nav_MA20_GrC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+Based on Raman 13 state model. Adapted from Magistretti et al, 2006.
+ENDCOMMENT
+
+=== GrC/ion/CdpCR_MA20_GrC.mod
+COMMENT
+1) Extended using parameters from Schmidt et al. 2003.
+2) Pump rate was tuned according to data from Maeda et al. 1999
+Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Haroon Anwar, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2010.
+Modified by Stefano Masoli, Department Brain and Behavioral Sciences, University of Pavia, 2015
+1) Buffer for Granule cell model 2015, without Parvalbumin and Calretinin instead of Calbindin.
+ENDCOMMENT
+```
+
+**No `.mod` file found** for `CdpStC_NoCAM_MA2020_GoC` (expected filename
+`CdpStC_NoCAM_MA20_GoC.mod` does not exist under
+`examples/neuron_compare/Cerebellum_mod/GoC/ion/`; only
+`CdpStC_CAMOnly_MA20_GoC.mod` and `CdpStC_MA20_GoC.mod` exist there). This
+symbol's provenance is unresolved by this harvest — see "Unresolved
+attributions" below.
+
+**Inconsistent-author cases in this bucket** (header names an author who
+is not the `MA2020`/Masoli-family search target):
+`CaHVA_MA20_GoC.mod`, `CaHVA_MA20_GrC.mod`, `Kv4p3_MA20_GoC.mod`,
+`Kv4p3_MA20_GrC.mod` (all "Author: E.D'Angelo, T.Nieus, A. Fontana");
+`HCN1_MA20_GoC.mod`, `HCN2_MA20_GoC.mod` ("Author:L. Forti & S. Solinas");
+`KM_MA20_GoC.mod`, `KM_MA20_GrC.mod` ("Author: A. Fontana" /
+"CoAuthor: T.Nieus"); `Kca2p2_MA20_GoC.mod`, `Kca2p2_MA20_GrC.mod`
+("Author:Sergio Solinas, Lia Forti, Egidio DAngelo");
+`Kv2p2_0010_MA20_GrC.mod` (SVN keyword "Author: rajnish", clearly a
+repository-tooling artifact, not a scientific author).
+
+### Verified record
+
+_TODO (Task 3): not yet verified._
+
+### Attribution
+
+_TODO (Task 3): not yet filled in._
+
+---
+
+## MA2024  (19 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::Cav3p1_MA2024_PC`
+- `braincell/channel/calcium.py::Cav3p1_MA2024_PC_Frozen`
+- `braincell/channel/calcium.py::Cav2p1_MA2024_PC`
+- `braincell/channel/calcium.py::Cav2p1_MA2024_PC_Frozen`
+- `braincell/channel/calcium.py::Cav3p3_MA2024_PC_Frozen`
+- `braincell/channel/calcium.py::Cav3p2_MA2024_PC`
+- `braincell/channel/calcium.py::Cav3p3_MA2024_PC`
+- `braincell/channel/hyperpolarization_activated.py::HCN1_MA2024_PC`
+- `braincell/channel/potassium.py::Kir2p3_MA2024_PC`
+- `braincell/channel/potassium.py::Kv1p1_MA2024_PC`
+- `braincell/channel/potassium.py::Kv1p5_MA2024_PC`
+- `braincell/channel/potassium.py::Kv3p3_MA2024_PC`
+- `braincell/channel/potassium.py::Kv3p4_MA2024_PC`
+- `braincell/channel/potassium.py::Kv4p3_MA2024_PC`
+- `braincell/channel/potassium_calcium.py::Kca3p1_MA2024_PC`
+- `braincell/channel/potassium_calcium.py::Kca2p2_MA2024_PC`
+- `braincell/channel/potassium_calcium.py::Kca1p1_MA2024_PC`
+- `braincell/channel/sodium.py::Nav1p6_MA2024_PC`
+- `braincell/ion/calcium.py::CdpCAM_MA2024_PC`
+
+Mod-file year code: `MA24`. Cell type: `PC` (Purkinje cell). All 19 symbols
+map 1:1 onto a `<mechanism>_MA24_PC.mod` file. Two extra `.mod` files exist
+in `PC/channel/` that are **not** claimed by any `MA2024` symbol —
+`Cav3_1_test.mod` and `Cav3_1_test2.mod` — see the `PC24` key section
+below; the `Cav3p1Test_PC24` symbol's own docstring already identifies
+`Cav3_1_test.mod` as its source.
+
+### Provenance evidence
+
+```
+=== PC/channel/Cav2p1_MA24_PC.mod
+TITLE P-type calcium channel
+COMMENT
+Reference: Swensen AM and Bean BP (2005) Robustness of burst firing in dissociated purkinje neurons with acute or long-term reductions in sodium conductance. J Neurosci 25:3509-20
+Current Model Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Sungho Hong, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2009.
+ENDCOMMENT
+
+=== PC/channel/Cav3p1_MA24_PC.mod
+TITLE Low threshold calcium current Cerebellum Purkinje Cell Model
+COMMENT
+Kinetics adapted to fit the Cav3.1 Iftinca et al 2006, Temperature dependence of T-type Calcium channel gating, NEUROSCIENCE
+Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Haroon Anwar, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2010.
+ENDCOMMENT
+
+=== PC/channel/Cav3p2_MA24_PC.mod
+TITLE Low threshold calcium current
+:   Model of Huguenard & McCormick, J Neurophysiol 68: 1373-1383, 1992.
+:   Written by Alain Destexhe, Salk Institute, Sept 18, 1992
+:    - see Vitko et al., J. Neurosci 25(19) :4844-4855, 2005
+
+=== PC/channel/Cav3p3_MA24_PC.mod
+TITLE CaV 3.3 CA3 hippocampal neuron
+COMMENT
+    Xu J, Clancy CE (2008) Ionic mechanisms of endogenous bursting in CA3 hippocampal pyramidal neurons:
+        a model study. PLoS ONE 3:e2056- [PubMed]
+ENDCOMMENT
+
+=== PC/channel/HCN1_MA24_PC.mod
+TITLE I-h HCN1 channel from Kamilla Angelo, Michael London,Soren R. Christensen, and Michael Hausser 2007 J. of Neurosci.
+COMMENT
+We call it HCN1 as PC express only HCN1 Santoro et al. 2000
+ENDCOMMENT
+
+=== PC/channel/Kca1p1_MA24_PC.mod
+TITLE Large conductance Ca2+ activated K+ channel mslo
+COMMENT
+Parameters from Cox et al. (1987) J Gen Physiol 110:257-81 (patch 1).
+Current Model Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Sungho Hong, Okinawa Institute of Science and Technology, March 2009.
+ENDCOMMENT
+
+=== PC/channel/Kca2p2_MA24_PC.mod
+TITLE SK2 multi-state model Cerebellum Golgi Cell Model
+COMMENT
+Author:Sergio Solinas, Lia Forti, Egidio DAngelo
+Based on data from: Hirschberg, Maylie, Adelman, Marrion J Gen Physiol 1998
+Last revised: May 2007
+             Jonathan Mapelli, Erik De Schutter and Egidio D`Angelo (2008)
+ENDCOMMENT
+
+=== PC/channel/Kca3p1_MA24_PC.mod
+TITLE Calcium dependent potassium channel
+: Implemented in Rubin and Cleland (2006) J Neurophysiology
+: Parameters from Bhalla and Bower (1993) J Neurophysiology
+:   by Andrew Davison, The Babraham Institute  [Brain Res Bulletin, 2000]
+
+=== PC/channel/Kir2p3_MA24_PC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Reference: Theta-Frequency Bursting and Resonance in Cerebellar Granule Cells:Experimental
+ENDCOMMENT
+
+=== PC/channel/Kv1p1_MA24_PC.mod
+TITLE Voltage-gated low threshold potassium current from Kv1 subunits
+COMMENT
+Human Kv1.1 expressed in xenopus oocytes: Zerr et al., J Neurosci 18, 2842, 2848, 1998
+Reference: Akemann et al., Biophys. J. (2009) 96: 3959-3976
+
+=== PC/channel/Kv1p5_MA24_PC.mod
+TITLE Cardiac IKur  current & nonspec cation current with identical kinetics
+: Hodgkin - Huxley type channels, modified to fit IKur data from Feng et al Am J Physiol 1998 275:H1717 - H 1725
+	 gKur=0.13195e-3 (S/cm2) <0,1e9>
+
+=== PC/channel/Kv3p3_MA24_PC.mod
+TITLE Voltage-gated potassium channel from Kv3 subunits
+COMMENT
+Values derive from least-square fits to experimental data of G/Gmax(v) and taun(v) in Martina et al. J Neurophys. 97 (563-671, 2007.
+Reference: Akemann et al., Biophys. J. (2009) 96: 3959-3976
+Date of Implementation: April 2007
+
+=== PC/channel/Kv3p4_MA24_PC.mod
+(no TITLE/COMMENT/Author/Ref/revis/year lines in first 25 lines)
+
+=== PC/channel/Kv4p3_MA24_PC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: E.D'Angelo, T.Nieus, A. Fontana
+	Last revised: Egidio 3.12.2003
+ENDCOMMENT
+
+=== PC/channel/Nav1p6_MA24_PC.mod
+TITLE resurgent sodium channel
+COMMENT
+Based om updated kinetic parameters from Raman and Bean, Biophys.J. 80 (2001) 729
+Modified from Khaliq et al., J.Neurosci. 23(2003)4899
+Reference: Akemann and Knoepfel, J.Neurosci. 26 (2006) 4602
+Date of Implementation: May 2005
+ENDCOMMENT
+
+=== PC/ion/CdpCAM_MA24_PC.mod
+COMMENT
+1) Extended using parameters from Schmidt et al. 2003.
+2) Pump rate was tuned according to data from Maeda et al. 1999
+Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Haroon Anwar, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2010.
+ENDCOMMENT
+```
+
+**Inconsistent-author cases in this bucket:** `Kca2p2_MA24_PC.mod`
+("Author:Sergio Solinas, Lia Forti, Egidio DAngelo") and `Kv4p3_MA24_PC.mod`
+("Author: E.D'Angelo, T.Nieus, A. Fontana") both name an author unrelated
+to the `MA2024`/Masoli-family search target — same pattern as the `MA2020`
+bucket (these two mechanisms carry the identical header text copy-pasted
+across all cell-type ports).
+
+### Verified record
+
+_TODO (Task 3): not yet verified._
+
+### Attribution
+
+_TODO (Task 3): not yet filled in._
+
+---
+
+## SU2015  (16 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::CaHVA_SU2015_DCN`
+- `braincell/channel/calcium.py::CaL_SU2015_DCN`
+- `braincell/channel/calcium.py::CaLVA_SU2015_DCN`
+- `braincell/channel/hyperpolarization_activated.py::HCN_SU2015_DCN`
+- `braincell/channel/potassium.py::fKdr_SU2015_DCN`
+- `braincell/channel/potassium.py::sKdr_SU2015_DCN`
+- `braincell/channel/potassium_calcium.py::SK_SU2015_DCN`
+- `braincell/channel/sodium.py::NaF_SU2015_DCN`
+- `braincell/channel/sodium.py::NaP_SU2015_DCN`
+- `braincell/ion/calcium.py::ToyCaBindingKinetic_SU2015_DCN`
+- `braincell/ion/calcium.py::ToyCaBindingSourceKinetic_SU2015_DCN`
+- `braincell/ion/calcium.py::ToyCaBindingIcaSourceKinetic_SU2015_DCN`
+- `braincell/ion/calcium.py::ToyCaPumpFactorKinetic_SU2015_DCN`
+- `braincell/ion/calcium.py::ToyDiamFactorKinetic_SU2015_DCN`
+- `braincell/ion/calcium.py::CdpHVA_SU2015_DCN`
+- `braincell/ion/calcium.py::CdpLVA_SU2015_DCN`
+
+Mod-file year code: `SU15`. Cell type: `DCN` (deep cerebellar nuclei). All
+16 symbols map 1:1 onto a `<mechanism>_SU15_DCN.mod` file. One extra `.mod`
+file, `DCN/ion/ToyStoich3ABtoCKinetic_SU15_DCN.mod`, exists but is **not**
+claimed by any braincell symbol — it was apparently not ported. None of
+the 11 `DCN` `.mod` files harvested here carry an `Author:`/`Ref:` line at
+all — their headers are bare `TITLE ... (DCN) neuron` / empty `COMMENT`
+blocks, so this bucket has essentially no in-repo textual provenance
+beyond the mechanism name and species (DCN neuron).
+
+### Provenance evidence
+
+```
+=== DCN/channel/CaHVA_SU15_DCN.mod
+TITLE High voltage activated calcium current (CaHVA) of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/channel/CaL_SU15_DCN.mod
+TITLE LVA calcium current (CaLVA) of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/channel/CaLVA_SU15_DCN.mod
+TITLE Low voltage activated calcium current (CaLVA) of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/channel/fKdr_SU15_DCN.mod
+TITLE Fast delayed rectifier (fKdr) of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/channel/HCN_SU15_DCN.mod
+TITLE h current of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/channel/NaF_SU15_DCN.mod
+TITLE Fast sodium current (NaF) of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/channel/NaP_SU15_DCN.mod
+TITLE Persistent sodium current (NaP) of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/channel/sKdr_SU15_DCN.mod
+TITLE Slow delayed rectifier (sKdr) of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/channel/SK_SU15_DCN.mod
+TITLE Small conductance calcium dependent potassium current (SK) of deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/ion/CdpHVA_SU15_DCN.mod
+TITLE Intracellular calcium concentration in deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/ion/CdpLVA_SU15_DCN.mod
+TITLE Intracellular calcium concentration from the CaLVA channel in deep cerebellar nucleus (DCN) neuron
+COMMENT
+ENDCOMMENT
+
+=== DCN/ion/ToyCaBindingIcaSourceKinetic_SU15_DCN.mod
+TITLE Minimal reversible calcium-binding kinetic toy with ica-driven source in deep cerebellar nucleus (DCN)
+COMMENT
+ENDCOMMENT
+
+=== DCN/ion/ToyCaBindingKinetic_SU15_DCN.mod
+TITLE Minimal reversible calcium-binding kinetic toy in deep cerebellar nucleus (DCN)
+COMMENT
+ENDCOMMENT
+
+=== DCN/ion/ToyCaBindingSourceKinetic_SU15_DCN.mod
+TITLE Minimal reversible calcium-binding kinetic toy with constant source in deep cerebellar nucleus (DCN)
+COMMENT
+ENDCOMMENT
+
+=== DCN/ion/ToyCaPumpFactorKinetic_SU15_DCN.mod
+TITLE Minimal factor-crossing calcium pump toy in deep cerebellar nucleus (DCN)
+COMMENT
+ENDCOMMENT
+
+=== DCN/ion/ToyDiamFactorKinetic_SU15_DCN.mod
+TITLE Minimal diameter-driven factor reaction toy in deep cerebellar nucleus (DCN)
+COMMENT
+ENDCOMMENT
+```
+
+No `Author:`/`Ref:`-bearing header found anywhere in this bucket — flagged
+in "Unresolved attributions" below.
+
+### Verified record
+
+_TODO (Task 3): not yet verified._
+
+### Attribution
+
+_TODO (Task 3): not yet filled in._
+
+---
+
+## MA2025  (16 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::Cav1p2_MA2025_BC`
+- `braincell/channel/calcium.py::Cav1p3_MA2025_BC`
+- `braincell/channel/calcium.py::Cav2p1_MA2025_BC`
+- `braincell/channel/calcium.py::Cav2p1_MA2025_BC_Frozen`
+- `braincell/channel/calcium.py::Cav3p2_MA2025_BC`
+- `braincell/channel/hyperpolarization_activated.py::HCN1_MA2025_BC`
+- `braincell/channel/potassium.py::Kir2p3_MA2025_BC`
+- `braincell/channel/potassium.py::Kv1p1_MA2025_BC`
+- `braincell/channel/potassium.py::Kv3p4_MA2025_BC`
+- `braincell/channel/potassium.py::Kv4p3_MA2025_BC`
+- `braincell/channel/potassium_calcium.py::Kca3p1_MA2025_BC`
+- `braincell/channel/potassium_calcium.py::Kca2p2_MA2025_BC`
+- `braincell/channel/potassium_calcium.py::Kca1p1_MA2025_BC`
+- `braincell/channel/sodium.py::Nav1p6_MA2025_BC`
+- `braincell/channel/sodium.py::Nav1p1_MA2025_BC`
+- `braincell/ion/calcium.py::CdpStC_MA2025_BC`
+
+Mod-file year code: `MA25`. Cell type: `BC` (basket cell). All 16 symbols
+map 1:1 onto a `<mechanism>_MA25_BC.mod` file.
+
+### Provenance evidence
+
+```
+=== BC/channel/Cav1p2_MA25_BC.mod
+: model from Evans et al 2013, transferred from GENESIS to NEURON by Beining et al (2016), "A novel comprehensive and consistent electrophysiologcal model of dentate granule cells"
+
+=== BC/channel/Cav1p3_MA25_BC.mod
+: model from Evans et al 2013, transferred from GENESIS to NEURON by Beining et al (2016), "A novel comprehensive and consistent electrophysiologcal model of dentate granule cells"
+
+=== BC/channel/Cav2p1_MA25_BC.mod
+TITLE P-type calcium channel
+COMMENT
+Reference: Swensen AM and Bean BP (2005) Robustness of burst firing in dissociated purkinje neurons with acute or long-term reductions in sodium conductance. J Neurosci 25:3509-20
+Current Model Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Sungho Hong, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2009.
+ENDCOMMENT
+
+=== BC/channel/Cav3p2_MA25_BC.mod
+TITLE Low threshold calcium current
+:   Model of Huguenard & McCormick, J Neurophysiol 68: 1373-1383, 1992.
+:   Written by Alain Destexhe, Salk Institute, Sept 18, 1992
+:    - see Vitko et al., J. Neurosci 25(19) :4844-4855, 2005
+
+=== BC/channel/HCN1_MA25_BC.mod
+TITLE I-h HCN1 channel from Kamilla Angelo, Michael London,Soren R. Christensen, and Michael Hausser 2007 J. of Neurosci.
+COMMENT
+We call it HCN1 as PC express only HCN1 Santoro et al. 2000
+ENDCOMMENT
+
+=== BC/channel/Kca1p1_MA25_BC.mod
+TITLE Large conductance Ca2+ activated K+ channel mslo
+COMMENT
+Parameters from Cox et al. (1987) J Gen Physiol 110:257-81 (patch 1).
+Current Model Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Sungho Hong, Okinawa Institute of Science and Technology, March 2009.
+ENDCOMMENT
+
+=== BC/channel/Kca2p2_MA25_BC.mod
+TITLE SK2 multi-state model Cerebellum Golgi Cell Model
+COMMENT
+Author:Sergio Solinas, Lia Forti, Egidio DAngelo
+Based on data from: Hirschberg, Maylie, Adelman, Marrion J Gen Physiol 1998
+Last revised: May 2007
+             Jonathan Mapelli, Erik De Schutter and Egidio D`Angelo (2008)
+ENDCOMMENT
+
+=== BC/channel/Kca3p1_MA25_BC.mod
+TITLE Calcium dependent potassium channel
+: Implemented in Rubin and Cleland (2006) J Neurophysiology
+: Parameters from Bhalla and Bower (1993) J Neurophysiology
+:   by Andrew Davison, The Babraham Institute  [Brain Res Bulletin, 2000]
+
+=== BC/channel/Kir2p3_MA25_BC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Reference: Theta-Frequency Bursting and Resonance in Cerebellar Granule Cells:Experimental
+ENDCOMMENT
+
+=== BC/channel/Kv1p1_MA25_BC.mod
+TITLE Voltage-gated low threshold potassium current from Kv1 subunits
+COMMENT
+Human Kv1.1 expressed in xenopus oocytes: Zerr et al., J Neurosci 18, 2842, 2848, 1998
+Reference: Akemann et al., Biophys. J. (2009) 96: 3959-3976
+
+=== BC/channel/Kv3p4_MA25_BC.mod
+(no TITLE/COMMENT/Author/Ref/revis/year lines in first 25 lines)
+
+=== BC/channel/Kv4p3_MA25_BC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: E.D'Angelo, T.Nieus, A. Fontana
+	Last revised: Egidio 3.12.2003
+ENDCOMMENT
+
+=== BC/channel/Nav1p1_MA25_BC.mod
+TITLE Non-resurgent sodium channel in Purkinje cells
+COMMENT
+This channel was derived from the Narsg channel of Khaliq et al., J. Neurosci. 23(2003)4899
+Reference: Akemann et al. Biophys. J. (2009) 96: 3959-3976
+Date of Implementation: April 2007
+ENDCOMMENT
+
+=== BC/channel/Nav1p6_MA25_BC.mod
+TITLE resurgent sodium channel
+COMMENT
+Based om updated kinetic parameters from Raman and Bean, Biophys.J. 80 (2001) 729
+Modified from Khaliq et al., J.Neurosci. 23(2003)4899
+Reference: Akemann and Knoepfel, J.Neurosci. 26 (2006) 4602
+Date of Implementation: May 2005
+ENDCOMMENT
+
+=== BC/ion/CdpStC_MA25_BC.mod
+COMMENT
+1) Extended using parameters from Schmidt et al. 2003.
+2) Pump rate was tuned according to data from Maeda et al. 1999
+Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Haroon Anwar, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2010.
+ENDCOMMENT
+```
+
+**Inconsistent-author cases in this bucket:** `Kca2p2_MA25_BC.mod`
+("Author:Sergio Solinas, Lia Forti, Egidio DAngelo") and `Kv4p3_MA25_BC.mod`
+("Author: E.D'Angelo, T.Nieus, A. Fontana") — same header text
+copy-pasted from the `MA2020`/`MA2024` ports, again naming an author
+unrelated to the `MA2025` search target.
+
+### Verified record
+
+_TODO (Task 3): not yet verified._
+
+### Attribution
+
+_TODO (Task 3): not yet filled in._
+
+---
+
+## RI2021  (15 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::Cav2p1_RI2021_SC`
+- `braincell/channel/calcium.py::Cav2p1_RI2021_SC_Frozen`
+- `braincell/channel/calcium.py::Cav3p2_RI2021_SC`
+- `braincell/channel/calcium.py::Cav3p3_RI2021_SC`
+- `braincell/channel/hyperpolarization_activated.py::HCN1_RI2021_SC`
+- `braincell/channel/potassium.py::KM_RI2021_SC`
+- `braincell/channel/potassium.py::Kir2p3_RI2021_SC`
+- `braincell/channel/potassium.py::Kv1p1_RI2021_SC`
+- `braincell/channel/potassium.py::Kv3p4_RI2021_SC`
+- `braincell/channel/potassium.py::Kv4p3_RI2021_SC`
+- `braincell/channel/potassium_calcium.py::Kca2p2_RI2021_SC`
+- `braincell/channel/potassium_calcium.py::Kca1p1_RI2021_SC`
+- `braincell/channel/sodium.py::Nav1p6_RI2021_SC`
+- `braincell/channel/sodium.py::Nav1p1_RI2021_SC`
+- `braincell/ion/calcium.py::CdpStC_RI2021_SC`
+
+Mod-file year code: `RI21`. Cell type: `SC` (stellate cell). All 15
+symbols map 1:1 onto a `<mechanism>_RI21_SC.mod` file.
+
+### Provenance evidence
+
+```
+=== SC/channel/Cav2p1_RI21_SC.mod
+TITLE P-type calcium channel
+COMMENT
+Reference: Swensen AM and Bean BP (2005) Robustness of burst firing in dissociated purkinje neurons with acute or long-term reductions in sodium conductance. J Neurosci 25:3509-20
+Current Model Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Sungho Hong, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2009.
+ENDCOMMENT
+
+=== SC/channel/Cav3p2_RI21_SC.mod
+TITLE Low threshold calcium current
+:   Model of Huguenard & McCormick, J Neurophysiol 68: 1373-1383, 1992.
+:   Written by Alain Destexhe, Salk Institute, Sept 18, 1992
+:    - see Vitko et al., J. Neurosci 25(19) :4844-4855, 2005
+
+=== SC/channel/Cav3p3_RI21_SC.mod
+TITLE CaV 3.3 CA3 hippocampal neuron
+COMMENT
+    Xu J, Clancy CE (2008) Ionic mechanisms of endogenous bursting in CA3 hippocampal pyramidal neurons:
+        a model study. PLoS ONE 3:e2056- [PubMed]
+ENDCOMMENT
+
+=== SC/channel/HCN1_RI21_SC.mod
+TITLE I-h HCN1 channel from Kamilla Angelo, Michael London,Soren R. Christensen, and Michael Hausser 2007 J. of Neurosci.
+COMMENT
+We call it HCN1 as PC express only HCN1 Santoro et al. 2000
+ENDCOMMENT
+
+=== SC/channel/Kca1p1_RI21_SC.mod
+TITLE Large conductance Ca2+ activated K+ channel mslo
+COMMENT
+Parameters from Cox et al. (1987) J Gen Physiol 110:257-81 (patch 1).
+Current Model Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Sungho Hong, Okinawa Institute of Science and Technology, March 2009.
+ENDCOMMENT
+
+=== SC/channel/Kca2p2_RI21_SC.mod
+TITLE SK2 multi-state model Cerebellum Golgi Cell Model
+COMMENT
+Author:Sergio Solinas, Lia Forti, Egidio DAngelo
+Based on data from: Hirschberg, Maylie, Adelman, Marrion J Gen Physiol 1998
+Last revised: May 2007
+             Jonathan Mapelli, Erik De Schutter and Egidio D`Angelo (2008)
+ENDCOMMENT
+
+=== SC/channel/Kir2p3_RI21_SC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Reference: Theta-Frequency Bursting and Resonance in Cerebellar Granule Cells:Experimental
+ENDCOMMENT
+
+=== SC/channel/KM_RI21_SC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: A. Fontana
+	CoAuthor: T.Nieus Last revised: 20.11.99
+ENDCOMMENT
+
+=== SC/channel/Kv1p1_RI21_SC.mod
+TITLE Voltage-gated low threshold potassium current from Kv1 subunits
+COMMENT
+Human Kv1.1 expressed in xenopus oocytes: Zerr et al., J Neurosci 18, 2842, 2848, 1998
+Reference: Akemann et al., Biophys. J. (2009) 96: 3959-3976
+
+=== SC/channel/Kv3p4_RI21_SC.mod
+(no TITLE/COMMENT/Author/Ref/revis/year lines in first 25 lines)
+
+=== SC/channel/Kv4p3_RI21_SC.mod
+TITLE Cerebellum Granule Cell Model
+COMMENT
+	Author: E.D'Angelo, T.Nieus, A. Fontana
+	Last revised: Egidio 3.12.2003
+ENDCOMMENT
+
+=== SC/channel/Nav1p1_RI21_SC.mod
+TITLE Non-resurgent sodium channel in Purkinje cells
+COMMENT
+This channel was derived from the Narsg channel of Khaliq et al., J. Neurosci. 23(2003)4899
+Reference: Akemann et al. Biophys. J. (2009) 96: 3959-3976
+Date of Implementation: April 2007
+ENDCOMMENT
+
+=== SC/channel/Nav1p6_RI21_SC.mod
+TITLE resurgent sodium channel
+COMMENT
+Based om updated kinetic parameters from Raman and Bean, Biophys.J. 80 (2001) 729
+Modified from Khaliq et al., J.Neurosci. 23(2003)4899
+Reference: Akemann and Knoepfel, J.Neurosci. 26 (2006) 4602
+Date of Implementation: May 2005
+ENDCOMMENT
+
+=== SC/ion/CdpStC_RI21_SC.mod
+COMMENT
+1) Extended using parameters from Schmidt et al. 2003.
+2) Pump rate was tuned according to data from Maeda et al. 1999
+Reference: Anwar H, Hong S, De Schutter E (2010) Controlling Ca2+-activated K+ channels with models of Ca2+ buffering in Purkinje cell. Cerebellum*
+PubMed link: http://www.ncbi.nlm.nih.gov/pubmed/20981513
+Written by Haroon Anwar, Computational Neuroscience Unit, Okinawa Institute of Science and Technology, 2010.
+ENDCOMMENT
+```
+
+**Inconsistent-author cases in this bucket:** `Kca2p2_RI21_SC.mod`
+("Author:Sergio Solinas, Lia Forti, Egidio DAngelo") and `KM_RI21_SC.mod`
+/ `Kv4p3_RI21_SC.mod` ("Author: A. Fontana" / "CoAuthor: T.Nieus" and
+"Author: E.D'Angelo, T.Nieus, A. Fontana" respectively) — same pattern as
+the other cerebellar buckets.
+
+### Verified record
+
+_TODO (Task 3): not yet verified._
+
+### Attribution
+
+_TODO (Task 3): not yet filled in._
+
+---
+
+## HM1992  (7 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::CaT_HM1992`
+- `braincell/channel/calcium.py::CaHT_HM1992`
+- `braincell/channel/hyperpolarization_activated.py::HCN_HM1992`
+- `braincell/channel/potassium.py::KA1_HM1992`
+- `braincell/channel/potassium.py::KA2_HM1992`
+- `braincell/channel/potassium.py::KK2A_HM1992`
+- `braincell/channel/potassium.py::KK2B_HM1992`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries an
+`HM1992`/`HM19` filename fragment. This is a classical/thalamic-literature
+key (per the project plan, verified in Task 2, not the cerebellar NEURON
+port harvested in Step 2). No repository-local provenance text exists for
+this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## ZH2019  (5 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::Ca_ZH2019_IO`
+- `braincell/channel/calcium.py::Ca_ZH2019_IO_Frozen`
+- `braincell/channel/hyperpolarization_activated.py::HCN_ZH2019_IO`
+- `braincell/channel/potassium.py::Kdr_ZH2019_IO`
+- `braincell/channel/sodium.py::Na_ZH2019_IO`
+
+Mod-file year code: `ZH19`. Cell type: `IO` (inferior olive). All 5
+symbols map 1:1 onto a `<mechanism>_ZH19_IO.mod` file. `IO` has no `ion/`
+subfolder under `Cerebellum_mod`, so this key has no ion-state symbol.
+
+### Provenance evidence
+
+```
+=== IO/channel/Ca_ZH19_IO.mod
+COMMENT
+Ca channel from Manor (Rinzel, Segev, Yarom) 1997
+B. Torben-Nielsen @ HUJI, 7-10-2010
+ENDCOMMENT
+
+=== IO/channel/HCN_ZH19_IO.mod
+COMMENT
+Somatic h channel from Schweighofer et al., 1999
+Xu Zhang @ UConn, 6-22-2018
+ENDCOMMENT
+
+=== IO/channel/Kdr_ZH19_IO.mod
+COMMENT
+K_dr channel from Schweighofer et al 1999.
+The referred model is an inferior olive neuron
+B. Torben-Nielsen @ HUJI, 21-10-2010
+ENDCOMMENT
+
+=== IO/channel/Na_ZH19_IO.mod
+COMMENT
+Na channel from Schweighofer et al 1999.
+The referred model is an inferior olive neuron
+B. Torben-Nielsen @ HUJI, 21-10-2010
+ENDCOMMENT
+```
+
+**Inconsistent-author cases in this bucket:** all four files name an
+origin unrelated to the `ZH2019`/Zhang-family search target: `Ca_ZH19_IO.mod`
+credits "Manor (Rinzel, Segev, Yarom) 1997" and porter "B. Torben-Nielsen
+@ HUJI, 7-10-2010"; `HCN_ZH19_IO.mod` credits "Schweighofer et al., 1999"
+and porter "Xu Zhang @ UConn, 6-22-2018"; `Kdr_ZH19_IO.mod` and
+`Na_ZH19_IO.mod` both credit "Schweighofer et al 1999" and porter
+"B. Torben-Nielsen @ HUJI, 21-10-2010". Note `HCN_ZH19_IO.mod`'s "Xu Zhang"
+porter credit is at least consistent with the `ZH` initials in the key,
+unlike the other three files in this bucket — this is worth flagging to
+Task 3 as a possible (not yet verified) partial match.
+
+### Verified record
+
+_TODO (Task 3): not yet verified._
+
+### Attribution
+
+_TODO (Task 3): not yet filled in._
+
+---
+
+## IS2008  (2 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::CaN_IS2008`
+- `braincell/channel/calcium.py::CaL_IS2008`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries an
+`IS2008`/`IS20` filename fragment. Classical/thalamic-literature key
+(Task 2). No repository-local provenance text exists for this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## Ba2002  (2 symbols)
+
+### Symbols
+
+- `braincell/channel/potassium.py::KDR_Ba2002`
+- `braincell/channel/sodium.py::Na_Ba2002`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
+`Ba2002`/`Ba20` filename fragment. Classical/thalamic-literature key
+(Task 2). No repository-local provenance text exists for this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## TM1991  (2 symbols)
+
+### Symbols
+
+- `braincell/channel/potassium.py::K_TM1991`
+- `braincell/channel/sodium.py::Na_TM1991`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
+`TM1991`/`TM19` filename fragment. Classical/thalamic-literature key
+(Task 2). No repository-local provenance text exists for this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## HH1952  (2 symbols)
+
+### Symbols
+
+- `braincell/channel/potassium.py::K_HH1952`
+- `braincell/channel/sodium.py::Na_HH1952`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries an
+`HH1952`/`HH19` filename fragment. Classical/thalamic-literature key
+(Task 2) — this is expected to resolve to the original Hodgkin & Huxley
+(1952) squid giant axon paper, but that resolution is Task 2's job, not
+this harvest's. No repository-local provenance text exists for this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## HP1992  (1 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::CaT_HP1992`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries an
+`HP1992`/`HP19` filename fragment. Classical/thalamic-literature key
+(Task 2). No repository-local provenance text exists for this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## Re1993  (1 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::CaHT_Re1993`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
+`Re1993`/`Re19` filename fragment. Classical/thalamic-literature key
+(Task 2). No repository-local provenance text exists for this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## PC24  (1 symbols)
+
+### Symbols
+
+- `braincell/channel/calcium.py::Cav3p1Test_PC24`
+
+### Provenance evidence
+
+No `.mod` file matches the `PC24` fragment by filename convention (the
+regex captured `PC24` from the class name `Cav3p1Test_PC24`, but `PC` is
+also the cell-type suffix used elsewhere in this harvest, not a year code
+here — this key does not follow the `<initials><2-digit-year>` pattern the
+other buckets do). However, the symbol's own docstring in
+`braincell/channel/calcium.py` states directly:
+
+> "Template-based import of ``Cav3_1_test.mod``."
+
+Two matching files exist: `examples/neuron_compare/Cerebellum_mod/PC/channel/Cav3_1_test.mod`
+and `.../PC/channel/Cav3_1_test2.mod`. Both were harvested by the Step 2
+scan (they appear in the file list) but **produced zero matching header
+lines** — neither file contains a `TITLE`, `COMMENT`, `Author`, `Ref`, or
+`revis` line anywhere at all (checked beyond the first 25 lines too, not
+just the Step 2 window). Their only content matching the harvest's `[0-9]
+{4}` filter was the numeric constant `9.6485e4` (Faraday's constant), a
+false positive, not provenance text:
+
+```
+=== PC/channel/Cav3_1_test.mod
+	F = 9.6485e4 (coulombs)
+	R = 8.3145 (joule/kelvin)
+
+=== PC/channel/Cav3_1_test2.mod
+	F = 9.6485e4 (coulombs)
+	R = 8.3145 (joule/kelvin)
+```
+
+This is a genuine zero-provenance case: the `.mod` source itself is
+anonymous. `Cav3p1Test_PC24` is a defrosted/"test" variant of `Cav3p1`
+sharing the same steady-state/tau formulas as the templated `Cav3p1`
+family (see the docstring already in the source), but nothing in the
+`.mod` file names who wrote it or what paper it implements.
+
+### Verified record
+
+_TODO (Task 3): not yet verified._
+
+### Attribution
+
+_TODO (Task 3): not yet filled in._
+
+---
+
+## Ya1989  (1 symbols)
+
+### Symbols
+
+- `braincell/channel/potassium.py::KNI_Ya1989`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
+`Ya1989`/`Ya19` filename fragment. Classical/thalamic-literature key
+(Task 2). No repository-local provenance text exists for this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## De1994  (1 symbols)
+
+### Symbols
+
+- `braincell/channel/potassium_calcium.py::AHP_De1994`
+
+### Provenance evidence
+
+No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
+`De1994`/`De19` filename fragment. Classical/thalamic-literature key
+(Task 2). No repository-local provenance text exists for this key.
+
+### Verified record
+
+_TODO (Task 2): not yet verified._
+
+### Attribution
+
+_TODO (Task 2): not yet filled in._
+
+---
+
+## Unresolved attributions
+
+Items below need explicit attention in Task 2/3 beyond the default
+literature search, because Step 1/Step 2 of this harvest could not
+resolve them cleanly:
+
+1. **`CdpStC_NoCAM_MA2020_GoC`** (`braincell/ion/calcium.py`) — no
+   `CdpStC_NoCAM_MA20_GoC.mod` file exists anywhere under
+   `examples/neuron_compare/Cerebellum_mod`. Only the `CAMOnly` and
+   plain `CdpStC` variants have `.mod` counterparts in `GoC/ion/`. The
+   `NoCAM` variant's provenance (is it a hand-derived complement of the
+   other two, or ported from elsewhere?) must be established directly
+   from the BrainCell source/tests, not from a `.mod` header.
+
+2. **`SU2015` bucket (all 16 symbols)** — none of the 11 `.mod` files
+   under `DCN/channel/` and `DCN/ion/` carry any `Author:`/`Ref:`/
+   `Written by` line. Headers are bare `TITLE ... (DCN) neuron` with an
+   empty `COMMENT` block. Task 3 has zero in-repo textual lead for this
+   entire cell type and must resolve purely from the `SU2015` key
+   (presumably a "Su" or similarly-initialed 2015 DCN modeling paper)
+   and cross-checking with published deep cerebellar nuclei models.
+
+3. **`HM1992`, `IS2008`, `Ba2002`, `TM1991`, `HH1952`, `HP1992`,
+   `Re1993`, `Ya1989`, `De1994`, `PC24`** — no `.mod` file evidence at
+   all was found for any of these 10 keys (9 classical/thalamic keys are
+   simply outside the cerebellar `.mod` tree scanned in Step 2; `PC24`'s
+   two candidate `.mod` files are themselves anonymous — see the `PC24`
+   section above). Task 2 must resolve the 9 classical/thalamic keys from
+   the general neuroscience literature directly (short author-initial +
+   year keys strongly suggestive of well-known papers, e.g. `HH1952` ->
+   Hodgkin & Huxley 1952 — but that identification is Task 2's job to
+   make and verify, not this task's).
+
+4. **Unclaimed `.mod` file**: `examples/neuron_compare/Cerebellum_mod/DCN/ion/ToyStoich3ABtoCKinetic_SU15_DCN.mod`
+   has no corresponding BrainCell symbol in the `SU2015` bucket (or
+   anywhere else in `braincell/ion/` or `braincell/channel/`). Flagged in
+   case a future task needs to know it was intentionally left unported,
+   not missed.
+
+5. **Systemic author mismatch** — every one of the 18 cerebellar `.mod`
+   files that carries an explicit `Author:`/`CoAuthor:` line (across the
+   `MA2020`, `MA2024`, `MA2025`, and `RI2021` buckets) names an author
+   different from the key's own search target. The pattern is completely
+   consistent: `Kca2p2_*` and `Kv4p3_*`/`KM_*`/`HCN1_*`/`HCN2_*`/`CaHVA_*`
+   variants all carry the *same* header text (D'Angelo/Nieus/Fontana,
+   Forti/Solinas, or Solinas/Forti/D'Angelo) copy-pasted verbatim across
+   every cell-type port (`GoC`, `GrC`, `PC`, `BC`, `SC`). This is not a
+   handful of exceptions — it is the norm for every mechanism that has
+   an author line at all. Treat the key name as a "ported by" label, not
+   an "authored by" label, for the entire cerebellar half of this
+   bibliography.

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -44,9 +44,16 @@ name alone; read the harvested header text.
 
 ## Status of this file
 
-- `### Verified record` and `### Attribution` blocks are intentionally
-  **empty** in this task. They are filled in by Task 2 (classical/thalamic
-  keys) and Task 3 (cerebellar-model keys) after literature verification.
+- `### Verified record` and `### Attribution` blocks are filled in
+  progressively. Task 2 (2026-08-15) completed the nine
+  classical/thalamic keys -- `HH1952`, `TM1991`, `Ba2002`, `HM1992`,
+  `Ya1989`, `Re1993`, `HP1992`, `De1994` and `IS2008`. Eight of them
+  carry a published `.. [N]` entry; `IS2008` is recorded as NOT FILLED
+  because its attribution did not close (see `## Unresolved
+  attributions` item 6), and one symbol of the otherwise-verified
+  `HM1992` key is carved out the same way (item 7). Every remaining
+  key still shows `_TODO (Task 3)` and is owned by Task 3
+  (cerebellar-model keys).
 - Nothing in this file's `### Provenance evidence` blocks is a citation.
   It is raw, unedited text copied from `.mod` file headers (typos,
   inconsistent spacing, and missing apostrophes preserved verbatim) plus
@@ -65,9 +72,15 @@ Entries are written in the reST form that goes straight into a NumPy-doc
 - Authors: `Surname, A. B., & Surname, C. D.` -- initials with periods
   and spaces, `&` before the last author, all authors listed in full
   (no `et al.`), then `(YEAR).`
-- Title: sentence case exactly as published, ending in a period. Do not
-  "fix" the publisher's capitalisation, and do not silently correct a
-  singular/plural mismatch without noting it.
+- Title: sentence case, ending in a period. Most of the journals cited
+  here (The Journal of Neuroscience, Journal of Neurophysiology) print
+  their titles in title case, so down-casing is the normal operation,
+  not an exception -- all eight Task 2 entries do it. Preserve proper
+  nouns, species names, ion and chemical symbols (Ca2+, K+, GABAergic)
+  and capitalised acronyms as published. What must never change is the
+  *wording*: do not silently correct a publisher's singular/plural,
+  spelling or hyphenation oddity -- reproduce it verbatim and record
+  the discrepancy in the surrounding prose.
 - Journal articles: `Journal Name, VOL(ISSUE), FIRST-LAST.` with the
   journal spelled out in title case and no italics markup. Page ranges
   use an ASCII hyphen, never an en dash.
@@ -1083,19 +1096,55 @@ onto the BrainCell symbols as:
   ``:352``)
 - Ih  -> ``HCN_HM1992`` (``hyperpolarization_activated.py:45``)
 
-Constants were cross-checked against Destexhe's NEURON implementations
-of this paper: ``IT.mod`` (ModelDB 3817) and ``ITGHK.mod`` (ModelDB
-279), both headed "Model of Huguenard & McCormick, J Neurophysiol 68:
-1373-1383, 1992". Those files use
-``m_inf = 1/(1 + exp(-(v + shift + 57)/6.2))``,
-``h_inf = 1/(1 + exp((v + shift + 81)/4))``,
-``tau_m = 0.612 + 1/(exp(-(v+132)/16.7) + exp((v+16.8)/18.2))``, and a
-piecewise ``tau_h`` of ``exp((v+467)/66.6)`` below -80 mV and
-``28 + exp(-(v+22)/10.5)`` above, with ``shift = 2 mV`` (screening
-charge at 2 mM external Ca). BrainCell's ``CaT_HM1992`` carries 59 and
-83 as the Boltzmann midpoints -- i.e. the mod-file values with the 2 mV
-shift already folded in -- and reproduces ``tau_m``, the piecewise
-``tau_h``, and the ``p^2 q`` gating exactly. ``HCN_HM1992``'s
+Constants were cross-checked against ``ITGHK.mod`` (ModelDB 279),
+Destexhe's NEURON implementation of this paper, headed "Model of
+Huguenard & McCormick, J Neurophysiol 68: 1373-1383, 1992".
+**Every equation quoted in this paragraph comes from ``ITGHK.mod``
+alone** (re-read from the ModelDB GitHub mirror, 2026-08-15). It uses
+``m_inf = 1/(1 + exp(-(v+shift+actshift+57)/6.2))``,
+``h_inf = 1/(1 + exp((v+shift+81)/4))``,
+``tau_m = (0.612 + 1/(exp(-(v+shift+actshift+132)/16.7)
++ exp((v+shift+actshift+16.8)/18.2)))/phi_m``, and a piecewise
+``tau_h`` branching on ``(v+shift) < -80``:
+``exp((v+shift+467)/66.6)/phi_h`` below the branch and
+``(28 + exp(-(v+shift+22)/10.5))/phi_h`` above it. ``shift = 2 mV``
+(screening charge at 2 mM external Ca); ``actshift`` defaults to 0.
+
+**``IT.mod`` (ModelDB 3817) is a different model and is NOT a source
+for any constant above.** An earlier revision of this block wrongly
+presented the two mod files as interchangeable. They are not:
+
+- Its header reads "Model based **on the data of** Huguenard &
+  McCormick, J Neurophysiol 68: 1373-1383, 1992 **and Huguenard &
+  Prince, J Neurosci. 12: 3804-3817, 1992**" -- not "Model of", and
+  it draws on two papers, not one.
+- It shares only ``m_inf`` and ``h_inf`` with ``ITGHK.mod``.
+- It has **no ``tau_m`` at all**. Activation is taken at steady state
+  ("activation considered at steady-state"); ``tau_m`` appears in the
+  ``ASSIGNED`` block annotated "dummy variable for compatibility" and
+  is never assigned a value.
+- Its piecewise ``tau_h`` is **commented out**, replaced by the
+  bi-exponential fit ``30.8 + (211.4 + exp((Vm+113.2)/5))/(1 +
+  exp((Vm+84)/3.2))``.
+- It carries a single ``q10 = 3``, applied to inactivation only.
+
+**How the 2 mV shift is actually applied -- read this before writing
+the ``CaT_HM1992`` docstring.** ``CaT_HM1992``
+(``braincell/channel/calcium.py:177-195``) folds the shift into the
+Boltzmann midpoints **only**: 57 -> 59 in ``f_p_inf``, 81 -> 83 in
+``f_q_inf``. The time constants do **not** fold it in. ``f_p_tau``
+carries bare 132 and 16.8, and ``f_q_tau`` carries bare 467 and 22
+with the branch at ``V >= -80`` -- i.e. exactly ``ITGHK.mod``'s
+numbers read at ``shift = 0``, not at its shipped ``shift = 2 mV``.
+
+So the correct claim is: ``CaT_HM1992`` reproduces ``ITGHK.mod``'s
+``tau_m``, its piecewise ``tau_h`` and its ``p^2 q`` gating exactly
+**against a shift = 0 reading of the mod file**, while its
+steady-state midpoints match the mod file **with the 2 mV shift folded
+in**. Against the shipped ``shift = 2 mV`` the two taus sit 2 mV away
+from the mod file. A docstring must **not** describe the kinetics as
+those of the mod file "with the 2 mV screening-charge shift folded
+in": that is true of the midpoints and false of the taus. ``HCN_HM1992``'s
 ``p_inf = 1/(1 + exp((V+75)/5.5))`` and
 ``tau_p = 1/(exp(-0.086 V - 14.59) + exp(0.0701 V - 1.87))`` are the
 standard published Ih parameterisation and are already documented in
@@ -1234,7 +1283,8 @@ below.
 .. [1] Bazhenov, M., Timofeev, I., Steriade, M., & Sejnowski, T. J.
        (2002). Model of thalamocortical slow-wave sleep oscillations and
        transitions to activated states. The Journal of Neuroscience,
-       22(19), 8691-8704. doi:10.1523/JNEUROSCI.22-19-08691.2002
+       22(19), 8691-8704.
+       doi:10.1523/JNEUROSCI.22-19-08691.2002
 
 ### Attribution
 
@@ -1318,8 +1368,7 @@ modified by Traub, for Hippocampal Pyramidal cells, in: Traub & Miles,
 Neuronal Networks of the Hippocampus, Cambridge, 1991".
 
 With ``v2 = v - vtraub`` in the mod file and ``V' = V - V_sh`` in
-BrainCell (both defaulting to a -63 mV shift), all six rate functions
-match term for term:
+BrainCell, all six rate functions match term for term:
 
 - alpha_m = 0.32 (13 - V') / (exp((13 - V')/4) - 1)
 - beta_m  = 0.28 (V' - 40) / (exp((V' - 40)/5) - 1)
@@ -1327,6 +1376,20 @@ match term for term:
 - beta_h  = 4 / (1 + exp(-(V' - 40)/5))
 - alpha_n = 0.032 (15 - V') / (exp((15 - V')/5) - 1)
 - beta_n  = 0.5 exp((10 - V')/40)
+
+**Shift defaults differ -- do not write "both defaulting to -63 mV".**
+An earlier revision of this block said the mod file and BrainCell share
+a -63 mV default. They do not. ``HH2.mod``'s own ``PARAMETER`` block
+ships ``vtraub = -55 (mV)`` (re-read from the ModelDB 3670 GitHub
+mirror, 2026-08-15). BrainCell's ``V_sh = -63 mV``
+(``braincell/channel/sodium.py:121``, and the matching default in
+``potassium.py``) is nevertheless the correct value to ship: -63 mV is
+what Destexhe's network ``.hoc`` code assigns to ``vtraub`` when it
+uses this mechanism, and it is the offset associated with the
+Traub-Miles hippocampal pyramidal cell. Only the mod file's *own*
+default differs; the six rate equations above are confirmed to match
+term for term either way, since the shift enters only through
+``v2``/``V'``.
 
 Gating m^3 h and n^4 also match. The mod file's ``tadj = 3^((celsius -
 36)/10)`` corresponds to BrainCell's ``q10 = 1.0`` at ``temp_ref = 36
@@ -1488,7 +1551,8 @@ PMCID PMC6576337.
        Stepwise repolarization from Ca2+ plateaus in neocortical
        pyramidal cells: evidence for nonhomogeneous distribution of HVA
        Ca2+ channels in dendrites. The Journal of Neuroscience, 13(11),
-       4609-4621. doi:10.1523/JNEUROSCI.13-11-04609.1993
+       4609-4621.
+       doi:10.1523/JNEUROSCI.13-11-04609.1993
 
 ### Attribution
 
@@ -1695,14 +1759,36 @@ exactly, and the ``p^2`` gating, the ``n = 2`` exponent, and the pure
 Ca dependence all match.
 
 **Discrepancy found -- flag for the module task.** BrainCell defaults
-to ``beta = 0.09 ms^-1``; the reference implementation and the paper's
-own reported value are ``beta = 0.03 ms^-1`` (a factor of 3). This is
-inherited from BrainPy, whose ``IAHP_De1994v2`` docstring itself states
-"The values n=2, alpha=48 ms^-1 mM^-2 and beta=0.03 ms^-1 yielded AHPs
-very similar to those RE cells recorded in vivo and in vitro" while its
-constructor still defaults ``beta = 0.09``. The docstring must not
-claim that ``beta = 0.09`` is the published value; either state 0.03 as
-the paper's value and 0.09 as the BrainCell default, or raise the
+to ``beta = 0.09 ms^-1`` (confirmed by reading
+``braincell/channel/potassium_calcium.py:72``). The reference value is
+``beta = 0.03 ms^-1``, a factor of 3 lower.
+
+**Where the 0.03 comes from -- state this precisely.** An earlier
+revision of this block called 0.03 "the paper's own reported value".
+That overstates the evidence: the 1994 paper is paywalled and was
+**not** read; only the PubMed abstract was retrieved. The 0.03 rests
+on two secondary sources that agree with each other:
+
+1. ``IAHP.mod``'s ``PARAMETER`` block, which ships ``beta = 0.03
+   (1/ms)``. This is the authors' own NEURON implementation, and the
+   value was confirmed identical in two independent ModelDB
+   accessions (3670 and 3808).
+2. BrainPy's ``IAHP_De1994v2`` docstring, which *quotes* the paper as
+   saying "The values n=2, alpha=48 ms^-1 mM^-2 and beta=0.03 ms^-1
+   yielded AHPs very similar to those RE cells recorded in vivo and in
+   vitro" -- while its own constructor nonetheless defaults
+   ``beta = 0.09``, which is where BrainCell inherited 0.09 from.
+
+So write "the value used by the authors' reference implementation, and
+quoted from the paper by BrainPy" -- not "the paper's own reported
+value". Checking that quotation against the published text is still
+open.
+
+Unaffected by this: the ``alpha = 48`` derivation above, which is
+computed directly from ``IAHP.mod``'s own ``beta`` and ``cac`` and
+which BrainCell's default reproduces exactly. In no case may a
+docstring present ``beta = 0.09`` as the published value; state 0.03
+as the reference value and 0.09 as the BrainCell default, or raise the
 mismatch as a separate issue.
 
 ---
@@ -1843,26 +1929,74 @@ resolve them cleanly:
    PMID 17959743, PMCID PMC6086124, epub 24 Oct 2007. That record check
    passes cleanly.
 
-   **Why the attribution still fails.** The paper's Methods could not be
-   read, so it was not possible to confirm that it contains the two
-   currents these symbols implement:
+   **CORRECTION: the full text IS readable.** An earlier revision of
+   this item claimed the Methods section was unreadable and rested the
+   whole "not confirmed" verdict on that. The claim was false, and the
+   readable text changes the evidence for both symbols.
 
-   - The full text is *not* open access. `oa.fcgi` returns
-     `idIsNotOpenAccess` for PMC6086124; the Europe PMC `fullTextXML`
-     endpoint 404s; the PMC PDF endpoint is behind a proof-of-work
-     challenge; and `journals.physiology.org` returns 403.
-   - No ModelDB deposit for this paper was found (ModelDB's API returns
-     nothing for "Strowbridge", and a targeted web search surfaced no
-     accession), so there is no reference `.mod` implementation to
-     compare constants against -- unlike every other key in this task.
-   - The published **abstract** is consistent with, but does not
-     establish, the attribution. It confirms a computational model of
-     olfactory bulb granule cells and says persistent activity "results
-     from interactions between calcium-dependent afterdepolarizations
-     and low-threshold Ca spikes in granule cells". A Ca-dependent ADP
-     is the usual signature of an I_CAN, and "Ca spikes" implies a Ca
-     current, so both classes are *plausible*. Plausible is not
-     confirmed.
+   *The access route that works.* Fetch the PMC article **HTML** at
+   `https://pmc.ncbi.nlm.nih.gov/articles/PMC6086124/` with an
+   ordinary browser user-agent. It returns HTTP 200 and serves the
+   complete author manuscript (re-confirmed 2026-08-15).
+
+   *Why the OA APIs mislead -- generalise this.* The deposit is an
+   NIHPA author manuscript: made freely **readable** under the NIH
+   Public Access Policy, but not open-access **licensed**. The
+   machine-readable OA surfaces key off the licence, not the
+   readability, so every one of them reports absence: `oa.fcgi`
+   returns `idIsNotOpenAccess` (re-confirmed 2026-08-15), Europe PMC's
+   `fullTextXML` 404s (re-confirmed), the PMC PDF endpoint sits behind
+   a proof-of-work challenge, and `journals.physiology.org` returns
+   403. **A negative from `oa.fcgi` or `fullTextXML` is not evidence
+   that a paper cannot be read.** Always retry the PMC article HTML
+   before recording any PMC-hosted paper as inaccessible.
+
+   *What the Methods actually say.* The "Computer simulations" section
+   states verbatim:
+
+   ```
+   We employed a set of five purely voltage-dependent currents in our
+   granule cell model [fast Na current, delayed rectifier K current,
+   transient (A-type) K current, low-threshold (T-type) Ca current,
+   and high-threshold (P/N-type) Ca current] and one calcium-dependent
+   current (calcium- and voltage-dependent nonselective cation
+   current).
+   ```
+
+   **`CaN_IS2008` -- attribution now substantially supported.** The
+   calcium- and voltage-dependent nonselective cation current (I_CAN)
+   is present, named explicitly, and central to the paper's thesis:
+   it is the current that generates the calcium-dependent
+   afterdepolarization underlying the persistent activity the paper is
+   about. This lifts the attribution from "plausible" to substantially
+   supported.
+
+   **`CaL_IS2008` -- positive evidence of MISATTRIBUTION.** The paper
+   contains **no L-type calcium current**. Its only two calcium
+   currents are a low-threshold T-type and a high-threshold
+   **P/N-type**. The strings "L-type", "L type" and "ICaL" do not
+   occur anywhere in the article text. This is the same evidential
+   status as `CaHT_HM1992` in item 7 -- not an absence of evidence,
+   but positive evidence that the symbol does not correspond to any
+   current the cited paper models. Either `CaL_IS2008` is meant to be
+   this paper's high-threshold current, in which case it is a P/N-type
+   and the symbol name is wrong, or it is a genuine L-type current and
+   its source is a different paper entirely.
+
+   **Both symbols still ship no citation. The conservative outcome is
+   unchanged; only the evidence behind it changed.** Reading the
+   Methods does not close either attribution, because the Methods do
+   not print the gating constants. They say only: "Detailed
+   information about these models is described in the supplementary
+   materials section." That supplement was **not** deposited with the
+   PMC author manuscript, so the eight constants listed below still
+   cannot be checked against the source.
+
+   Also still true, and still an obstacle: no ModelDB deposit for this
+   paper was found (ModelDB's API returns nothing for "Strowbridge",
+   and a targeted web search surfaced no accession), so there is no
+   reference `.mod` implementation to compare constants against --
+   unlike every other key in this task.
 
    **Positive evidence that these are ports, not original work.** The
    two BrainCell classes are verbatim ports of BrainPy's
@@ -1892,13 +2026,20 @@ resolve them cleanly:
      -- byte-identical to `CaT_HM1992`'s temperature defaults, and 24
      degC is the Huguenard reference temperature, not an olfactory bulb
      one. These read as inherited `p^2 q` template defaults rather than
-     values from an Inoue & Strowbridge table.
+     values from an Inoue & Strowbridge table. This now compounds with
+     the absence of any L-type current in the paper, above: two
+     independent signs pointing the same way.
 
-   **What would close this.** Read the Methods/Appendix of
-   doi:10.1152/jn.00526.2007 (institutional access, or the print issue)
-   and check for the eight constants listed above. Until then, the two
-   docstrings should either omit a `References` section or state the
-   attribution as unverified; they must not print a confident citation.
+   **What would close this.** The Methods are readable but defer the
+   constants, so the remaining artefact is the **supplementary
+   materials** of doi:10.1152/jn.00526.2007, which are not deposited
+   with the PMC author manuscript. Obtain them from the publisher
+   (institutional access) or the print issue and check the eight
+   constants listed above. For `CaL_IS2008`, also settle whether the
+   symbol is a mislabelled P/N-type or belongs to a different paper.
+   Until then the two docstrings must either omit a `References`
+   section or state the attribution as unverified; neither may print a
+   confident citation.
 
 7. **`CaHT_HM1992`** (`braincell/channel/calcium.py:248`) --
    *attribution FAILED; the record for the `HM1992` key itself is fine.*
@@ -1922,6 +2063,29 @@ resolve them cleanly:
 
    This is inherited from BrainPy's `ICaHT_HM1992`, which has the same
    shape and the same citation.
+
+   **Lead for whoever traces this further: the companion paper.** A
+   high-threshold thalamic Ca2+ current *does* exist in the immediately
+   adjacent article -- McCormick, D. A., & Huguenard, J. R. (1992),
+   "A model of the electrophysiological properties of thalamocortical
+   relay neurons", J Neurophysiol 68(4), 1384-1400,
+   doi:10.1152/jn.1992.68.4.1384, PMID 1331356. This is the same paper
+   the `HM1992` Verified record block warns not to confuse with the
+   cited one (note the reversed author order and the adjacent page
+   range). Its abstract, retrieved via E-utilities 2026-08-15,
+   enumerates the model's currents as "a fast and transient Na+
+   current, INa; a persistent, depolarization-activated Na+ current,
+   INap; a low-threshold Ca2+ current, I(T); a **high-threshold Ca2+
+   current, IL**; a Ca(2+)-activated K+ current, IC; ...". So the
+   obvious hypothesis is that `CaHT_HM1992` was meant to be that IL.
+
+   **But the code refutes even that.** `CaHT_HM1992` is not IL: it is
+   `CaT_HM1992`'s gating functions verbatim with `V_sh` moved from
+   -3 mV to +25 mV, as established above. A translated T current is
+   not the companion paper's IL, which has its own kinetics. Cite the
+   companion paper only if a future task actually re-derives the class
+   against IL's published parameters; do not swap one unverified
+   citation for another.
 
    **Consequence for the module task.** Do not give `CaHT_HM1992` a bare
    `.. [1] Huguenard & McCormick (1992)` reference implying the paper

--- a/docs/design/ion-channel-bibliography.md
+++ b/docs/design/ion-channel-bibliography.md
@@ -53,6 +53,49 @@ name alone; read the harvested header text.
   structural notes about what was and was not found. Do not treat any of
   it as verified.
 
+## Citation house style
+
+Established by Task 2; **Task 3 and every module task must follow it.**
+Entries are written in the reST form that goes straight into a NumPy-doc
+`References` section, so they can be copied verbatim with no reformatting.
+
+- Numbered `.. [N]` entries. Continuation lines are indented 7 spaces so
+  they align under the text, not under the bracket. Keep every line
+  under 79 characters.
+- Authors: `Surname, A. B., & Surname, C. D.` -- initials with periods
+  and spaces, `&` before the last author, all authors listed in full
+  (no `et al.`), then `(YEAR).`
+- Title: sentence case exactly as published, ending in a period. Do not
+  "fix" the publisher's capitalisation, and do not silently correct a
+  singular/plural mismatch without noting it.
+- Journal articles: `Journal Name, VOL(ISSUE), FIRST-LAST.` with the
+  journal spelled out in title case and no italics markup. Page ranges
+  use an ASCII hyphen, never an en dash.
+- DOI last, on its own line, as `doi:10.xxxx/yyyy` -- bare prefix, no
+  `https://doi.org/` URL. Omit the line only when no DOI exists.
+- Books: `Author, A. B., & Author, C. D. (Year). Title of book.
+  Publisher.` followed by the DOI line if one exists. No place of
+  publication (APA 7 style). Record the ISBN in the surrounding prose,
+  not in the `.. [N]` entry.
+- Book chapters: `Author, A. B. (Year). Chapter title. In E. Editor &
+  F. Editor (Eds.), Book title: Subtitle (pp. FIRST-LAST). Publisher.`
+- Each `### Verified record` block opens with one or two sentences
+  naming *what was checked and where* (PubMed PMID, DOI resolution,
+  publisher page, PMC ID, catalogue record), dated, so the entry can be
+  re-audited later. Then the `.. [N]` entry. Then any correction or
+  ambiguity notes.
+- Each `### Attribution` block names the symbols, cites the code
+  location(s) read, names the external artefact the constants were
+  compared against (paper section, abstract, or a specific reference
+  `.mod` file with its ModelDB accession), lists the matching
+  equations, and then lists parameter-default divergences separately as
+  **caveats** -- a default that differs from the paper is not a citation
+  error, but it must not be presented as the paper's value.
+- A key that fails either check gets no `.. [N]` entry at all. Its
+  `### Verified record` block says NOT FILLED and points at the
+  numbered item in `## Unresolved attributions` that carries the
+  evidence.
+
 ---
 
 ## NO_KEY  (32 symbols)
@@ -1000,11 +1043,75 @@ this key.
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+Confirmed 2026-08-15 against PubMed (PMID 1279135, full structured
+abstract retrieved via NCBI E-utilities) and the American Physiological
+Society publisher record for the DOI.
+
+.. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of the
+       currents involved in rhythmic oscillations in thalamic relay
+       neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+       doi:10.1152/jn.1992.68.4.1373
+
+**Title correction.** The existing docstring at
+``braincell/channel/hyperpolarization_activated.py:78-80`` ends the
+title "... in thalamic relay neuron" (singular). The published title is
+"... in thalamic relay neurons" (plural), per PubMed and the publisher
+record. It also carries no DOI. The module task must fix both. (Do not
+confuse this paper with its companion, McCormick & Huguenard, 1992,
+J Neurophysiol 68(4), 1384-1400, doi:10.1152/jn.1992.68.4.1384.)
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbols:** ``CaT_HM1992``, ``CaHT_HM1992``, ``HCN_HM1992``,
+``KA1_HM1992``, ``KA2_HM1992``, ``KK2A_HM1992``, ``KK2B_HM1992``.
+
+**Attribution check: PASSED for 6 of 7 symbols; FAILED for**
+``CaHT_HM1992`` **(see "Unresolved attributions" item 7).**
+
+The published abstract (retrieved via E-utilities) enumerates exactly
+four currents: "the transient, low-voltage-activated Ca2+ current (IT),
+the rapidly inactivating transient K+ current (IA), the slowly
+inactivating K+ current (IK2), and the hyperpolarization-activated,
+mixed cationic current (Ih)". It further states that IA "was modeled by
+assuming two components with different time constants of inactivation"
+and that IK2 "was also modeled by assuming two components". That maps
+onto the BrainCell symbols as:
+
+- IT  -> ``CaT_HM1992`` (``braincell/channel/calcium.py:146``)
+- IA  -> ``KA1_HM1992`` / ``KA2_HM1992`` (``potassium.py:197``, ``:250``)
+- IK2 -> ``KK2A_HM1992`` / ``KK2B_HM1992`` (``potassium.py:303``,
+  ``:352``)
+- Ih  -> ``HCN_HM1992`` (``hyperpolarization_activated.py:45``)
+
+Constants were cross-checked against Destexhe's NEURON implementations
+of this paper: ``IT.mod`` (ModelDB 3817) and ``ITGHK.mod`` (ModelDB
+279), both headed "Model of Huguenard & McCormick, J Neurophysiol 68:
+1373-1383, 1992". Those files use
+``m_inf = 1/(1 + exp(-(v + shift + 57)/6.2))``,
+``h_inf = 1/(1 + exp((v + shift + 81)/4))``,
+``tau_m = 0.612 + 1/(exp(-(v+132)/16.7) + exp((v+16.8)/18.2))``, and a
+piecewise ``tau_h`` of ``exp((v+467)/66.6)`` below -80 mV and
+``28 + exp(-(v+22)/10.5)`` above, with ``shift = 2 mV`` (screening
+charge at 2 mM external Ca). BrainCell's ``CaT_HM1992`` carries 59 and
+83 as the Boltzmann midpoints -- i.e. the mod-file values with the 2 mV
+shift already folded in -- and reproduces ``tau_m``, the piecewise
+``tau_h``, and the ``p^2 q`` gating exactly. ``HCN_HM1992``'s
+``p_inf = 1/(1 + exp((V+75)/5.5))`` and
+``tau_p = 1/(exp(-0.086 V - 14.59) + exp(0.0701 V - 1.87))`` are the
+standard published Ih parameterisation and are already documented in
+the class docstring.
+
+**Caveats for the module task:**
+
+- ``CaT_HM1992`` defaults ``q10_p = 3.55`` at 24 degC. Destexhe's
+  reference implementations use ``qm = 5`` for activation (citing
+  Coulter et al., J Physiol 414: 587, 1989) and ``qh = 3`` for
+  inactivation. The value 3.55 could **not** be traced to the paper or
+  to any reference implementation; treat it as a BrainCell/BrainPy
+  default and do not attribute it to Huguenard & McCormick.
+- ``CaT_HM1992`` applies a further ``V_sh = -3 mV`` on top of the
+  folded 2 mV shift, so shipped defaults sit 3 mV from the mod-file
+  defaults. This is a documented free parameter, not a citation error.
 
 ---
 
@@ -1088,11 +1195,19 @@ No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries an
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+**NOT FILLED -- see "Unresolved attributions" item 6.**
+
+The bibliographic record for the candidate paper resolves cleanly, but
+the attribution check could not be completed, so no citation is
+published here. Do not copy a reference for ``CaN_IS2008`` or
+``CaL_IS2008`` out of this file until item 6 is closed.
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbols:** ``CaN_IS2008``, ``CaL_IS2008``.
+
+**Attribution check: NOT CONFIRMED.** Recorded in full under
+"Unresolved attributions" item 6.
 
 ---
 
@@ -1111,11 +1226,53 @@ No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+Confirmed 2026-08-15 against PubMed (PMID 12351744), the Journal of
+Neuroscience article page, and the full text as deposited in PubMed
+Central (PMC6757797), which was read directly for the attribution check
+below.
+
+.. [1] Bazhenov, M., Timofeev, I., Steriade, M., & Sejnowski, T. J.
+       (2002). Model of thalamocortical slow-wave sleep oscillations and
+       transitions to activated states. The Journal of Neuroscience,
+       22(19), 8691-8704. doi:10.1523/JNEUROSCI.22-19-08691.2002
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbols:** ``KDR_Ba2002``, ``Na_Ba2002``.
+
+**Attribution check: PASSED.** Code read at
+``braincell/channel/potassium.py:95`` and
+``braincell/channel/sodium.py:59``. Full text read from PMC6757797.
+
+Two independent confirmations:
+
+1. *Currents.* The Methods section ("Intrinsic currents: thalamus")
+   states verbatim: "For both RE and TC cells we considered a fast
+   sodium current, I_Na, a fast potassium current, I_K (Traub and
+   Miles, 1991), a low-threshold Ca2+ current, I_T ...". So the paper
+   does contain the two currents these symbols implement, and the
+   authors themselves attribute their kinetics to Traub & Miles (1991).
+2. *Conductance fingerprint.* The same paragraph gives, for TC cells,
+   "g_K = 10 mS/cm^2, g_Na = 90 mS/cm^2". BrainCell's defaults are
+   ``KDR_Ba2002 g_max = 10.0 mS/cm^2`` and ``Na_Ba2002 g_max = 90.0
+   mS/cm^2`` -- an exact match to the paper's TC-cell values, and a
+   much stronger fingerprint than the rate equations alone.
+
+Algebraically, ``KDR_Ba2002`` and ``Na_Ba2002`` are the same
+Traub-Miles rate functions as ``K_TM1991`` / ``Na_TM1991`` (see the
+``TM1991`` attribution block) written in the mirrored sign convention,
+with ``V_sh = -50 mV`` instead of -63 mV and ``q10 = 3`` instead of 1.
+
+**Caveat for the module task:** the paper does *not* print the rate
+equations. It defers them: "The expressions for voltage- and
+Ca2+-dependent transition rates for all currents are given in Bazhenov
+et al. (1998)" (= Bazhenov, Timofeev, Steriade, & Sejnowski, 1998,
+J Neurophysiol 79(5), 2730-2748, doi:10.1152/jn.1998.79.5.2730, PMID
+9582241 -- record independently confirmed here). The ``V_sh = -50 mV``
+shift could therefore not be traced to a printed equation in the 2002
+paper itself. A docstring may state that the current is *the one used
+in* Bazhenov et al. (2002); it must not claim the 2002 paper prints
+these alpha/beta expressions.
 
 ---
 
@@ -1134,11 +1291,52 @@ No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+Confirmed 2026-08-15 against the Cambridge University Press catalogue
+and Cambridge Core chapter landing pages (which expose the book DOI and
+its chapter-level suffixes), plus the reference list of Bazhenov et al.
+(2002) as retrieved from PMC6757797, which cites the same edition.
+
+This is a book, not a journal article, so the entry takes the book form:
+
+.. [1] Traub, R. D., & Miles, R. (1991). Neuronal networks of the
+       hippocampus. Cambridge University Press.
+       doi:10.1017/CBO9780511895401
+
+ISBN 9780521364812 (0521364817). Chapter-level DOIs exist as
+``10.1017/CBO9780511895401.00N`` but no BrainCell symbol needs one.
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbols:** ``K_TM1991``, ``Na_TM1991``.
+
+**Attribution check: PASSED.** Code read at
+``braincell/channel/potassium.py:129`` and
+``braincell/channel/sodium.py:104``. Compared against ``HH2.mod`` from
+ModelDB accession 3670 (Destexhe's own NEURON implementation, mirrored
+at github.com/ModelDBRepository/3670), whose header reads: "Equations
+modified by Traub, for Hippocampal Pyramidal cells, in: Traub & Miles,
+Neuronal Networks of the Hippocampus, Cambridge, 1991".
+
+With ``v2 = v - vtraub`` in the mod file and ``V' = V - V_sh`` in
+BrainCell (both defaulting to a -63 mV shift), all six rate functions
+match term for term:
+
+- alpha_m = 0.32 (13 - V') / (exp((13 - V')/4) - 1)
+- beta_m  = 0.28 (V' - 40) / (exp((V' - 40)/5) - 1)
+- alpha_h = 0.128 exp((17 - V')/18)
+- beta_h  = 4 / (1 + exp(-(V' - 40)/5))
+- alpha_n = 0.032 (15 - V') / (exp((15 - V')/5) - 1)
+- beta_n  = 0.5 exp((10 - V')/40)
+
+Gating m^3 h and n^4 also match. The mod file's ``tadj = 3^((celsius -
+36)/10)`` corresponds to BrainCell's ``q10 = 1.0`` at ``temp_ref = 36
+degC`` defaults (both give unity at 36 degC); this is consistent, not a
+discrepancy.
+
+**Caveat:** ``Na_TM1991`` ``g_max = 120 mS/cm^2`` and ``K_TM1991``
+``g_max = 10 mS/cm^2`` are BrainCell defaults; ``HH2.mod`` ships
+gnabar = 0.1 mho/cm^2 (100 mS/cm^2) and gkbar = 0.01 mho/cm^2
+(10 mS/cm^2). Do not attribute the 120 to Traub & Miles.
 
 ---
 
@@ -1159,11 +1357,51 @@ this harvest's. No repository-local provenance text exists for this key.
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+Confirmed 2026-08-15 against PubMed (PMID 12991237), the Physiological
+Society / Wiley publisher record for the DOI, and the PubMed Central
+deposit PMC1392413. All fields (authors, title, journal, volume, issue,
+pages, year, DOI) agree across the three.
+
+.. [1] Hodgkin, A. L., & Huxley, A. F. (1952). A quantitative description
+       of membrane current and its application to conduction and
+       excitation in nerve. The Journal of Physiology, 117(4), 500-544.
+       doi:10.1113/jphysiol.1952.sp004764
+
+Do **not** cite doi:10.1007/BF02459568 -- that is the 1990 Bulletin of
+Mathematical Biology reprint (52, 25-71), not the original.
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbols:** ``K_HH1952``, ``Na_HH1952``.
+
+**Attribution check: PASSED.** Code read at
+``braincell/channel/potassium.py:163`` and
+``braincell/channel/sodium.py:149``; every rate constant was expanded by
+hand and compared with the classical Hodgkin-Huxley rate equations.
+
+With the default ``V_sh = -45 mV`` (so ``V' = V + 45``, putting rest at
+-65 mV in the modern absolute-potential convention), the implementation
+expands to exactly the published HH rates:
+
+- ``K_HH1952``: alpha_n = 0.01 (V+55) / (1 - exp(-(V+55)/10)),
+  beta_n = 0.125 exp(-(V+65)/80), gating n^4.
+- ``Na_HH1952``: alpha_m = 0.1 (V+40) / (1 - exp(-(V+40)/10)),
+  beta_m = 4 exp(-(V+65)/18), alpha_h = 0.07 exp(-(V+65)/20),
+  beta_h = 1 / (1 + exp(-(V+35)/10)), gating m^3 h.
+
+``exprel(x) = (exp(x) - 1) / x`` is used only to remove the removable
+singularity at the Boltzmann midpoint; it does not change the function.
+
+**Caveats for the module task (parameter defaults, not citation errors):**
+
+- ``Na_HH1952`` default ``g_max = 120 mS/cm^2`` matches HH's g_Na, but
+  ``K_HH1952`` default ``g_max = 10 mS/cm^2`` does **not** match HH's
+  g_K = 36 mS/cm^2. Document it as a BrainCell default, not as HH's
+  value.
+- ``temp_ref`` defaults to 36 degC while HH's rates were measured at
+  6.3 degC. ``q10 = 3`` is HH's own factor-of-3-per-10-degC, but the
+  reference temperature as shipped makes the correction a no-op at 36
+  degC. Do not claim the defaults reproduce HH at 6.3 degC.
 
 ---
 
@@ -1181,11 +1419,50 @@ No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries an
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+Confirmed 2026-08-15 against PubMed (PMID 1403085, abstract retrieved
+via NCBI E-utilities) and the Journal of Neuroscience article page.
+PMCID PMC6575965.
+
+.. [1] Huguenard, J. R., & Prince, D. A. (1992). A novel T-type current
+       underlies prolonged Ca2+-dependent burst firing in GABAergic
+       neurons of rat thalamic reticular nucleus. The Journal of
+       Neuroscience, 12(10), 3804-3817.
+       doi:10.1523/JNEUROSCI.12-10-03804.1992
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbol:** ``CaT_HP1992`` (``braincell/channel/calcium.py:199``).
+
+**Attribution check: PASSED.** The abstract confirms the paper's
+subject is a slowly inactivating transient Ca2+ current (I_Ts) measured
+by whole-cell voltage clamp in acutely isolated rat thalamic reticular
+(nRt) neurons -- exactly the "T-type calcium current for reticular
+nucleus" the symbol claims.
+
+Constants were compared against ``IT2.mod`` from ModelDB accession
+3670, whose header reads: "The kinetics is described by standard
+equations (NOT GHK) using a m2h format, according to the voltage-clamp
+data (whole cell patch clamp) of Huguenard & Prince, J Neurosci. 12:
+3804-3817, 1992", with "Q10 changed to 5 and 3". The mod file computes:
+
+- ``m_inf = 1/(1 + exp(-(v + shift + 50)/7.4))``
+- ``h_inf = 1/(1 + exp((v + shift + 78)/5.0))``
+- ``tau_m = 3 + 1/(exp((v+shift+25)/10) + exp(-(v+shift+100)/15))``
+- ``tau_h = 85 + 1/(exp((v+shift+46)/4) + exp(-(v+shift+405)/50))``
+
+with ``shift = 2 mV`` (screening charge for external Ca = 2 mM), and
+``phi_m = 5^((celsius-24)/10)``, ``phi_h = 3^((celsius-24)/10)``.
+
+``CaT_HP1992`` carries 52, 80, 27, 102, 48 and 407 -- i.e. each
+mod-file constant with the 2 mV shift folded in -- and defaults to
+``q10_p = 5.0`` / ``q10_q = 3.0`` at ``temp_ref = 24 degC``, matching
+phi_m and phi_h exactly. Gating is ``p^2 q`` in both.
+
+**Caveat:** ``CaT_HP1992`` applies a further ``V_sh = -3 mV`` on top of
+the folded 2 mV shift, so shipped defaults sit 3 mV depolarized
+relative to ``IT2.mod`` defaults. Documented free parameter, not a
+citation error. ``g_max = 1.75 mS/cm^2`` matches ``IT2.mod``'s
+``gcabar = .00175 mho/cm2``.
 
 ---
 
@@ -1203,11 +1480,42 @@ No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+Confirmed 2026-08-15 against PubMed (PMID 8229187, abstract retrieved
+via NCBI E-utilities) and the Journal of Neuroscience article page.
+PMCID PMC6576337.
+
+.. [1] Reuveni, I., Friedman, A., Amitai, Y., & Gutnick, M. J. (1993).
+       Stepwise repolarization from Ca2+ plateaus in neocortical
+       pyramidal cells: evidence for nonhomogeneous distribution of HVA
+       Ca2+ channels in dendrites. The Journal of Neuroscience, 13(11),
+       4609-4621. doi:10.1523/JNEUROSCI.13-11-04609.1993
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbol:** ``CaHT_Re1993`` (``braincell/channel/calcium.py:301``).
+
+**Attribution check: PASSED, verbatim.** The abstract confirms the
+paper models "the high-voltage-activated Ca2+ conductance underlying
+the spike" in compartmental computer models -- i.e. an HVA
+(high-threshold) Ca2+ current, which is what the symbol implements.
+
+Constants were compared against ``ca.mod`` from ModelDB accession 2488,
+headed "HVA Ca current / Based on Reuveni, Friedman, Amitai and Gutnick
+(1993) / J. Neurosci. 13:4609-4621" (implementation by Zach Mainen,
+Salk Institute, 1994). Every rate constant matches:
+
+- alpha_m = 0.055 (-27 - V) / (exp((-27 - V)/3.8) - 1)
+- beta_m  = 0.94 exp((-75 - V)/17)
+- alpha_h = 0.000457 exp((-13 - V)/50)
+- beta_h  = 0.0065 / (exp((-15 - V)/28) + 1)
+
+Gating is ``m^2 h`` in both. The temperature parameters also match
+exactly: ``ca.mod`` uses ``temp = 23 degC, q10 = 2.3``; ``CaHT_Re1993``
+defaults to ``q10_p = q10_q = 2.3`` at ``temp_ref = 23 degC``.
+
+BrainCell writes the rates through ``temp = (-V + V_sh)``, i.e. in the
+negated-voltage form the mod file uses inline; with the default
+``V_sh = 0 mV`` the two are identical. No discrepancies found.
 
 ---
 
@@ -1277,11 +1585,63 @@ No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+Confirmed 2026-08-15 against the CaltechAUTHORS record for the chapter
+(authors.library.caltech.edu/records/9dnr2-hez54), the Open Library
+edition record for ISBN 0262111330 (which supplies the 1989 first
+edition's subtitle, "from synapses to networks", publisher, and place),
+and the header of Destexhe's ``IM.mod`` (ModelDB 3817), which cites the
+chapter directly.
+
+This is a book chapter, not a journal article, so the entry takes the
+chapter-in-edited-volume form:
+
+.. [1] Yamada, W. M., Koch, C., & Adams, P. R. (1989). Multiple channels
+       and calcium dynamics. In C. Koch & I. Segev (Eds.), Methods in
+       neuronal modeling: From synapses to networks (pp. 97-133). MIT
+       Press.
+
+**Known ambiguity, recorded rather than papered over.** Sources
+disagree on the final page: the CaltechAUTHORS imprint field gives
+"97-133", while Destexhe's ``IM.mod`` header gives "p 97-134". Neither
+could be adjudicated against a scan of the first edition. 97-133 is
+used above because it is the machine-readable bibliographic record; a
+maintainer re-auditing this entry should treat the last page as +/- 1.
+
+Note also that CaltechAUTHORS files this 1989 chapter under the
+*second* edition's subtitle ("from ions to networks", 1998, ISBN
+9780585375878). The 1989 first edition (ISBN 0262111330, MIT Press /
+A Bradford Book, Cambridge MA, 524 pp.) is subtitled "From synapses to
+networks" per Open Library; that is the edition cited above and the one
+contemporaneous with the key's year.
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbol:** ``KNI_Ya1989`` (``braincell/channel/potassium.py:405``).
+
+**Attribution check: PASSED, verbatim.** Compared against ``IM.mod``
+from ModelDB accession 3817, whose header reads: "Model taken from
+Yamada, W.M., Koch, C. and Adams, P.R. Multiple channels and calcium
+dynamics. In: Methods in Neuronal Modeling, edited by C. Koch and I.
+Segev, MIT press, 1989, p 97-134."
+
+The mod file computes:
+
+- ``m_inf = 1 / (1 + exp(-(v + 35)/10))``
+- ``tau_m = tau_peak / (3.3 exp((v + 35)/20) + exp(-(v + 35)/20))``
+
+and a single, non-inactivating, linear-in-m potassium conductance
+(``ik = gkbar * m * (v - ek)``). ``KNI_Ya1989`` implements exactly these
+two functions and a single ``Gate("p")`` of power 1. This is the M
+current (slow non-inactivating K+) of the bullfrog sympathetic ganglion
+B-type cell, which the CaltechAUTHORS abstract confirms is the
+chapter's subject.
+
+**Caveats for the module task:** ``IM.mod`` ships ``taumax = 1000 ms``
+and ``gkbar = 1e-6 mho/cm^2`` (= 1e-3 mS/cm^2); ``KNI_Ya1989`` defaults
+to ``tau_max = 4000 ms`` and ``g_max = 0.004 mS/cm^2``. Both are
+BrainCell defaults, not values from the chapter. ``IM.mod`` also
+assumes Q10 = 2.3 referenced to 36 degC, whereas ``KNI_Ya1989``
+defaults to ``q10 = 1.0`` (no temperature correction).
 
 ---
 
@@ -1299,11 +1659,114 @@ No `.mod` file under `examples/neuron_compare/Cerebellum_mod` carries a
 
 ### Verified record
 
-_TODO (Task 2): not yet verified._
+Confirmed 2026-08-15 against PubMed (PMID 7527077, abstract retrieved
+via NCBI E-utilities) and the American Physiological Society publisher
+record for the DOI.
+
+.. [1] Destexhe, A., Contreras, D., Sejnowski, T. J., & Steriade, M.
+       (1994). A model of spindle rhythmicity in the isolated thalamic
+       reticular nucleus. Journal of Neurophysiology, 72(2), 803-818.
+       doi:10.1152/jn.1994.72.2.803
 
 ### Attribution
 
-_TODO (Task 2): not yet filled in._
+**Symbol:** ``AHP_De1994``
+(``braincell/channel/potassium_calcium.py:58``).
+
+**Attribution check: PASSED.** The abstract states that "The intrinsic
+bursting properties of RE cells in the model were due to the presence
+of a low-threshold Ca2+ current and two Ca(2+)-activated currents" --
+the slow Ca2+-activated K+ (AHP) current is one of those two.
+
+Constants were compared against ``IAHP.mod`` from ModelDB accession
+3670 (the authors' own NEURON implementation of this paper;
+``iahp2.mod`` in accession 3808 is the same file). Its header reads:
+"Ref: Destexhe et al., J. Neurophysiology 72: 803-818, 1994", and it
+implements exactly the scheme ``AHP_De1994`` implements:
+
+    <closed> + n Ca_i <-> <open>     (alpha, beta)
+
+with ``n = 2`` binding sites and ``ik = gkbar * m * m * (v - ek)``,
+i.e. Ca-dependent and *not* voltage dependent. The mod file
+parameterises it as ``beta = 0.03 (1/ms)`` and ``cac = 0.025 (mM)``,
+from which ``alpha = beta / cac^n = 0.03 / 0.025^2 = 48 mM^-2 ms^-1``.
+BrainCell's default ``alpha = 48`` reproduces that derived value
+exactly, and the ``p^2`` gating, the ``n = 2`` exponent, and the pure
+Ca dependence all match.
+
+**Discrepancy found -- flag for the module task.** BrainCell defaults
+to ``beta = 0.09 ms^-1``; the reference implementation and the paper's
+own reported value are ``beta = 0.03 ms^-1`` (a factor of 3). This is
+inherited from BrainPy, whose ``IAHP_De1994v2`` docstring itself states
+"The values n=2, alpha=48 ms^-1 mM^-2 and beta=0.03 ms^-1 yielded AHPs
+very similar to those RE cells recorded in vivo and in vitro" while its
+constructor still defaults ``beta = 0.09``. The docstring must not
+claim that ``beta = 0.09`` is the published value; either state 0.03 as
+the paper's value and 0.09 as the BrainCell default, or raise the
+mismatch as a separate issue.
+
+---
+
+## Corrections to pre-existing in-code citations
+
+Two `References` blocks already existed in the source tree before this
+documentation project began. Task 2 was asked to check them. **This file
+is the only artefact Task 2 touches -- no `.py` file was edited.** The
+findings below are for whichever module task rewrites those docstrings.
+
+1. **`braincell/ion/calcium.py:227-229`** (in `CalciumDetailed`) --
+   "Destexhe, Alain, Agnessa Babloyantz, and Terrence J. Sejnowski.
+   *Ionic mechanisms for intrinsic slow oscillations in thalamic relay
+   neuron.* Biophysical journal 65, no. 4 (1993): 1538-1552."
+
+   *Record check: PASSED with one error.* Confirmed 2026-08-15 against
+   PubMed (PMID 8274647, via NCBI E-utilities); PMCID PMC1225880.
+   Authors, journal, volume, issue, pages and year are all correct. The
+   title is wrong: the published title ends "... in thalamic relay
+   **neurons**" (plural), not "neuron". The entry also carries no DOI.
+   Corrected form:
+
+   ```
+   .. [1] Destexhe, A., Babloyantz, A., & Sejnowski, T. J. (1993). Ionic
+          mechanisms for intrinsic slow oscillations in thalamic relay
+          neurons. Biophysical Journal, 65(4), 1538-1552.
+          doi:10.1016/S0006-3495(93)81190-1
+   ```
+
+   *Attribution check: not performed here.* `CalciumDetailed` is in the
+   `NO_KEY` bucket, which Task 3 owns. The abstract does confirm the
+   paper's model "included Ca2+ diffusion", which is consistent with the
+   Michaelis-Menten Ca pump the class implements, but the pump constants
+   were not compared. Task 3 must finish this.
+
+2. **`braincell/ion/calcium.py:230-233`** (in `CalciumDetailed`) --
+   "Bazhenov, Maxim, Igor Timofeev, Mircea Steriade, and Terrence J.
+   Sejnowski. *Cellular and network models for intrathalamic augmenting
+   responses during 10-Hz stimulation.* Journal of neurophysiology 79,
+   no. 5 (1998): 2730-2748."
+
+   *Record check: PASSED, no errors.* Confirmed 2026-08-15 against
+   PubMed (PMID 9582241, via NCBI E-utilities). Authors, title, journal,
+   volume, issue, pages and year are all correct as written. Only the
+   DOI is missing. Corrected form:
+
+   ```
+   .. [2] Bazhenov, M., Timofeev, I., Steriade, M., & Sejnowski, T. J.
+          (1998). Cellular and network models for intrathalamic
+          augmenting responses during 10-Hz stimulation. Journal of
+          Neurophysiology, 79(5), 2730-2748.
+          doi:10.1152/jn.1998.79.5.2730
+   ```
+
+   *Attribution check: not performed here* (same reason as item 1). Note
+   that this same paper is where Bazhenov et al. (2002) says its INa/IK
+   rate expressions live -- see the `Ba2002` attribution block.
+
+3. **`braincell/channel/hyperpolarization_activated.py:78-80`** (in
+   `HCN_HM1992`) -- same singular/plural title error ("thalamic relay
+   neuron" should be "thalamic relay neurons") and no DOI. Full detail
+   and the corrected entry are in the `HM1992` **Verified record** block
+   above. The class summary line also contains the typo "propsoed".
 
 ---
 
@@ -1358,3 +1821,114 @@ resolve them cleanly:
    an author line at all. Treat the key name as a "ported by" label, not
    an "authored by" label, for the entire cerebellar half of this
    bibliography.
+
+6. **`IS2008` (both symbols: `CaN_IS2008`, `CaL_IS2008`)** -- *record
+   resolves; attribution NOT CONFIRMED. Do not cite yet.*
+
+   **What was established.** The key does resolve to a real paper. The
+   in-code prose is more specific than the Task 1 brief knew: both class
+   summary lines in `braincell/channel/calcium.py` (lines 109 and 352)
+   say "Inoue & Strowbridge 2008", not merely "Strowbridge 2008". A
+   Crossref bibliographic query plus a PubMed author/year search
+   (E-utilities, `Inoue T[Author] AND Strowbridge[Author] AND 2008[DP]`)
+   each return exactly one hit, and they agree on every field:
+
+   ```
+   Inoue, T., & Strowbridge, B. W. (2008). Transient activity induces a
+   long-lasting increase in the excitability of olfactory bulb
+   interneurons. Journal of Neurophysiology, 99(1), 187-199.
+   doi:10.1152/jn.00526.2007
+   ```
+
+   PMID 17959743, PMCID PMC6086124, epub 24 Oct 2007. That record check
+   passes cleanly.
+
+   **Why the attribution still fails.** The paper's Methods could not be
+   read, so it was not possible to confirm that it contains the two
+   currents these symbols implement:
+
+   - The full text is *not* open access. `oa.fcgi` returns
+     `idIsNotOpenAccess` for PMC6086124; the Europe PMC `fullTextXML`
+     endpoint 404s; the PMC PDF endpoint is behind a proof-of-work
+     challenge; and `journals.physiology.org` returns 403.
+   - No ModelDB deposit for this paper was found (ModelDB's API returns
+     nothing for "Strowbridge", and a targeted web search surfaced no
+     accession), so there is no reference `.mod` implementation to
+     compare constants against -- unlike every other key in this task.
+   - The published **abstract** is consistent with, but does not
+     establish, the attribution. It confirms a computational model of
+     olfactory bulb granule cells and says persistent activity "results
+     from interactions between calcium-dependent afterdepolarizations
+     and low-threshold Ca spikes in granule cells". A Ca-dependent ADP
+     is the usual signature of an I_CAN, and "Ca spikes" implies a Ca
+     current, so both classes are *plausible*. Plausible is not
+     confirmed.
+
+   **Positive evidence that these are ports, not original work.** The
+   two BrainCell classes are verbatim ports of BrainPy's
+   `ICaN_IS2008` and `ICaL_IS2008`
+   (`brainpy/dyn/channels/calcium.py`, lines 269 and 757 at HEAD, read
+   2026-08-15). Every constant matches: `p_inf = 1/(1 + exp(-(V+43)
+   /5.2))`, `tau_p = 2.7/(exp(-(V+55)/15) + exp((V+55)/15)) + 1.6`, the
+   `[Ca]/([Ca] + 0.2 mM)` modulation and `E = 10 mV` for the CAN
+   channel; `p_inf = 1/(1 + exp(-(V+10)/4))`, `tau_p = 0.4 + 0.7/
+   (exp(-(V+5)/15) + exp((V+5)/15))`, `q_inf = 1/(1 + exp((V+25)/2))`,
+   `tau_q = 300 + 100/(exp((V+40)/9.5) + exp(-(V+40)/9.5))` and `p^2 q`
+   gating for the L-type channel. BrainPy cites the Inoue & Strowbridge
+   record above. So the citation is *inherited*, and inheriting an
+   unverified citation is exactly what this project exists to stop.
+
+   **Two specific reasons for suspicion, not just missing evidence.**
+
+   - BrainPy's own `ICaN_IS2008` docstring lists *two* references and
+     attributes the CAN dynamics to Destexhe et al. (1994) as `[1]`,
+     with Inoue & Strowbridge only as `[2]`. The
+     `M([Ca]) = [Ca]/([Ca] + 0.2 mM)` modulation term is the standard
+     Destexhe I_CAN form. So `CaN_IS2008` looks like a hybrid: a
+     Destexhe-family CAN framework carrying an Inoue-Strowbridge
+     voltage dependence. A single-source `IS2008` citation would
+     misattribute the framework.
+   - `CaL_IS2008` defaults to `q10_p = 3.55` / `q10_q = 3.0` at 24 degC
+     -- byte-identical to `CaT_HM1992`'s temperature defaults, and 24
+     degC is the Huguenard reference temperature, not an olfactory bulb
+     one. These read as inherited `p^2 q` template defaults rather than
+     values from an Inoue & Strowbridge table.
+
+   **What would close this.** Read the Methods/Appendix of
+   doi:10.1152/jn.00526.2007 (institutional access, or the print issue)
+   and check for the eight constants listed above. Until then, the two
+   docstrings should either omit a `References` section or state the
+   attribution as unverified; they must not print a confident citation.
+
+7. **`CaHT_HM1992`** (`braincell/channel/calcium.py:248`) --
+   *attribution FAILED; the record for the `HM1992` key itself is fine.*
+
+   Huguenard & McCormick (1992) models exactly four currents. Its
+   abstract enumerates them: IT (transient, **low**-voltage-activated
+   Ca2+), IA, IK2 and Ih. There is **no** high-threshold /
+   high-voltage-activated Ca2+ current anywhere in the paper. Six of the
+   seven `HM1992` symbols map onto those four currents (see the
+   `HM1992` attribution block); `CaHT_HM1992` does not.
+
+   Reading the code makes the situation clear: `CaHT_HM1992` is
+   character-for-character the same four gating functions as
+   `CaT_HM1992` (same 59, 6.2, 0.612, 132, 16.7, 16.8, 18.2, 83, 4.0,
+   467, 66.6, 22, 10.5, 28 and the same -80 mV branch point, same
+   `p^2 q`, same `q10_p = 3.55` / `q10_q = 3.0` at 24 degC). The *only*
+   difference is `V_sh`: `+25.0 mV` instead of `-3.0 mV`. It is the
+   low-threshold T current translated 28 mV depolarized and relabelled
+   "high-threshold" -- a derived variant, not a current the cited paper
+   reports.
+
+   This is inherited from BrainPy's `ICaHT_HM1992`, which has the same
+   shape and the same citation.
+
+   **Consequence for the module task.** Do not give `CaHT_HM1992` a bare
+   `.. [1] Huguenard & McCormick (1992)` reference implying the paper
+   describes a high-threshold current. The honest docstring says the
+   gating kinetics are those of the T current of Huguenard & McCormick
+   (1992) (citation as in the `HM1992` Verified record block), applied
+   with a +25 mV shift to produce a high-threshold variant, and that the
+   shift is a BrainCell/BrainPy convention with no source in that paper.
+   If a genuine high-threshold thalamic Ca current is wanted, the
+   provenance of the +25 mV shift needs to be traced separately.

--- a/docs/specs/2026-08-15-ion-channel-docstring-references.md
+++ b/docs/specs/2026-08-15-ion-channel-docstring-references.md
@@ -1008,9 +1008,15 @@ git commit -m "Verify cerebellar model citations and mod-file provenance"
 **Interfaces:**
 - Produces: `braincell._testing.public_symbols(module)`,
   `own_docstring(obj) -> str | None`, `sections(doc) -> dict[str, str]`,
-  `has_citation(doc) -> bool`. Each guard module exposes a `_COVERED_MODULES`
+  `has_citation(doc) -> bool`, and the `DocstringConformanceTests` mixin
+  carrying the four assertions. Each guard module exposes a `_COVERED_MODULES`
   tuple that Tasks 5–17 extend by exactly one entry, and a
   `_NO_PRIMARY_SOURCE` frozenset.
+
+The assertions live in the shared mixin rather than being copied into both
+guard modules. Each package's `*_test.py` stays co-located per AGENTS.md rule 10
+but contains only its coverage tuple, its allowlist, and the class that binds
+them to the mixin.
 
 - [ ] **Step 1: Write the shared helper**
 
@@ -1061,6 +1067,59 @@ def has_citation(doc: str) -> bool:
     """True when ``doc`` has a References section holding a ``.. [n]`` entry."""
     body = sections(doc).get("References")
     return bool(body) and bool(_CITATION.search(body))
+
+
+class DocstringConformanceTests:
+    """Assertions shared by the per-package docstring guards.
+
+    Mix into a :class:`unittest.TestCase` subclass that sets
+    ``covered_modules`` and ``no_primary_source``. This class is deliberately
+    not a ``TestCase`` itself, so it is never collected on its own.
+    """
+
+    covered_modules: tuple[ModuleType, ...] = ()
+    no_primary_source: frozenset[str] = frozenset()
+
+    def _symbols(self):
+        for module in self.covered_modules:
+            for name, obj in public_symbols(module):
+                yield module.__name__, name, obj
+
+    def test_every_public_symbol_defines_its_own_docstring(self):
+        missing = [
+            f"{mod}.{name}"
+            for mod, name, obj in self._symbols()
+            if own_docstring(obj) is None
+        ]
+        self.assertEqual(missing, [], f"undocumented public symbols: {missing}")
+
+    def test_summary_is_a_single_sentence_line(self):
+        bad = []
+        for mod, name, obj in self._symbols():
+            doc = own_docstring(obj)
+            if doc is None:
+                continue
+            summary = doc.splitlines()[0].strip()
+            if not summary.endswith("."):
+                bad.append(f"{mod}.{name}: {summary!r}")
+        self.assertEqual(bad, [], f"summary must be one sentence ending in '.': {bad}")
+
+    def test_every_public_symbol_cites_a_reference(self):
+        uncited = []
+        for mod, name, obj in self._symbols():
+            if name in self.no_primary_source:
+                continue
+            doc = own_docstring(obj)
+            if doc is None or not has_citation(doc):
+                uncited.append(f"{mod}.{name}")
+        self.assertEqual(uncited, [], f"missing References with '.. [n]': {uncited}")
+
+    def test_no_primary_source_allowlist_has_no_dead_entries(self):
+        if not self.covered_modules:
+            self.skipTest("no modules covered yet")
+        live = {name for _, name, _ in self._symbols()}
+        dead = sorted(n for n in self.no_primary_source if n not in live)
+        self.assertEqual(dead, [], f"allowlist names no longer public: {dead}")
 ```
 
 - [ ] **Step 2: Write the channel guard with an empty coverage tuple**
@@ -1072,10 +1131,10 @@ Create `braincell/channel/_docstring_test.py`:
 
 import unittest
 
-from braincell import _testing
+from braincell._testing import DocstringConformanceTests
 
-# Extended by one module per docstring task. A module is listed only once its
-# every public symbol satisfies the assertions below.
+# Extended by one module per docstring task. A module is listed only once
+# every one of its public symbols satisfies the shared assertions.
 _COVERED_MODULES = ()
 
 # Public symbols with no primary literature source. Membership must be a
@@ -1084,49 +1143,9 @@ _COVERED_MODULES = ()
 _NO_PRIMARY_SOURCE = frozenset()
 
 
-class ChannelDocstringTest(unittest.TestCase):
-
-    def _symbols(self):
-        for module in _COVERED_MODULES:
-            for name, obj in _testing.public_symbols(module):
-                yield module.__name__, name, obj
-
-    def test_every_public_symbol_defines_its_own_docstring(self):
-        missing = [
-            f"{mod}.{name}"
-            for mod, name, obj in self._symbols()
-            if _testing.own_docstring(obj) is None
-        ]
-        self.assertEqual(missing, [], f"undocumented public symbols: {missing}")
-
-    def test_summary_is_a_single_sentence_line(self):
-        bad = []
-        for mod, name, obj in self._symbols():
-            doc = _testing.own_docstring(obj)
-            if doc is None:
-                continue
-            summary = doc.splitlines()[0].strip()
-            if not summary.endswith("."):
-                bad.append(f"{mod}.{name}: {summary!r}")
-        self.assertEqual(bad, [], f"summary must be one sentence ending in '.': {bad}")
-
-    def test_every_public_symbol_cites_a_reference(self):
-        uncited = []
-        for mod, name, obj in self._symbols():
-            if name in _NO_PRIMARY_SOURCE:
-                continue
-            doc = _testing.own_docstring(obj)
-            if doc is None or not _testing.has_citation(doc):
-                uncited.append(f"{mod}.{name}")
-        self.assertEqual(uncited, [], f"missing References with '.. [n]': {uncited}")
-
-    def test_no_primary_source_allowlist_has_no_dead_entries(self):
-        live = {name for _, name, _ in self._symbols()}
-        covered_names = {m.__name__ for m in _COVERED_MODULES}
-        if not covered_names:
-            return
-        dead = sorted(n for n in _NO_PRIMARY_SOURCE if n not in live)
-        self.assertEqual(dead, [], f"allowlist names no longer public: {dead}")
+class ChannelDocstringTest(DocstringConformanceTests, unittest.TestCase):
+    covered_modules = _COVERED_MODULES
+    no_primary_source = _NO_PRIMARY_SOURCE
 
 
 if __name__ == "__main__":
@@ -1135,10 +1154,11 @@ if __name__ == "__main__":
 
 - [ ] **Step 3: Write the ion guard**
 
-Create `braincell/ion/_docstring_test.py` with identical content, changing the
-module docstring to name `braincell.ion` and the class to `IonDocstringTest`.
-Both files are deliberately parallel; the shared logic already lives in
-`braincell/_testing.py`.
+Create `braincell/ion/_docstring_test.py` with the same shape: module docstring
+naming `braincell.ion`, its own `_COVERED_MODULES` and `_NO_PRIMARY_SOURCE`, and
+`class IonDocstringTest(DocstringConformanceTests, unittest.TestCase)` binding
+them. Only the coverage data differs between the two files; the assertions are
+inherited from the mixin.
 
 - [ ] **Step 4: Verify both modules collect and pass vacuously**
 
@@ -1146,9 +1166,11 @@ Both files are deliberately parallel; the shared logic already lives in
 pytest braincell/channel/_docstring_test.py braincell/ion/_docstring_test.py -v
 ```
 
-Expected: 8 tests PASS (4 per module). A result of "no tests ran" means the
-filename or class name is wrong — fix before continuing, since a guard that
-collects nothing is the exact failure AGENTS.md rule 10 exists to prevent.
+Expected: 8 tests collected (4 per module) — 6 pass vacuously against the empty
+coverage tuple and 2 skip with "no modules covered yet". A result of "no tests
+ran" means the filename or class name is wrong; fix it before continuing, since
+a guard that collects nothing is the exact failure AGENTS.md rule 10 exists to
+prevent. Also confirm `DocstringConformanceTests` is not itself collected.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/specs/2026-08-15-ion-channel-docstring-references.md
+++ b/docs/specs/2026-08-15-ion-channel-docstring-references.md
@@ -69,6 +69,40 @@ supersede any figure obtained by grepping class names, which over-counts.
 Phase 1 re-derives the exact key-to-class mapping programmatically rather than
 trusting this table.
 
+### The citation key names the model, not always the kinetics
+
+103 of the 122 cited classes were imported from NMODL. Their current docstrings
+say so — `"""Template-based import of ``Kv4p3_MA20_GoC.mod``."""` — and the repo
+ships the 98 source `.mod` files under
+`examples/neuron_compare/Cerebellum_mod/{BC,DCN,GoC,GrC,IO,PC,SC}/`. Eighteen of
+them carry an explicit author attribution in their header, and it frequently is
+not the author the class name implies. `Kv4p3_MA20_GoC.mod`, keyed `MA2020`,
+opens:
+
+```
+TITLE Cerebellum Granule Cell Model
+COMMENT
+        KA channel
+	Author: E.D'Angelo, T.Nieus, A. Fontana
+	Last revised: Egidio 3.12.2003
+ENDCOMMENT
+```
+
+The equations are D'Angelo, Nieus & Fontana's; Masoli et al. (2020) reused them
+in the Golgi cell assembly that BrainCell imported from. Both facts are true and
+a reader needs both.
+
+This is systematic across the cerebellar imports rather than a handful of
+mistakes, so it is handled structurally by the two-level reference format in
+decision 7, not by 103 individual discrepancy notes under the mismatch policy.
+The mismatch policy still governs genuine one-off errors.
+
+`examples/neuron_compare/Cerebellum_mod/README.md` additionally pins each suffix
+to a cell type — BC basket, DCN deep cerebellar nuclei, GoC Golgi, GrC granule,
+IO inferior olive, PC Purkinje, SC stellate — and records per-mechanism import
+deviations (`TABLE` removal, `derivimplicit`→`cnexp`, NMODL default-precision
+rewrites). Those deviations belong in `Notes`.
+
 ## Scope
 
 **In scope.** Every name in the `__all__` of each source module in
@@ -106,6 +140,11 @@ them:
    and the design doc logs it as an open question. Nothing is renamed.
 6. **Enforcement**: ship a references-presence guard test, not a
    Parameters-versus-signature guard, to avoid brittleness when signatures change.
+7. **Two-level references for imported mechanisms**: where a class was imported
+   from an NMODL file whose kinetics predate the model named in the class name,
+   `References` carries both entries — `.. [1]` the origin of the equations,
+   `.. [2]` the model BrainCell imported from — and `Notes` names the source
+   `.mod` file. Where the two coincide, a single entry is used.
 
 ## Phase 1 — Verified bibliography
 
@@ -119,6 +158,14 @@ per `AGENTS.md` rule 8.
   text is copied rather than retyped;
 - the list of classes citing the key, generated from the AST;
 - an attribution note recording what was checked and how confident the result is.
+
+**Step 0 — harvest in-repo provenance first.** Before any web search, read the
+`TITLE`/`COMMENT` header of all 98 `.mod` files under
+`examples/neuron_compare/Cerebellum_mod/*/{channel,ion}/` and record every author,
+title, and revision date found. This is free, authoritative for what BrainCell
+actually imported, and is what surfaces cases like `Kv4p3_MA20_GoC`. Web
+verification then confirms and completes what the headers assert, rather than
+starting from a guess.
 
 **Verification protocol.** A key is verified only when both of the following hold:
 
@@ -305,6 +352,13 @@ one. The test uses a ~20-line section splitter over `inspect.getdoc` output.
 
 **Deliverable**: one commit adding both test modules.
 
+**Ordering refinement.** The implementation plan below lands the guard *before*
+the module docstring tasks rather than after, scoped by a `_COVERED_MODULES`
+tuple that each module task extends by one entry. This keeps the TDD cycle
+(extend tuple → test fails → write docstrings → test passes → commit) without
+ever leaving the guard red across the whole package, which was the objection to
+building the guard first.
+
 ## Edge cases
 
 - **`Cav3p1Test_PC24`** (`channel/calcium.py`) uses the suffix `PC24`, a
@@ -366,3 +420,917 @@ Logged for later decision; none blocks implementation.
   the code's constants rather than matching on author and year alone.
 - **Scale.** 155 symbols is a large diff. Mitigated by per-module commits and by
   the fact that the change cannot alter behavior.
+
+---
+
+# Implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> `superpowers:subagent-driven-development` (recommended) or
+> `superpowers:executing-plans` to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give all 155 public symbols in `braincell/ion/` and `braincell/channel/`
+complete NumPy-doc docstrings with web-verified references, guarded by a
+conformance test.
+
+**Architecture:** Three stages. A verified bibliography is built first from
+in-repo `.mod` provenance plus literature verification, and written to
+`docs/design/ion-channel-bibliography.md`. A conformance guard then lands with an
+empty coverage tuple. Thirteen module tasks each add one module to that tuple,
+watch the guard fail, write the docstrings, and watch it pass.
+
+**Tech Stack:** Python 3, pytest + `unittest.TestCase`, `brainstate`,
+`brainunit`, `braintools`. Sphinx with `numpydoc`-style parsing for rendering.
+No new runtime or test dependency is added.
+
+## Global constraints
+
+- Documentation only. No renames, no signature changes, no behavior changes. The
+  existing suite must pass unchanged at every commit.
+- All work on branch `worktree-ion-channel-docstrings`. Never commit to `main`.
+- Test modules use the `*_test.py` suffix, co-located with the code under test.
+  Never `test_*.py`, never a `tests/` directory.
+- Shared test-only helpers live in a leading-underscore module so pytest does not
+  collect them.
+- Physical quantities always carry explicit `brainunit` units. Docstrings state
+  defaults in the unit a user would write, so `u.celsius2kelvin(36.0)` is
+  documented as "36 degrees Celsius", not as a kelvin number.
+- Docstrings are raw strings (`r"""`) wherever `Notes` carries LaTeX.
+- Sections follow the AGENTS.md canonical order. `Examples` is omitted throughout.
+- No new dependency. `numpydoc` is not installed and must not be added.
+- Maintain JAX >= 0.8.0 compatibility (no JAX API is touched by this change).
+
+## File structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `docs/design/ion-channel-bibliography.md` | create | Canonical verified bibliography; every docstring citation is copied from here |
+| `braincell/_testing.py` | create | Test-only NumPy-doc section splitter shared by both guard modules |
+| `braincell/channel/_docstring_test.py` | create | Conformance guard for `braincell.channel` |
+| `braincell/ion/_docstring_test.py` | create | Conformance guard for `braincell.ion` |
+| `braincell/channel/*.py` (8 files) | modify | Docstrings only |
+| `braincell/ion/*.py` (5 files) | modify | Docstrings only |
+
+## Docstring templates
+
+Seven structural cases cover all 155 symbols. Each module task names which
+template applies to which symbol. **The citation text in these templates shows
+format only — the actual entry text is copied verbatim from
+`docs/design/ion-channel-bibliography.md` produced by Tasks 1–3.**
+
+### T1 — Literature channel, `OhmicHH` or `HH`, single source
+
+Applies where the class name's key is also the origin of the equations
+(`KA1_HM1992`, `K_HH1952`, `Na_Ba2002`, `KNI_Ya1989`, …).
+
+```python
+@register_channel("KA1_HM1992")
+class KA1_HM1992(OhmicHH):
+    r"""Huguenard & McCormick (1992) fast transient A-type K+ current (IA1).
+
+    Rapidly activating and inactivating outward potassium current of thalamic
+    relay neurons, responsible for delaying the onset of firing after a
+    hyperpolarizing step. This is the faster of the two A-type components in
+    the Huguenard & McCormick thalamocortical relay cell model; see
+    :class:`KA2_HM1992` for the slower component. Gating follows the
+    Hodgkin-Huxley form :math:`g = \bar{g} p^4 q`.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Population and compartment shape of the channel.
+    g_max : brainstate.typing.ArrayLike or Callable
+        Maximal conductance density. Defaults to ``30 mS/cm^2``.
+    temp : brainstate.typing.ArrayLike
+        Absolute simulation temperature. Defaults to 36 degrees Celsius.
+    q10_p : brainstate.typing.ArrayLike or Callable
+        Temperature coefficient of the activation gate. Defaults to ``1.0``.
+    temp_ref_p : brainstate.typing.ArrayLike
+        Reference temperature at which the ``p`` rates were measured.
+        Defaults to 36 degrees Celsius.
+    q10_q : brainstate.typing.ArrayLike or Callable
+        Temperature coefficient of the inactivation gate. Defaults to ``1.0``.
+    temp_ref_q : brainstate.typing.ArrayLike
+        Reference temperature at which the ``q`` rates were measured.
+        Defaults to 36 degrees Celsius.
+    V_sh : brainstate.typing.ArrayLike or Callable
+        Voltage shift applied to every rate expression. Defaults to ``0 mV``.
+    name : str, optional
+        Instance name.
+
+    See Also
+    --------
+    KA2_HM1992 : Slower A-type component of the same model.
+
+    Notes
+    -----
+    Writing :math:`v = (V - V_{sh})/\mathrm{mV}`, activation is
+
+    .. math::
+        p_\infty(v) = \frac{1}{1 + \exp(-(v + 60)/8.5)}
+
+    .. math::
+        \tau_p(v) = \frac{1}{\exp((v + 35.8)/19.7)
+                   + \exp(-(v + 79.7)/12.7)} + 0.37
+
+    and inactivation is
+
+    .. math::
+        q_\infty(v) = \frac{1}{1 + \exp((v + 78)/6)}
+
+    .. math::
+        \tau_q(v) = \begin{cases}
+            \left[\exp((v + 46)/5)
+                + \exp(-(v + 238)/37.5)\right]^{-1} & v < -63 \\
+            19 & v \ge -63
+        \end{cases}
+
+    All time constants are in milliseconds. Each gate is scaled independently
+    by :math:`q_{10}^{(T - T_{ref})/10}`, so ``q10_p``/``temp_ref_p`` and
+    ``q10_q``/``temp_ref_q`` act only on their own gate. The class binds to
+    :class:`braincell.ion.Potassium` through ``root_type``.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of the
+           currents involved in rhythmic oscillations in thalamic relay
+           neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    """
+```
+
+### T2 — NMODL import with two-level provenance
+
+Applies wherever the bibliography records that the `.mod` kinetics predate the
+model named in the class name.
+
+```python
+@register_channel("Kv4p3_MA2020_GoC")
+class Kv4p3_MA2020_GoC(OhmicHH):
+    r"""A-type (Kv4.3) potassium current of the Masoli et al. (2020) Golgi cell.
+
+    Fast transient outward potassium current, gated as
+    :math:`g = \bar{g} a^3 b` with independent activation ``a`` and
+    inactivation ``b``. The kinetics originate in the D'Angelo et al.
+    cerebellar granule cell model and were reused unchanged in the Masoli
+    et al. (2020) Golgi cell, which is the assembly BrainCell imported.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Population and compartment shape of the channel.
+    g_max : brainstate.typing.ArrayLike or Callable
+        Maximal conductance density. Defaults to ``3.2 mS/cm^2``.
+    temp : brainstate.typing.ArrayLike
+        Absolute simulation temperature. Defaults to 23 degrees Celsius.
+    V_sh : brainstate.typing.ArrayLike or Callable
+        Voltage shift applied to every rate expression. Defaults to ``0 mV``.
+    name : str, optional
+        Instance name.
+
+    Notes
+    -----
+    Imported from ``Kv4p3_MA20_GoC.mod`` under
+    ``examples/neuron_compare/Cerebellum_mod/GoC/channel/``. Two deviations
+    from that source are deliberate and documented in
+    ``examples/neuron_compare/Cerebellum_mod/README.md``: the NMODL ``TABLE``
+    over ``[-100, 30] mV`` is not reproduced, so rates are evaluated from the
+    continuous formulas at every step and no longer clamp outside that range;
+    and the gate ODEs are integrated as ``cnexp`` rather than
+    ``derivimplicit``, which is exact here because the two gates are
+    independent.
+
+    References
+    ----------
+    .. [1] D'Angelo, E., Nieus, T., Fontana, A., et al. (2001). Theta-frequency
+           bursting and resonance in cerebellar granule cells. Journal of
+           Neuroscience, 21(3), 759-770.
+           doi:10.1523/JNEUROSCI.21-03-00759.2001
+    .. [2] Masoli, S., Tognolina, M., Narang, U., et al. (2020). Single neuron
+           optimization as a basis for accurate biophysical modeling.
+           Frontiers in Cellular Neuroscience, 14, 517.
+           doi:10.3389/fncel.2020.00517
+    """
+```
+
+### T3 — Parameter-variant subclass
+
+Applies to the 30-odd classes whose body is only `__module__` plus overrides
+(`Cav1p2_MA2025_BC`, `Nav1p6_MA2024_PC`, `Kca3p1_MA2024_PC`, the `*_Frozen`
+variants, …). These must define their own docstring — an inherited one fails the
+guard and would cite the wrong cell type.
+
+```python
+@register_channel("Cav1p2_MA2025_BC")
+class Cav1p2_MA2025_BC(Cav1p2_MA2020_GoC):
+    r"""Cav1.2 L-type calcium current of the Masoli et al. (2025) basket cell.
+
+    Parameter variant of :class:`Cav1p2_MA2020_GoC`: the gating structure and
+    rate expressions are identical, and only the basket-cell parameter values
+    differ. See the base class for the full kinetics.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Population and compartment shape of the channel.
+    g_max : brainstate.typing.ArrayLike or Callable
+        Maximal conductance density. Defaults to the basket-cell value.
+    V_sh : brainstate.typing.ArrayLike or Callable
+        Voltage shift applied to every rate expression. Defaults to ``0 mV``.
+    temp : brainstate.typing.ArrayLike
+        Absolute simulation temperature. Defaults to 22 degrees Celsius.
+    q10 : brainstate.typing.ArrayLike or Callable
+        Temperature coefficient shared by all gates. Defaults to ``1.0``.
+    temp_ref : brainstate.typing.ArrayLike
+        Reference temperature for ``q10``. Defaults to 22 degrees Celsius.
+    name : str, optional
+        Instance name.
+
+    See Also
+    --------
+    Cav1p2_MA2020_GoC : Golgi cell variant this class derives from.
+
+    Notes
+    -----
+    Imported from ``Cav1p2_MA25_BC.mod`` under
+    ``examples/neuron_compare/Cerebellum_mod/BC/channel/``. Rate refresh was
+    moved from the NMODL ``BREAKPOINT`` into the derivative evaluation so that
+    ``inf``/``tau`` are current before each ``cnexp`` state update.
+
+    References
+    ----------
+    .. [1] <origin-of-kinetics entry from the bibliography>
+    .. [2] <Masoli et al. (2025) basket cell entry from the bibliography>
+    """
+```
+
+### T4 — `Markov` channel
+
+Applies to `Nav1p6_MA2020_GoC`, `Nav1p1_MA2025_BC`, `Nav_MA2020_GrC`,
+`NaFHF_MA2020_GrC`, `Kca2p2_MA2020_GoC`, `Kca1p1_MA2020_GoC`. `Notes` documents
+the state graph and the `dependent_state`, not per-gate equations.
+
+```python
+@register_channel("Nav1p6_MA2020_GoC")
+class Nav1p6_MA2020_GoC(Markov):
+    r"""Nav1.6 sodium current of the Masoli et al. (2020) Golgi cell.
+
+    Thirteen-state Markov sodium channel with five closed states, six
+    inactivated states, one open state, and one blocked state. Current flows
+    only through the open state ``O``.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Population and compartment shape of the channel.
+    temp : brainstate.typing.ArrayLike
+        Absolute simulation temperature. Defaults to 22 degrees Celsius.
+    g_max : brainstate.typing.ArrayLike or Callable
+        Maximal conductance density. Defaults to ``16 mS/cm^2``.
+    name : str, optional
+        Instance name.
+    solver : str, optional
+        Solver used when this channel is integrated independently.
+    substeps : int, optional
+        Number of substeps run inside one parent update.
+
+    Notes
+    -----
+    The transition graph is declared in ``pairs`` as 17 reversible edges over
+    the states ``C1``-``C5``, ``I1``-``I6``, ``O``, and ``B``. ``I6`` is the
+    ``dependent_state``: its occupancy is recovered from the conservation
+    relation rather than integrated, so only twelve states carry ODEs.
+
+    Forward and backward rates are exponential in voltage,
+    :math:`f(V) = A \exp(V/x)\,\phi`, with the temperature factor
+    :math:`\phi = 3^{(T - 22^\circ\mathrm{C})/10}`. Allosteric coupling uses
+    :math:`\mathrm{alfac} = (O_{on}/C_{on})^{1/4}` and
+    :math:`\mathrm{btfac} = (O_{off}/C_{off})^{1/4}`. The current is
+    :math:`I = \bar{g}\,[O]\,(E_{Na} - V)`.
+
+    References
+    ----------
+    .. [1] <origin-of-kinetics entry from the bibliography>
+    .. [2] <Masoli et al. (2020) entry from the bibliography>
+    """
+```
+
+### T5 — `KineticIon` calcium pool
+
+Applies to the 14 keyed classes in `ion/calcium.py` (`CdpStC_MA2020_GoC`,
+`CdpCAM_MA2024_PC`, the `Toy*_SU2015_DCN` family, …). `Notes` documents the
+species table, factors, and conservation, and preserves the existing
+unit-conversion comments.
+
+```python
+@register_ion("CdpStC_MA2020_GoC")
+class CdpStC_MA2020_GoC(Calcium, KineticIon):
+    r"""Calcium pool with pump, buffers, and calmodulin of the Masoli (2020) Golgi cell.
+
+    Reaction-network calcium dynamics combining a plasma-membrane pump, two
+    generic buffers, the BTC and DMNPE indicator dyes, parvalbumin, and the
+    full calmodulin binding cascade. ``Ci`` is the cytosolic free calcium
+    concentration and is what the ion protocol exposes to channels.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Population and compartment shape of the ion container.
+    temp : brainstate.typing.ArrayLike
+        Absolute temperature used by the Nernst equation.
+    Co : brainstate.typing.ArrayLike, optional
+        Extracellular calcium concentration override.
+    valence : brainstate.typing.ArrayLike, optional
+        Ionic valence override. Defaults to ``2``.
+    solver : str, optional
+        Solver used when this ion is integrated independently.
+    substeps : int, optional
+        Number of substeps run inside one parent update.
+    name : str, optional
+        Instance name.
+
+    Notes
+    -----
+    ``Ci`` corresponds to the NMODL calcium pool ``ca``/``cai``. The reversible
+    kinetic scheme is preserved as 20 explicit reactions, plus the original
+    current-driven source and the single pump conservation relation, so
+    ``uses_total_current`` is ``True``.
+
+    Three factors mediate the visible-to-amount mapping: ``cyto`` for cytosolic
+    species, ``pump_area`` for the surface pump, and ``cam_unit`` for the
+    calmodulin states. The source NMODL uses ``COMPARTMENT (1e10)*parea``
+    because ``pump`` and ``pumpca`` are stored visibly in ``mol/cm2`` and
+    NEURON needs an explicit area conversion; BrainCell factors already provide
+    that mapping, so the extra ``1e10`` is intentionally not carried over.
+
+    Imported from ``CdpStC_MA20_GoC.mod`` under
+    ``examples/neuron_compare/Cerebellum_mod/GoC/ion/``.
+
+    References
+    ----------
+    .. [1] <origin-of-kinetics entry from the bibliography>
+    .. [2] <Masoli et al. (2020) entry from the bibliography>
+    """
+```
+
+### T6 — Ion container
+
+Applies to `Calcium`, `CalciumFixed`, `CalciumInitNernst`, `CalciumFirstOrder`,
+`Potassium`, `PotassiumFixed`, `PotassiumInitNernst`, `Sodium`, `SodiumFixed`,
+`SodiumInitNernst`, `NonSpecific`, `NonSpecificFixed`. These carry no primary
+literature source and go in the guard's `_NO_PRIMARY_SOURCE` allowlist —
+`CalciumDetailed` is the exception and cites Destexhe.
+
+```python
+class PotassiumFixed(Potassium):
+    r"""Potassium container with a fixed reversal potential.
+
+    Holds a constant intracellular concentration and a constant reversal
+    potential, so no potassium dynamics are integrated. Use it when channels
+    need a potassium reversal potential but the concentration is not itself a
+    state variable.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Population and compartment shape of the ion container.
+    E : brainstate.typing.ArrayLike or Callable
+        Reversal potential. Defaults to ``-95 mV``.
+    C : brainstate.typing.ArrayLike or Callable
+        Intracellular concentration. Defaults to ``0.0407 mM``.
+    name : str, optional
+        Instance name.
+
+    See Also
+    --------
+    Potassium : Abstract potassium interface.
+    PotassiumInitNernst : Variant whose reversal potential is initialized from
+        the Nernst equation.
+    """
+```
+
+### T7 — Template base, dataclass, or function
+
+Applies to `Gate`, `Transition`, `HH`, `OhmicHH`, `Markov`, `ghk_flux`,
+`Factor`, `Species`, `Reaction`, `Source`, `Conserve`, `FixedIon`,
+`InitNernstIon`, `DynamicNernstIon`, `KineticIon`. **All fifteen already have
+substantive docstrings.** The work is to bring them to canonical section order
+and add references to the three that have one:
+
+- `ghk_flux` — Goldman (1943) and Hodgkin & Katz (1949).
+- `KineticIon` — Hines & Carnevale's NEURON/NMODL `KINETIC` semantics, which its
+  existing `Notes` already invokes by name.
+- `CalciumDetailed` (in `ion/calcium.py`, not a template base) — Destexhe et al.
+
+The remaining twelve go in `_NO_PRIMARY_SOURCE`. Do not rewrite their existing
+prose where it is already correct; `Gate`'s parameter documentation and
+`OhmicHH`'s 40-line docstring are good and only need section-order checks.
+
+---
+
+## Task 1: Provenance harvest and bibliography skeleton
+
+**Files:**
+- Create: `docs/design/ion-channel-bibliography.md`
+
+**Interfaces:**
+- Produces: `docs/design/ion-channel-bibliography.md` with a complete key→symbol
+  inventory and one empty section per citation key. Tasks 2 and 3 fill the
+  sections; Tasks 5–17 copy citation text out of them.
+
+- [ ] **Step 1: Generate the authoritative key→symbol inventory**
+
+Run from the worktree root:
+
+```bash
+python -c "
+import ast, glob, re, collections
+KEY = re.compile(r'(?:[A-Za-z]{2}(?:19|20)\d{2}|[A-Z]{2}\d{2}\b)')
+rows = collections.defaultdict(list)
+for f in sorted(glob.glob('braincell/channel/*.py') + glob.glob('braincell/ion/*.py')):
+    if f.endswith('_test.py') or f.endswith('__init__.py'):
+        continue
+    tree = ast.parse(open(f).read())
+    names = []
+    for n in tree.body:
+        if isinstance(n, ast.Assign) and getattr(n.targets[0], 'id', '') == '__all__':
+            names = [e.value for e in n.value.elts]
+    for n in tree.body:
+        if isinstance(n, (ast.ClassDef, ast.FunctionDef)) and n.name in names:
+            k = KEY.findall(n.name)
+            rows[k[-1] if k else 'NO_KEY'].append(f'{f}::{n.name}')
+for k in sorted(rows, key=lambda k: -len(rows[k])):
+    print(f'## {k}  ({len(rows[k])} symbols)')
+    for r in rows[k]:
+        print(f'   - {r}')
+"
+```
+
+Expected: 16 key buckets plus `NO_KEY`, totalling 155 symbols.
+
+- [ ] **Step 2: Harvest every `.mod` header**
+
+```bash
+for f in $(find examples/neuron_compare/Cerebellum_mod -name '*.mod' \( -path '*channel*' -o -path '*ion*' \) | sort); do
+  echo "=== $f"
+  sed -n '1,25p' "$f" | grep -iE 'TITLE|COMMENT|Author|Ref|revis|[0-9]{4}' || true
+done
+```
+
+Expected: 98 files listed; roughly 18 carry an explicit `Author:` line.
+
+- [ ] **Step 3: Write the skeleton**
+
+Create `docs/design/ion-channel-bibliography.md` with `# Ion and channel
+bibliography` as its H1, a short preamble stating that docstring `References`
+entries are copied verbatim from this file, then one `## <KEY>` section per
+bucket containing: the symbol list from Step 1, a `### Provenance evidence`
+block with the raw `.mod` header text from Step 2, and empty `### Verified
+record` and `### Attribution` blocks for Tasks 2–3. Add an
+`## Unresolved attributions` section at the end.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/design/ion-channel-bibliography.md
+git commit -m "Add ion/channel bibliography skeleton with mod-file provenance"
+```
+
+---
+
+## Task 2: Verify the classical and thalamic citations
+
+**Files:**
+- Modify: `docs/design/ion-channel-bibliography.md`
+
+**Interfaces:**
+- Consumes: the skeleton from Task 1.
+- Produces: filled `### Verified record` and `### Attribution` blocks for
+  `HH1952`, `TM1991`, `Ba2002`, `HM1992`, `Ya1989`, `Re1993`, `HP1992`,
+  `De1994`, `IS2008` — 19 symbols.
+
+- [ ] **Step 1: Verify each key against the literature**
+
+For each of the nine keys, establish authors, title, journal, volume, issue,
+pages, year, and DOI, then confirm the paper actually contains the current
+implemented by its symbols. Symbols per key are in the Task 1 inventory. Starting
+hypotheses, all of which must be confirmed or corrected, not assumed:
+
+| Key | Hypothesis | Symbols |
+|---|---|---|
+| `HH1952` | Hodgkin & Huxley (1952), J Physiol | `K_HH1952`, `Na_HH1952` |
+| `TM1991` | Traub & Miles (1991), *Neuronal Networks of the Hippocampus* | `K_TM1991`, `Na_TM1991` |
+| `Ba2002` | Bazhenov et al. (2002), J Neurosci | `KDR_Ba2002`, `Na_Ba2002` |
+| `HM1992` | Huguenard & McCormick (1992), J Neurophysiol | 7 symbols across 3 modules |
+| `Ya1989` | Yamada, Koch & Adams (1989), book chapter | `KNI_Ya1989` |
+| `Re1993` | Reuveni et al. (1993), J Neurosci | `CaHT_Re1993` |
+| `HP1992` | Huguenard & Prince (1992), J Neurosci | `CaT_HP1992` |
+| `De1994` | Destexhe et al. (1994) | `AHP_De1994` |
+| `IS2008` | unknown; only in-repo evidence is the prose "Strowbridge 2008" | `CaN_IS2008`, `CaL_IS2008` |
+
+`HM1992` is already cited in `channel/hyperpolarization_activated.py:78-80` and
+`De1994`-adjacent entries in `ion/calcium.py:227-233`; check those existing
+strings and correct them if verification disagrees.
+
+- [ ] **Step 2: Record failures honestly**
+
+Any key that cannot be confirmed goes in `## Unresolved attributions` with the
+evidence gathered. `IS2008` is the most likely candidate. Do not invent a
+citation to fill the gap.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/design/ion-channel-bibliography.md
+git commit -m "Verify classical and thalamic channel citations"
+```
+
+---
+
+## Task 3: Verify the cerebellar model citations
+
+**Files:**
+- Modify: `docs/design/ion-channel-bibliography.md`
+
+**Interfaces:**
+- Consumes: Task 1 skeleton, Task 2 conventions for entry formatting.
+- Produces: filled records for `MA2020`, `MA2024`, `MA2025`, `RI2021`, `SU2015`,
+  `ZH2019`, `PC24` — 103 symbols, plus origin-of-kinetics entries for every
+  `.mod` whose header names a different author.
+
+- [ ] **Step 1: Verify the seven model papers**
+
+Cell-type mapping is fixed by `examples/neuron_compare/Cerebellum_mod/README.md`:
+
+| Key | Cell type | Hypothesis to confirm |
+|---|---|---|
+| `MA2020` | Golgi (GoC) and granule (GrC) | Masoli et al. (2020) |
+| `MA2024` | Purkinje (PC) | Masoli et al. (2024) |
+| `MA2025` | basket (BC) | Masoli et al. (2025) |
+| `RI2021` | stellate (SC) | Rizza et al. (2021) |
+| `SU2015` | deep cerebellar nuclei (DCN) | Sudhakar et al. (2015) |
+| `ZH2019` | inferior olive (IO) | Zang et al. (2019) |
+| `PC24` | Purkinje, one symbol | same as `MA2024` |
+
+- [ ] **Step 2: Resolve every origin-of-kinetics reference**
+
+For each `.mod` header from Task 1 Step 2 that names an author other than the
+model authors, verify that origin paper too and add it as its own bibliography
+entry. `Kv4p3_MA20_GoC.mod` (Author: E. D'Angelo, T. Nieus, A. Fontana) is the
+known case; find the rest. Record, per symbol, whether it needs one citation or
+the two-level pair from template T2.
+
+- [ ] **Step 3: Record the import deviations**
+
+Copy the per-mechanism deviations from
+`examples/neuron_compare/Cerebellum_mod/README.md` — `TABLE` removal and its
+former clamp range, `derivimplicit`→`cnexp` substitutions, rate-refresh
+relocation, NMODL default-precision rewrites — into each key's section, so
+module tasks can put them in `Notes` without re-reading that file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/design/ion-channel-bibliography.md
+git commit -m "Verify cerebellar model citations and mod-file provenance"
+```
+
+---
+
+## Task 4: Conformance guard
+
+**Files:**
+- Create: `braincell/_testing.py`
+- Create: `braincell/channel/_docstring_test.py`
+- Create: `braincell/ion/_docstring_test.py`
+
+**Interfaces:**
+- Produces: `braincell._testing.public_symbols(module)`,
+  `own_docstring(obj) -> str | None`, `sections(doc) -> dict[str, str]`,
+  `has_citation(doc) -> bool`. Each guard module exposes a `_COVERED_MODULES`
+  tuple that Tasks 5–17 extend by exactly one entry, and a
+  `_NO_PRIMARY_SOURCE` frozenset.
+
+- [ ] **Step 1: Write the shared helper**
+
+Create `braincell/_testing.py`:
+
+```python
+"""Test-only helpers for the docstring conformance guards.
+
+Not a test module: the leading underscore keeps pytest from collecting it.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+from types import ModuleType
+from typing import Iterator
+
+_SECTION = re.compile(r"^(?P<title>[A-Z][A-Za-z ]{2,})\n(?P<rule>-{3,})[ \t]*$", re.MULTILINE)
+_CITATION = re.compile(r"^\s*\.\.\s+\[\d+\]\s+\S", re.MULTILINE)
+
+
+def public_symbols(module: ModuleType) -> Iterator[tuple[str, object]]:
+    """Yield ``(name, obj)`` for every entry in ``module.__all__``."""
+    for name in getattr(module, "__all__", ()):
+        yield name, getattr(module, name)
+
+
+def own_docstring(obj) -> str | None:
+    """Return the docstring defined on ``obj`` itself, never an inherited one."""
+    doc = obj.__dict__.get("__doc__") if inspect.isclass(obj) else getattr(obj, "__doc__", None)
+    if isinstance(doc, str) and doc.strip():
+        return inspect.cleandoc(doc)
+    return None
+
+
+def sections(doc: str) -> dict[str, str]:
+    """Split a NumPy-doc docstring into ``{section title: section body}``."""
+    found = {}
+    matches = list(_SECTION.finditer(doc))
+    for i, match in enumerate(matches):
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(doc)
+        found[match.group("title").rstrip()] = doc[match.end():end]
+    return found
+
+
+def has_citation(doc: str) -> bool:
+    """True when ``doc`` has a References section holding a ``.. [n]`` entry."""
+    body = sections(doc).get("References")
+    return bool(body) and bool(_CITATION.search(body))
+```
+
+- [ ] **Step 2: Write the channel guard with an empty coverage tuple**
+
+Create `braincell/channel/_docstring_test.py`:
+
+```python
+"""Docstring conformance guard for :mod:`braincell.channel`."""
+
+import unittest
+
+from braincell import _testing
+
+# Extended by one module per docstring task. A module is listed only once its
+# every public symbol satisfies the assertions below.
+_COVERED_MODULES = ()
+
+# Public symbols with no primary literature source. Membership must be a
+# deliberate decision: a new channel that lands undocumented fails instead of
+# silently inheriting an exemption.
+_NO_PRIMARY_SOURCE = frozenset()
+
+
+class ChannelDocstringTest(unittest.TestCase):
+
+    def _symbols(self):
+        for module in _COVERED_MODULES:
+            for name, obj in _testing.public_symbols(module):
+                yield module.__name__, name, obj
+
+    def test_every_public_symbol_defines_its_own_docstring(self):
+        missing = [
+            f"{mod}.{name}"
+            for mod, name, obj in self._symbols()
+            if _testing.own_docstring(obj) is None
+        ]
+        self.assertEqual(missing, [], f"undocumented public symbols: {missing}")
+
+    def test_summary_is_a_single_sentence_line(self):
+        bad = []
+        for mod, name, obj in self._symbols():
+            doc = _testing.own_docstring(obj)
+            if doc is None:
+                continue
+            summary = doc.splitlines()[0].strip()
+            if not summary.endswith("."):
+                bad.append(f"{mod}.{name}: {summary!r}")
+        self.assertEqual(bad, [], f"summary must be one sentence ending in '.': {bad}")
+
+    def test_every_public_symbol_cites_a_reference(self):
+        uncited = []
+        for mod, name, obj in self._symbols():
+            if name in _NO_PRIMARY_SOURCE:
+                continue
+            doc = _testing.own_docstring(obj)
+            if doc is None or not _testing.has_citation(doc):
+                uncited.append(f"{mod}.{name}")
+        self.assertEqual(uncited, [], f"missing References with '.. [n]': {uncited}")
+
+    def test_no_primary_source_allowlist_has_no_dead_entries(self):
+        live = {name for _, name, _ in self._symbols()}
+        covered_names = {m.__name__ for m in _COVERED_MODULES}
+        if not covered_names:
+            return
+        dead = sorted(n for n in _NO_PRIMARY_SOURCE if n not in live)
+        self.assertEqual(dead, [], f"allowlist names no longer public: {dead}")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 3: Write the ion guard**
+
+Create `braincell/ion/_docstring_test.py` with identical content, changing the
+module docstring to name `braincell.ion` and the class to `IonDocstringTest`.
+Both files are deliberately parallel; the shared logic already lives in
+`braincell/_testing.py`.
+
+- [ ] **Step 4: Verify both modules collect and pass vacuously**
+
+```bash
+pytest braincell/channel/_docstring_test.py braincell/ion/_docstring_test.py -v
+```
+
+Expected: 8 tests PASS (4 per module). A result of "no tests ran" means the
+filename or class name is wrong — fix before continuing, since a guard that
+collects nothing is the exact failure AGENTS.md rule 10 exists to prevent.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add braincell/_testing.py braincell/channel/_docstring_test.py braincell/ion/_docstring_test.py
+git commit -m "Add docstring conformance guards with empty coverage"
+```
+
+---
+
+## Tasks 5-17: Module docstrings
+
+Thirteen tasks, one per module, in this order. Each follows the identical
+five-step cycle below.
+
+| Task | Module | Symbols | Templates | Allowlist additions |
+|---|---|---|---|---|
+| 5 | `channel/potassium_sodium.py` | 1 | T3 | — |
+| 6 | `channel/leaky.py` | 2 | T7 | `LeakageChannel`, `IL` |
+| 7 | `ion/nonspecific.py` | 2 | T6 | `NonSpecific`, `NonSpecificFixed` |
+| 8 | `ion/potassium.py` | 3 | T6 | `Potassium`, `PotassiumFixed`, `PotassiumInitNernst` |
+| 9 | `ion/sodium.py` | 3 | T6 | `Sodium`, `SodiumFixed`, `SodiumInitNernst` |
+| 10 | `channel/_base.py` | 6 | T7 | `Gate`, `Transition`, `HH`, `OhmicHH`, `Markov` (not `ghk_flux`) |
+| 11 | `channel/hyperpolarization_activated.py` | 8 | T1, T2, T3 | — |
+| 12 | `ion/_base.py` | 9 | T7 | all but `KineticIon` |
+| 13 | `channel/sodium.py` | 14 | T1, T2, T3, T4 | — |
+| 14 | `channel/potassium_calcium.py` | 15 | T2, T3, T4 | — |
+| 15 | `ion/calcium.py` | 19 | T5, T6 | `Calcium`, `CalciumFixed`, `CalciumInitNernst`, `CalciumFirstOrder` (not `CalciumDetailed`) |
+| 16 | `channel/calcium.py` | 35 | T1, T2, T3 | — |
+| 17 | `channel/potassium.py` | 38 | T1, T2, T3 | `K_Leak`, `K_Kv_test` |
+
+**The five-step cycle, run once per task.** Substitute the module and the
+guard file for that package (`braincell/channel/_docstring_test.py` for channel
+modules, `braincell/ion/_docstring_test.py` for ion modules).
+
+- [ ] **Step 1: Extend coverage and the allowlist**
+
+Add the module to the import list and to `_COVERED_MODULES`, and add that row's
+allowlist additions to `_NO_PRIMARY_SOURCE`. For Task 5 that is:
+
+```python
+from braincell.channel import potassium_sodium
+
+_COVERED_MODULES = (potassium_sodium,)
+
+_NO_PRIMARY_SOURCE = frozenset()
+```
+
+- [ ] **Step 2: Run the guard and watch it fail**
+
+```bash
+pytest braincell/channel/_docstring_test.py -v
+```
+
+Expected: FAIL on `test_every_public_symbol_cites_a_reference` listing that
+module's uncited symbols. If it passes, the module was already compliant — verify
+that is genuinely true before moving on.
+
+- [ ] **Step 3: Write the docstrings**
+
+Apply the template named in the table to each public symbol. Rules that apply to
+every module:
+
+- Transcribe every equation from the code as written, including
+  `u.math.where` piecewise branches and the `_linoid_stable` /
+  `_x_over_one_minus_exp_neg_stable` guards, not from the paper's closed form.
+- Copy `References` text verbatim from `docs/design/ion-channel-bibliography.md`.
+  Use the two-level T2 form wherever Task 3 recorded a distinct origin.
+- Document every `__init__` parameter, with defaults in user-facing units.
+- Name the source `.mod` file and its import deviations in `Notes` for imported
+  mechanisms.
+- Subclasses get their own docstring; never rely on inheritance.
+- For any symbol whose attribution landed in `## Unresolved attributions`, state
+  in `Notes` that the source is unconfirmed and add the symbol to
+  `_NO_PRIMARY_SOURCE` with an inline comment saying why.
+
+- [ ] **Step 4: Run the guard and the module's own tests**
+
+```bash
+pytest braincell/channel/_docstring_test.py braincell/channel/potassium_sodium_test.py -v
+```
+
+Expected: all PASS. Modules without a sibling `*_test.py`
+(`channel/leaky.py`, `channel/potassium_sodium.py`, `ion/nonspecific.py`) run the
+guard plus `pytest braincell/channel/` for that package.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add braincell/channel/potassium_sodium.py braincell/channel/_docstring_test.py
+git commit -m "Document braincell.channel.potassium_sodium public API"
+```
+
+---
+
+## Task 18: Full verification
+
+**Files:** none modified unless a check fails.
+
+- [ ] **Step 1: Confirm complete coverage**
+
+```bash
+python -c "
+import braincell.channel as c, braincell.ion as i
+from braincell.channel import _docstring_test as ct
+from braincell.ion import _docstring_test as it
+print('channel modules covered:', len(ct._COVERED_MODULES), 'expect 8')
+print('ion modules covered:', len(it._COVERED_MODULES), 'expect 5')
+"
+```
+
+Expected: `8` and `5`.
+
+- [ ] **Step 2: Run the full suite**
+
+```bash
+pytest braincell/ -q
+```
+
+Expected: all pass, no new failures against the `ca9ec8c` baseline.
+
+- [ ] **Step 3: Run pre-commit**
+
+```bash
+pre-commit run --all
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Build the docs and check for new warnings**
+
+```bash
+python -m sphinx -b html -W --keep-going docs docs/_build/html 2>&1 | tail -40
+```
+
+Expected: no warnings referencing `braincell.channel` or `braincell.ion`
+docstrings. Duplicate citation labels across docstrings are handled by
+per-docstring label mangling; a warning about them means the markup is wrong.
+
+- [ ] **Step 5: Confirm the bibliography and the code agree**
+
+```bash
+python -c "
+import ast, glob, re
+cited = set()
+for f in glob.glob('braincell/channel/*.py') + glob.glob('braincell/ion/*.py'):
+    if f.endswith('_test.py'):
+        continue
+    for m in re.finditer(r'^\s*\.\.\s+\[\d+\]\s+(.+)$', open(f).read(), re.MULTILINE):
+        cited.add(m.group(1).strip())
+bib = open('docs/design/ion-channel-bibliography.md').read()
+missing = sorted(c for c in cited if c.split('(')[0].strip() not in bib)
+print('citation first-lines absent from bibliography:', missing)
+"
+```
+
+Expected: an empty list. Any entry printed means a docstring citation was typed
+rather than copied.
+
+- [ ] **Step 6: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "Fix documentation build and bibliography consistency issues"
+```
+
+## Plan self-review
+
+Checked against the spec:
+
+- Spec Phase 1 → Tasks 1–3. Phase 2 → Tasks 5–17. Phase 3 → Task 4, moved
+  earlier per the ordering refinement recorded in Phase 3.
+- All six original decisions plus decision 7 are reflected: full NumPy-doc
+  without `Examples` (templates T1–T7), web verification (Tasks 2–3), duplicated
+  entries plus central doc (Task 1 + Task 18 Step 5), public API plus template
+  bases (T7, Tasks 10 and 12), mismatch policy (Task 2 Step 2 and the Step 3
+  rule), references-only guard (Task 4 Step 2), two-level references (T2, Task 3
+  Step 2).
+- Every spec edge case has a home: `Cav3p1Test_PC24` and `K_Kv_test` in Task 17,
+  deprecated aliases excluded because the guard iterates `__all__`, subclass
+  chains via `own_docstring`, celsius defaults in Global Constraints, stabilized
+  rate functions in the Task 5–17 Step 3 rules.
+- Names used consistently throughout: `_COVERED_MODULES`, `_NO_PRIMARY_SOURCE`,
+  `public_symbols`, `own_docstring`, `sections`, `has_citation`.
+- Symbol counts in the Task 5–17 table sum to 155.

--- a/docs/specs/2026-08-15-ion-channel-docstring-references.md
+++ b/docs/specs/2026-08-15-ion-channel-docstring-references.md
@@ -1291,9 +1291,11 @@ every module:
 pytest braincell/channel/_docstring_test.py braincell/channel/potassium_sodium_test.py -v
 ```
 
-Expected: all PASS. Modules without a sibling `*_test.py`
-(`channel/leaky.py`, `channel/potassium_sodium.py`, `ion/nonspecific.py`) run the
-guard plus `pytest braincell/channel/` for that package.
+Expected: all PASS. Confirm the sibling test path with `ls` before running —
+`channel/leaky.py` and `channel/potassium_sodium.py` both do have one, contrary
+to an earlier draft of this line. `ion/nonspecific.py` is the only module in the
+sequence with no sibling `*_test.py`; there, run the guard plus
+`pytest braincell/ion/` for the package instead.
 
 - [ ] **Step 5: Commit**
 

--- a/docs/specs/2026-08-15-ion-channel-docstring-references.md
+++ b/docs/specs/2026-08-15-ion-channel-docstring-references.md
@@ -973,7 +973,7 @@ Cell-type mapping is fixed by `examples/neuron_compare/Cerebellum_mod/README.md`
 | `ZH2019` | inferior olive (IO) | Zang et al. (2019) |
 | `PC24` | Purkinje, one symbol | same as `MA2024` |
 
-**Verification outcome — three of these hypotheses were wrong.** Recorded here
+**Verification outcome — four of these hypotheses were wrong.** Recorded here
 so the refuted guesses are not mistaken for findings; the authoritative records
 are in `docs/design/ion-channel-bibliography.md`.
 
@@ -1230,26 +1230,42 @@ modules, `braincell/ion/_docstring_test.py` for ion modules).
 
 - [ ] **Step 1: Extend coverage and the allowlist**
 
-Add the module to the import list and to `_COVERED_MODULES`, and add that row's
-allowlist additions to `_NO_PRIMARY_SOURCE`. For Task 5 that is:
+Both `_COVERED_MODULES` and `_NO_PRIMARY_SOURCE` are **cumulative**: append this
+task's module and allowlist entries to whatever earlier tasks already put there.
+Never replace either collection with a fresh literal — that silently drops a
+completed module out of coverage. For Task 5, with Task 6 (`leaky`) already
+landed, that is:
 
 ```python
-from braincell.channel import potassium_sodium
+from braincell.channel import leaky, potassium_sodium
 
-_COVERED_MODULES = (potassium_sodium,)
+_COVERED_MODULES = (leaky, potassium_sodium)
 
-_NO_PRIMARY_SOURCE = frozenset()
+# potassium_sodium adds no allowlist entries; leaky's stay.
+_NO_PRIMARY_SOURCE = frozenset({
+    "LeakageChannel",
+    "IL",
+})
 ```
 
-- [ ] **Step 2: Run the guard and watch it fail**
+- [ ] **Step 2: Run the guard and record what it does**
 
 ```bash
 pytest braincell/channel/_docstring_test.py -v
 ```
 
-Expected: FAIL on `test_every_public_symbol_cites_a_reference` listing that
-module's uncited symbols. If it passes, the module was already compliant — verify
-that is genuinely true before moving on.
+For a module with **keyed symbols** (any symbol needing a citation), expect
+FAIL on `test_every_public_symbol_cites_a_reference` listing that module's
+uncited symbols.
+
+For a module whose symbols are **all allowlisted** the run legitimately passes
+here, and that is not evidence the docstrings are adequate. The guard checks
+only four things — own docstring present, summary ends in a period, citation
+present unless allowlisted, allowlist not dead — so a one-line docstring
+satisfies it. Task 6 hit exactly this: both `leaky` symbols passed all four
+assertions before any documentation work. Record the actual result and
+continue to Step 3 regardless; the guard is a floor, not the acceptance
+criterion. Section completeness is the task reviewer's job.
 
 - [ ] **Step 3: Write the docstrings**
 

--- a/docs/specs/2026-08-15-ion-channel-docstring-references.md
+++ b/docs/specs/2026-08-15-ion-channel-docstring-references.md
@@ -973,6 +973,28 @@ Cell-type mapping is fixed by `examples/neuron_compare/Cerebellum_mod/README.md`
 | `ZH2019` | inferior olive (IO) | Zang et al. (2019) |
 | `PC24` | Purkinje, one symbol | same as `MA2024` |
 
+**Verification outcome — three of these hypotheses were wrong.** Recorded here
+so the refuted guesses are not mistaken for findings; the authoritative records
+are in `docs/design/ion-channel-bibliography.md`.
+
+- `ZH2019` is **Zhang & Santaniello**, PNAS 116(27), 13592-13601 — not Zang &
+  De Schutter. ModelDB accession 257028 names "Xu Zhang" as submitter, matching
+  the porter credit in the `.mod` headers.
+- `RI2021` is Rizza et al., **Scientific Reports** 11(1), 3873 — not
+  Communications Biology.
+- `SU2015` is Sudhakar, **Torben-Nielsen & De Schutter**, PLOS Computational
+  Biology 11(12), e1004641. The author list guessed above belongs to a
+  different, 2017 paper.
+- `MA2020` needs **two** papers, not one: PLOS Computational Biology 16(12),
+  e1007937 for the Golgi cell and Communications Biology 3(1), 222 for the
+  granule cell. No single paper covers both cell types.
+
+Step 0's `.mod` harvest also needs a wider window than the first pass used.
+Reading only the first 25 lines, and grepping only for keywords like `Author:`
+or `Ref:`, missed the DCN attribution "Translated from GENESIS by Johannes
+Luthman and Volker Steuber" — which contains none of those keywords and is the
+evidence that resolved `SU2015`.
+
 - [ ] **Step 2: Resolve every origin-of-kinetics reference**
 
 For each `.mod` header from Task 1 Step 2 that names an author other than the

--- a/docs/specs/2026-08-15-ion-channel-docstring-references.md
+++ b/docs/specs/2026-08-15-ion-channel-docstring-references.md
@@ -1,0 +1,368 @@
+# Docstring and reference upgrade for `braincell.ion` and `braincell.channel`
+
+Status: proposed
+Branch: `worktree-ion-channel-docstrings`
+Base: `ca9ec8c` (main)
+
+## Goal
+
+Bring every public symbol in `braincell/ion/` and `braincell/channel/` up to the
+NumPy-doc standard mandated by `AGENTS.md`, and give every literature-derived
+channel and ion a complete, web-verified bibliographic citation.
+
+This is a documentation-only change. No class is renamed, no signature changes,
+no behavior changes.
+
+## Background: the current state
+
+A survey of the two packages at `ca9ec8c` found:
+
+| Package | Source modules | Public symbols | Lines |
+|---|---|---|---|
+| `braincell/channel/` | 8 | 119 (118 classes + `ghk_flux`) | 6,013 |
+| `braincell/ion/` | 5 | 36 classes | 3,698 |
+
+Across both packages there are **two `References` sections and three numbered
+citations** in total — one in `channel/hyperpolarization_activated.py`, one in
+`ion/calcium.py` — plus a third citation block that exists only inside a
+commented-out class. There is one `Examples` section.
+
+Most channel classes carry a single summary line and nothing else. The current
+state of `KA1_HM1992` is representative: eight constructor parameters, four rate
+functions full of hard-coded literature constants, and this docstring:
+
+```python
+r"""Huguenard & McCormick 1992 IA1 potassium current."""
+```
+
+**The bibliography currently lives in the class names, not in the docstrings.**
+Names encode a two-letter author key plus a year — `KDR_Ba2002`, `Kv4p3_MA2024_PC`,
+`Nav1p6_MA2020_GoC`. A reader who wants the source paper has to decode the key
+and guess. Fifteen distinct keys cover 122 of the 154 public classes:
+
+| Key | Public classes | Modules |
+|---|---|---|
+| `MA2020` | 32 | channel: calcium, hyperpolarization_activated, potassium, potassium_calcium, potassium_sodium, sodium |
+| `MA2024` | 19 | channel: calcium, hyperpolarization_activated, potassium, potassium_calcium, sodium |
+| `SU2015` | 16 | channel: calcium, hyperpolarization_activated, potassium, potassium_calcium, sodium |
+| `MA2025` | 16 | channel: calcium, hyperpolarization_activated, potassium, potassium_calcium, sodium |
+| `RI2021` | 15 | channel: calcium, hyperpolarization_activated, potassium, potassium_calcium, sodium |
+| `HM1992` | 7 | channel: calcium, hyperpolarization_activated, potassium |
+| `ZH2019` | 5 | channel: calcium, hyperpolarization_activated, potassium, sodium |
+| `IS2008` | 2 | channel: calcium |
+| `Ba2002` | 2 | channel: potassium, sodium |
+| `TM1991` | 2 | channel: potassium, sodium |
+| `HH1952` | 2 | channel: potassium, sodium |
+| `HP1992` | 1 | channel: calcium |
+| `Re1993` | 1 | channel: calcium |
+| `Ya1989` | 1 | channel: potassium |
+| `De1994` | 1 | channel: potassium_calcium |
+
+The remaining 32 public classes carry no key: the template layer (`Gate`,
+`Transition`, `HH`, `OhmicHH`, `Markov`, `ghk_flux`, `KineticIon`, the ion
+mixins, the reaction-network dataclasses), the ion containers (`Calcium`,
+`CalciumFixed`, `CalciumDetailed`, …), the leak channels, and two apparent
+scratch classes.
+
+Counts in this table are derived from `__all__` membership via AST parsing and
+supersede any figure obtained by grepping class names, which over-counts.
+Phase 1 re-derives the exact key-to-class mapping programmatically rather than
+trusting this table.
+
+## Scope
+
+**In scope.** Every name in the `__all__` of each source module in
+`braincell/ion/` and `braincell/channel/`, including the public template bases
+in both `_base.py` files. That is 155 symbols.
+
+**Out of scope.**
+
+- Underscore-private helpers: `_Specs`, `_Species`, `_Conserve`, `_Flux` in
+  `ion/_base.py`.
+- Module-level docstrings in the two `__init__.py` files.
+- Any rename, signature change, or behavior change.
+- `Examples` sections. Individual channels are exercised by the module-level
+  documentation and tutorials; 155 doctested example blocks would be a large
+  maintenance surface for little gain.
+- `braincell.mech`, `braincell.synapse`, and every other package.
+
+## Decisions
+
+Settled during brainstorming, recorded so implementation does not relitigate
+them:
+
+1. **Depth**: full NumPy-doc — summary, extended summary, Parameters, Notes,
+   References — with `Examples` omitted.
+2. **Verification standard**: every citation is web-verified against the real
+   literature record. No citation ships on recall alone.
+3. **Bibliography layout**: the complete entry is repeated in every docstring
+   that cites it, so `help(cls)` and the rendered API page are self-contained;
+   `docs/design/ion-channel-bibliography.md` holds the single canonical list
+   that those entries are copied from.
+4. **Coverage**: public API plus public template bases; private helpers excluded.
+5. **Mismatch policy**: where verification shows the code's equations came from
+   a different paper than the class name implies, the docstring cites the paper
+   the equations actually came from, a `Notes` line explains the discrepancy,
+   and the design doc logs it as an open question. Nothing is renamed.
+6. **Enforcement**: ship a references-presence guard test, not a
+   Parameters-versus-signature guard, to avoid brittleness when signatures change.
+
+## Phase 1 — Verified bibliography
+
+**Artifact**: `docs/design/ion-channel-bibliography.md`, a durable design note
+per `AGENTS.md` rule 8.
+
+**Structure**: one section per citation key, each containing
+
+- the full record: authors, title, journal, volume, issue, page range, year, DOI;
+- the exact `.. [1]` reST block to be pasted into docstrings, so the docstring
+  text is copied rather than retyped;
+- the list of classes citing the key, generated from the AST;
+- an attribution note recording what was checked and how confident the result is.
+
+**Verification protocol.** A key is verified only when both of the following hold:
+
+1. *Record check.* The bibliographic fields are confirmed against the publisher
+   record or an equivalent authoritative index. A DOI that resolves to the
+   stated title, authors, and year is sufficient.
+2. *Attribution check.* The paper is confirmed to actually describe the current
+   in question, by comparing the kinetics the paper reports against the
+   hard-coded constants in the citing class. A paper by the right authors in the
+   right year that does not contain the channel is a failed attribution, not a
+   pass.
+
+The attribution check is what makes this phase worth doing separately. It is
+also where `IS2008` is most at risk: the only in-repo evidence for it is the
+prose fragment "Strowbridge 2008", and the two classes citing it are calcium
+channels whose provenance has not been confirmed.
+
+**Failure handling.** A key that fails either check is recorded in the
+bibliography's "Unresolved attributions" section with the evidence gathered so
+far, and its classes get a `Notes` line stating that the source is unconfirmed
+rather than a fabricated citation. Shipping an unverified citation formatted to
+look verified is worse than shipping an explicit gap.
+
+**Deliverable**: one commit adding `docs/design/ion-channel-bibliography.md`.
+
+## Phase 2 — Docstrings
+
+### Template
+
+Raw strings (`r"""`) throughout, since `Notes` carries LaTeX. Sections follow the
+`AGENTS.md` canonical order with `Examples` omitted.
+
+- **Short summary** — one line naming the current and its source.
+- **Extended summary** — 2–4 sentences: the biophysical role of the current, the
+  preparation or cell type it was characterized in, the model it belongs to, and
+  its gating structure.
+- **Parameters** — every `__init__` argument, with its default and unit stated in
+  the description. Units go in prose, not the type field, because the type is
+  almost always `brainstate.typing.ArrayLike or Callable`.
+- **See Also** — only where it earns its place: sibling variants such as
+  `KA1_HM1992`/`KA2_HM1992`, or a channel and the ion it binds to. Not
+  boilerplate across all 155.
+- **Notes** — the gating equations as `.. math::`, plus the conventions needed to
+  reproduce them: that `V` enters as `(V - V_sh)` in mV, that τ is in ms, and how
+  `q10`/`temp_ref` scale each gate. Class attributes (`root_type`, `gates`) are
+  described here rather than in a separate `Attributes` section, keeping to the
+  nine canonical sections.
+- **References** — the full entry, byte-identical to the bibliography.
+
+**Equations are transcribed from the code, not from the paper.** The docstring
+documents the implementation as it stands. Any place where the two disagree is a
+Phase 1 finding handled under the mismatch policy.
+
+### Worked example
+
+Replacing the current one-liner in `braincell/channel/potassium.py`:
+
+```python
+@register_channel("KA1_HM1992")
+class KA1_HM1992(OhmicHH):
+    r"""Huguenard & McCormick (1992) fast transient A-type K+ current (IA1).
+
+    Rapidly activating and inactivating outward potassium current of thalamic
+    relay neurons, responsible for delaying the onset of firing after a
+    hyperpolarizing step. This is the faster of the two A-type components in
+    the Huguenard & McCormick thalamocortical relay cell model; see
+    :class:`KA2_HM1992` for the slower component. Gating follows the
+    Hodgkin-Huxley form :math:`g = \bar{g} p^4 q`, with a fourth-power
+    activation gate ``p`` and a single inactivation gate ``q``.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Population and compartment shape of the channel.
+    g_max : brainstate.typing.ArrayLike or Callable
+        Maximal conductance density. Defaults to ``30 mS/cm^2``.
+    temp : brainstate.typing.ArrayLike
+        Absolute simulation temperature. Defaults to 36 degrees Celsius.
+    q10_p : brainstate.typing.ArrayLike or Callable
+        Temperature coefficient of the activation gate. Defaults to ``1.0``.
+    temp_ref_p : brainstate.typing.ArrayLike
+        Reference temperature at which the ``p`` rates were measured.
+        Defaults to 36 degrees Celsius.
+    q10_q : brainstate.typing.ArrayLike or Callable
+        Temperature coefficient of the inactivation gate. Defaults to ``1.0``.
+    temp_ref_q : brainstate.typing.ArrayLike
+        Reference temperature at which the ``q`` rates were measured.
+        Defaults to 36 degrees Celsius.
+    V_sh : brainstate.typing.ArrayLike or Callable
+        Voltage shift applied to every rate expression. Defaults to ``0 mV``.
+    name : str, optional
+        Instance name.
+
+    See Also
+    --------
+    KA2_HM1992 : Slower A-type component of the same model.
+
+    Notes
+    -----
+    Writing :math:`v = (V - V_{sh})/\mathrm{mV}`, activation is
+
+    .. math::
+        p_\infty(v) = \frac{1}{1 + \exp(-(v + 60)/8.5)}
+
+    .. math::
+        \tau_p(v) = \frac{1}{\exp((v + 35.8)/19.7)
+                   + \exp(-(v + 79.7)/12.7)} + 0.37
+
+    and inactivation is
+
+    .. math::
+        q_\infty(v) = \frac{1}{1 + \exp((v + 78)/6)}
+
+    .. math::
+        \tau_q(v) = \begin{cases}
+            \left[\exp((v + 46)/5)
+                + \exp(-(v + 238)/37.5)\right]^{-1} & v < -63 \\
+            19 & v \ge -63
+        \end{cases}
+
+    All time constants are in milliseconds. Each gate is scaled independently
+    by :math:`q_{10}^{(T - T_{ref})/10}`, so ``q10_p``/``temp_ref_p`` and
+    ``q10_q``/``temp_ref_q`` act only on their own gate. The class binds to
+    :class:`braincell.ion.Potassium` through ``root_type``.
+
+    References
+    ----------
+    .. [1] Huguenard, J. R., & McCormick, D. A. (1992). Simulation of the
+           currents involved in rhythmic oscillations in thalamic relay
+           neurons. Journal of Neurophysiology, 68(4), 1373-1383.
+           doi:10.1152/jn.1992.68.4.1373
+    """
+```
+
+### Commit order
+
+One commit per source module, smallest first so the template is exercised on
+cheap modules before the large ones:
+
+| # | Module | Public symbols |
+|---|---|---|
+| 1 | `channel/potassium_sodium.py` | 1 |
+| 2 | `channel/leaky.py` | 2 |
+| 3 | `ion/nonspecific.py` | 2 |
+| 4 | `ion/potassium.py` | 3 |
+| 5 | `ion/sodium.py` | 3 |
+| 6 | `channel/_base.py` | 6 |
+| 7 | `channel/hyperpolarization_activated.py` | 8 |
+| 8 | `ion/_base.py` | 9 |
+| 9 | `channel/sodium.py` | 14 |
+| 10 | `channel/potassium_calcium.py` | 15 |
+| 11 | `ion/calcium.py` | 19 |
+| 12 | `channel/calcium.py` | 35 |
+| 13 | `channel/potassium.py` | 38 |
+
+## Phase 3 — Conformance guard
+
+**Files**: `braincell/channel/_docstring_test.py` and
+`braincell/ion/_docstring_test.py`, co-located per `AGENTS.md` rule 10. The
+leading underscore is cosmetic; the `*_test.py` suffix is what pytest collects.
+
+**Assertions**, for every in-scope symbol:
+
+1. It has a non-empty docstring whose first line is a summary ending in a period.
+2. It has a `References` section containing at least one `.. [n]` entry, **unless**
+   it appears in the test module's explicit `_NO_PRIMARY_SOURCE` allowlist.
+3. Every name in `_NO_PRIMARY_SOURCE` still exists and is still public, so the
+   allowlist cannot rot into a list of deleted symbols.
+
+References are therefore required by default. The citation-key pattern is not
+itself an assertion — it is only the heuristic used when populating the
+allowlist, since a key-named class can never legitimately belong on it.
+
+**Why the allowlist.** 32 public classes have no citation key, and requiring a
+`References` section from all of them would be wrong — `Gate`, `Transition`, and
+`CalciumFixed` have no primary literature source. But some of them genuinely do:
+`ghk_flux` implements Goldman–Hodgkin–Katz, `CalciumDetailed` derives from
+Destexhe, and `KineticIon` follows NEURON's NMODL `KINETIC` semantics. An
+allowlist forces each of the 32 to be a conscious decision rather than a silent
+exemption, and forces the same decision when a new class is added.
+
+**Parsing.** `numpydoc` is not a project dependency and this change does not add
+one. The test uses a ~20-line section splitter over `inspect.getdoc` output.
+
+**Deliverable**: one commit adding both test modules.
+
+## Edge cases
+
+- **`Cav3p1Test_PC24`** (`channel/calcium.py`) uses the suffix `PC24`, a
+  two-digit year, so key-matching over four-digit years alone misses it. Under
+  the references-required-by-default rule this is not a silent exemption — the
+  class would fail the guard until documented — but the Phase 1 key inventory
+  must still match the two-digit form or the class is dropped from the
+  bibliography mapping. Treated as `MA2024`-derived pending confirmation.
+- **`K_Kv_test`** (`channel/potassium.py`) and **`Cav3p1Test_PC24`** appear to be
+  scratch or fixture classes that are nonetheless public. They get docstrings
+  that say so plainly. Whether they should be public at all is logged as an open
+  question, not resolved here.
+- **Deprecated aliases** in `channel/__init__.py` (`INa_HH1952` → `Na_HH1952`,
+  and 18 others) resolve through `__getattr__` and inherit the target's
+  docstring. No separate documentation; the guard iterates `__all__`, which
+  excludes them.
+- **Subclass chains** such as `Nav1p6_MA2024_PC(Nav1p6_MA2020_GoC)` inherit a
+  docstring if none is written. The guard uses `cls.__dict__.get("__doc__")`,
+  not `cls.__doc__`, so an inherited docstring does not count as documented —
+  otherwise the four `Nav1p6_*` subclasses would pass while citing the wrong
+  paper for their cell type.
+- **`u.celsius2kelvin(36.0)` defaults** must be described as "36 degrees Celsius",
+  not as a kelvin number, or the docs will not match how a user writes the value.
+- **Piecewise and numerically-stabilized rate functions** (`_linoid_stable`,
+  `_x_over_one_minus_exp_neg_stable`) differ from the paper's closed form near
+  singularities. `Notes` documents the stabilization where it applies rather than
+  presenting the naive expression.
+
+## Verification
+
+- `pytest braincell/channel/ braincell/ion/` passes at every commit. Since the
+  change is documentation-only, any failure means an edit escaped a docstring.
+- `pytest braincell/` passes before the branch is proposed for merge.
+- The new `_docstring_test.py` modules pass, and are confirmed to actually
+  collect (`pytest --collect-only`) — a file that collects nothing is the failure
+  mode `AGENTS.md` rule 10 exists to prevent.
+- `pre-commit run --all` passes.
+- Sphinx builds `docs/apis/braincell.channel.rst` and `docs/apis/braincell.ion.rst`
+  without new warnings, confirming the `.. math::` and `.. [n]` markup renders.
+  Duplicate citation labels across docstrings are expected and handled by
+  numpydoc's per-docstring label mangling; a build that warns about them means
+  the markup is wrong.
+
+## Open questions
+
+Logged for later decision; none blocks implementation.
+
+- Should `K_Kv_test` and `Cav3p1Test_PC24` remain in the public `__all__`?
+- Any attribution that fails Phase 1 verification is appended here with its
+  evidence, per the mismatch policy.
+
+## Risks
+
+- **`IS2008` may not verify.** Handled by the failure protocol: an explicit
+  "source unconfirmed" note, never a fabricated citation.
+- **The Masoli-family papers (`MA2020`, `MA2024`, `MA2025`) cover 67 classes
+  between them.** A wrong attribution there is the highest-impact error in the
+  change, which is why the attribution check compares reported kinetics against
+  the code's constants rather than matching on author and year alone.
+- **Scale.** 155 symbols is a large diff. Mitigated by per-module commits and by
+  the fact that the change cannot alter behavior.


### PR DESCRIPTION
Upgrades every public docstring in `braincell.ion` and `braincell.channel`
to full NumPy-doc with verified literature references, and adds a
canonical bibliography plus a conformance guard.

**155 public symbols · 302 citations · 19 files**

## What changed

- Full NumPy-doc for every public symbol in both packages: summary,
  extended summary, Parameters, Notes, References. `Examples` sections
  are deliberately omitted.
- Every citation was web-verified; none ships on recall alone. Each
  docstring carries a full self-contained reference block, and
  `docs/design/ion-channel-bibliography.md` is the canonical source
  those blocks are copied from verbatim.
- Two-level citation convention throughout: `.. [1]` is the origin of
  the kinetics, the final entry is the model paper the mechanism was
  imported from.
- Conformance guards at `braincell/channel/_docstring_test.py` and
  `braincell/ion/_docstring_test.py` covering all 13 non-`__init__`
  modules in the two packages.
- Where the code and the literature disagree, the docstring documents
  what the code actually does and flags the discrepancy. Nothing was
  renamed and no behaviour changed.

## Verification

| Check | Result |
| --- | --- |
| `pytest braincell/` | 2245 passed, 0 failed, 19 skipped |
| Sphinx build | 0 errors, 0 warnings |
| `pre-commit run --all-files` | all hooks pass |
| Citations verbatim in bibliography | 302 entries; 4 misses, all pre-existing in `braincell/quad/_runge_kutta.py`, outside scope |
| Repeated citation blocks byte-identical | 57 records, 0 split wraps |
| `.mod` filenames resolve on disk | 0 nonexistent (34 upstream/ModelDB refs correctly untouched) |
| Documentation-only | all 13 modified modules AST-byte-identical to base with docstrings stripped |

## One change outside the docstrings

`docs/conf.py:169` fixes a pre-existing bug. `_FIELD_LINE =
re.compile(r'^:[^:]+:')` also matched wrapped *prose* lines beginning
with a role (`` :class:`X` ``, `` :math:`y` ``), so the blank-line
restoring hook injected a blank line mid-paragraph and tore the
paragraph in two — roughly 330 injections across ~145 docstrings, of
which only about six surfaced as warnings and the rest corrupted
rendering silently. Fixed with a negative lookahead,
`r'^:[^:]+:(?!`)'`: a role is always followed by a backtick, a field
line never is.

`git log` confirms `_FIELD_LINE` predates this branch, and the bug
reaches beyond these two packages into `_base_channel.py` and
`_compute/runtime.py`. Rewording ~145 docstrings to avoid the trigger
was the alternative; fixing the regex was judged correct.

## Known limitations of the guard

Enforcement is references-presence only, by design. Two consequences
worth recording:

1. The guard cannot detect a **fabricated** citation — only a missing
   one. A fabricated citation did ship during this work (at
   `HCN1_MA2025_BC`, splicing one paper's author list onto another's
   title and DOI) and was caught by a human read, not by a test.
2. For the 36 symbols in `_NO_PRIMARY_SOURCE`, the only surviving
   assertion is "non-empty docstring whose first line ends in a
   period". Stubbing `SodiumFixed` to `"""Stub."""` passes all four
   assertions. Those docstrings can regress undetected.

## Follow-up: code-level defects documented, not fixed

This branch is documentation-only, so these were recorded in the
docstrings rather than corrected. Each needs its own change:

- `CalciumFirstOrder.derivative` — bibliography row corrected here; the
  rectified `max(alpha*I, 0) - beta*Ci` form differs from the symmetric
  form the generic model implies.
- `Cav3p2_RI2021_SC.g_max` — `8.0e-4 mS/cm^2` in Python against
  `gcabar = .0008 (mho/cm2)` = 0.8 mS/cm² in the `.mod` source, a 1000×
  unit-scale discrepancy.
- `K_Kv_test.f_n_tau` — returns `nan` at `V = V_sh + v12`, where the
  limit is finite (~4.27 ms).
- `Kir2p3_MA2024_PC` — its `.mod` declares `celsius = 10` where the
  granule/basket/stellate ports declare `30`, a 9× gate-speed
  difference. Hedged: NEURON's `celsius` is a simulator-wide global a
  host model normally overrides.
- `Kv4p3_MA2024_PC` / `Kv4p3_MA2025_BC` — store `Kalpha_a` as a bare
  float where their three siblings attach `u.mV`, against the
  mandatory-units convention.
- The five `Kv3p4_*` `.mod` files declare no `celsius`, so BrainCell's
  22 °C default is the package's own choice, 15° below the 37 °C
  reference (φ ≈ 0.192, ~5.2× slower gates).

## Deferred documentation items

- No module docstring on `braincell/channel/_base.py` or
  `braincell/ion/calcium.py` (11 of 13 modules have one; the guard
  checks none).
- `build_placeholder_ions` in `braincell/ion/__init__.py` is the one
  public `__all__` name outside guard coverage.
- `KA1_HM1992` / `KA2_HM1992` do not implement the two-inactivation-
  time-constant split their cited paper describes; this is documented
  in `KA1_HM1992`'s Notes rather than corrected.

## Summary by Sourcery

Document and docstring overhaul for potassium, sodium and calcium channels and ions, adding literature-backed NumPy-style documentation, tightening parameter descriptions and notes on provenance, and introducing a docstring conformance guard and a small Sphinx regex fix to prevent field-list detection on inline roles.

Enhancements:
- Improve and expand docstrings for a wide range of potassium, sodium and calcium channels, including detailed kinetic descriptions, parameter semantics, and cross-references to source mechanisms.
- Clarify and document the behavior of ion base classes and mixins (FixedIon, InitNernstIon, DynamicNernstIon, KineticIon), including their responsibilities, defaults and error conditions.
- Add explanatory module-level documentation for leakage channels, GHK flux helper, Markov transitions and HH templates to better describe their roles and shared semantics.
- Introduce a channel docstring conformance test that enforces presence of references or explicit 'no primary source' declarations for covered symbols.
- Refine Sphinx documentation build behavior by tightening the regex that detects field-list lines, avoiding misclassification of inline roles and preventing spurious blank-line insertion in rendered docs.

Documentation:
- Extensively update channel and ion docstrings to NumPy-style format with verified references, detailed notes and parameter sections, improving user-facing API documentation for electrophysiological mechanisms.

Tests:
- Add docstring conformance unit tests for the braincell.channel package, covering specified modules and enforcing documentation conventions for public symbols.