### PR TITLE
Deduplicate braincell.vis value handling and make 2D layout 30x faster

### DIFF
--- a/braincell/vis/_values.py
+++ b/braincell/vis/_values.py
@@ -38,20 +38,25 @@ raw floats and the unit string is reported back so the scene builder
 can forward it to the value spec's colour-bar label.
 """
 
+import dataclasses
+from typing import Iterable
+
+import brainunit as u
 import numpy as np
 
 from braincell.morph.morphology import Morphology
-from .scene import BranchValues, ValueSpec
-
-try:  # pragma: no cover - branched off at import
-    import brainunit as u
-except ModuleNotFoundError:  # pragma: no cover
-    u = None  # type: ignore[assignment]
+from .scene import BranchValues, OverlaySpec, ValueSpec
 
 
 def _strip_quantity(values) -> tuple[np.ndarray, str | None]:
-    """Return ``(raw_array, unit_string_or_None)`` for a possibly-unit-carrying input."""
-    if u is not None and isinstance(values, u.Quantity):
+    """Return ``(raw_array, unit_string_or_None)`` for a possibly-unit-carrying input.
+
+    This is the single unit-stripping boundary for the whole ``vis``
+    package — ``traces``, ``movie``, and ``point_topology`` all route
+    through it so that "what counts as a quantity" is decided in one
+    place.
+    """
+    if isinstance(values, u.Quantity):
         unit = u.get_unit(values)
         raw = np.asarray(u.get_mantissa(values), dtype=float)
         return raw, str(unit)
@@ -185,6 +190,21 @@ def _expand_per_point(
     return per_branch
 
 
+def compose_colorbar_label(label: str | None, unit: str | None) -> str | None:
+    """Combine a label and a unit string into one colour-bar title.
+
+    ``("V", "mV")`` → ``"V [mV]"``; ``(None, "mV")`` → ``"[mV]"``;
+    ``("V", None)`` → ``"V"``; ``(None, None)`` → ``None``.
+    """
+    if label is None and unit is None:
+        return None
+    if label is None:
+        return f"[{unit}]"
+    if unit is None:
+        return str(label)
+    return f"{label} [{unit}]"
+
+
 def resolved_colorbar_label(spec: ValueSpec, unit_label: str | None) -> str | None:
     """Compose the final colour-bar label.
 
@@ -193,12 +213,96 @@ def resolved_colorbar_label(spec: ValueSpec, unit_label: str | None) -> str | No
     array if the spec's field is ``None``). Returns ``None`` when no
     label information is available at all.
     """
-    label = spec.label
-    unit = spec.unit_label if spec.unit_label is not None else unit_label
-    if label is None and unit is None:
+    return compose_colorbar_label(
+        spec.label,
+        spec.unit_label if spec.unit_label is not None else unit_label,
+    )
+
+
+def resolve_value_limits(
+    spec: ValueSpec | None,
+    value_arrays: Iterable[np.ndarray],
+    *,
+    degenerate_pad: float = 0.5,
+) -> tuple[float, float]:
+    """Resolve the ``(vmin, vmax)`` colour scale for a value overlay.
+
+    Honours explicit ``spec.vmin`` / ``spec.vmax`` and derives whichever
+    bound is ``None`` from *value_arrays*. A degenerate range (all
+    scalars equal, or no data at all) is widened by ``±degenerate_pad``
+    so colormap normalisation stays well-defined.
+
+    Every backend resolves its own colour scale from the primitives it
+    happens to render, so *value_arrays* is supplied by the caller
+    rather than derived here — this helper owns the bound-resolution
+    and degenerate-range *policy*, not the choice of which scalars feed
+    it.
+
+    Parameters
+    ----------
+    spec : ValueSpec or None
+        Value spec whose explicit bounds take precedence, if any.
+    value_arrays : iterable of numpy.ndarray
+        Scalar arrays to derive the missing bounds from. Empty arrays
+        are skipped.
+    degenerate_pad : float
+        Half-width applied when the resolved range has zero extent.
+
+    Returns
+    -------
+    vmin, vmax : float
+        The resolved colour-scale bounds, always with ``vmin < vmax``.
+    """
+    explicit_min = None if spec is None else spec.vmin
+    explicit_max = None if spec is None else spec.vmax
+
+    low: float | None = None
+    high: float | None = None
+    if explicit_min is None or explicit_max is None:
+        for array in value_arrays:
+            array = np.asarray(array, dtype=float)
+            if array.size == 0:
+                continue
+            array_min = float(array.min())
+            array_max = float(array.max())
+            low = array_min if low is None else min(low, array_min)
+            high = array_max if high is None else max(high, array_max)
+
+    vmin = float(explicit_min) if explicit_min is not None else (0.0 if low is None else low)
+    vmax = float(explicit_max) if explicit_max is not None else (1.0 if high is None else high)
+    if vmin == vmax:
+        vmin -= degenerate_pad
+        vmax += degenerate_pad
+    return vmin, vmax
+
+
+def resolve_overlay_values(
+    overlay: OverlaySpec | None,
+    morpho: Morphology,
+) -> tuple[ValueSpec | None, dict[int, BranchValues] | None, str | None]:
+    """Return ``(spec, per_branch_values, unit_label)`` or ``(None, None, None)``.
+
+    Shared by the 2D and 3D scene builders — neither step depends on
+    the dimensionality of the scene being built.
+    """
+    if overlay is None:
+        return None, None, None
+    spec = overlay.values_spec()
+    if spec is None:
+        return None, None, None
+    per_branch, unit_label = resolve_values(morpho, spec)
+    return spec, per_branch, unit_label
+
+
+def with_unit_label(spec: ValueSpec | None, unit_label: str | None) -> ValueSpec | None:
+    """Inject the unit label derived from the input array into the spec.
+
+    A unit label already set on the spec always wins. Uses
+    :func:`dataclasses.replace` so that a new :class:`ValueSpec` field
+    cannot be silently dropped here.
+    """
+    if spec is None:
         return None
-    if label is None:
-        return f"[{unit}]"
-    if unit is None:
-        return str(label)
-    return f"{label} [{unit}]"
+    if unit_label is None or spec.unit_label is not None:
+        return spec
+    return dataclasses.replace(spec, unit_label=unit_label)

--- a/braincell/vis/backend.py
+++ b/braincell/vis/backend.py
@@ -14,10 +14,42 @@
 # ==============================================================================
 
 
+import importlib.util
+import sys
 from dataclasses import dataclass
 from typing import Protocol
 
 from .scene import RenderScene2D, RenderScene3D
+
+
+def module_available(module_name: str) -> bool:
+    """Return whether *module_name* can be imported, without importing it.
+
+    This is the probe every backend's ``available()`` uses, so an
+    optional dependency is detected the same way everywhere and none of
+    the backends import their heavy third-party module at import time.
+
+    Parameters
+    ----------
+    module_name : str
+        Top-level module name, e.g. ``"plotly"``.
+
+    Returns
+    -------
+    bool
+        ``True`` when the module is installed or already imported.
+
+    Notes
+    -----
+    :func:`importlib.util.find_spec` raises :class:`ValueError` for a
+    module that is present in :data:`sys.modules` but has no ``__spec__``
+    (which is what a test double injected into ``sys.modules`` looks
+    like); that case falls back to a membership test.
+    """
+    try:
+        return importlib.util.find_spec(module_name) is not None
+    except ValueError:
+        return module_name in sys.modules
 
 
 class RenderBackend(Protocol):

--- a/braincell/vis/backend_matplotlib.py
+++ b/braincell/vis/backend_matplotlib.py
@@ -14,13 +14,14 @@
 # ==============================================================================
 
 
-import importlib.util
-import sys
 from dataclasses import dataclass
+from itertools import chain
 
 import numpy as np
 
-from ._values import resolved_colorbar_label
+from ._values import resolve_value_limits, resolved_colorbar_label
+from .backend import module_available
+from .config import rgb_to_float as _rgb_to_float
 from .hooks import PickInfo, VisHooks
 from .scene import (
     HighlightStroke2D,
@@ -51,10 +52,7 @@ class MatplotlibBackend:
     show_axes: bool = False
 
     def available(self) -> bool:
-        try:
-            return importlib.util.find_spec("matplotlib") is not None
-        except ValueError:
-            return "matplotlib" in sys.modules
+        return module_available("matplotlib")
 
     def render(self, request: RenderRequest) -> object:
         scene = request.scene
@@ -148,10 +146,6 @@ def _primitive_order(primitive) -> int:
     return getattr(primitive, "draw_order", 0)
 
 
-def _rgb_to_float(rgb: tuple[int, int, int]) -> tuple[float, float, float]:
-    return tuple(float(channel) / 255.0 for channel in rgb)  # type: ignore[return-value]
-
-
 # ---------------------------------------------------------------------------
 # Vectorized base primitives (PolyCollection for frustum; per-segment
 # ``ax.plot`` for polylines so that `ax.lines` introspection remains
@@ -223,24 +217,16 @@ def _build_norm(scene: RenderScene2D, value_spec: ValueSpec | None):
 
     from matplotlib.colors import Normalize
 
-    all_values: list[float] = []
-    for polyline in scene.polyline_values:
-        if polyline.segment_values.size:
-            all_values.extend(float(v) for v in polyline.segment_values)
-    for batch in scene.polygon_value_batches:
-        if batch.polygon_values.size:
-            all_values.extend(float(v) for v in batch.polygon_values)
-
-    vmin = value_spec.vmin
-    vmax = value_spec.vmax
-    if vmin is None:
-        vmin = float(min(all_values)) if all_values else 0.0
-    if vmax is None:
-        vmax = float(max(all_values)) if all_values else 1.0
-    if vmin == vmax:
-        # Avoid degenerate colourmap: pad to ±1 around the single value.
-        vmin = vmin - 0.5
-        vmax = vmax + 0.5
+    # Reduce per array rather than flattening every scalar into a Python
+    # list first — the list build dominated this function on large
+    # morphologies.
+    vmin, vmax = resolve_value_limits(
+        value_spec,
+        chain(
+            (polyline.segment_values for polyline in scene.polyline_values),
+            (batch.polygon_values for batch in scene.polygon_value_batches),
+        ),
+    )
     return Normalize(vmin=vmin, vmax=vmax)
 
 

--- a/braincell/vis/backend_plotly.py
+++ b/braincell/vis/backend_plotly.py
@@ -31,15 +31,14 @@ The backend is gated on ``importlib.util.find_spec("plotly")``; when
 default :class:`BackendChooser` falls back to PyVista or matplotlib.
 """
 
-import importlib.util
-import sys
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Iterator
 
 import numpy as np
 
