### PR TITLE
Require brainstate>=0.5.4 for jax 0.11.1 compatibility

### DIFF
--- a/braincell/_multi_compartment/cell.py
+++ b/braincell/_multi_compartment/cell.py
@@ -221,47 +221,6 @@ class Cell(HHTypedNeuron):
         membrane_linearizer: str = "point",
         name: str | None = None,
     ) -> None:
-        """Initialize a multi-compartment cell declaration.
-
-        Parameters
-        ----------
-        morpho : Morphology
-            Morphology tree shared by every homogeneous population
-            instance.
-        pop_size : int or tuple of int, optional
-            Homogeneous population shape, defaulting to ``1``. Runtime
-            state is expanded to ``pop_size + (n_cv,)`` and point-space
-            arrays to ``pop_size + (n_point,)``. The population axis is
-            mandatory — an empty ``pop_size`` raises :class:`ValueError` —
-            because the trailing compartment axis is what makes every
-            ``Cell`` hidden state a :class:`brainstate.HiddenGroupState`.
-        cv_policy : CVPolicy, optional
-            Control-volume splitting policy.
-        V_th : Quantity, optional
-            Spike threshold.
-        V_init : Initializer, optional
-            Initial membrane voltage. ``None`` uses the per-CV resting
-            potential.
-        spk_fun : Callable, optional
-            Surrogate-gradient spike function.
-        solver : str or callable, optional
-            Integrator name or concrete step function.
-        subsolver : str or callable or None, optional
-            Shared integrator for Markov channels and kinetic ions. It must
-            be provided together with ``substeps``. When both are ``None``,
-            the effective schedule is ``backward_euler`` with one substep.
-        substeps : int or None, optional
-            Shared number of Markov/kinetic-ion steps per main cell step.
-        cache_ion_total_current : bool, optional
-            Whether to snapshot ion total current at step start for
-            NEURON-style schedules.
-        ion_channel_update_order : {"family", "integration"}, optional
-            Post-voltage ion/channel update order.
-        membrane_linearizer : {"point", "generic"}, optional
-            Membrane-current linearization strategy.
-        name : str, optional
-            Cell name.
-        """
         normalized_pop_size = _normalize_pop_size(pop_size)
         HHTypedNeuron.__init__(self, size=normalized_pop_size + (1,), name=name)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,11 @@ dynamic = [ "version" ]
 dependencies = [
   "brainevent>=0.0.7",
   "brainpy>=2.7.5",
-  "brainstate>=0.2.9",
+  # 0.5.4 is the first release that works with jax 0.11.1, which deleted
+  # `jax.extend.core.CallPrimitive`; every earlier brainstate imports that name
+  # unconditionally and fails at import time. CI installs unpinned jax, so this
+  # floor is what keeps `import braincell` working on current JAX.
+  "brainstate>=0.5.4",
   "braintools>=0.1",
   "brainunit>=0.0.8",
   "jax",


### PR DESCRIPTION
## Why CI is red

`main` has been failing since jax **0.11.1** landed, and no braincell change is at fault.

jax 0.11.1 deleted `jax.extend.core.CallPrimitive`. Every brainstate up to 0.5.3 imports that name **unconditionally** on its `jax >= 0.10.0` branch (`brainstate/_compatible_import.py`), so `import brainstate` — and therefore `import braincell` — raises at import time:

```
ImportError: cannot import name 'CallPrimitive' from 'jax.extend.core'
```

Verified directly against the wheels:

| jax | `CallPrimitive` exported from `jax.extend.core` |
|---|---|
| 0.11.0 | yes |
| 0.11.1 | **no** |

The split in CI matches exactly. The jobs that install **unpinned** jax all failed on this one error — `test_windows`, `test_macos`, `build_package`, `test_linux_neuron_compare_cable`, and the daily matrix's unpinned entry — while the pinned `0.8.0` / `0.9.0` / `0.10.0` matrix entries stayed green.

## The fix

brainstate 0.5.4 adds a compatibility shim that subclasses `Primitive` when the name is absent, so `CallPrimitive` stays part of its public API. Bump the floor from `>=0.2.9` to `>=0.5.4`.

That floor is the only braincell-side change needed — `pyproject.toml` intentionally leaves `jax` itself unpinned so users can pick their own CPU/CUDA/TPU build, and this keeps that property rather than adding a jax upper bound.

## Verification

- `jax 0.11.1` + `brainstate 0.5.4` → `import braincell` OK.
- `pytest braincell/` on that combination: **2245 passed, 0 failed, 19 skipped**.
- The pinned-jax matrix entries exercise `brainstate 0.5.4` against jax 0.8.0/0.9.0/0.10.0, so CI confirms the new floor does not break the documented jax >= 0.8.0 support window.

## Also included

`8e28783` — drops the duplicated `Cell.__init__` docstring (an unpushed local commit; the class docstring above already documents every one of those parameters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update the brainstate dependency floor to maintain compatibility with current JAX releases.

Bug Fixes:
- Require brainstate 0.5.4 or newer so braincell remains importable with JAX 0.11.1 and later compatibility changes.

Chores:
- Remove the duplicated Cell initializer docstring.