### PR TITLE
refactor: clean up reuse, efficiency, and dead code in the network refactor

### DIFF
--- a/braincell/__init__.py
+++ b/braincell/__init__.py
@@ -54,7 +54,6 @@ from ._discretization import (
 )
 from ._multi_compartment import (
     Cell,
-    CellSelection,
     CellView,
     ChannelView,
     IonView,
@@ -110,7 +109,6 @@ __all__ = [
     "Branch",
     "CableProperty",
     "Cell",
-    "CellSelection",
     "CellView",
     "ChannelView",
     "Channel",

--- a/braincell/_compute/bindings.py
+++ b/braincell/_compute/bindings.py
@@ -487,10 +487,14 @@ def _instantiate_runtime_node(
 ) -> tuple[object | None, tuple[str, ...], str | tuple[str, ...] | None]:
     if isinstance(mechanism, SynapsePlacement):
         runtime_cls = get_registry().get("synapse", mechanism.synapse_type)
+        # The runtime class's declared parameters are the same schema state.py used to
+        # write these buffers, so select against it rather than inferring which buffers
+        # are constructor arguments from a leading-underscore naming convention.
+        declared = set(runtime_cls.parameters)
         parameter_names = tuple(
             var_name
             for layout_id, var_name in state_buffers
-            if int(layout_id) == int(layout.id) and not var_name.startswith("_")
+            if int(layout_id) == int(layout.id) and var_name in declared
         )
         params = {
             var_name: _runtime_param_value(

--- a/braincell/_compute/layouts.py
+++ b/braincell/_compute/layouts.py
@@ -127,6 +127,51 @@ class MechanismLayout:
         """Whether point instances are stored once across the population."""
         return self.population_index is not None
 
+    def _point_selector(self) -> tuple:
+        """Index tuple selecting this layout's points along the trailing axes."""
+        if self.point_index is None:
+            raise ValueError(f"Point layout {self.id!r} is missing point_index.")
+        if self.is_packed:
+            return (Ellipsis, self.population_index, self.point_index)
+        return (Ellipsis, self.point_index)
+
+    def gather_points(self, values):
+        """Gather this layout's point entries from a point-space array.
+
+        Packed layouts store one instance per population entry and are indexed
+        by both the population and point axes; broadcast layouts share one
+        instance across the population and are indexed by the point axis only.
+        Callers read the rule from here rather than repeating the branch.
+
+        Parameters
+        ----------
+        values : array_like
+            Point-space array whose trailing axis indexes points.
+
+        Returns
+        -------
+        array_like
+            Values at this layout's active points.
+        """
+        return values[self._point_selector()]
+
+    def scatter_add_points(self, target, values):
+        """Accumulate ``values`` into ``target`` at this layout's points.
+
+        Parameters
+        ----------
+        target : array_like
+            Point-space array to accumulate into.
+        values : array_like
+            Per-instance values aligned with this layout's active points.
+
+        Returns
+        -------
+        array_like
+            ``target`` with ``values`` added at this layout's points.
+        """
+        return target.at[self._point_selector()].add(values)
+
     @property
     def point_axis_len(self) -> int:
         """Length of the axis this layout's buffers index points along.

--- a/braincell/_compute/state.py
+++ b/braincell/_compute/state.py
@@ -256,7 +256,6 @@ class CellRuntimeState:
                 continue
             store_rows = synapse_store.row_indices(logical_ids)
             mechanisms = tuple(synapse_store.mechanism[int(row)] for row in store_rows.tolist())
-            names = tuple(dict.fromkeys(item.instance_name for item in mechanisms))
             grouped[("point", "synapse", str(synapse_type))] = {
                 "id": layout_id,
                 "mechanism": mechanisms[0],
@@ -270,7 +269,6 @@ class CellRuntimeState:
                     else []
                 ),
                 "synapse_ids": np.asarray(logical_ids, dtype=np.int64),
-                "runtime_name": names[0] if len(names) == 1 else str(synapse_type),
             }
             layout_id += 1
 
@@ -710,23 +708,29 @@ def _apply_density_parameter_overrides(
     if len(pop_size) != 1:
         raise ValueError("Density parameter views currently require one-dimensional Cell.pop_size.")
     population_size = int(pop_size[0])
+
+    # One pass over the layouts builds the (category, name, cv) -> layouts index that
+    # every override then resolves in constant time; scanning per override is quadratic
+    # in the number of selected rows, and an unrestricted view selects every CV.
+    layouts_by_owner: dict[tuple[str, str, int], list[MechanismLayout]] = {}
+    for layout in layouts:
+        mechanism = layout_mechanisms[layout.id]
+        if not isinstance(mechanism, Density):
+            continue
+        for source_cv_id in layout.source_cv_ids:
+            owner = (mechanism.category, mechanism.instance_name, int(source_cv_id))
+            layouts_by_owner.setdefault(owner, []).append(layout)
+
+    # Resolve and validate every override first, then apply each buffer's writes in one
+    # scatter -- writing them one at a time copies the whole buffer per override.
+    writes: dict[tuple[int, str], list[tuple[int, int, object]]] = {}
     for (category, name, population_index, cv_id, var_name), value in overrides.items():
-        matches = []
-        for layout in layouts:
-            mechanism = layout_mechanisms[layout.id]
-            if (
-                isinstance(mechanism, Density)
-                and mechanism.category == category
-                and mechanism.instance_name == name
-                and int(cv_id) in layout.source_cv_ids
-            ):
-                matches.append(layout)
+        matches = layouts_by_owner.get((category, name, int(cv_id)), ())
         if len(matches) != 1:
             raise RuntimeError(
                 f"Expected one density layout for {category} {name!r} on CV {cv_id}, got {len(matches)!r}."
             )
-        layout = matches[0]
-        key = (int(layout.id), str(var_name))
+        key = (int(matches[0].id), str(var_name))
         if key not in state_buffers:
             raise KeyError(f"{category.title()} {name!r} has no parameter {var_name!r}.")
         buffer = state_buffers[key]
@@ -735,15 +739,20 @@ def _apply_density_parameter_overrides(
             if not isinstance(value, u.Quantity):
                 raise TypeError(f"Density parameter {var_name!r} requires a Quantity compatible with {unit}.")
             decimal = value.to_decimal(unit)
-            mantissa = np.array(buffer.to_decimal(unit), copy=True)
         else:
             if isinstance(value, u.Quantity):
                 raise TypeError(f"Density parameter {var_name!r} is dimensionless.")
             decimal = value
-            mantissa = np.array(buffer, copy=True)
         point_id = int(node_tree.cv_to_mid_node_id[int(cv_id)])
+        writes.setdefault(key, []).append((int(population_index), point_id, decimal))
+
+    for key, entries in writes.items():
+        buffer = state_buffers[key]
+        unit = buffer.unit if isinstance(buffer, u.Quantity) else None
+        mantissa = np.array(buffer.to_decimal(unit) if unit is not None else buffer, copy=True)
+        populations, points, values = zip(*entries)
         if mantissa.ndim >= 2 and mantissa.shape[0] == population_size:
-            mantissa[int(population_index), point_id] = decimal
+            mantissa[np.asarray(populations), np.asarray(points)] = values
         else:
-            mantissa[point_id] = decimal
+            mantissa[np.asarray(points)] = values
         state_buffers[key] = u.Quantity(mantissa, unit) if unit is not None else mantissa

--- a/braincell/_discretization/mechanism.py
+++ b/braincell/_discretization/mechanism.py
@@ -151,12 +151,7 @@ class _RegionCache:
         if cached is not None:
             return cached
         mask = locset.evaluate(self._morpho, cache=self._selection) if isinstance(locset, LocsetExpr) else locset
-        names = mask.display_names
-        if names is None:
-            names = tuple(
-                f"{self._morpho.branch(index=int(branch_id)).name}({float(branch_x):g})"
-                for branch_id, branch_x in mask.points
-            )
+        names = mask.resolved_display_names(self._morpho)
         result = tuple(
             (int(branch_id), float(branch_x), str(name))
             for branch_id, branch_x, name in zip(mask.branch_id, mask.branch_x, names)

--- a/braincell/_multi_compartment/__init__.py
+++ b/braincell/_multi_compartment/__init__.py
@@ -15,14 +15,13 @@
 
 """Multi-compartment cell declaration + runtime."""
 
-from .cell import Cell, CellSelection, CellView, MultiCompartment
+from .cell import Cell, CellView, MultiCompartment
 from .run import RunResult
 from .synapses import SynapseView
 from .density_views import ChannelView, IonView
 
 __all__ = [
     "Cell",
-    "CellSelection",
     "CellView",
     "ChannelView",
     "IonView",

--- a/braincell/_multi_compartment/cell.py
+++ b/braincell/_multi_compartment/cell.py
@@ -89,12 +89,9 @@ from braincell._discretization.base import (
     Node,
     NodeTree,
     build_discretization,
+    locate_cv_on_branch,
 )
-from braincell._discretization.node_build import (
-    _EPS_PARAM,
-    _locate_branch_cv_by_x,
-    locate_node_on_branch,
-)
+from braincell._discretization.node_build import locate_node_on_branch
 from braincell.filter import LocsetBatch, LocsetExpr, LocsetMask, RegionExpr, RegionMask, at
 from braincell.filter.helper import normalize_region_intervals
 from braincell.event import EventOutputCollection, _CellSpikeSource
@@ -111,7 +108,7 @@ from .synapses import SynapseView, _SynapseStore
 from .selection import BranchSelector, CVSelector, _CellScope
 from .density_views import ChannelView, IonView
 
-__all__ = ["Cell", "CellView", "CellSelection", "MultiCompartment"]
+__all__ = ["Cell", "CellView", "MultiCompartment"]
 
 
 @dataclass(frozen=True)
@@ -179,17 +176,13 @@ class _CellFacade:
         raise NotImplementedError
 
     @property
-    def _view_population_indices(self) -> tuple[int, ...]:
-        raise NotImplementedError
-
-    @property
     def root(self) -> "Cell":
         """Return the root Cell that owns this view."""
         return self._view_root
 
     @property
     def _scope(self) -> _CellScope:
-        return _CellScope.root(self._view_root)
+        return self._view_root._root_scope()
 
     def _with_scope(self, scope: _CellScope) -> "CellView":
         return CellView(self._view_root, scope.population_indices, scope=scope)
@@ -372,7 +365,7 @@ class CellView(_CellFacade):
         self._cell = cell
         self._population_indices = tuple(population_indices)
         self._selection_scope = (
-            _CellScope.root(cell).select_population(tuple(population_indices)) if scope is None else scope
+            cell._root_scope().select_population(tuple(population_indices)) if scope is None else scope
         )
 
     @property
@@ -393,10 +386,6 @@ class CellView(_CellFacade):
     @property
     def _view_root(self) -> "Cell":
         return self._cell
-
-    @property
-    def _view_population_indices(self) -> tuple[int, ...]:
-        return self._population_indices
 
     @property
     def _scope(self) -> _CellScope:
@@ -750,10 +739,6 @@ class CellView(_CellFacade):
         )
 
 
-# Compatibility name retained for code written against the first selection API.
-CellSelection = CellView
-
-
 class Cell(_CellFacade, HHTypedNeuron):
     """Multi-compartment cell with explicit declaration / initialization phases.
 
@@ -850,6 +835,7 @@ class Cell(_CellFacade, HHTypedNeuron):
 
         self._discretization_cache: Discretization | None = None
         self._discretization_cache_key: object = None
+        self._root_scope_cache: _CellScope | None = None
 
         self._current_time_state = brainstate.ShortTermState(0.0 * u.ms)
         self._node_scheduling_cache: dict[tuple[str, int], object] = {}
@@ -1237,6 +1223,7 @@ class Cell(_CellFacade, HHTypedNeuron):
         self._synapse_store_cache = None
         self._runtime_cvs_cache = None
         self._runtime_nodes_cache = None
+        self._root_scope_cache = None
         self._run_loop_cache.clear()
 
     def _discretization_key(self) -> tuple[object, ...]:
@@ -1262,6 +1249,18 @@ class Cell(_CellFacade, HHTypedNeuron):
         self._discretization_cache = discretization
         self._discretization_cache_key = key
         return discretization
+
+    def _root_scope(self) -> _CellScope:
+        """Return the cached unrestricted population/CV scope for this Cell.
+
+        The root scope materializes one entry per ``(population, CV)`` pair, so
+        rebuilding it per attribute access costs ``pop_size * n_cv`` tuples on
+        every ``cell.soma``, ``cell.channels``, or ``cell.record`` lookup. It
+        depends only on the discretization and is invalidated alongside it.
+        """
+        if self._root_scope_cache is None:
+            self._root_scope_cache = _CellScope.root(self)
+        return self._root_scope_cache
 
     @property
     def n_cv(self) -> int:
@@ -1548,10 +1547,6 @@ class Cell(_CellFacade, HHTypedNeuron):
     @property
     def _view_root(self) -> "Cell":
         return self
-
-    @property
-    def _view_population_indices(self) -> tuple[int, ...]:
-        return tuple(range(self._population_size))
 
     @property
     def varshape(self) -> tuple[int, ...]:
@@ -2409,7 +2404,7 @@ class Cell(_CellFacade, HHTypedNeuron):
             ids = cv_ids_by_branch.get(int(branch_id))
             if not ids:
                 continue
-            cv_id = _locate_branch_cv_by_x(ids, self.cvs, x=float(x), epsilon=_EPS_PARAM)
+            cv_id = locate_cv_on_branch(ids, self.cvs, x=float(x))
             cv_ids.add(int(cv_id))
         return cv_ids
 
@@ -3427,17 +3422,14 @@ class Cell(_CellFacade, HHTypedNeuron):
         if dt is None:
             raise ValueError("Connection event delivery requires brainstate.environ['dt'].")
 
-        output = jnp.zeros_like(
-            jnp.asarray(template.to_decimal(template.unit))
-            if isinstance(template, u.Quantity)
-            else jnp.asarray(template)
-        )
+        output = _zeros_like_event_template(template)
+        synapse_store = self._get_synapse_store()
         for connection in self.connections._call_views(scheduled=scheduled_only):
             synapse_type = str(connection.synapse_type[0])
-            if self._get_synapse_store().layout_id(synapse_type) != int(layout.id):
+            if synapse_store.layout_id(synapse_type) != int(layout.id):
                 continue
             row_index = np.arange(len(connection), dtype=np.int32)
-            local_index = self._get_synapse_store().runtime_rows(connection.synapse_id).astype(np.int32)
+            local_index = synapse_store.runtime_rows(connection.synapse_id).astype(np.int32)
             event_count = connection.source.event_count(
                 connection.source_index[row_index],
                 t=t,
@@ -3445,21 +3437,11 @@ class Cell(_CellFacade, HHTypedNeuron):
                 dt=dt,
             )
             connection_weight = connection.weight
-            if connection_weight is None:
-                if isinstance(template, u.Quantity):
-                    raise TypeError("Trigger-only Connection cannot target a physical event buffer.")
-                weight = 1.0
-            elif isinstance(template, u.Quantity):
-                if not isinstance(connection_weight, u.Quantity):
-                    raise TypeError("Connection weight is dimensionless but its target event buffer is not.")
-                weight = connection_weight[row_index].to_decimal(template.unit)
-            else:
-                if isinstance(connection_weight, u.Quantity):
-                    raise TypeError("Connection weight has units but its target event buffer is dimensionless.")
-                weight = connection_weight[row_index]
-            contribution = event_count * u.math.asarray(weight)
+            if connection_weight is not None:
+                connection_weight = connection_weight[row_index]
+            contribution = event_count * u.math.asarray(_connection_event_weight(template, connection_weight))
             output = output.at[local_index].add(contribution)
-        return u.Quantity(output, template.unit) if isinstance(template, u.Quantity) else output
+        return _rewrap_event_template(template, output)
 
     def _apply_direct_live_connection_events(self) -> None:
         """Route live direct sources and run target handlers at this boundary."""
@@ -3475,32 +3457,18 @@ class Cell(_CellFacade, HHTypedNeuron):
         for layout, _ in layouts:
             if layout.id not in self._runtime.event_buffers:
                 continue
-            template = self._runtime.get_event_buffer(layout.id)
-            raw = template.to_decimal(template.unit) if isinstance(template, u.Quantity) else template
-            drives[layout.id] = jnp.zeros_like(jnp.asarray(raw))
+            drives[layout.id] = _zeros_like_event_template(self._runtime.get_event_buffer(layout.id))
 
+        synapse_store = self._get_synapse_store()
         for connection in live_connections:
             counts = connection.event_count(t=t, dt=dt)
             synapse_type = str(connection.synapse_type[0])
-            layout_id = self._get_synapse_store().layout_id(synapse_type)
+            layout_id = synapse_store.layout_id(synapse_type)
             if layout_id not in drives:
                 continue
             template = self._runtime.get_event_buffer(layout_id)
-            connection_weight = connection.weight
-            if connection_weight is None:
-                if isinstance(template, u.Quantity):
-                    raise TypeError("Trigger-only Connection cannot target a physical event buffer.")
-                weight = 1.0
-            elif isinstance(template, u.Quantity):
-                if not isinstance(connection_weight, u.Quantity):
-                    raise TypeError("Connection weight is dimensionless but its target event buffer is not.")
-                weight = connection_weight.to_decimal(template.unit)
-            else:
-                if isinstance(connection_weight, u.Quantity):
-                    raise TypeError("Connection weight has units but its target event buffer is dimensionless.")
-                weight = connection_weight
-            contribution = counts * u.math.asarray(weight)
-            local_indices = self._get_synapse_store().runtime_rows(connection.synapse_id).astype(np.int32)
+            contribution = counts * u.math.asarray(_connection_event_weight(template, connection.weight))
+            local_indices = synapse_store.runtime_rows(connection.synapse_id).astype(np.int32)
             drives[layout_id] = drives[layout_id].at[local_indices].add(contribution)
 
         point_v = self._cv_to_point(self.V.value)
@@ -3508,14 +3476,12 @@ class Cell(_CellFacade, HHTypedNeuron):
             if layout.id not in drives:
                 continue
             template = self._runtime.get_event_buffer(layout.id)
-            drive = (
-                u.Quantity(drives[layout.id], template.unit) if isinstance(template, u.Quantity) else drives[layout.id]
-            )
+            drive = _rewrap_event_template(template, drives[layout.id])
             self._apply_synapse_layout_event_drive(layout.id, drive, point_v=point_v)
 
     def _apply_synapse_layout_event_drive(self, layout_id: int, drive, *, point_v=None) -> None:
         """Apply one already-aggregated boundary payload to a runtime layout."""
-        layout = next(layout for layout in self._runtime.layouts if int(layout.id) == int(layout_id))
+        layout = self._runtime.layouts[int(layout_id)]
         synapse = self._runtime.get_runtime_node(layout.id)
         if point_v is None:
             point_v = self._cv_to_point(self.V.value)
@@ -3938,31 +3904,6 @@ def _select_local_values(values, *, ids: tuple[int, ...]):
     return values[list(int(idx) for idx in ids)]
 
 
-def _normalize_population_selection(selection, *, size: int) -> tuple[int, ...]:
-    """Normalize one integer, slice, or one-dimensional integer selection."""
-    if isinstance(selection, slice):
-        indices = tuple(range(size))[selection]
-    elif isinstance(selection, (int, np.integer)) and not isinstance(selection, bool):
-        index = int(selection)
-        if index < 0:
-            index += size
-        indices = (index,)
-    else:
-        array = np.asarray(selection)
-        if array.ndim != 1 or not np.issubdtype(array.dtype, np.integer):
-            raise TypeError("Cell selection must be an integer, slice, or one-dimensional integer sequence.")
-        normalized = []
-        for raw in array.tolist():
-            index = int(raw)
-            if index < 0:
-                index += size
-            normalized.append(index)
-        indices = tuple(dict.fromkeys(normalized))
-    if any(index < 0 or index >= size for index in indices):
-        raise IndexError(f"Cell population selection is outside [0, {size!r}): {indices!r}.")
-    return tuple(indices)
-
-
 def _select_population_value(value, *, population_indices: tuple[int, ...], population_size: int):
     """Gather the population axis of an array-like value when it has one."""
     shape = tuple(getattr(value, "shape", ()))
@@ -4091,11 +4032,52 @@ def _layout_id_from_runtime_path(path) -> int:
 
 def _gather_layout_point_values(values, layout):
     """Gather point values for a broadcast or packed point layout."""
-    if layout.point_index is None:
-        raise ValueError(f"Point layout {layout.id!r} is missing point_index.")
-    if layout.population_index is None:
-        return values[..., layout.point_index]
-    return values[..., layout.population_index, layout.point_index]
+    return layout.gather_points(values)
+
+
+def _zeros_like_event_template(template):
+    """Build a zeroed mantissa array shaped like one event buffer template."""
+    raw = template.to_decimal(template.unit) if isinstance(template, u.Quantity) else template
+    return jnp.zeros_like(jnp.asarray(raw))
+
+
+def _rewrap_event_template(template, mantissa):
+    """Restore the event buffer template's unit onto an accumulated mantissa."""
+    return u.Quantity(mantissa, template.unit) if isinstance(template, u.Quantity) else mantissa
+
+
+def _connection_event_weight(template, connection_weight):
+    """Coerce one Connection weight into its target event buffer's unit system.
+
+    Parameters
+    ----------
+    template : array_like or brainunit.Quantity
+        Event buffer the weighted arrivals are accumulated into.
+    connection_weight : array_like, brainunit.Quantity, or None
+        Declared Connection weight, already narrowed to the contributing rows.
+        ``None`` marks a trigger-only Connection.
+
+    Returns
+    -------
+    array_like
+        Weight expressed in ``template``'s unit, ready to multiply event counts.
+
+    Raises
+    ------
+    TypeError
+        If the weight and the target event buffer disagree on dimensionality.
+    """
+    if connection_weight is None:
+        if isinstance(template, u.Quantity):
+            raise TypeError("Trigger-only Connection cannot target a physical event buffer.")
+        return 1.0
+    if isinstance(template, u.Quantity):
+        if not isinstance(connection_weight, u.Quantity):
+            raise TypeError("Connection weight is dimensionless but its target event buffer is not.")
+        return connection_weight.to_decimal(template.unit)
+    if isinstance(connection_weight, u.Quantity):
+        raise TypeError("Connection weight has units but its target event buffer is dimensionless.")
+    return connection_weight
 
 
 def _scope_name(prefix: str, path, node) -> str:

--- a/braincell/_multi_compartment/cell_test.py
+++ b/braincell/_multi_compartment/cell_test.py
@@ -32,7 +32,6 @@ from braincell import (
     Branch,
     CVPerBranch,
     Cell,
-    CellSelection,
     CellView,
     Channel,
     CurrentClamp,
@@ -220,8 +219,6 @@ class TestCellDeclaration(unittest.TestCase):
         nested = view[1:]
 
         self.assertIsInstance(view, CellView)
-        self.assertIsInstance(view, CellSelection)
-        self.assertIs(CellSelection, CellView)
         self.assertIs(view.root, cell)
         self.assertIs(view.cell, cell)
         self.assertEqual(view.population_indices, (4, 1, 2))

--- a/braincell/_multi_compartment/currents.py
+++ b/braincell/_multi_compartment/currents.py
@@ -136,12 +136,7 @@ def _profile_barrier_current(current):
 
 
 def _synapse_contrib_to_point(runtime: CellRuntimeState, layout, syn, point_V):
-    if layout.point_index is None:
-        raise ValueError(f"Synapse layout {layout.id!r} is missing point_index.")
-    if layout.population_index is None:
-        local_voltage = point_V[..., layout.point_index]
-    else:
-        local_voltage = point_V[..., layout.population_index, layout.point_index]
+    local_voltage = layout.gather_points(point_V)
     try:
         contrib = jax.named_call(
             syn.current,
@@ -158,13 +153,9 @@ def _synapse_contrib_to_point(runtime: CellRuntimeState, layout, syn, point_V):
             jnp.zeros(point_V.shape, dtype=u.get_mantissa(syn_contrib).dtype),
             syn_contrib.unit,
         )
-        if layout.population_index is not None:
-            return contrib_point.at[..., layout.population_index, layout.point_index].add(syn_contrib)
-        return contrib_point.at[..., layout.point_index].add(syn_contrib)
-    contrib_point = jnp.zeros(point_V.shape, dtype=jnp.asarray(syn_contrib).dtype)
-    if layout.population_index is not None:
-        return contrib_point.at[..., layout.population_index, layout.point_index].add(syn_contrib)
-    return contrib_point.at[..., layout.point_index].add(syn_contrib)
+    else:
+        contrib_point = jnp.zeros(point_V.shape, dtype=jnp.asarray(syn_contrib).dtype)
+    return layout.scatter_add_points(contrib_point, syn_contrib)
 
 
 def _clamp_density(runtime: CellRuntimeState, *, t):

--- a/braincell/_multi_compartment/density_views.py
+++ b/braincell/_multi_compartment/density_views.py
@@ -1,7 +1,23 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 """Logical Channel and Ion views over population/CV scopes."""
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 
 import brainstate
@@ -180,11 +196,9 @@ class _DensityView:
             )
 
     def __repr__(self) -> str:
-        grouped: dict[str, dict[str, int]] = {}
+        grouped: dict[str, Counter] = {}
         for row in self._rows:
-            grouped.setdefault(row.mechanism_type, {})[row.name] = (
-                grouped.setdefault(row.mechanism_type, {}).get(row.name, 0) + 1
-            )
+            grouped.setdefault(row.mechanism_type, Counter())[row.name] += 1
         details = ", ".join(
             f"{mechanism_type}({', '.join(f'{name}: {count}' for name, count in names.items())})"
             for mechanism_type, names in grouped.items()
@@ -214,27 +228,27 @@ class IonView(_DensityView):
 
 def _density_rows(cell, scope, category: str) -> tuple[_DensityRow, ...]:
     by_cv: dict[int, dict[tuple[str, str], Density]] = {}
+    species_by_type: dict[str, str | None] = {}
     for cv in cell.cvs:
         owners = by_cv.setdefault(int(cv.id), {})
         for mechanism in cv.density_mech:
             if not isinstance(mechanism, Density) or mechanism.category != category:
                 continue
             owners.setdefault((mechanism.class_name, mechanism.instance_name), mechanism)
+            if category == "ion" and mechanism.class_name not in species_by_type:
+                runtime_cls = get_registry().get("ion", mechanism.class_name)
+                species_by_type[mechanism.class_name] = _runtime_ion_species_key(runtime_cls)
 
     rows = []
     for population_index, cv_id in scope.pairs:
         point_id = int(cell.node_tree.cv_to_mid_node_id[int(cv_id)])
         for mechanism in by_cv.get(int(cv_id), {}).values():
-            species = None
-            if category == "ion":
-                runtime_cls = get_registry().get("ion", mechanism.class_name)
-                species = _runtime_ion_species_key(runtime_cls)
             rows.append(
                 _DensityRow(
                     category=category,
                     mechanism_type=mechanism.class_name,
                     name=mechanism.instance_name,
-                    species=species,
+                    species=species_by_type.get(mechanism.class_name),
                     population_index=int(population_index),
                     cv_id=int(cv_id),
                     point_id=point_id,
@@ -246,8 +260,8 @@ def _density_rows(cell, scope, category: str) -> tuple[_DensityRow, ...]:
 
 def _runtime_layout(cell, row: _DensityRow):
     matches = []
-    for layout in cell.runtime.layouts:
-        if layout.target != "density" or row.cv_id not in layout.source_cv_ids:
+    for layout in cell.runtime.get_cv_layouts(row.cv_id):
+        if layout.target != "density":
             continue
         mechanism = cell.runtime.get_layout_mechanism(layout.id)
         if (

--- a/braincell/_multi_compartment/density_views_test.py
+++ b/braincell/_multi_compartment/density_views_test.py
@@ -1,3 +1,18 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import unittest
 
 import brainunit as u

--- a/braincell/_multi_compartment/probes.py
+++ b/braincell/_multi_compartment/probes.py
@@ -39,7 +39,7 @@ from braincell._compute import bridge
 if TYPE_CHECKING:
     from .cell import Cell
 
-__all__ = ["sample_probe", "sample_probes"]
+__all__ = ["probe_names", "sample_probe", "sample_probes"]
 
 
 def sample_probe(rcell: "Cell", name: str) -> object:
@@ -58,24 +58,46 @@ def sample_probe(rcell: "Cell", name: str) -> object:
     return _sample_probe_layout(rcell, runtime, layout=layout, declaration=declaration)
 
 
-def sample_probes(rcell: "Cell") -> dict[str, object]:
-    """Return a ``{probe_name: sample}`` dict for every placed probe."""
-    runtime = rcell.runtime
-    sampled: dict[str, object] = {}
+def iter_probe_layouts(runtime: CellRuntimeState):
+    """Yield ``(probe_name, layout, declaration)`` for every placed probe.
+
+    Names are checked for uniqueness here so that callers needing only the
+    names do not have to evaluate the probes to discover a collision.
+
+    Raises
+    ------
+    ValueError
+        If two placed probes resolve to the same name.
+    """
+    seen: set[str] = set()
     for layout in runtime.layouts:
         declaration = runtime.get_layout_mechanism(layout.id)
         if not isinstance(declaration, (StateProbe, MechanismProbe, CurrentProbe)):
             continue
         probe_name = _probe_name(declaration)
-        if probe_name in sampled:
+        if probe_name in seen:
             raise ValueError(f"Multiple probes share the same name {probe_name!r}; probe names must be unique.")
-        sampled[probe_name] = _sample_probe_layout(
-            rcell,
-            runtime,
-            layout=layout,
-            declaration=declaration,
-        )
-    return sampled
+        seen.add(probe_name)
+        yield probe_name, layout, declaration
+
+
+def probe_names(rcell: "Cell") -> tuple[str, ...]:
+    """Return every placed probe's name without evaluating the probes.
+
+    ``run()`` needs the output ordering before it builds the compiled loop;
+    sampling the probes just to read their keys runs real gathers outside
+    ``jit`` on every call.
+    """
+    return tuple(name for name, _, _ in iter_probe_layouts(rcell.runtime))
+
+
+def sample_probes(rcell: "Cell") -> dict[str, object]:
+    """Return a ``{probe_name: sample}`` dict for every placed probe."""
+    runtime = rcell.runtime
+    return {
+        probe_name: _sample_probe_layout(rcell, runtime, layout=layout, declaration=declaration)
+        for probe_name, layout, declaration in iter_probe_layouts(runtime)
+    }
 
 
 def _sample_probe_layout(
@@ -203,10 +225,7 @@ def _sample_current_probe_point(
             layout_id = synapse_view._store.layout_id(synapse_type)
             layout = runtime.layouts[layout_id]
             node = runtime.get_runtime_node(layout_id)
-            if layout.population_index is None:
-                local_voltage = point_V[..., layout.point_index]
-            else:
-                local_voltage = point_V[..., layout.population_index, layout.point_index]
+            local_voltage = layout.gather_points(point_V)
             current = _probe_current_value(
                 node,
                 local_voltage,

--- a/braincell/_multi_compartment/run.py
+++ b/braincell/_multi_compartment/run.py
@@ -29,6 +29,7 @@ import brainunit as u
 import jax
 import numpy as np
 
+from braincell._multi_compartment import probes
 from braincell.recording import SampleBlock
 
 if TYPE_CHECKING:
@@ -117,8 +118,7 @@ def run(rcell: "Cell", *, dt, duration) -> RunResult:
     rcell.connections.prepare_runtime(dt)
 
     compiled_recordings = rcell._compiled_recordings(dt)
-    probe_samples = rcell.sample_probes()
-    ordered_probe_names = tuple(sorted(probe_samples))
+    ordered_probe_names = tuple(sorted(probes.probe_names(rcell)))
 
     with brainstate.environ.context(dt=dt):
         relative_times = u.math.arange(n_steps) * brainstate.environ.get_dt()

--- a/braincell/_multi_compartment/selection.py
+++ b/braincell/_multi_compartment/selection.py
@@ -1,12 +1,27 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 """Immutable spatial selections shared by Cell mechanism views."""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import numpy as np
 
-from braincell._discretization.node_build import _EPS_PARAM, _locate_branch_cv_by_x
+from braincell._discretization.base import locate_cv_on_branch
 from braincell.filter import LocsetBatch, LocsetExpr, LocsetMask, RegionExpr, RegionMask
 
 __all__ = ["BranchSelector", "CVSelector"]
@@ -61,15 +76,17 @@ class _CellScope:
     def select_population(self, local_selection) -> "_CellScope":
         local = _normalize_selection(local_selection, size=len(self.population_indices), name="Cell population")
         selected = tuple(self.population_indices[index] for index in local)
-        return _CellScope(
+        order = {population: rank for rank, population in enumerate(selected)}
+        return replace(
+            self,
             population_indices=selected,
-            pairs=tuple(pair for population in selected for pair in self.pairs if pair[0] == population),
-            coverage=self.coverage,
+            pairs=tuple(sorted((pair for pair in self.pairs if pair[0] in order), key=lambda pair: order[pair[0]])),
             locations=tuple(
-                row for population in selected for row in self.locations if row.population_index == population
+                sorted(
+                    (row for row in self.locations if row.population_index in order),
+                    key=lambda row: order[row.population_index],
+                )
             ),
-            exact_branch_ids=self.exact_branch_ids,
-            spatially_restricted=self.spatially_restricted,
         )
 
     def select_cv_local(self, selection) -> "_CellScope":
@@ -79,16 +96,13 @@ class _CellScope:
 
     def select_cv_ids(self, cv_ids) -> "_CellScope":
         requested = _normalize_global_ids(cv_ids, name="CV")
-        requested_set = set(requested)
         available = set(self.cv_ids)
-        selected = tuple(cv_id for cv_id in requested if cv_id in available)
-        selected_set = set(selected)
-        return _CellScope(
-            population_indices=self.population_indices,
+        selected_set = {cv_id for cv_id in requested if cv_id in available}
+        return replace(
+            self,
             pairs=tuple(pair for pair in self.pairs if pair[1] in selected_set),
             coverage=tuple((cv_id, fraction) for cv_id, fraction in self.coverage if cv_id in selected_set),
             locations=tuple(row for row in self.locations if row.cv_id in selected_set),
-            exact_branch_ids=self.exact_branch_ids,
             spatially_restricted=True,
         )
 
@@ -96,16 +110,9 @@ class _CellScope:
         selected = _normalize_global_ids(branch_ids, name="branch")
         if any(branch_id < 0 or branch_id >= len(cell.morpho.branches) for branch_id in selected):
             raise IndexError("Branch index is out of range.")
-        cv_ids = tuple(cv.id for cv in cell.cvs if cv.branch_id in set(selected))
-        result = self.select_cv_ids(cv_ids)
-        return _CellScope(
-            population_indices=result.population_indices,
-            pairs=result.pairs,
-            coverage=result.coverage,
-            locations=result.locations,
-            exact_branch_ids=selected,
-            spatially_restricted=True,
-        )
+        selected_branches = set(selected)
+        cv_ids = tuple(cv.id for cv in cell.cvs if cv.branch_id in selected_branches)
+        return replace(self.select_cv_ids(cv_ids), exact_branch_ids=selected)
 
     def select_region(self, cell, region: RegionExpr | RegionMask) -> "_CellScope":
         if not isinstance(region, (RegionExpr, RegionMask)):
@@ -114,23 +121,21 @@ class _CellScope:
         selected = tuple(cv_id for cv_id, fraction in fractions.items() if float(fraction) > 0.0)
         result = self.select_cv_ids(selected)
         selected_set = set(result.cv_ids)
-        return _CellScope(
-            population_indices=result.population_indices,
-            pairs=result.pairs,
+        return replace(
+            result,
             coverage=tuple((cv_id, float(fractions[cv_id])) for cv_id in selected if cv_id in selected_set),
             locations=(),
             exact_branch_ids=None,
-            spatially_restricted=True,
         )
 
     def select_locations(self, cell, locset) -> "_CellScope":
         rows = _resolve_location_rows(cell, self.population_indices, locset)
         allowed = set(self.pairs)
         rows = tuple(row for row in rows if (row.population_index, row.cv_id) in allowed)
-        pairs = _ordered_unique((row.population_index, row.cv_id) for row in rows)
-        return _CellScope(
-            population_indices=self.population_indices,
-            pairs=pairs,
+        return replace(
+            self,
+            pairs=_ordered_unique((row.population_index, row.cv_id) for row in rows),
+            coverage=(),
             locations=rows,
             exact_branch_ids=None,
             spatially_restricted=True,
@@ -216,22 +221,16 @@ def _resolve_location_rows(cell, population_indices: tuple[int, ...], locset) ->
 
 
 def _mask_rows(cell, population_index: int, mask: LocsetMask) -> tuple[_LocationRow, ...]:
-    names = mask.display_names
-    if names is None:
-        names = tuple(
-            f"{cell.morpho.branch(index=int(branch_id)).name}({float(branch_x):g})"
-            for branch_id, branch_x in mask.points
-        )
+    names = mask.resolved_display_names(cell.morpho)
     rows = []
     for branch_id, branch_x, display_name in zip(mask.branch_id, mask.branch_x, names):
         branch_id = int(branch_id)
         if branch_id < 0 or branch_id >= len(cell.cv_tree.branch_to_cv_ids):
             raise IndexError(f"Location branch id {branch_id!r} is out of range.")
-        cv_id = _locate_branch_cv_by_x(
+        cv_id = locate_cv_on_branch(
             cell.cv_tree.branch_to_cv_ids[branch_id],
             cell.cvs,
             x=float(branch_x),
-            epsilon=_EPS_PARAM,
         )
         rows.append(
             _LocationRow(

--- a/braincell/_multi_compartment/selection_test.py
+++ b/braincell/_multi_compartment/selection_test.py
@@ -1,3 +1,18 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import unittest
 
 import brainunit as u

--- a/braincell/_multi_compartment/synapses.py
+++ b/braincell/_multi_compartment/synapses.py
@@ -29,6 +29,7 @@ import brainunit as u
 import jax.numpy as jnp
 import numpy as np
 
+from braincell._compute.layouts import _stack_synapse_values
 from braincell.mech import SynapseSpec, get_registry
 
 __all__ = ["SynapseView"]
@@ -70,6 +71,7 @@ class _SynapseStore:
         "_row_by_id",
         "_layout_by_type",
         "_runtime_row_by_id",
+        "_mechanism_layouts",
     )
 
     def __init__(self, cell) -> None:
@@ -113,6 +115,7 @@ class _SynapseStore:
         self._type_local_by_id: dict[int, int] = {}
         self._layout_by_type: dict[str, int] = {}
         self._runtime_row_by_id: dict[int, int] = {}
+        self._mechanism_layouts: dict[int, _MechanismRowLayout] = {}
         self._validate_name_types()
         self._build_parameter_columns()
 
@@ -162,7 +165,7 @@ class _SynapseStore:
                         value = spec.default
                     spec.validate(value, parameter)
                     values.append(value)
-                columns[parameter] = _stack_values(values)
+                columns[parameter] = _stack_synapse_values(values, parameter=parameter)
             runtime_cls.validate_parameter_values(columns)
             self.parameter_columns[synapse_type] = columns
 
@@ -174,6 +177,20 @@ class _SynapseStore:
         self._runtime_row_by_id.update(
             (int(logical_id), int(runtime_row)) for runtime_row, logical_id in enumerate(ids.tolist())
         )
+
+    def mechanism_row_layout(self, mechanism: SynapseSpec) -> "_MechanismRowLayout":
+        """Return the cached row layout shared by one declaration's synapses.
+
+        The layout depends only on the declaring ``mechanism``, so it is built
+        once per declaration rather than re-derived for every logical synapse
+        that declaration produced.
+        """
+        key = id(mechanism)
+        cached = self._mechanism_layouts.get(key)
+        if cached is None:
+            cached = _MechanismRowLayout.build(self, mechanism)
+            self._mechanism_layouts[key] = cached
+        return cached
 
     def layout_id(self, synapse_type: str) -> int:
         try:
@@ -454,8 +471,9 @@ class SynapseView:
         if not self._cell._initialized:
             if field not in parameter_names:
                 raise KeyError(f"Synapse field {field!r} is unavailable before init_state().")
-            return _stack_values(
-                [self._store.parameter_value(int(index), field) for index in self._logical_ids.tolist()]
+            return _stack_synapse_values(
+                [self._store.parameter_value(int(index), field) for index in self._logical_ids.tolist()],
+                parameter=field,
             )
 
         layout_id = self._store.layout_id(synapse_type)
@@ -569,6 +587,7 @@ class SynapseView:
         layout_id = self._store.layout_id(synapse_type)
         node = self._cell.runtime.get_runtime_node(layout_id)
         parameters = self._parameter_names(synapse_type)
+        rows = self._store.runtime_rows(self._logical_ids)
         for state, value in states.items():
             target = getattr(node, state, None)
             if not isinstance(target, brainstate.State):
@@ -576,9 +595,9 @@ class SynapseView:
                     raise KeyError(f"Synapse field {state!r} is a parameter; use set().")
                 raise KeyError(f"Synapse type {synapse_type!r} has no dynamic state {state!r}.")
             current = target.value
-            selected = _take_last_axis(current, self._store.runtime_rows(self._logical_ids))
+            selected = _take_last_axis(current, rows)
             normalized = _normalize_selected_value(value, template=selected, count=len(self))
-            target.value = _set_last_axis(current, self._store.runtime_rows(self._logical_ids), normalized)
+            target.value = _set_last_axis(current, rows, normalized)
         return self
 
     def _parameter_names(self, synapse_type: str) -> set[str]:
@@ -611,7 +630,7 @@ class SynapseView:
             names = _count_labels(self.name)
             parameters = tuple(sorted(self._parameter_names(synapse_type)))
             if len(self) == 1:
-                values = {field: _single_repr_value(self.get(field)) for field in parameters}
+                values = {field: self.get(field)[0] for field in parameters}
                 return (
                     f"SynapseView(target={target}, size=1, synapse_type={synapse_type}, "
                     f"names={names!r}, parameters={values!r})"
@@ -636,11 +655,6 @@ def _count_labels(values) -> dict[str, int]:
     return counts
 
 
-def _single_repr_value(value):
-    """Return the scalar row from a size-one gathered parameter column."""
-    return value[0]
-
-
 def _cell_label(cell, population_indices) -> str:
     owners = tuple(dict.fromkeys(int(item) for item in np.asarray(population_indices).tolist()))
     size = 1 if len(cell.pop_size) == 0 else int(cell.pop_size[0])
@@ -649,52 +663,70 @@ def _cell_label(cell, population_indices) -> str:
     return f"CellView(name={cell.name!r}, cells={list(owners)!r})"
 
 
+@dataclass(frozen=True)
+class _MechanismRowLayout:
+    """Row bookkeeping shared by every logical synapse of one declaration.
+
+    Declared parameters broadcast over the ``(owner, local position)`` grid this
+    describes. It depends only on the declaration, so it is built once and
+    reused for each of that declaration's synapses and parameters.
+    """
+
+    size: int
+    owner_count: int
+    common_length: int | None
+    #: logical id -> (flat position, owner position, position within that owner)
+    positions: dict[int, tuple[int, int, int]]
+
+    @classmethod
+    def build(cls, store: "_SynapseStore", mechanism: SynapseSpec) -> "_MechanismRowLayout":
+        matching_rows = np.asarray(
+            [row for row, candidate in enumerate(store.mechanism) if candidate is mechanism],
+            dtype=np.int64,
+        )
+        matching = store.id[matching_rows]
+        owners = store.population_index[matching_rows]
+        owner_order = tuple(dict.fromkeys(int(owner) for owner in owners.tolist()))
+        owner_position_by_owner = {owner: index for index, owner in enumerate(owner_order)}
+        counts = tuple(int(np.sum(owners == item)) for item in owner_order)
+        common_length = counts[0] if counts and all(count == counts[0] for count in counts) else None
+
+        positions: dict[int, tuple[int, int, int]] = {}
+        seen_per_owner: dict[int, int] = {}
+        for position, (logical_id, owner) in enumerate(zip(matching.tolist(), owners.tolist())):
+            local_position = seen_per_owner.get(int(owner), 0)
+            seen_per_owner[int(owner)] = local_position + 1
+            positions[int(logical_id)] = (position, owner_position_by_owner[int(owner)], local_position)
+        return cls(
+            size=int(matching.size),
+            owner_count=len(owner_order),
+            common_length=common_length,
+            positions=positions,
+        )
+
+
 def _select_declared_parameter_value(value, *, logical_id: int, store: _SynapseStore, mechanism: SynapseSpec):
     shape = getattr(value, "shape", ())
     if shape in ((), None):
         return value
-    matching_rows = np.asarray(
-        [row for row, candidate in enumerate(store.mechanism) if candidate is mechanism],
-        dtype=np.int64,
-    )
-    matching = store.id[matching_rows]
+    layout = store.mechanism_row_layout(mechanism)
+    position, owner_position, local_position = layout.positions[int(logical_id)]
+    common_length = layout.common_length
     array = np.asarray(value.to_decimal(value.unit) if isinstance(value, u.Quantity) else value)
-    position = int(np.flatnonzero(matching == int(logical_id))[0])
-    owners = store.population_index[matching_rows]
-    owner_order = tuple(dict.fromkeys(int(owner) for owner in owners.tolist()))
-    owner = int(store.population_index[store.row_index(int(logical_id))])
-    owner_position = owner_order.index(owner)
-    owner_rows = matching[owners == owner]
-    local_position = int(np.flatnonzero(owner_rows == int(logical_id))[0])
-    counts = tuple(int(np.sum(owners == item)) for item in owner_order)
-    common_length = counts[0] if counts and all(count == counts[0] for count in counts) else None
 
     if array.size == 1:
         selected = array.reshape(-1)[0]
     elif common_length is not None and array.shape == (common_length,):
         selected = array[local_position]
-    elif array.shape == (len(owner_order), 1):
+    elif array.shape == (layout.owner_count, 1):
         selected = array[owner_position, 0]
-    elif common_length is not None and array.shape == (len(owner_order), common_length):
+    elif common_length is not None and array.shape == (layout.owner_count, common_length):
         selected = array[owner_position, local_position]
-    elif array.shape == (matching.size,):
+    elif array.shape == (layout.size,):
         selected = array[position]
     else:
-        raise ValueError(f"Synapse parameter shape {shape!r} cannot broadcast to {matching.size!r} logical instances.")
+        raise ValueError(f"Synapse parameter shape {shape!r} cannot broadcast to {layout.size!r} logical instances.")
     return u.Quantity(selected, value.unit) if isinstance(value, u.Quantity) else selected
-
-
-def _stack_values(values: list[object]):
-    if not values:
-        return np.asarray([], dtype=float)
-    first = values[0]
-    if isinstance(first, u.Quantity):
-        unit = first.unit
-        decimal = [np.asarray(item.to_decimal(unit)) for item in values]
-        return u.Quantity(np.asarray(decimal), unit)
-    if any(isinstance(item, u.Quantity) for item in values):
-        raise TypeError("Synapse parameter values mix dimensioned and dimensionless data.")
-    return np.asarray(values)
 
 
 def _take_vector_item(value, index: int):

--- a/braincell/_multi_compartment/synapses_test.py
+++ b/braincell/_multi_compartment/synapses_test.py
@@ -1,3 +1,18 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
 import unittest
 
 import brainunit as u

--- a/braincell/filter/locset.py
+++ b/braincell/filter/locset.py
@@ -303,6 +303,29 @@ class LocsetMask:
             object.__setattr__(self, "_points_cache", cached)
         return cached
 
+    def resolved_display_names(self, morpho) -> tuple[str, ...]:
+        """Return display names, deriving ``branch(x)`` labels when unset.
+
+        Locations carry optional author-supplied names; when they are absent
+        every consumer needs the same ``branch_name(x)`` fallback, so the
+        label format is defined here rather than at each call site.
+
+        Parameters
+        ----------
+        morpho : braincell.morph.Morphology
+            Morphology used to resolve branch names.
+
+        Returns
+        -------
+        tuple of str
+            One label per location row.
+        """
+        if self._display_names is not None:
+            return self._display_names
+        return tuple(
+            f"{morpho.branch(index=int(branch_id)).name}({float(branch_x):g})" for branch_id, branch_x in self.points
+        )
+
     def __len__(self) -> int:
         return len(self._branch_id)
 

--- a/docs/specs/2026-08-20-cell-population-view.md
+++ b/docs/specs/2026-08-20-cell-population-view.md
@@ -14,7 +14,6 @@ selected rows on demand.
   `CellView`. Negative indices are normalized and repeated fancy indices are
   deduplicated in first-occurrence order.
 - Views can be indexed again. The second selection is relative to the first.
-- `CellSelection` remains an alias for source compatibility.
 - Shared declarations and topology (`morpho`, CV policy/tree, node tree,
   solver configuration, and paint rules) are exposed without copying.
 - `point_placements`, `place_rules`, `synapses`, and contact groups are


### PR DESCRIPTION
Follow-up quality pass over the modules touched by #132 — `_multi_compartment/`, `_discretization/`, `_compute/`. Reviewed for reuse, simplification, efficiency, and altitude; no correctness-bug hunting and no intended behavior change.

Verification: full suite **2549 passed, 7 skipped** — identical to the pre-change baseline. `pre-commit run --all-files` passes.

## Reuse
- Add `MechanismLayout.gather_points()` / `scatter_add_points()`. The packed-vs-broadcast `population_index is None` branch was inlined at four sites (`cell.py`, `currents.py` ×3, `probes.py`). This also gives the previously unused `is_packed` property a caller.
- Drop `synapses._stack_values` in favour of `layouts._stack_synapse_values`, which already validated the same data downstream.
- Add `LocsetMask.resolved_display_names()`. The `branch(x)` label fallback was duplicated verbatim in `selection.py` and `_discretization/mechanism.py`.
- Extract `_connection_event_weight` / `_zeros_like_event_template` / `_rewrap_event_template`. The 12-line weight/unit ladder, including three character-identical `TypeError` strings, existed twice in `cell.py`.

## Efficiency
- `_apply_density_parameter_overrides` was `O(overrides × layouts × CVs)` with a whole-buffer copy per override. Now builds one owner index and applies grouped scatters — an unrestricted `channels.set()` on a 100×500 cell drops from 50k full-array copies to one per buffer.
- `density_views._runtime_layout` scanned every layout per row; now uses the existing O(1) `runtime.get_cv_layouts()`.
- `_MechanismRowLayout` caches per-declaration row bookkeeping that `_select_declared_parameter_value` re-derived for every (parameter, row) pair.
- `Cell._root_scope()` caches the `pop_size × n_cv` pair grid, invalidated alongside the discretization cache. It was rebuilt on every `cell.soma` / `cell.channels` / `cell.record` access.
- `probes.probe_names()` added. `run()` was executing a full eager probe evaluation — real JAX gathers outside `jit` — on every call just to read the keys.
- Hoisted a `set()` built inside a generator, a duplicated `runtime_rows()` call, and a per-row ion-registry lookup.

## Simplification / altitude
- Deleted dead code: `_normalize_population_selection` (a copy of the live `selection._normalize_selection`), `_view_population_indices` (3 sites), the never-read `runtime_name` layout key, `_single_repr_value`.
- `_CellScope` transitions use `dataclasses.replace` instead of rebuilding all six fields by hand five times.
- `bindings.py` selects synapse constructor args from `runtime_cls.parameters` rather than a `startswith("_")` naming convention.
- `selection.py` / `cell.py` import the public `locate_cv_on_branch` instead of the private `_locate_branch_cv_by_x` shim across package boundaries.
- Replaced an O(n) `next(...)` layout scan with the direct index used everywhere else.

## Housekeeping
- Five new files (`selection.py`, `density_views.py`, and three `*_test.py`) were missing the mandatory Apache-2.0 header required by `AGENTS.md`. Added.
- Removed the `CellSelection` compatibility alias across all six sites, including its spec doc line.

## Deliberately not done
- **`RunResult.traces` / `samples` duplication.** Every recording is reachable twice and `concat` reconciles them under two different rules. Real smell, but the fix changes a public result type's constructor and concat semantics — an API decision, not a cleanup.
- **Merging `base.locate_cv_on_branch` with `geometry.locate_cv_on_branch`.** Different record types, and the geometry one has an extra epsilon-tolerant fallback loop; consolidating would change boundary behavior.
- **`_with_optional_unit` → `_split_unit`.** `_split_unit` casts to `float64`; the synapse parameter path must preserve integer dtypes.
- **The `_compute` ↔ `_multi_compartment` layering inversions** (`_compute/state.py` reaching into `Cell._density_parameter_overrides` and `_SynapseStore`; synapse layouts bypassing `register()`). The most substantive findings, but each is a multi-module interface redesign that warrants its own spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Streamline the network refactor modules by consolidating shared behavior, reducing repeated work, and removing obsolete code without changing runtime behavior.

Enhancements:
- Centralize point gathering/scattering, location naming, event handling, and synapse value stacking to reduce duplicated logic across network modules.
- Improve runtime efficiency for density overrides, density layout lookup, synapse row selection, cell scope creation, and probe name discovery.
- Simplify selection and scope transformations, use public APIs across module boundaries, and remove obsolete compatibility and dead code.

Chores:
- Add required Apache-2.0 headers to affected source and test files and remove the deprecated CellSelection compatibility alias.