-from ._values import resolved_colorbar_label
-from .scene import RenderRequest, RenderScene3D, ValueSpec
+from ._values import resolve_value_limits, resolved_colorbar_label
+from .backend import module_available
+from .scene import BranchTypeBatch3D, RenderRequest, RenderScene3D, ValueBatch3D, ValueSpec
 
 
 @dataclass(frozen=True)
@@ -76,10 +75,7 @@ class PlotlyBackend:
     show_scalar_bar: bool = True
 
     def available(self) -> bool:
-        try:
-            return importlib.util.find_spec("plotly") is not None
-        except ValueError:
-            return "plotly" in sys.modules
+        return module_available("plotly")
 
     def render(self, request: RenderRequest) -> object:
         scene = request.scene
@@ -154,6 +150,30 @@ def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:
     return "#{:02x}{:02x}{:02x}".format(int(rgb[0]), int(rgb[1]), int(rgb[2]))
 
 
+def _iter_batch_polylines(batch: BranchTypeBatch3D | ValueBatch3D) -> Iterator[tuple[str, np.ndarray]]:
+    """Yield ``(branch_name, point_indices)`` for each branch in a 3D batch.
+
+    ``batch.lines`` is the VTK-style ``[n, i0, i1, … i{n-1}]`` repeating
+    cell encoding produced by
+    :func:`~braincell.vis.scene3d.build_render_scene_3d`. It is written
+    in one place, so it is decoded in one place too — both trace
+    builders below consume this.
+
+    A branch whose slot has no matching name falls back to the batch's
+    branch type.
+    """
+    lines = batch.lines
+    cursor = 0
+    branch_slot = 0
+    while cursor < len(lines):
+        n_points = int(lines[cursor])
+        indices = lines[cursor + 1 : cursor + 1 + n_points]
+        branch_name = batch.branch_names[branch_slot] if branch_slot < len(batch.branch_names) else batch.branch_type
+        yield branch_name, indices
+        cursor += 1 + n_points
+        branch_slot += 1
+
+
 def _add_branch_type_traces(fig: Any, go: Any, scene: RenderScene3D, *, line_width: float) -> None:
     """Render one ``Scatter3d`` line per branch type with NaN separators."""
     for batch in scene.batches:
@@ -164,17 +184,7 @@ def _add_branch_type_traces(fig: Any, go: Any, scene: RenderScene3D, *, line_wid
         ys: list[float] = []
         zs: list[float] = []
         hover_texts: list[str] = []
-        offset = 0
-        # ``batch.lines`` is the VTK-style ``[n, i0, i1, … i{n-1}]``
-        # repeating encoding. Walk it to recover per-branch point ranges.
-        i = 0
-        branch_slot = 0
-        while i < len(batch.lines):
-            n = int(batch.lines[i])
-            indices = batch.lines[i + 1 : i + 1 + n]
-            branch_name = (
-                batch.branch_names[branch_slot] if branch_slot < len(batch.branch_names) else batch.branch_type
-            )
+        for branch_name, indices in _iter_batch_polylines(batch):
             for index in indices:
                 pt = batch.points_um[int(index)]
                 xs.append(float(pt[0]))
@@ -186,9 +196,6 @@ def _add_branch_type_traces(fig: Any, go: Any, scene: RenderScene3D, *, line_wid
             ys.append(float("nan"))
             zs.append(float("nan"))
             hover_texts.append("")
-            i += 1 + n
-            branch_slot += 1
-            offset += n
         if not xs:
             continue
         color = _rgb_to_hex(batch.color_rgb)
@@ -217,17 +224,7 @@ def _add_value_traces(
 ) -> None:
     """Render value batches as coloured ``Scatter3d`` lines with a shared scale."""
     # Shared colour-scale bounds across every batch.
-    vmins: list[float] = []
-    vmaxs: list[float] = []
-    for batch in scene.value_batches:
-        if batch.point_values.size:
-            vmins.append(float(np.min(batch.point_values)))
-            vmaxs.append(float(np.max(batch.point_values)))
-    vmin = value_spec.vmin if value_spec.vmin is not None else (min(vmins) if vmins else 0.0)
-    vmax = value_spec.vmax if value_spec.vmax is not None else (max(vmaxs) if vmaxs else 1.0)
-    if vmin == vmax:
-        vmin -= 0.5
-        vmax += 0.5
+    vmin, vmax = resolve_value_limits(value_spec, (batch.point_values for batch in scene.value_batches))
 
     title = resolved_colorbar_label(value_spec, value_spec.unit_label)
 
@@ -237,16 +234,8 @@ def _add_value_traces(
         zs: list[float] = []
         values: list[float] = []
         hover_texts: list[str] = []
-        i = 0
-        point_cursor = 0
-        branch_slot = 0
-        while i < len(batch.lines):
-            n = int(batch.lines[i])
-            indices = batch.lines[i + 1 : i + 1 + n]
-            branch_name = (
-                batch.branch_names[branch_slot] if branch_slot < len(batch.branch_names) else batch.branch_type
-            )
-            for k, idx in enumerate(indices):
+        for branch_name, indices in _iter_batch_polylines(batch):
+            for idx in indices:
                 pt = batch.points_um[int(idx)]
                 xs.append(float(pt[0]))
                 ys.append(float(pt[1]))
@@ -259,9 +248,6 @@ def _add_value_traces(
             zs.append(float("nan"))
             values.append(float("nan"))
             hover_texts.append("")
-            i += 1 + n
-            branch_slot += 1
-            point_cursor += n
         if not xs:
             continue
         line_kwargs: dict[str, Any] = {

--- a/braincell/vis/backend_plotly_test.py
+++ b/braincell/vis/backend_plotly_test.py
@@ -128,8 +128,10 @@ class PlotlyBackendTest(unittest.TestCase):
         backend = PlotlyBackend()
         scene = build_render_scene_3d(self.tree)
         request = RenderRequest(morpho=self.tree, dimensionality="3d", scene=scene)
+        # The availability probe lives in ``backend.module_available``,
+        # which every backend shares.
         with mock.patch(
-            "braincell.vis.backend_plotly.importlib.util.find_spec",
+            "braincell.vis.backend.importlib.util.find_spec",
             return_value=None,
         ):
             with mock.patch.dict(sys.modules, {"plotly": None}, clear=False):

--- a/braincell/vis/backend_pyvista.py
+++ b/braincell/vis/backend_pyvista.py
@@ -16,7 +16,6 @@
 
 import importlib.util
 import os
-import sys
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from html import escape
@@ -24,7 +23,9 @@ from typing import Any
 
 import numpy as np
 
-from ._values import resolved_colorbar_label
+from ._values import resolve_value_limits, resolved_colorbar_label
+from .backend import module_available
+from .config import rgb_to_float as _rgb_to_float
 from .hooks import PickInfo, VisHooks
 from .scene import RenderRequest, RenderScene3D, ValueBatch3D, ValueSpec
 
@@ -64,10 +65,7 @@ class PyVistaBackend:
     skeleton_line_width: float = 2.0
 
     def available(self) -> bool:
-        try:
-            return importlib.util.find_spec("pyvista") is not None
-        except ValueError:
-            return "pyvista" in sys.modules
+        return module_available("pyvista")
 
     def render(self, request: RenderRequest) -> object:
         scene = request.scene
@@ -252,10 +250,6 @@ def _suppress_stderr_fd():
         os.close(saved_fd)
 
 
-def _rgb_to_float(rgb: tuple[int, int, int]) -> tuple[float, float, float]:
-    return tuple(float(channel) / 255.0 for channel in rgb)  # type: ignore[return-value]
-
-
 def _render_value_batches_pyvista(
     pv: Any,
     plotter: Any,
@@ -268,21 +262,10 @@ def _render_value_batches_pyvista(
     skeleton_line_width: float,
 ) -> None:
     """Render scalar-valued PolyData batches with a single scalar bar."""
-    import numpy as np  # local import keeps module-level surface small
 
     # Compute a shared vmin/vmax over every batch so the colour scale
     # is consistent across branches/types.
-    all_values: list[float] = []
-    for batch in value_batches:
-        if batch.point_values.size:
-            all_values.append(float(np.min(batch.point_values)))
-            all_values.append(float(np.max(batch.point_values)))
-    vmin = value_spec.vmin if value_spec.vmin is not None else (min(all_values) if all_values else 0.0)
-    vmax = value_spec.vmax if value_spec.vmax is not None else (max(all_values) if all_values else 1.0)
-    if vmin == vmax:
-        vmin = vmin - 0.5
-        vmax = vmax + 0.5
-    clim = (vmin, vmax)
+    clim = resolve_value_limits(value_spec, (batch.point_values for batch in value_batches))
 
     title = resolved_colorbar_label(value_spec, value_spec.unit_label)
     scalar_bar_args = {"title": title if title is not None else "values"}
@@ -402,7 +385,6 @@ def _build_point_branch_map(scene: RenderScene3D) -> list[dict[str, Any]]:
     this table.
     """
     entries: list[dict[str, Any]] = []
-    n_branches = len(scene.branches)
     for branch in scene.branches:
         n_points = int(branch.points_um.shape[0])
         for local_index in range(n_points):
@@ -416,8 +398,6 @@ def _build_point_branch_map(scene: RenderScene3D) -> list[dict[str, Any]]:
                     "position_um": np.asarray(branch.points_um[local_index], dtype=float),
                 }
             )
-    if not entries and n_branches == 0:
-        return entries
     return entries
 
 

--- a/braincell/vis/config.py
+++ b/braincell/vis/config.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 from contextlib import contextmanager
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace as dataclass_replace
 from typing import Iterable, Iterator
 
 DEFAULT_BRANCH_TYPE_COLORS = {
@@ -107,23 +107,17 @@ def configure(
     if mode_3d_default is not None:
         updated.mode_3d_default = _normalize_mode(mode_3d_default, supported=SUPPORTED_3D_MODES, label="3D")
     if branch_type_colors is not None:
-        normalized = {str(branch_type): _normalize_color(color) for branch_type, color in branch_type_colors.items()}
-        if replace_branch_type_colors:
-            updated.branch_type_colors = normalized
-        else:
-            merged = dict(updated.branch_type_colors)
-            merged.update(normalized)
-            updated.branch_type_colors = merged
+        updated.branch_type_colors = _merge_color_map(
+            updated.branch_type_colors,
+            branch_type_colors,
+            replace=replace_branch_type_colors,
+        )
     if branch_type_edge_colors_2d is not None:
-        normalized_edge_2d = {
-            str(branch_type): _normalize_color(color) for branch_type, color in branch_type_edge_colors_2d.items()
-        }
-        if replace_branch_type_edge_colors_2d or updated.branch_type_edge_colors_2d is None:
-            updated.branch_type_edge_colors_2d = normalized_edge_2d
-        else:
-            merged_edge_2d = dict(updated.branch_type_edge_colors_2d)
-            merged_edge_2d.update(normalized_edge_2d)
-            updated.branch_type_edge_colors_2d = merged_edge_2d
+        updated.branch_type_edge_colors_2d = _merge_color_map(
+            updated.branch_type_edge_colors_2d,
+            branch_type_edge_colors_2d,
+            replace=replace_branch_type_edge_colors_2d,
+        )
     if alpha_2d is not None:
         updated.alpha_2d = _normalize_alpha(alpha_2d, label="alpha_2d")
     if alpha_2d_poly is not None:
@@ -449,25 +443,42 @@ def marker_radius_3d_um() -> float:
 
 
 def _copy_defaults(defaults: VisDefaults) -> VisDefaults:
-    return VisDefaults(
-        layout_2d_default=defaults.layout_2d_default,
-        shape_2d_default=defaults.shape_2d_default,
-        mode_3d_default=defaults.mode_3d_default,
+    """Return a deep-enough copy of *defaults* for snapshot/restore.
+
+    Only the two mutable dict fields need copying; everything else is
+    an immutable scalar or tuple. Going through
+    :func:`dataclasses.replace` rather than re-listing every field means
+    a newly added :class:`VisDefaults` field is carried automatically —
+    forgetting it here would silently leak that field across a
+    ``theme()`` / ``publication_theme()`` block.
+    """
+    return dataclass_replace(
+        defaults,
         branch_type_colors=dict(defaults.branch_type_colors),
         branch_type_edge_colors_2d=(
             dict(defaults.branch_type_edge_colors_2d) if defaults.branch_type_edge_colors_2d is not None else None
         ),
-        alpha_2d=defaults.alpha_2d,
-        alpha_2d_poly=defaults.alpha_2d_poly,
-        alpha_2d_line=defaults.alpha_2d_line,
-        frustum_edge_linewidth_2d=defaults.frustum_edge_linewidth_2d,
-        alpha_3d_tube=defaults.alpha_3d_tube,
-        highlight_color=defaults.highlight_color,
-        highlight_alpha=defaults.highlight_alpha,
-        marker_color=defaults.marker_color,
-        marker_size_2d=defaults.marker_size_2d,
-        marker_radius_3d_um=defaults.marker_radius_3d_um,
     )
+
+
+def _merge_color_map(
+    current: dict[str, tuple[int, int, int]] | None,
+    incoming: dict[str, object],
+    *,
+    replace: bool,
+) -> dict[str, tuple[int, int, int]]:
+    """Normalize *incoming* colours and merge them over *current*.
+
+    When *replace* is true (or there is nothing to merge into) the
+    normalized map wins outright; otherwise it is layered on top of the
+    existing entries.
+    """
+    normalized = {str(branch_type): _normalize_color(color) for branch_type, color in incoming.items()}
+    if replace or current is None:
+        return normalized
+    merged = dict(current)
+    merged.update(normalized)
+    return merged
 
 
 def _normalize_mode(mode: str, *, supported: frozenset[str], label: str) -> str:
@@ -513,3 +524,33 @@ def _normalize_color(color: object) -> tuple[int, int, int]:
 
 def _darken_color(color: tuple[int, int, int], *, factor: float) -> tuple[int, int, int]:
     return tuple(max(0, min(255, int(round(channel * factor)))) for channel in color)
+
+
+def rgb_to_float(rgb: tuple[int, int, int]) -> tuple[float, float, float]:
+    """Convert a 0-255 palette colour to the 0-1 floats plotting libraries want.
+
+    The palette in this module is stored as 0-255 integer triples, so
+    this is its decode step; it lives here rather than in each backend
+    so matplotlib, PyVista, and the morphometry charts cannot drift
+    apart on it.
+
+    Parameters
+    ----------
+    rgb : tuple of int
+        Colour as ``(r, g, b)`` with each channel in ``[0, 255]``.
+
+    Returns
+    -------
+    tuple of float
+        The same colour with each channel scaled into ``[0.0, 1.0]``.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        >>> from braincell.vis.config import rgb_to_float
+        >>> rgb_to_float((255, 128, 0))
+        (1.0, 0.5019607843137255, 0.0)
+    """
+    return tuple(float(channel) / 255.0 for channel in rgb)  # type: ignore[return-value]

--- a/braincell/vis/layout/_cache.py
+++ b/braincell/vis/layout/_cache.py
@@ -34,8 +34,12 @@ metric) needs to invalidate the entry. A bounded LRU keeps memory
 under control in long-running notebooks.
 """
 
+import dataclasses
 from collections import OrderedDict
 from typing import Callable, Hashable
+
+import brainunit as u
+import numpy as np
 
 from braincell.morph.morphology import Morphology
 from ._common import LayoutBranch2D
@@ -125,15 +129,18 @@ def _metric_key(morpho: Morphology) -> Hashable:
     enough to make two morphologies with identical topology share a
     cache entry, while any edit (length change, new branch, ...)
     produces a different key automatically.
-    """
-    import brainunit as u
 
+    The per-segment arrays are rounded and hashed as raw bytes rather
+    than as tuples of Python floats: this runs on every cache *hit*,
+    and a per-element ``round(float(x), 6)`` genexpr made the key cost
+    more than the lookup saved on large morphologies.
+    """
     rows: list[tuple] = []
     for branch_view in morpho.branches:
         branch = branch_view.branch
-        lengths = tuple(round(float(length), 6) for length in branch.lengths.to_decimal(u.um))
-        radii_proximal = tuple(round(float(r), 6) for r in branch.radii_proximal.to_decimal(u.um))
-        radii_distal = tuple(round(float(r), 6) for r in branch.radii_distal.to_decimal(u.um))
+        lengths = _rounded_bytes(branch.lengths.to_decimal(u.um))
+        radii_proximal = _rounded_bytes(branch.radii_proximal.to_decimal(u.um))
+        radii_distal = _rounded_bytes(branch.radii_distal.to_decimal(u.um))
         parent = branch_view.parent
         parent_index = None if parent is None else parent.index
         parent_x = branch_view.parent_x
@@ -154,6 +161,11 @@ def _metric_key(morpho: Morphology) -> Hashable:
     return ("morpho", tuple(rows))
 
 
+def _rounded_bytes(values) -> bytes:
+    """Return a hashable byte snapshot of *values* rounded to 6 decimals."""
+    return np.round(np.asarray(values, dtype=float), 6).tobytes()
+
+
 def _layout_config_key(layout_config: LayoutConfig) -> Hashable:
     """Return a hashable key for a :class:`LayoutConfig`.
 
@@ -162,8 +174,6 @@ def _layout_config_key(layout_config: LayoutConfig) -> Hashable:
     key without needing :func:`dataclasses.astuple` (which would break
     if anyone added a field containing a mutable default).
     """
-    import dataclasses
-
     return tuple((field.name, getattr(layout_config, field.name)) for field in dataclasses.fields(layout_config))
 
 

--- a/braincell/vis/layout/_collision.py
+++ b/braincell/vis/layout/_collision.py
@@ -49,6 +49,19 @@ function is invariant to the backend choice. The score is a sum of:
 
 Shared endpoints (parent → child attach) are excluded so that a legal
 fork does not accidentally score as a collision.
+
+Implementation note
+-------------------
+Every predicate below is written twice: a ``_scalar`` core that takes
+loose ``float`` coordinates, and a thin array-taking wrapper that
+unpacks and delegates. The scalar core is what the hot loop calls.
+These are 2-element vectors, so a :func:`numpy.linalg.norm` call spends
+microseconds of dispatch on nanoseconds of arithmetic — scoring one
+114-branch morphology issued 17M ``norm`` calls and took 56 seconds.
+The scalar rewrite is ~30x faster while producing bit-identical
+scores (``math.sqrt(dx * dx + dy * dy)`` is the same sequence of IEEE
+operations ``norm`` performs for a 2-vector; ``math.hypot`` is *not*
+and is deliberately avoided).
 """
 
 import math
@@ -70,8 +83,39 @@ def _segments_share_endpoint(
     b0: np.ndarray,
     b1: np.ndarray,
 ) -> bool:
-    endpoint_pairs = ((a0, b0), (a0, b1), (a1, b0), (a1, b1))
-    return any(np.linalg.norm(point_a - point_b) <= 1e-6 for point_a, point_b in endpoint_pairs)
+    return _segments_share_endpoint_scalar(
+        float(a0[0]),
+        float(a0[1]),
+        float(a1[0]),
+        float(a1[1]),
+        float(b0[0]),
+        float(b0[1]),
+        float(b1[0]),
+        float(b1[1]),
+    )
+
+
+def _segments_share_endpoint_scalar(
+    ax0: float,
+    ay0: float,
+    ax1: float,
+    ay1: float,
+    bx0: float,
+    by0: float,
+    bx1: float,
+    by1: float,
+) -> bool:
+    for px, py, qx, qy in (
+        (ax0, ay0, bx0, by0),
+        (ax0, ay0, bx1, by1),
+        (ax1, ay1, bx0, by0),
+        (ax1, ay1, bx1, by1),
+    ):
+        dx = px - qx
+        dy = py - qy
+        if math.sqrt(dx * dx + dy * dy) <= 1e-6:
+            return True
+    return False
 
 
 def _segments_intersect(
@@ -80,14 +124,35 @@ def _segments_intersect(
     b0: np.ndarray,
     b1: np.ndarray,
 ) -> bool:
-    def orientation(p: np.ndarray, q: np.ndarray, r: np.ndarray) -> float:
-        return float((q[0] - p[0]) * (r[1] - p[1]) - (q[1] - p[1]) * (r[0] - p[0]))
+    return _segments_intersect_scalar(
+        float(a0[0]),
+        float(a0[1]),
+        float(a1[0]),
+        float(a1[1]),
+        float(b0[0]),
+        float(b0[1]),
+        float(b1[0]),
+        float(b1[1]),
+    )
 
-    o1 = orientation(a0, a1, b0)
-    o2 = orientation(a0, a1, b1)
-    o3 = orientation(b0, b1, a0)
-    o4 = orientation(b0, b1, a1)
-    return (o1 * o2 < 0.0) and (o3 * o4 < 0.0)
+
+def _segments_intersect_scalar(
+    ax0: float,
+    ay0: float,
+    ax1: float,
+    ay1: float,
+    bx0: float,
+    by0: float,
+    bx1: float,
+    by1: float,
+) -> bool:
+    o1 = (ax1 - ax0) * (by0 - ay0) - (ay1 - ay0) * (bx0 - ax0)
+    o2 = (ax1 - ax0) * (by1 - ay0) - (ay1 - ay0) * (bx1 - ax0)
+    if not (o1 * o2 < 0.0):
+        return False
+    o3 = (bx1 - bx0) * (ay0 - by0) - (by1 - by0) * (ax0 - bx0)
+    o4 = (bx1 - bx0) * (ay1 - by0) - (by1 - by0) * (ax1 - bx0)
+    return o3 * o4 < 0.0
 
 
 def _segment_distance_um(
@@ -96,11 +161,38 @@ def _segment_distance_um(
     b0: np.ndarray,
     b1: np.ndarray,
 ) -> float:
+    return math.sqrt(
+        _segment_distance_sq_scalar(
+            float(a0[0]),
+            float(a0[1]),
+            float(a1[0]),
+            float(a1[1]),
+            float(b0[0]),
+            float(b0[1]),
+            float(b1[0]),
+            float(b1[1]),
+        )
+    )
+
+
+def _segment_distance_sq_scalar(
+    ax0: float,
+    ay0: float,
+    ax1: float,
+    ay1: float,
+    bx0: float,
+    by0: float,
+    bx1: float,
+    by1: float,
+) -> float:
+    # ``sqrt`` is monotonic and correctly rounded, so taking the min of
+    # the squared distances and rooting once equals rooting each and
+    # taking the min — three fewer square roots per pair.
     return min(
-        _point_to_segment_distance_um(a0, b0, b1),
-        _point_to_segment_distance_um(a1, b0, b1),
-        _point_to_segment_distance_um(b0, a0, a1),
-        _point_to_segment_distance_um(b1, a0, a1),
+        _point_to_segment_distance_sq_scalar(ax0, ay0, bx0, by0, bx1, by1),
+        _point_to_segment_distance_sq_scalar(ax1, ay1, bx0, by0, bx1, by1),
+        _point_to_segment_distance_sq_scalar(bx0, by0, ax0, ay0, ax1, ay1),
+        _point_to_segment_distance_sq_scalar(bx1, by1, ax0, ay0, ax1, ay1),
     )
 
 
@@ -109,14 +201,41 @@ def _point_to_segment_distance_um(
     seg0_um: np.ndarray,
     seg1_um: np.ndarray,
 ) -> float:
-    seg_vec_um = seg1_um - seg0_um
-    seg_len_sq_um = float(np.dot(seg_vec_um, seg_vec_um))
-    if seg_len_sq_um <= 0.0:
-        return float(np.linalg.norm(point_um - seg0_um))
-    projection = float(np.dot(point_um - seg0_um, seg_vec_um) / seg_len_sq_um)
-    projection = min(max(projection, 0.0), 1.0)
-    closest_um = seg0_um + projection * seg_vec_um
-    return float(np.linalg.norm(point_um - closest_um))
+    return math.sqrt(
+        _point_to_segment_distance_sq_scalar(
+            float(point_um[0]),
+            float(point_um[1]),
+            float(seg0_um[0]),
+            float(seg0_um[1]),
+            float(seg1_um[0]),
+            float(seg1_um[1]),
+        )
+    )
+
+
+def _point_to_segment_distance_sq_scalar(
+    px: float,
+    py: float,
+    sx0: float,
+    sy0: float,
+    sx1: float,
+    sy1: float,
+) -> float:
+    vx = sx1 - sx0
+    vy = sy1 - sy0
+    seg_len_sq = vx * vx + vy * vy
+    wx = px - sx0
+    wy = py - sy0
+    if seg_len_sq <= 0.0:
+        return wx * wx + wy * wy
+    projection = (wx * vx + wy * vy) / seg_len_sq
+    if projection < 0.0:
+        projection = 0.0
+    elif projection > 1.0:
+        projection = 1.0
+    dx = wx - projection * vx
+    dy = wy - projection * vy
+    return dx * dx + dy * dy
 
 
 def _pair_score(
@@ -127,11 +246,63 @@ def _pair_score(
     *,
     margin_um: float,
 ) -> float:
-    if _segments_share_endpoint(a0, a1, b0, b1):
+    return _pair_score_scalar(
+        float(a0[0]),
+        float(a0[1]),
+        float(a1[0]),
+        float(a1[1]),
+        float(b0[0]),
+        float(b0[1]),
+        float(b1[0]),
+        float(b1[1]),
+        margin_um=margin_um,
+    )
+
+
+def _pair_score_scalar(
+    ax0: float,
+    ay0: float,
+    ax1: float,
+    ay1: float,
+    bx0: float,
+    by0: float,
+    bx1: float,
+    by1: float,
+    *,
+    margin_um: float,
+) -> float:
+    # AABB reject first. If the boxes are more than ``margin_um`` apart
+    # on either axis then the segments cannot share an endpoint, cannot
+    # cross, and are farther apart than the margin — the score is
+    # exactly 0.0 and the expensive predicates are skipped. This is the
+    # common case: the spatial hash returns whole cells, most of whose
+    # occupants are not near the candidate.
+    if ax0 < ax1:
+        a_min_x, a_max_x = ax0, ax1
+    else:
+        a_min_x, a_max_x = ax1, ax0
+    if bx0 < bx1:
+        b_min_x, b_max_x = bx0, bx1
+    else:
+        b_min_x, b_max_x = bx1, bx0
+    if a_min_x - margin_um > b_max_x or b_min_x - margin_um > a_max_x:
         return 0.0
-    if _segments_intersect(a0, a1, b0, b1):
+    if ay0 < ay1:
+        a_min_y, a_max_y = ay0, ay1
+    else:
+        a_min_y, a_max_y = ay1, ay0
+    if by0 < by1:
+        b_min_y, b_max_y = by0, by1
+    else:
+        b_min_y, b_max_y = by1, by0
+    if a_min_y - margin_um > b_max_y or b_min_y - margin_um > a_max_y:
+        return 0.0
+
+    if _segments_share_endpoint_scalar(ax0, ay0, ax1, ay1, bx0, by0, bx1, by1):
+        return 0.0
+    if _segments_intersect_scalar(ax0, ay0, ax1, ay1, bx0, by0, bx1, by1):
         return 1000.0
-    distance_um = _segment_distance_um(a0, a1, b0, b1)
+    distance_um = math.sqrt(_segment_distance_sq_scalar(ax0, ay0, ax1, ay1, bx0, by0, bx1, by1))
     if distance_um < margin_um:
         return margin_um - distance_um
     return 0.0
@@ -167,17 +338,22 @@ class _SegmentSpatialHash:
         self.cell_size_um = float(cell_size_um)
         self._cells: dict[tuple[int, int], list[int]] = {}
         self._layouts: list[LayoutBranch2D] = []
-        self._segments: list[tuple[np.ndarray, np.ndarray]] = []
+        # Flat ``(x0, y0, x1, y1)`` float tuples rather than ndarray
+        # pairs: the scoring loop wants loose floats, and unpacking a
+        # tuple is far cheaper than indexing two arrays per pair.
+        self._segments: list[tuple[float, float, float, float]] = []
 
     def insert(self, layout: LayoutBranch2D) -> None:
         self._layouts.append(layout)
-        points = layout.segment_points_um
+        points = np.asarray(layout.segment_points_um, dtype=float)
         for segment_index in range(len(points) - 1):
-            p0 = np.asarray(points[segment_index], dtype=float)
-            p1 = np.asarray(points[segment_index + 1], dtype=float)
+            x0 = float(points[segment_index, 0])
+            y0 = float(points[segment_index, 1])
+            x1 = float(points[segment_index + 1, 0])
+            y1 = float(points[segment_index + 1, 1])
             segment_flat_index = len(self._segments)
-            self._segments.append((p0, p1))
-            for cell_key in self._iter_segment_cells(p0, p1, pad_um=0.0):
+            self._segments.append((x0, y0, x1, y1))
+            for cell_key in self._iter_segment_cells(x0, y0, x1, y1, pad_um=0.0):
                 self._cells.setdefault(cell_key, []).append(segment_flat_index)
 
     def insert_all(self, layouts: tuple[LayoutBranch2D, ...]) -> None:
@@ -186,35 +362,41 @@ class _SegmentSpatialHash:
 
     def scored_candidate(self, candidate: LayoutBranch2D, margin_um: float) -> float:
         score = 0.0
-        candidate_points = candidate.segment_points_um
+        candidate_points = np.asarray(candidate.segment_points_um, dtype=float)
+        cells = self._cells
+        segments = self._segments
         for segment_index in range(len(candidate_points) - 1):
-            a0 = np.asarray(candidate_points[segment_index], dtype=float)
-            a1 = np.asarray(candidate_points[segment_index + 1], dtype=float)
+            ax0 = float(candidate_points[segment_index, 0])
+            ay0 = float(candidate_points[segment_index, 1])
+            ax1 = float(candidate_points[segment_index + 1, 0])
+            ay1 = float(candidate_points[segment_index + 1, 1])
             seen: set[int] = set()
-            for cell_key in self._iter_segment_cells(a0, a1, pad_um=margin_um):
-                bucket = self._cells.get(cell_key)
+            for cell_key in self._iter_segment_cells(ax0, ay0, ax1, ay1, pad_um=margin_um):
+                bucket = cells.get(cell_key)
                 if bucket is None:
                     continue
                 for other_flat_index in bucket:
                     if other_flat_index in seen:
                         continue
                     seen.add(other_flat_index)
-                    b0, b1 = self._segments[other_flat_index]
-                    score += _pair_score(a0, a1, b0, b1, margin_um=margin_um)
+                    bx0, by0, bx1, by1 = segments[other_flat_index]
+                    score += _pair_score_scalar(ax0, ay0, ax1, ay1, bx0, by0, bx1, by1, margin_um=margin_um)
         return score
 
     def _iter_segment_cells(
         self,
-        p0: np.ndarray,
-        p1: np.ndarray,
+        x0: float,
+        y0: float,
+        x1: float,
+        y1: float,
         *,
         pad_um: float,
     ):
         cell_size = self.cell_size_um
-        min_x = min(float(p0[0]), float(p1[0])) - pad_um
-        max_x = max(float(p0[0]), float(p1[0])) + pad_um
-        min_y = min(float(p0[1]), float(p1[1])) - pad_um
-        max_y = max(float(p0[1]), float(p1[1])) + pad_um
+        min_x = (x0 if x0 < x1 else x1) - pad_um
+        max_x = (x1 if x0 < x1 else x0) + pad_um
+        min_y = (y0 if y0 < y1 else y1) - pad_um
+        max_y = (y1 if y0 < y1 else y0) + pad_um
         cx0 = int(math.floor(min_x / cell_size))
         cx1 = int(math.floor(max_x / cell_size))
         cy0 = int(math.floor(min_y / cell_size))

--- a/braincell/vis/layout/_fan.py
+++ b/braincell/vis/layout/_fan.py
@@ -43,7 +43,7 @@ from ._config import DEFAULT_LAYOUT_CONFIG, LayoutConfig
 from ._geometry import (
     _make_centered_horizontal_layout_branch,
     _make_straight_layout_branch,
-    sample_layout_branch,
+    point_on_layout_branch,
 )
 
 _LEFT_ROOT_CENTER_RAD = math.pi
@@ -130,8 +130,7 @@ def _layout_children_fan(
         node_layout = layouts[node.index]
         frames: list[tuple[MorphoBranch, tuple[float, float] | None, bool]] = []
         for child, child_interval, child_angle in allocations:
-            attach_um, attach_tangent_um = sample_layout_branch(node_layout, child.parent_x)
-            _ = attach_tangent_um
+            attach_um = point_on_layout_branch(node_layout, child.parent_x)
             layouts[child.index] = _make_straight_layout_branch(
                 child,
                 spec=layout_specs[child.index],

--- a/braincell/vis/layout/_geometry.py
+++ b/braincell/vis/layout/_geometry.py
@@ -146,11 +146,15 @@ def _layout_branch_from_angles(
     segment_directions_um = np.column_stack((np.cos(segment_angles_rad), np.sin(segment_angles_rad)))
     segment_normals_um = np.column_stack((-segment_directions_um[:, 1], segment_directions_um[:, 0]))
     cumulative_lengths_um = np.concatenate(([0.0], np.cumsum(spec.segment_lengths_um)))
+    # Walking the segments in Python is a plain prefix sum; the stem
+    # family calls this once per placement candidate, so the vectorized
+    # form is worth several-fold on the whole layout build.
     raw_segment_points_um = np.zeros((len(spec.segment_lengths_um) + 1, 2), dtype=float)
-    for segment_index, segment_length_um in enumerate(spec.segment_lengths_um):
-        raw_segment_points_um[segment_index + 1] = raw_segment_points_um[segment_index] + segment_directions_um[
-            segment_index
-        ] * float(segment_length_um)
+    np.cumsum(
+        segment_directions_um * np.asarray(spec.segment_lengths_um, dtype=float)[:, None],
+        axis=0,
+        out=raw_segment_points_um[1:],
+    )
 
     raw_layout = LayoutBranch2D(
         branch_index=branch.index,

--- a/braincell/vis/layout/_stem.py
+++ b/braincell/vis/layout/_stem.py
@@ -37,13 +37,14 @@ sibling ordering helpers defined below.
 
 import math
 from dataclasses import dataclass
+from itertools import islice
 
 import numpy as np
 
 from braincell.morph import MorphoBranch
 from braincell.morph.morphology import Morphology
 
-from ._collision import _build_collision_index, _layout_collision_score
+from ._collision import _build_collision_index
 from ._common import (
     LayoutBranch2D,
     _allocate_weighted_angles,
@@ -176,6 +177,20 @@ class _StemSideContext:
     angle_assignments: dict[int, float]
     side_children: tuple[MorphoBranch, ...]
     stem_depth: int
+
+
+def _recent_layouts(layouts: dict[int, LayoutBranch2D], window: int) -> tuple[LayoutBranch2D, ...]:
+    """Return the last *window* layouts placed, in insertion order.
+
+    Collision scoring only looks at a rolling window of recently placed
+    branches. ``tuple(layouts.values())[-window:]`` would copy every
+    layout placed so far on each call, making the walk quadratic in
+    branch count; :func:`itertools.islice` allocates only the window.
+    """
+    if window <= 0:
+        return ()
+    start = max(0, len(layouts) - window)
+    return tuple(islice(layouts.values(), start, None))
 
 
 def _layout_children_stem_linear(
@@ -316,7 +331,11 @@ def _place_stem_linear_side_child(
         side_index=side_index,
         stem_depth=context.stem_depth + 1,
         min_branch_angle_rad=min_branch_angle_rad,
-        existing_layouts=tuple(layouts.values())[-48:],
+        # NOTE: this path uses a fixed window of 48 rather than
+        # ``layout_config.stem_collision_window`` (default 24), unlike
+        # the tree path below. Preserved as-is because widening or
+        # narrowing the window changes the rendered layout.
+        existing_layouts=_recent_layouts(layouts, 48),
         layout_config=layout_config,
     )
 
@@ -433,7 +452,7 @@ def _expand_stem_node(
         branch_order=branch_order,
     )
     collision_window = layout_config.stem_collision_window
-    recent_layouts = tuple(layouts.values())[-collision_window:]
+    recent_layouts = _recent_layouts(layouts, collision_window)
     trunk_attach_um, trunk_attach_tangent_um = sample_layout_branch(parent_layout, trunk_child.parent_x)
     trunk_attach_angle_rad = _vector_angle_rad(trunk_attach_tangent_um)
     trunk_preferred_sign = _preferred_turn_sign(
@@ -502,7 +521,7 @@ def _place_stem_side_child(
         desired_tail_angle_rad=context.angle_assignments[child.index],
         preferred_sign=preferred_sign,
         min_branch_angle_rad=min_branch_angle_rad,
-        existing_layouts=tuple(layouts.values())[-collision_window:],
+        existing_layouts=_recent_layouts(layouts, collision_window),
         layout_config=layout_config,
     )
 

--- a/braincell/vis/morphometry.py
+++ b/braincell/vis/morphometry.py
@@ -41,7 +41,7 @@ import numpy as np
 from braincell.morph import MorphoBranch
 from braincell.morph.morphology import Morphology
 from ._traversal import iter_bottom_up, iter_depth_first
-from .config import color_for_branch_type
+from .config import color_for_branch_type, rgb_to_float as _rgb_to_float
 
 
 @dataclass(frozen=True)
@@ -392,7 +392,3 @@ def plot_branch_order_histogram(
     for spine in ("top", "right"):
         ax.spines[spine].set_visible(False)
     return ax
-
-
-def _rgb_to_float(rgb: tuple[int, int, int]) -> tuple[float, float, float]:
-    return tuple(float(channel) / 255.0 for channel in rgb)  # type: ignore[return-value]

--- a/braincell/vis/movie.py
+++ b/braincell/vis/movie.py
@@ -42,8 +42,9 @@ from typing import Any
 import numpy as np
 
 from braincell.morph.morphology import Morphology
+from ._values import _strip_quantity, resolve_value_limits, resolve_values
 from .layout import LayoutConfig
-from .scene import ValueSpec
+from .scene import ValueSpec as _ValueSpec
 
 
 @dataclass(frozen=True)
@@ -136,21 +137,16 @@ def plot_movie(
     if not isinstance(morpho, Morphology):
         raise TypeError(f"plot_movie(...) expects Morphology, got {type(morpho).__name__!s}.")
 
-    arr = _strip_units(values_over_time)
+    arr, _ = _strip_quantity(values_over_time)
     if arr.ndim != 2:
         raise ValueError(f"plot_movie(...) expects a 2-D (T, N) values array, got shape {arr.shape!r}.")
     n_frames = arr.shape[0]
     if n_frames == 0:
         raise ValueError("plot_movie(...) requires at least one frame.")
 
-    # Precompute a shared vmin/vmax so every frame lands on the same scale.
-    if vmin is None:
-        vmin = float(np.min(arr))
-    if vmax is None:
-        vmax = float(np.max(arr))
-    if vmin == vmax:
-        vmin = vmin - 0.5
-        vmax = vmax + 0.5
+    # Resolve a shared vmin/vmax across every frame so the colour scale
+    # is fixed for the whole animation.
+    vmin, vmax = resolve_value_limits(_ValueSpec(values=arr, vmin=vmin, vmax=vmax), (arr,))
 
     if dimensionality == "2d":
         return _plot_movie_2d(
@@ -183,16 +179,6 @@ def plot_movie(
             mode=mode,
         )
     raise ValueError(f"plot_movie(...) dimensionality must be '2d' or '3d', got {dimensionality!r}.")
-
-
-def _strip_units(values) -> np.ndarray:
-    try:
-        import brainunit as u
-    except ModuleNotFoundError:  # pragma: no cover
-        return np.asarray(values, dtype=float)
-    if isinstance(values, u.Quantity):
-        return np.asarray(u.get_mantissa(values), dtype=float)
-    return np.asarray(values, dtype=float)
 
 
 # ---------------------------------------------------------------------------
@@ -250,31 +236,26 @@ def _plot_movie_2d(
         if isinstance(collection, (LineCollection, PolyCollection)) and collection.get_array() is not None
     ]
 
-    # Resolve per-frame per-primitive value arrays once so update() is
-    # just an in-place assignment.
-    from ._values import resolve_values
-    from .scene import ValueSpec as _ValueSpec
+    # Value collections come back in the order the scene builder
+    # produced them: one per branch, in branch-index order. That order
+    # does not change between frames, so resolve it once.
+    scene_order_branch_indices = [branch.index for branch in morpho.branches]
 
-    per_frame_scalars: list[list[np.ndarray]] = []
-    for frame_index in range(values.shape[0]):
+    title_obj = ax.set_title("") if dt is None else ax.set_title(_format_time(0))
+
+    def _update(frame_index: int):
+        # Resolved lazily per frame rather than materialising all T
+        # frames upfront: FuncAnimation only ever needs one at a time,
+        # and precomputing held T x n_branches arrays alive for the
+        # lifetime of the animation.
         per_branch, _ = resolve_values(
             morpho,
             _ValueSpec(values=values[frame_index], cmap=cmap, vmin=vmin, vmax=vmax),
         )
-        # Values collections are in the same order the scene builder
-        # produced them (one per branch, in branch-index order).
-        scene_order_branch_indices = [branch.index for branch in morpho.branches]
-        frame_arrays = [per_branch[idx].segment_values for idx in scene_order_branch_indices]
-        per_frame_scalars.append(frame_arrays)
-
-    title_obj = ax.set_title("") if dt is None else ax.set_title(_format_time(0, dt))
-
-    def _update(frame_index: int):
-        frame_values = per_frame_scalars[frame_index]
-        for collection, values_arr in zip(value_collections, frame_values):
-            collection.set_array(values_arr)
+        for collection, branch_index in zip(value_collections, scene_order_branch_indices):
+            collection.set_array(per_branch[branch_index].segment_values)
         if dt is not None:
-            title_obj.set_text(_format_time(frame_index, dt))
+            title_obj.set_text(_format_time(frame_index))
         return (*value_collections, title_obj)
 
     animation = FuncAnimation(
@@ -294,19 +275,16 @@ def _plot_movie_2d(
     return MovieResult(animation=animation, frames=values.shape[0], output_path=output_path)
 
 
-def _format_time(frame_index: int, dt) -> str:
+def _format_time(frame_index: int) -> str:
+    # NOTE: this renders the frame index, not the elapsed time — the
+    # ``dt`` the caller passes is not folded in. Kept as-is because
+    # changing it would change every rendered title.
     return f"t = {frame_index} × dt"
 
 
 def _save_animation_2d(animation, out: Path, *, fps: int) -> None:
     """Write the matplotlib animation to disk, selecting the writer by suffix."""
-    suffix = out.suffix.lower()
-    if suffix == ".gif":
-        writer = "pillow"
-    elif suffix in {".mp4", ".mov", ".m4v"}:
-        writer = "ffmpeg"
-    else:
-        writer = "ffmpeg"
+    writer = "pillow" if out.suffix.lower() == ".gif" else "ffmpeg"
     animation.save(str(out), writer=writer, fps=fps)
 
 
@@ -340,8 +318,6 @@ def _plot_movie_3d(
     """
     import pyvista as pv
 
-    from ._values import resolve_values
-    from .scene import ValueSpec as _ValueSpec
     from .scene3d import build_render_scene_3d
 
     scene = build_render_scene_3d(morpho, mode=mode or "skeleton")

--- a/braincell/vis/plot2d.py
+++ b/braincell/vis/plot2d.py
@@ -154,7 +154,7 @@ def _build_value_spec(
             norm=norm if norm is not None else values.norm,
             label=value_label if value_label is not None else values.label,
             unit_label=values.unit_label,
-            show_colorbar=show_colorbar if show_colorbar is not values.show_colorbar else values.show_colorbar,
+            show_colorbar=show_colorbar,
         )
     return ValueSpec(
         values=values,

--- a/braincell/vis/point_topology.py
+++ b/braincell/vis/point_topology.py
@@ -24,12 +24,14 @@ algorithm rather than morphology geometry.
 from __future__ import annotations
 
 import warnings
+from collections import deque
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, Literal, get_args
 
 import numpy as np
 
 from braincell._discretization.base import NodeTree
+from ._values import _strip_quantity, compose_colorbar_label
 
 ColorMode = Literal["solid", "depth", "values"]
 CoverageMode = Literal["fraction", "any", "all"]
@@ -75,8 +77,10 @@ _PRESETS: dict[str, _PointTopologyPreset] = {
 _GRAPHVIZ_LAYOUTS = {"twopi", "dot", "neato"}
 _LAYOUT_ALIASES = {"kamada-kawai": "kamada_kawai"}
 _VALID_LAYOUTS = _GRAPHVIZ_LAYOUTS | {"kamada_kawai"}
-_VALID_COLOR_MODES = {"solid", "depth", "values"}
-_VALID_COVERAGE_MODES = {"fraction", "any", "all"}
+# Derived from the Literal aliases above so the allowed values are
+# spelled exactly once.
+_VALID_COLOR_MODES = set(get_args(ColorMode))
+_VALID_COVERAGE_MODES = set(get_args(CoverageMode))
 
 
 def plot_point_topology(
@@ -599,13 +603,11 @@ def _resolve_node_rgba(
 
 
 def _normalize_values_array(values, *, n_points: int) -> tuple[np.ndarray, str | None]:
-    if hasattr(values, "to_decimal") and hasattr(values, "unit"):
-        unit = values.unit
-        raw = np.asarray(values.to_decimal(unit), dtype=float)
-        unit_label = str(unit)
-    else:
-        raw = np.asarray(values, dtype=float)
-        unit_label = None
+    # Unit stripping goes through the shared helper so this path agrees
+    # with the scene builders on what counts as a brainunit quantity —
+    # duck-typing on ``to_decimal``/``unit`` here used to accept objects
+    # the rest of the package rejected.
+    raw, unit_label = _strip_quantity(values)
     if raw.ndim != 1:
         raise ValueError(f"values must be 1-D, got shape {raw.shape!r}.")
     array = raw.reshape(-1)
@@ -631,23 +633,6 @@ def _build_value_norm(values: np.ndarray, *, vmin: float | None, vmax: float | N
     return mcolors.Normalize(vmin=lo, vmax=hi)
 
 
-def _normalize_scalar_values(values: np.ndarray) -> np.ndarray:
-    values = np.asarray(values, dtype=float)
-    finite_mask = np.isfinite(values)
-    if not np.any(finite_mask):
-        return np.zeros_like(values, dtype=float)
-    finite_values = values[finite_mask]
-    lo = float(np.min(finite_values))
-    hi = float(np.max(finite_values))
-    if hi - lo <= 1e-12:
-        out = np.zeros_like(values, dtype=float)
-        out[~finite_mask] = 0.0
-        return out
-    out = np.zeros_like(values, dtype=float)
-    out[finite_mask] = (finite_values - lo) / (hi - lo)
-    return out
-
-
 def _graph_depths(*, node_ids: tuple[int, ...], edges: tuple[tuple[int, int], ...]) -> np.ndarray:
     if not node_ids:
         return np.zeros((0,), dtype=float)
@@ -661,9 +646,11 @@ def _graph_depths(*, node_ids: tuple[int, ...], edges: tuple[tuple[int, int], ..
     id_to_index = {node_id: index for index, node_id in enumerate(node_ids)}
     depths = np.full(len(node_ids), -1.0, dtype=float)
     depths[id_to_index[root_id]] = 0.0
-    queue = [root_id]
+    # ``deque.popleft`` is O(1); ``list.pop(0)`` is O(len(queue)), which
+    # makes the whole BFS quadratic on wide trees.
+    queue = deque([root_id])
     while queue:
-        node_id = queue.pop(0)
+        node_id = queue.popleft()
         parent_depth = depths[id_to_index[node_id]]
         for child_id in adjacency[node_id]:
             depths[id_to_index[child_id]] = parent_depth + 1.0
@@ -715,13 +702,10 @@ def _blend_node_rgba(
 
 
 def _resolved_colorbar_label(*, value_label: str | None, unit_label: str | None) -> str | None:
-    if value_label and unit_label:
-        return f"{value_label} [{unit_label}]"
-    if value_label:
-        return value_label
-    if unit_label:
-        return f"[{unit_label}]"
-    return None
+    # Empty strings are treated as "absent" here (a colour bar with a
+    # blank title is not what the caller meant); past that, composition
+    # is the shared rule.
+    return compose_colorbar_label(value_label or None, unit_label or None)
 
 
 def _apply_axes_style(ax, coordinates: np.ndarray) -> None:

--- a/braincell/vis/scene2d.py
+++ b/braincell/vis/scene2d.py
@@ -18,7 +18,7 @@ import brainunit as u
 import numpy as np
 
 from braincell.morph.morphology import Morphology
-from ._values import resolve_values
+from ._values import resolve_overlay_values as _resolve_overlay_values, with_unit_label as _with_unit_label
 from .config import (
     highlight_alpha as _highlight_alpha,
     highlight_color as _highlight_color,
@@ -27,7 +27,6 @@ from .config import (
 )
 from .layout import LayoutBranch2D, LayoutConfig, build_layout_branches_2d
 from .scene import (
-    BranchValues,
     HighlightStroke2D,
     Marker2D,
     OverlaySpec,
@@ -36,7 +35,6 @@ from .scene import (
     Polyline2D,
     PolylineValues2D,
     RenderScene2D,
-    ValueSpec,
     alpha_for_2d_line,
     alpha_for_2d_poly,
     color_for_2d_branch_type,
@@ -105,8 +103,11 @@ def build_scene2d_projected(
     polylines: list[Polyline2D] = []
     polyline_values: list[PolylineValues2D] = []
     centerlines: dict[int, _Centerline2D] = {}
-    for branch_index in range(len(morpho)):
-        branch_view = morpho.branch(index=branch_index)
+    # ``morpho.branch(index=...)`` re-sorts the node table on every
+    # call, so indexing it in a loop is O(n^2 log n); ``morpho.branches``
+    # resolves the same "default" ordering once.
+    for branch_view in morpho.branches:
+        branch_index = branch_view.index
         branch = branch_view.branch
         if branch.points_proximal is None or branch.points_distal is None:
             raise ValueError(
@@ -300,27 +301,16 @@ def build_scene2d_frustum(
         edge_color = edge_color_for_2d_branch_type(branch_layout.branch_type)
         edge_linewidth = frustum_edge_linewidth_2d()
 
+        polygons_um = _segment_quads_um(branch_layout)
+
         if per_branch_values is None:
             for segment_index in range(n_segments):
-                start_um = branch_layout.segment_points_um[segment_index]
-                end_um = branch_layout.segment_points_um[segment_index + 1]
-                normal_um = branch_layout.segment_normals_um[segment_index]
-                radius_prox_um = float(branch_layout.radii_proximal_um[segment_index])
-                radius_dist_um = float(branch_layout.radii_distal_um[segment_index])
-                polygon_points_um = np.vstack(
-                    [
-                        start_um + normal_um * radius_prox_um,
-                        end_um + normal_um * radius_dist_um,
-                        end_um - normal_um * radius_dist_um,
-                        start_um - normal_um * radius_prox_um,
-                    ]
-                )
                 polygons.append(
                     Polygon2D(
                         branch_index=branch_layout.branch_index,
                         branch_name=branch_layout.branch_name,
                         branch_type=branch_layout.branch_type,
-                        points_um=polygon_points_um,
+                        points_um=polygons_um[segment_index],
                         color_rgb=fill_color,
                         edge_color_rgb=edge_color,
                         edge_linewidth=edge_linewidth,
@@ -332,21 +322,6 @@ def build_scene2d_frustum(
         else:
             branch_values = per_branch_values[branch_layout.branch_index]
             if n_segments > 0:
-                polygons_um = np.empty((n_segments, 4, 2), dtype=float)
-                for segment_index in range(n_segments):
-                    start_um = branch_layout.segment_points_um[segment_index]
-                    end_um = branch_layout.segment_points_um[segment_index + 1]
-                    normal_um = branch_layout.segment_normals_um[segment_index]
-                    radius_prox_um = float(branch_layout.radii_proximal_um[segment_index])
-                    radius_dist_um = float(branch_layout.radii_distal_um[segment_index])
-                    polygons_um[segment_index] = np.vstack(
-                        [
-                            start_um + normal_um * radius_prox_um,
-                            end_um + normal_um * radius_dist_um,
-                            end_um - normal_um * radius_dist_um,
-                            start_um - normal_um * radius_prox_um,
-                        ]
-                    )
                 polygon_value_batches.append(
                     PolygonValuesBatch2D(
                         branch_index=branch_layout.branch_index,
@@ -382,6 +357,37 @@ def build_scene2d_frustum(
 
 def build_projected_scene_2d(morpho: Morphology, *, projection_plane: str = "xy") -> RenderScene2D:
     return build_scene2d_projected(morpho, projection_plane=projection_plane)
+
+
+def _segment_quads_um(branch_layout: LayoutBranch2D) -> np.ndarray:
+    """Return the ``(n_segments, 4, 2)`` frustum quads for a branch layout.
+
+    Each segment becomes a trapezoid whose corners are the segment
+    endpoints offset by ``±normal * radius`` — proximal radius at the
+    start, distal radius at the end. Corner order is
+    ``(start+, end+, end-, start-)`` so the polygon winds consistently.
+
+    Building this per segment with :func:`numpy.vstack` costs one array
+    allocation and four dispatches per segment; the whole branch is a
+    single :func:`numpy.stack`.
+    """
+    points_um = np.asarray(branch_layout.segment_points_um, dtype=float)
+    start_um = points_um[:-1]
+    end_um = points_um[1:]
+    normals_um = np.asarray(branch_layout.segment_normals_um, dtype=float)
+    radius_prox_um = np.asarray(branch_layout.radii_proximal_um, dtype=float)[:, None]
+    radius_dist_um = np.asarray(branch_layout.radii_distal_um, dtype=float)[:, None]
+    offset_prox_um = normals_um * radius_prox_um
+    offset_dist_um = normals_um * radius_dist_um
+    return np.stack(
+        [
+            start_um + offset_prox_um,
+            end_um + offset_dist_um,
+            end_um - offset_dist_um,
+            start_um - offset_prox_um,
+        ],
+        axis=1,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -560,38 +566,3 @@ def _build_overlay_primitives_2d(
             order += 1
 
     return tuple(strokes), tuple(markers)
-
-
-def _resolve_overlay_values(
-    overlay: OverlaySpec | None,
-    morpho: Morphology,
-) -> tuple[ValueSpec | None, dict[int, BranchValues] | None, str | None]:
-    """Return ``(spec, per_branch_values, unit_label)`` or ``(None, None, None)``."""
-    if overlay is None:
-        return None, None, None
-    spec = overlay.values_spec()
-    if spec is None:
-        return None, None, None
-    per_branch, unit_label = resolve_values(morpho, spec)
-    return spec, per_branch, unit_label
-
-
-def _with_unit_label(
-    spec: ValueSpec | None,
-    unit_label: str | None,
-) -> ValueSpec | None:
-    """Inject the unit label from the input array into the spec when empty."""
-    if spec is None:
-        return None
-    if unit_label is None or spec.unit_label is not None:
-        return spec
-    return ValueSpec(
-        values=spec.values,
-        cmap=spec.cmap,
-        vmin=spec.vmin,
-        vmax=spec.vmax,
-        norm=spec.norm,
-        label=spec.label,
-        unit_label=unit_label,
-        show_colorbar=spec.show_colorbar,
-    )

--- a/braincell/vis/scene3d.py
+++ b/braincell/vis/scene3d.py
@@ -20,7 +20,10 @@ import brainunit as u
 import numpy as np
 
 from braincell.morph.morphology import Morphology
-from ._values import resolve_values
+from ._values import (
+    resolve_overlay_values as _resolve_overlay_values_3d,
+    with_unit_label as _with_unit_label_3d,
+)
 from .config import (
     highlight_alpha as _highlight_alpha,
     highlight_color as _highlight_color,
@@ -30,13 +33,11 @@ from .config import (
 from .scene import (
     BranchPolyline3D,
     BranchTypeBatch3D,
-    BranchValues,
     HighlightStroke3D,
     Marker3D,
     OverlaySpec,
     RenderScene3D,
     ValueBatch3D,
-    ValueSpec,
     alpha_for_3d_tube,
     color_for_branch_type,
 )
@@ -61,8 +62,11 @@ def build_render_scene_3d(
     value_spec, per_branch_values, unit_label = _resolve_overlay_values_3d(overlay, morpho)
 
     branches: list[BranchPolyline3D] = []
-    for branch_index in range(len(morpho)):
-        branch_view = morpho.branch(index=branch_index)
+    # ``morpho.branch(index=...)`` re-sorts the node table on every
+    # call, so indexing it in a loop is O(n^2 log n); ``morpho.branches``
+    # resolves the same "default" ordering once.
+    for branch_view in morpho.branches:
+        branch_index = branch_view.index
         branch = branch_view.branch
         if branch.points_proximal is None or branch.points_distal is None:
             raise ValueError(
@@ -308,36 +312,3 @@ def _build_overlay_primitives_3d(
             )
 
     return tuple(strokes), tuple(markers)
-
-
-def _resolve_overlay_values_3d(
-    overlay: OverlaySpec | None,
-    morpho: Morphology,
-) -> tuple[ValueSpec | None, dict[int, BranchValues] | None, str | None]:
-    if overlay is None:
-        return None, None, None
-    spec = overlay.values_spec()
-    if spec is None:
-        return None, None, None
-    per_branch, unit_label = resolve_values(morpho, spec)
-    return spec, per_branch, unit_label
-
-
-def _with_unit_label_3d(
-    spec: ValueSpec | None,
-    unit_label: str | None,
-) -> ValueSpec | None:
-    if spec is None:
-        return None
-    if unit_label is None or spec.unit_label is not None:
-        return spec
-    return ValueSpec(
-        values=spec.values,
-        cmap=spec.cmap,
-        vmin=spec.vmin,
-        vmax=spec.vmax,
-        norm=spec.norm,
-        label=spec.label,
-        unit_label=unit_label,
-        show_colorbar=spec.show_colorbar,
-    )

--- a/braincell/vis/traces.py
+++ b/braincell/vis/traces.py
@@ -34,6 +34,7 @@ import numpy as np
 
 from braincell.filter import LocsetMask
 from braincell.morph.morphology import Morphology
+from ._values import _strip_quantity, compose_colorbar_label
 
 
 @dataclass(frozen=True)
@@ -255,19 +256,14 @@ def plot_traces(
     )
 
 
-def _strip_quantity(values) -> tuple[np.ndarray, str | None]:
-    try:
-        import brainunit as u
-    except ModuleNotFoundError:  # pragma: no cover
-        return np.asarray(values, dtype=float), None
-    if isinstance(values, u.Quantity):
-        return np.asarray(u.get_mantissa(values), dtype=float), str(u.get_unit(values))
-    return np.asarray(values, dtype=float), None
-
-
 def _axis_label(kind: str, user_label: str | None, detected: str | None) -> str | None:
-    if user_label is not None:
-        return f"{kind} [{user_label}]"
-    if detected is not None:
-        return f"{kind} [{detected}]"
-    return None
+    """Label an axis as ``"<kind> [<unit>]"``, or ``None`` when no unit is known.
+
+    An explicit *user_label* always wins over the unit detected on the
+    array. Unlike a colour-bar label, *kind* is always present, so a
+    missing unit means no label at all rather than a bare ``"[unit]"``.
+    """
+    unit = user_label if user_label is not None else detected
+    if unit is None:
+        return None
+    return compose_colorbar_label(kind, unit)

--- a/docs/specs/2026-09-01-vis-simplification.md
+++ b/docs/specs/2026-09-01-vis-simplification.md
@@ -1,0 +1,154 @@
+# Quality cleanup of `braincell.vis`
+
+Reuse, simplification, efficiency, and altitude cleanup across the 33
+source modules of `braincell/vis` (~9,200 lines). No public API change,
+no intended change to rendered output.
+
+## Scope and method
+
+Four independent reviews swept the package, one per angle. Their
+findings were deduplicated — the same three clusters (value-scale
+policy, unit stripping, 2D/3D helper duplication) surfaced in three of
+the four reviews — and the ones with a concrete, behaviour-preserving
+fix were applied.
+
+Two invariants governed every edit:
+
+1. **Rendered output must not change.** Layout geometry is verified
+   bit-identical against a pre-change snapshot (see below).
+2. **Where two code paths disagreed, the disagreement was preserved,
+   not silently unified.** Several duplicated helpers had drifted; the
+   shared helper takes the differing input from its caller rather than
+   imposing one answer. Divergences worth a decision are listed under
+   *Deliberately not changed*.
+
+## Verification
+
+- `braincell/vis/layout` output snapshotted for 11 (fixture, mode,
+  family, root_layout) combinations across `grc.swc` and `io.swc`,
+  before and after: **bit-identical** (`np.array_equal` on every
+  concatenated `segment_points_um`).
+- `pytest braincell/` — 2537 passed, 0 failed, 19 skipped, matching the
+  pre-change baseline exactly.
+- `ruff check` and `ruff format --check` clean across the package.
+
+## Performance
+
+The layout snapshot (11 cases) went from **10.95 s to 0.36 s**. The
+dominant term was collision scoring:
+
+| Case | Before | After |
+|---|---|---|
+| `io.swc` stem/tree | 6.60 s | 0.21 s |
+| `io.swc` stem/frustum | 4.11 s | 0.10 s |
+
+### `layout/_collision.py` — scalar rewrite
+
+The pair-scoring predicates ran `numpy.linalg.norm` and `numpy.dot` on
+*2-element* vectors, spending microseconds of dispatch on nanoseconds of
+arithmetic. Scoring one 114-branch morphology issued ~17M `norm` calls.
+
+Each predicate is now a `_scalar` core over loose floats, with a thin
+array-taking wrapper retained for the public/test-facing signature.
+`math.sqrt(dx*dx + dy*dy)` is used rather than `math.hypot` precisely
+because it reproduces `norm`'s IEEE operation sequence bit-for-bit.
+`_pair_score_scalar` also opens with an AABB reject: when the boxes are
+more than `margin_um` apart on either axis the score is provably 0.0, so
+the expensive predicates are skipped — which is the common case, since
+the spatial hash returns whole cells. `_SegmentSpatialHash` stores
+`(x0, y0, x1, y1)` float tuples instead of ndarray pairs.
+
+### Other efficiency fixes
+
+- `layout/_geometry.py` — the segment-point walk is a prefix sum;
+  replaced with `np.cumsum(..., out=...)`. Runs once per stem placement
+  *candidate*, so the saving multiplies.
+- `layout/_cache.py` — `_metric_key` ran a per-element
+  `round(float(x), 6)` genexpr on every cache **hit**; now one
+  `np.round(...).tobytes()` per array.
+- `layout/_stem.py` — `tuple(layouts.values())[-N:]` copied every
+  layout placed so far on each call (quadratic); replaced with
+  `_recent_layouts`, which `islice`s only the window.
+- `scene2d.py` / `scene3d.py` — `morpho.branch(index=i)` in a loop
+  re-sorts the node table each iteration (O(n² log n)); switched to
+  iterating `morpho.branches`, keyed by `branch_view.index`.
+- `scene2d.py` — frustum quads built one `np.vstack` per segment, in two
+  copies; now one vectorized `_segment_quads_um` per branch.
+- `movie.py` — the 2D path materialised all `T` frames of resolved
+  scalars before the first frame drew, and rebuilt a loop-invariant
+  branch-index list inside the loop. Now hoisted and resolved lazily
+  per frame.
+- `point_topology.py` — BFS used `list.pop(0)`; now `deque.popleft`.
+
+## Reuse and simplification
+
+- **`_values.py` is now the single home for value/overlay normalisation.**
+  It gained `resolve_overlay_values`, `with_unit_label` (via
+  `dataclasses.replace`, so a new `ValueSpec` field cannot be dropped),
+  `resolve_value_limits`, and `compose_colorbar_label`. `scene2d` and
+  `scene3d` had four near-identical private copies of the first two;
+  those are gone.
+- **One unit stripper.** `_values._strip_quantity` replaces the four
+  variants in `traces`, `movie`, and `point_topology` — the last of
+  which duck-typed on `to_decimal`/`unit` and so disagreed with the
+  others about what counts as a quantity. The dead
+  `try: import brainunit / except ModuleNotFoundError` guards are
+  removed; the package imports brainunit unconditionally elsewhere.
+- **One colour-scale policy.** `resolve_value_limits` replaces the
+  bound-resolution and degenerate-range padding open-coded in all three
+  backends and `movie`. It takes the scalar arrays from its caller, so
+  each backend keeps feeding it the arrays it actually renders.
+- **One availability probe.** `backend.module_available` replaces the
+  identical 5-line `find_spec`/`sys.modules` body in all three backends.
+- **One palette decode.** `config.rgb_to_float` replaces three
+  byte-identical `_rgb_to_float` definitions.
+- **One VTK cell-walk.** `backend_plotly._iter_batch_polylines` replaces
+  two copies of the `[n, i0…i{n-1}]` decoder, each of which carried a
+  dead cursor variable the other did not.
+- `config._copy_defaults` re-listed all 15 `VisDefaults` fields by hand
+  — a field forgotten there leaks across a `theme()` block. Now
+  `dataclasses.replace` with explicit copies of only the two mutable
+  dicts. The two colour-map merge blocks collapse into `_merge_color_map`.
+- Dead code removed: `point_topology._normalize_scalar_values` (no
+  callers), a tautological `show_colorbar` expression in `plot2d`, a
+  redundant `elif` arm in `movie._save_animation_2d`, a no-op branch and
+  its `n_branches` local in `backend_pyvista`, a discarded
+  `sample_layout_branch` tangent in `layout/_fan` (now
+  `point_on_layout_branch`), and six unused imports.
+- `point_topology._VALID_COLOR_MODES` / `_VALID_COVERAGE_MODES` are
+  derived from their `Literal` aliases via `typing.get_args` rather than
+  restating each value.
+
+## Deliberately not changed
+
+These are real findings whose fix would change behaviour or exceed the
+remit of a quality pass. Each needs a decision, not a refactor.
+
+- **`layout/_stem.py:319` uses a hardcoded collision window of 48**
+  while the tree path reads `layout_config.stem_collision_window`
+  (default 24) — so that config knob silently does nothing on the
+  `shape='frustum'` path. Preserved, and now commented at the site.
+  Aligning them changes rendered geometry.
+- **The matplotlib backend derives its colour scale from segment-midpoint
+  values; PyVista and Plotly derive it from point values.** The same
+  `ValueSpec` therefore yields a slightly wider scale in 3D than in 2D.
+  `resolve_value_limits` deliberately does not unify this — each caller
+  still passes its own arrays.
+- **`point_topology` pads a degenerate colour range by `+1.0`** where
+  everything else uses `±0.5`. Left alone for the same reason.
+- **`movie._format_time` renders `"t = <frame> × dt"`** — a placeholder
+  that ignores the `dt` the caller threads in, despite the docstring
+  promising elapsed time. The unused parameter is removed; whether to
+  render real time is a product decision.
+- **`traces.plot_traces` builds the 2D scene twice** and reconstructs
+  centerlines from rendered polygons, defaulting to `layout="stem"`
+  where `plot2d` defaults to `"fan"`. Fixing it properly means letting
+  `OverlaySpec` carry per-point marker colours.
+- **`layout/_legacy.py` carries ~175 lines its own docstring marks as
+  preserved-for-history.** Deleting is a maintainer's call, not a
+  cleanup.
+- **Larger structural items** left for a dedicated change: the
+  duplicated stem/stem-linear walker (~180 lines), a `LayoutFamily`
+  registry to replace the family list spread across five places,
+  `export.py`'s second backend registry, and unifying the 2D/3D
+  arc-length samplers.


### PR DESCRIPTION
Quality pass over `braincell/vis` — reuse, simplification, efficiency, and altitude. **No public API change and no intended change to rendered output.**

## Verification

| Check | Result |
|---|---|
| Layout bit-identity vs pre-change snapshot (11 cases across `grc.swc` / `io.swc`) | **BIT-IDENTICAL** |
| `pytest braincell/vis/` | 319 passed, 0 failed, 10 skipped |
| `pytest braincell/` | 2537 passed, 0 failed, 19 skipped — matches baseline exactly |
| `ruff check` / `ruff format --check` | clean |

The snapshot harness was written *before* touching the hot path, so every optimization here is provably output-preserving: `np.array_equal` on the concatenated `segment_points_um` of every branch, for each (fixture, mode, family, root_layout) combination.

## Efficiency — layout snapshot 10.95s → 0.37s

`layout/_collision.py` dominated. The pair-scoring predicates called `numpy.linalg.norm` and `numpy.dot` on *2-element* vectors, spending microseconds of dispatch on nanoseconds of arithmetic — scoring one 114-branch morphology issued ~17M `norm` calls. Each predicate is now a `_scalar` core over loose floats, with the array-taking wrapper retained for the public/test-facing signature. `math.sqrt(dx*dx + dy*dy)` is used rather than `math.hypot` precisely because it reproduces `norm`'s IEEE operation sequence bit-for-bit. `_pair_score_scalar` also opens with an AABB reject: when the boxes are more than `margin_um` apart on either axis the score is provably `0.0`, so the expensive predicates are skipped — the common case, since the spatial hash returns whole cells.

| Case | Before | After |
|---|---|---|
| `io.swc` stem/tree | 6.60s | 0.22s |
| `io.swc` stem/frustum | 4.11s | 0.10s |

Also: `np.cumsum` for the segment prefix-sum walk; `np.round(...).tobytes()` for a cache key that ran a per-element `round()` on every cache **hit**; `islice` for a `tuple(layouts.values())[-N:]` that copied every layout placed so far; iterating `morpho.branches` instead of `morpho.branch(index=i)`, which re-sorts the node table each call; one vectorized quad build per branch instead of an `np.vstack` per segment; lazy per-frame scalar resolution in `movie` instead of materializing all `T` frames up front; `deque.popleft` for a BFS using `list.pop(0)`.

## Reuse

`_values.py` is now the single home for value/overlay normalization — `resolve_overlay_values`, `with_unit_label` (via `dataclasses.replace`, so a new `ValueSpec` field cannot be silently dropped), `resolve_value_limits`, `compose_colorbar_label`. This replaces four near-identical private copies across `scene2d`/`scene3d`, four unit strippers that disagreed about what counts as a quantity, and colour-bound resolution open-coded in three backends plus `movie`. Adds one `backend.module_available`, one `config.rgb_to_float`, and one `_iter_batch_polylines` VTK cell decoder in place of duplicated bodies.

## Simplification

`config._copy_defaults` re-listed all 15 `VisDefaults` fields by hand — a field forgotten there leaks across a `theme()` block; it now uses `dataclasses.replace`. Two colour-map merge blocks collapse into `_merge_color_map`; the mode allowlists derive from their `Literal` aliases via `typing.get_args`; and dead code goes (`_normalize_scalar_values`, a tautological `show_colorbar`, a redundant `elif`, a no-op pyvista branch, a discarded tangent sample, six unused imports).

## What was deliberately *not* changed

Where two code paths had drifted, the divergence is preserved rather than silently unified — the shared helper takes the differing input from its caller. These need a decision, not a refactor, and are written up in `docs/specs/2026-09-01-vis-simplification.md`:

- **`layout/_stem.py` hardcodes a collision window of 48** while the tree path reads `layout_config.stem_collision_window` (default 24) — so that config knob silently does nothing on the `shape='frustum'` path. Now commented at the site; aligning them would move rendered geometry.
- **matplotlib scales colour from segment-midpoint values; PyVista and Plotly from point values**, so the same `ValueSpec` yields a slightly wider scale in 3D. `resolve_value_limits` shares only the bound-resolution policy.
- **`point_topology` pads a degenerate colour range by `+1.0`** where everything else uses `±0.5`.
- **`movie._format_time` renders the frame index, not elapsed time**, despite its docstring promising otherwise. The unused `dt` parameter is dropped and the gap flagged; rendering real time is a product decision.

Larger structural items left for a dedicated change: `traces.plot_traces` building the 2D scene twice, `_legacy.py`'s ~175 self-declared historical lines, the duplicated stem/stem-linear walker, a `LayoutFamily` registry, and `export.py`'s second backend registry.

## Summary by Sourcery

Improve braincell.vis performance and maintainability without changing its public API or rendered output.

Enhancements:
- Centralize visualization value, unit, colour-scale, backend availability, and palette handling to make behavior consistent across rendering paths.
- Accelerate 2D layout generation and collision scoring while preserving bit-identical layout output.
- Reduce visualization rendering and animation overhead through vectorized geometry, lazy frame processing, efficient traversal, and optimized caching.
- Simplify configuration, topology, and Plotly rendering code by consolidating duplicated logic and removing dead paths.

Documentation:
- Document the visualization cleanup scope, verification results, performance improvements, and behavior differences intentionally left unchanged.

Tests:
- Verify layout snapshots remain bit-identical and the full test suite continues to pass without regressions.