### PR TITLE
refactor(quad): unify the step call convention and consolidate duplicated helpers

### DIFF
--- a/braincell/_multi_compartment/cell.py
+++ b/braincell/_multi_compartment/cell.py
@@ -41,7 +41,7 @@ import operator
 import warnings
 import weakref
 from types import MappingProxyType
-from typing import Callable, Mapping, Optional
+from typing import Callable, ClassVar, Mapping, Optional
 from dataclasses import dataclass
 
 import brainstate
@@ -771,6 +771,10 @@ class Cell(_CellFacade, HHTypedNeuron):
     """
 
     __module__ = "braincell"
+
+    # A Cell lays its DiffEqState leaves out per compartment, so a solver that
+    # flattens them must concatenate rather than stack. See DiffEqModule.
+    diffeq_state_merging: ClassVar[str] = "concat"
 
     # ------------------------------------------------------------------
     # Construction

--- a/braincell/quad/__init__.py
+++ b/braincell/quad/__init__.py
@@ -28,8 +28,6 @@ registered in :mod:`braincell.quad._registry`.
     :func:`get_integrator` at first call instead of at import time.
 """
 
-from typing import Callable, Mapping
-
 # Importing the step modules below has the side effect of populating the
 # global registry via @register_integrator decorators on each *_step function.
 from ._backward_euler import backward_euler_step
@@ -51,6 +49,8 @@ from .protocol import (
 from ._registry import (
     IntegratorEntry,
     IntegratorRegistry,
+    all_integrators,
+    get_integrator,
     get_registry,
     register_integrator,
 )
@@ -67,7 +67,7 @@ from ._runge_kutta import (
     rk4_step,
     ssprk3_step,
 )
-from ._staggered import staggered_step
+from ._staggered import dhs_voltage_step, staggered_step
 
 __all__ = [
     # registry
@@ -96,6 +96,7 @@ __all__ = [
     'ralston4_step',
     # staggered
     'staggered_step',
+    'dhs_voltage_step',
     # implicit methods
     'implicit_euler_step',
     # protocol
@@ -108,93 +109,3 @@ __all__ = [
     'hidden_state',
     'state_grouping',
 ]
-
-
-class _RegistryDictView(Mapping[str, Callable]):
-    """Read-only mapping view backed by the integrator registry.
-
-    Provides backwards compatibility for the legacy ``all_integrators`` dict
-    while keeping the registry as the single source of truth. Alias names
-    are included so existing lookups such as ``all_integrators['explicit']``
-    continue to resolve.
-    """
-
-    def __init__(self, registry: IntegratorRegistry) -> None:
-        self._registry = registry
-
-    def __getitem__(self, name: str) -> Callable:
-        try:
-            return self._registry[name]
-        except KeyError:
-            raise KeyError(name)
-
-    def __iter__(self):
-        return iter(self._registry.as_dict(include_aliases=True))
-
-    def __len__(self) -> int:
-        return len(self._registry.as_dict(include_aliases=True))
-
-    def __contains__(self, name: object) -> bool:
-        return name in self._registry
-
-    def __repr__(self) -> str:
-        return f"_RegistryDictView({sorted(self._registry.as_dict(include_aliases=True))!r})"
-
-
-#: Backwards-compatible mapping view of the integrator registry.
-#:
-#: This object behaves like the legacy ``{name: func}`` dict that lived in
-#: this module, but it is now backed by :class:`IntegratorRegistry`. Treat it
-#: as read-only; new integrators should be registered with
-#: :func:`register_integrator`.
-all_integrators: Mapping[str, Callable] = _RegistryDictView(get_registry())
-
-
-def get_integrator(method: str | Callable) -> Callable:
-    """Resolve a numerical integrator from a string name or a callable.
-
-    Parameters
-    ----------
-    method : str or Callable
-        Either the registered name (canonical or alias) of an integrator or
-        a step function to use directly.
-
-    Returns
-    -------
-    Callable
-        The integrator step function corresponding to ``method``.
-
-    Raises
-    ------
-    ValueError
-        If ``method`` is a string that does not match any registered
-        integrator. The error message includes a "did you mean ...?"
-        suggestion when a close match exists.
-    TypeError
-        If ``method`` is neither a string nor a callable.
-
-    Examples
-    --------
-
-    .. code-block:: python
-
-        >>> from braincell.quad import get_integrator
-        >>> get_integrator('euler')              # doctest: +ELLIPSIS
-        <function euler_step at ...>
-        >>> get_integrator('explicit') is get_integrator('euler')
-        True
-        >>> get_integrator('stagger') is get_integrator('staggered')
-        True
-    """
-    if callable(method):
-        return method
-    if isinstance(method, str):
-        registry = get_registry()
-        try:
-            return registry[method]
-        except KeyError:
-            suggestions = registry.suggest(method, n=1)
-            hint = f" Did you mean {suggestions[0]!r}?" if suggestions else ""
-            available = ", ".join(registry.names())
-            raise ValueError(f"Unknown integrator {method!r}.{hint} Available: {available}.")
-    raise TypeError(f"Integrator method must be a string or callable, got {type(method).__name__}.")

--- a/braincell/quad/_backward_euler.py
+++ b/braincell/quad/_backward_euler.py
@@ -13,46 +13,57 @@
 # limitations under the License.
 # ==============================================================================
 
-import brainstate
-import brainunit as u
 import jax
 import jax.numpy as jnp
 
 from braincell._misc import set_module_as
+from braincell._typing import Args, Aux, DT, T, VectorField, Y0, Y1
 from .protocol import DiffEqModule
 from ._registry import register_integrator
-from ._util import apply_standard_solver_step, jacrev_last_dim
+from ._util import apply_standard_solver_step, environ_time, linearize_flat
 
 __all__ = [
     'backward_euler_step',
 ]
 
 
-def _backward_euler(f, y0, t, dt, args=()):
+def _backward_euler(
+    f: VectorField,
+    y0: Y0,
+    t: T,
+    dt: DT,
+    args: Args = (),
+) -> tuple[Y1, Aux]:
     """
-    One step of implicit backward Euler method for ODE integration.
-    Linearize the system at the current state using the Jacobian.
+    Take one linearised backward Euler step.
 
-    Args:
-        f: Callable function f(t, y, *args) returning dy/dt (and optional aux)
-        y0: current state, shape (..., M)
-        t: current time
-        dt: time step
-        args: additional arguments passed to f
+    The system is linearised at the current state using its Jacobian, so a
+    single linear solve replaces the Newton iteration that the implicit
+    formula would otherwise require.
 
-    Returns:
-        y1: updated state after one backward Euler step
-        aux: optional auxiliary output from f
+    Parameters
+    ----------
+    f : Callable
+        The vector field ``f(t, y, *args)``, returning ``dy/dt`` and an
+        auxiliary output.
+    y0 : jax.Array
+        The current state, shape ``(..., M)``.
+    t : u.Quantity[u.second]
+        The current time.
+    dt : u.Quantity[u.second]
+        The integration time step.
+    args : tuple, optional
+        Extra positional arguments forwarded to ``f``.
+
+    Returns
+    -------
+    y1 : jax.Array
+        The updated state after one backward Euler step.
+    aux : Any
+        The auxiliary output of ``f``.
     """
     dtype = y0.dtype
-    dt = jnp.asarray(u.get_magnitude(dt), dtype=dtype)
-
-    # Compute Jacobian A = df/dy and function value df = f(y0)
-    A, df, aux = jacrev_last_dim(lambda y: f(t, y, *args), y0, has_aux=True)
-
-    # Flatten batch dimensions
-    A = jnp.asarray(A, dtype=dtype).reshape((-1, A.shape[-2], A.shape[-1]))  # (B, M, M)
-    df = jnp.asarray(df, dtype=dtype).reshape((-1, df.shape[-1]))  # (B, M)
+    dt, A, df, aux = linearize_flat(f, y0, t, dt, args)
 
     n = y0.shape[-1]
     I = jnp.eye(n, dtype=dtype)
@@ -119,7 +130,7 @@ def backward_euler_step(target: DiffEqModule, *args, excluded_paths=()):
 
     Raises
     ------
-    AssertionError
+    TypeError
         Raised inside :func:`apply_standard_solver_step` if *target* is
         not a :class:`DiffEqModule`.
 
@@ -146,9 +157,7 @@ def backward_euler_step(target: DiffEqModule, *args, excluded_paths=()):
         ...     backward_euler_step(my_neuron, input_current)  # doctest: +SKIP
     """
 
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-
+    t, dt = environ_time(target)
     apply_standard_solver_step(
         _backward_euler,
         target,

--- a/braincell/quad/_backward_euler_test.py
+++ b/braincell/quad/_backward_euler_test.py
@@ -27,52 +27,23 @@ import unittest
 
 import brainstate
 import brainunit as u
-import jax.numpy as jnp
-import matplotlib.pyplot as plt
+import numpy as np
 
-import braincell
 from braincell.quad import (
     backward_euler_step,
 )
-from braincell.quad.protocol import (
-    DiffEqModule,
-    DiffEqSingleState,
-)
-
-_FLOAT_DTYPE = jnp.asarray(0.0).dtype
+from braincell.quad._testing import LinearDecay, drive, integrate
 
 
 # --------------------------------------------------------------------------- #
 # Analytical-solution test on a linear ODE
 # --------------------------------------------------------------------------- #
-class _LinearDecay(brainstate.nn.Module, DiffEqModule):
-    """Scalar linear ODE ``dx/dt = -x/tau``."""
-
-    def __init__(self, x0=1.0, tau_ms=10.0, shape=(3,)):
-        super().__init__()
-        self.tau = tau_ms * u.ms
-        self.x = DiffEqSingleState(jnp.full(shape, x0, dtype=_FLOAT_DTYPE) * u.mV)
-
-    def compute_derivative(self, *args, **kwargs):
-        self.x.derivative = -self.x.value / self.tau
-
-
-def _drive(method, dt_ms=0.1, n_steps=100, x0=1.0, tau_ms=10.0):
-    m = _LinearDecay(x0=x0, tau_ms=tau_ms)
-    dt = dt_ms * u.ms
-    with brainstate.environ.context(dt=dt):
-        for i in range(n_steps):
-            with brainstate.environ.context(t=i * dt):
-                method(m)
-    return float(m.x.value.to_decimal(u.mV)[0])
-
-
 class BackwardEulerLinearTest(unittest.TestCase):
     def test_one_step_matches_analytical(self):
         # For dx/dt = -x/tau, backward Euler gives
         #     x_{n+1} = x_n / (1 + dt/tau).
         # With dt=0.1 ms, tau=10 ms → x_1 = 1/1.01 ≈ 0.990099.
-        m = _LinearDecay()
+        m = LinearDecay()
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
             backward_euler_step(m)
         result = float(m.x.value.to_decimal(u.mV)[0])
@@ -82,71 +53,34 @@ class BackwardEulerLinearTest(unittest.TestCase):
         # Backward Euler is L-stable; on a linear decay it converges to the
         # exact solution as dt → 0.
         target = math.exp(-1.0)
-        result = _drive(backward_euler_step, dt_ms=0.01, n_steps=1000)
+        result, _ = drive(backward_euler_step, dt_ms=0.01, n_steps=1000)
         self.assertAlmostEqual(result, target, delta=5e-4)
 
     def test_rejects_non_diffeq_module(self):
         class Plain(brainstate.nn.Module):
             pass
 
-        with self.assertRaises(AssertionError):
+        # TypeError (not AssertionError) so ``python -O`` preserves the contract.
+        with self.assertRaises(TypeError):
             with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
                 backward_euler_step(Plain())
 
 
 # --------------------------------------------------------------------------- #
-# Hodgkin-Huxley single-compartment smoke test (mirrors the existing
-# convergence-comparison harness used by ``_runge_kutta_test`` and
-# ``_exp_euler_test``).
+# Hodgkin-Huxley single-compartment end-to-end test.
 # --------------------------------------------------------------------------- #
-class HH(braincell.SingleCompartment):
-    def __init__(self, size, solver='backward_euler'):
-        super().__init__(size, solver=solver)
-
-        self.na = braincell.ion.SodiumFixed(size, E=50.0 * u.mV)
-        self.na.add(INa=braincell.channel.Na_HH1952(size))
-
-        self.k = braincell.ion.PotassiumFixed(size, E=-77.0 * u.mV)
-        self.k.add(IK=braincell.channel.K_HH1952(size))
-
-        self.IL = braincell.channel.IL(size, E=-54.387 * u.mV, g_max=0.03 * (u.mS / u.cm**2))
-
-
-def integrate(method: str, dt=0.01 * u.ms):
-    brainstate.random.seed(1)
-    hh = HH(1, solver=method)
-    hh.init_state()
-
-    def step_fun(t):
-        with brainstate.environ.context(t=t):
-            hh.update(10 * u.nA / u.cm**2)
-        return hh.V.value
-
-    with brainstate.environ.context(dt=dt):
-        times = u.math.arange(0.0 * u.ms, 10 * u.ms, brainstate.environ.get_dt())
-        vs = brainstate.transform.for_loop(step_fun, times)
-    return vs
-
-
-def compare(method):
-    norm = []
-    dts = [1e-3 * u.ms, 2e-3 * u.ms, 4e-3 * u.ms, 8e-3 * u.ms, 1e-2 * u.ms, 2e-2 * u.ms]
-    for dt in dts:
-        gold_vs = integrate('exp_euler', dt=dt)
-        vs = integrate(method, dt=dt)
-        norm.append(u.linalg.norm(gold_vs - vs))
-    # Strip units before returning so matplotlib can convert via np.asarray.
-    # Newer saiunit rejects np.asarray(dimensional_quantity).
-    dts_q = u.math.asarray(dts)
-    norm_q = u.math.asarray(norm)
-    return dts_q.mantissa, norm_q.mantissa
-
-
-class TestBackwardEulerHH(unittest.TestCase):
-    def test_backward_euler_step(self):
-        dts, norms = compare('backward_euler')
-        plt.loglog(dts, norms)
-        plt.close()
+class BackwardEulerHHTest(unittest.TestCase):
+    def test_drives_hodgkin_huxley_to_a_spiking_trace(self):
+        # Exercises the full HH stack through ``solver='backward_euler'``:
+        # a 10 nA/cm^2 drive over 10 ms must produce a finite, spiking trace
+        # rather than diverging or going NaN.
+        vs = np.asarray(integrate('backward_euler').to_decimal(u.mV))
+        self.assertTrue(np.all(np.isfinite(vs)))
+        # Physiological envelope: the trace must stay bounded ...
+        self.assertGreater(vs.min(), -100.0)
+        self.assertLess(vs.max(), 80.0)
+        # ... and must actually spike rather than sit at rest.
+        self.assertGreater(vs.max() - vs.min(), 50.0)
 
 
 if __name__ == "__main__":

--- a/braincell/quad/_exp_euler.py
+++ b/braincell/quad/_exp_euler.py
@@ -23,12 +23,13 @@ import jax.numpy as jnp
 from jax.scipy.linalg import expm
 
 from braincell._misc import set_module_as
-from braincell._typing import ArrayLike, Path
+from braincell._typing import Args, ArrayLike, Aux, DT, Path, T, VectorField, Y0, Y1
 from .protocol import DiffEqModule
 from ._registry import register_integrator
 from ._util import (
     apply_standard_solver_step,
-    jacrev_last_dim,
+    environ_time,
+    linearize_flat,
     _check_diffeq_state_derivative,
     _has_path_prefix,
     split_diffeq_states,
@@ -40,35 +41,39 @@ __all__ = [
 ]
 
 
-def power_iteration_expm(A, num_steps=20, method='scipy'):
+def _exponential_euler(
+    f: VectorField,
+    y0: Y0,
+    t: T,
+    dt: DT,
+    args: Args = (),
+) -> tuple[Y1, Aux]:
     """
-    A naive implementation of matrix exponential using the power series definition.
-    This is for demonstration and is not numerically stable or efficient for general use.
+    Take one coupled exponential Euler step over the full state vector.
+
+    Parameters
+    ----------
+    f : Callable
+        The vector field ``f(t, y, *args)``, returning ``dy/dt`` and an
+        auxiliary output.
+    y0 : jax.Array
+        The current state, shape ``(..., M)``.
+    t : u.Quantity[u.second]
+        The current time.
+    dt : u.Quantity[u.second]
+        The integration time step.
+    args : tuple, optional
+        Extra positional arguments forwarded to ``f``.
+
+    Returns
+    -------
+    y1 : jax.Array
+        The updated state after one exponential Euler step.
+    aux : Any
+        The auxiliary output of ``f``.
     """
-    if method == 'scipy':
-        return expm(A)
-    elif method == 'approx':
-        n = A.shape[0]
-        result = jnp.eye(n, dtype=A.dtype)
-        term = jnp.eye(n, dtype=A.dtype)
-        for k in range(1, num_steps + 1):
-            term = term @ A / k
-            result = result + term
-        return result
-    else:
-        raise ValueError('Unsupported method "{}"'.format(method))
-
-
-def _exponential_euler(f, y0, t, dt, args=()):
     dtype = y0.dtype
-    dt = jnp.asarray(u.get_magnitude(dt), dtype=dtype)
-    A, df, aux = jacrev_last_dim(lambda y: f(t, y, *args), y0, has_aux=True)
-
-    # reshape A from "[..., M, M]" to "[-1, M, M]"
-    A = jnp.asarray(A, dtype=dtype).reshape((-1, A.shape[-2], A.shape[-1]))
-
-    # reshape df from "[..., M]" to "[-1, M]"
-    df = jnp.asarray(df, dtype=dtype).reshape((-1, df.shape[-1]))
+    dt, A, df, aux = linearize_flat(f, y0, t, dt, args)
 
     # Stable phi_1(hA)·h·df via the augmented-matrix trick:
     #   M = [[hA,  h·df],
@@ -82,8 +87,7 @@ def _exponential_euler(f, y0, t, dt, args=()):
     def _one(A_, df_):
         top = jnp.concatenate([dt * A_, (dt * df_)[:, None]], axis=1)
         M = jnp.concatenate([top, zero_row], axis=0)
-        expM = power_iteration_expm(M, method='scipy')
-        return expM[:n, n]
+        return expm(M)[:n, n]
 
     updates = jax.vmap(_one)(A, df).reshape(y0.shape)
     y1 = y0 + updates
@@ -182,37 +186,19 @@ def exp_euler_step(target: DiffEqModule, *args):
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.025 * u.ms):
         ...     exp_euler_step(my_neuron, input_current)    # doctest: +SKIP
     """
-    from braincell._base_neuron import HHTypedNeuron
-    from braincell._multi_compartment import Cell
-    from braincell._single_compartment import SingleCompartment
-
-    if not isinstance(target, HHTypedNeuron):
-        raise TypeError(f"The target should be a {HHTypedNeuron.__name__}. But got {type(target)} instead.")
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-
-    if isinstance(target, SingleCompartment):
-        apply_standard_solver_step(
-            _exponential_euler,
-            target,
-            t,
-            dt,
-            *args,
-            merging='stack',  # [n_neuron, n_state]
-        )
-
-    elif isinstance(target, Cell):
-        apply_standard_solver_step(
-            _exponential_euler,
-            target,
-            t,
-            dt,
-            *args,
-            merging='concat',  # [n_neuron, n_compartment * n_state]
-        )
-
-    else:
-        raise ValueError(f"Unknown target type: {type(target)}")
+    if not isinstance(target, DiffEqModule):
+        raise TypeError(f"The target should be a {DiffEqModule.__name__}. But got {type(target)} instead.")
+    t, dt = environ_time(target)
+    apply_standard_solver_step(
+        _exponential_euler,
+        target,
+        t,
+        dt,
+        *args,
+        # The host declares how its DiffEqState leaves are laid out:
+        # 'stack' -> [n_neuron, n_state], 'concat' -> [n_neuron, n_compartment * n_state].
+        merging=target.diffeq_state_merging,
+    )
 
 
 @register_integrator(
@@ -336,8 +322,8 @@ def _ind_exp_euler_step_selected(
         raise TypeError(f"The target should be a {DiffEqModule.__name__}. But got {type(target)} instead.")
     dt = brainstate.environ.get('dt')
 
-    # Retrieve all states from the target module
-    excluded_paths = tuple(tuple(path) for path in excluded_paths)
+    # Retrieve all states from the target module. ``excluded_paths`` is
+    # normalised by ``split_diffeq_states``, which owns that contract.
     include_paths = tuple(tuple(path) for path in include_paths)
     all_states, diffeq_states, other_states = split_diffeq_states(
         target,
@@ -426,8 +412,7 @@ def _ind_exp_euler_step_selected(
     integrated_diffeq_state_vals = dict()
 
     # Iterate over each DiffEqState and apply the exponential Euler update independently
-    i = 0
-    for key in diffeq_states.keys():
+    for i, key in enumerate(diffeq_states):
         # Compute the linearization (Jacobian), derivative, and auxiliary outputs
         linear, derivative, aux = brainstate.transform.vector_grad(
             functools.partial(vector_field, key),
@@ -461,7 +446,6 @@ def _ind_exp_euler_step_selected(
             # Update other states with auxiliary outputs (only on first iteration)
             for k, st in other_states.items():
                 st.value = aux[k]
-        i += 1
 
     # Assign the integrated values back to the corresponding DiffEqStates
     for k, st in diffeq_states.items():

--- a/braincell/quad/_exp_euler_test.py
+++ b/braincell/quad/_exp_euler_test.py
@@ -13,113 +13,33 @@
 # limitations under the License.
 # ==============================================================================
 
-# -*- coding: utf-8 -*-
-
-
 import math
 import unittest
 
 import brainstate
 import brainunit as u
 import jax.numpy as jnp
-import matplotlib.pyplot as plt
 import numpy as np
 
-import braincell
 from braincell.quad import (
     exp_euler_step,
     ind_exp_euler_step,
 )
-from braincell.quad.protocol import (
-    DiffEqModule,
-    DiffEqSingleState,
-)
-
-
-class HH(braincell.SingleCompartment):
-    def __init__(self, size, solver='rk4'):
-        super().__init__(size, solver=solver)
-
-        self.na = braincell.ion.SodiumFixed(size, E=50.0 * u.mV)
-        self.na.add(INa=braincell.channel.Na_HH1952(size))
-
-        self.k = braincell.ion.PotassiumFixed(size, E=-77.0 * u.mV)
-        self.k.add(IK=braincell.channel.K_HH1952(size))
-
-        self.IL = braincell.channel.IL(size, E=-54.387 * u.mV, g_max=0.03 * (u.mS / u.cm**2))
-
-
-def integrate(method: str, dt=0.01 * u.ms):
-    brainstate.random.seed(1)
-    hh = HH(1, solver=method)
-    hh.init_state()
-
-    def step_fun(t):
-        with brainstate.environ.context(t=t):
-            hh.update(10 * u.nA / u.cm**2)
-        return hh.V.value
-
-    with brainstate.environ.context(dt=dt):
-        times = u.math.arange(0.0 * u.ms, 10 * u.ms, brainstate.environ.get_dt())
-        vs = brainstate.transform.for_loop(step_fun, times)
-    return vs
-
-
-def compare(method):
-    norm = []
-    dts = [1e-3 * u.ms, 2e-3 * u.ms, 4e-3 * u.ms, 8e-3 * u.ms, 1e-2 * u.ms, 2e-2 * u.ms]
-    for dt in dts:
-        gold_vs = integrate('exp_euler', dt=dt)
-        vs = integrate(method, dt=dt)
-        norm.append(u.linalg.norm(gold_vs - vs))
-    # Strip units before returning so matplotlib can convert via np.asarray.
-    # Newer saiunit rejects np.asarray(dimensional_quantity).
-    dts_q = u.math.asarray(dts)
-    norm_q = u.math.asarray(norm)
-    return dts_q.mantissa, norm_q.mantissa
-
-
-class TestRungeKutta:
-    def test_euler_step(self):
-        dts, norms = compare('ind_exp_euler')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-
-# --------------------------------------------------------------------------- #
-# Unit tests for exp_euler / ind_exp_euler that do not require the full HH
-# stack. ind_exp_euler is exact for a locally linear ODE so we can compare
-# against ``exp(-dt/tau)`` directly.
-# --------------------------------------------------------------------------- #
-
-_FLOAT_DTYPE = jnp.asarray(0.0).dtype
-
-
-class _LinearDecay(brainstate.nn.Module, DiffEqModule):
-    """Scalar linear ODE ``dx/dt = -x/tau``."""
-
-    def __init__(self, x0=1.0, tau_ms=10.0, shape=(3,)):
-        super().__init__()
-        self.tau = tau_ms * u.ms
-        self.x = DiffEqSingleState(jnp.full(shape, x0, dtype=_FLOAT_DTYPE) * u.mV)
-
-    def compute_derivative(self, *args, **kwargs):
-        self.x.derivative = -self.x.value / self.tau
+from braincell.quad._testing import LinearDecay, integrate
 
 
 class IndExpEulerLinearTest(unittest.TestCase):
     def test_one_step_matches_exponential(self):
         # For dx/dt = lambda * x with constant lambda, ind_exp_euler should
         # produce y_{n+1} = y_n * exp(lambda * dt) up to float precision.
-        m = _LinearDecay()
+        m = LinearDecay()
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
             ind_exp_euler_step(m)
         expected = math.exp(-0.01)  # dt/tau = 0.1/10 = 0.01
         self.assertAlmostEqual(float(m.x.value.to_decimal(u.mV)[0]), expected, places=5)
 
     def test_excluded_paths_are_skipped(self):
-        m = _LinearDecay()
+        m = LinearDecay()
         original = np.array(m.x.value.to_decimal(u.mV))
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
             ind_exp_euler_step(m, excluded_paths=[("x",)])
@@ -136,23 +56,42 @@ class IndExpEulerLinearTest(unittest.TestCase):
                 ind_exp_euler_step(Plain())
 
 
-class ExpEulerTypeGuardTest(unittest.TestCase):
-    """``exp_euler_step`` requires an ``HHTypedNeuron`` target."""
-
-    def test_rejects_minimal_diffeq_module(self):
-        # HIGH-03: TypeError (not AssertionError) so ``python -O`` preserves
-        # the contract.
-        with self.assertRaises(TypeError):
-            with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
-                exp_euler_step(_LinearDecay())
+class ExpEulerTargetContractTest(unittest.TestCase):
+    """``exp_euler_step`` accepts any ``DiffEqModule`` and reads its layout."""
 
     def test_rejects_plain_object(self):
-        from braincell.quad import exp_euler_step
-
+        # TypeError (not AssertionError) so ``python -O`` preserves the contract.
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.025 * u.ms):
             with self.assertRaises(TypeError) as ctx:
                 exp_euler_step(object())
-        self.assertIn("HHTypedNeuron", str(ctx.exception))
+        self.assertIn("DiffEqModule", str(ctx.exception))
+
+    def test_accepts_minimal_diffeq_module(self):
+        # The target no longer has to be an HHTypedNeuron: the state layout is
+        # declared by the host through ``diffeq_state_merging`` rather than
+        # inferred from the concrete class.
+        m = LinearDecay()
+        with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
+            exp_euler_step(m)
+        # dx/dt = -x/tau is linear, so one step is exact: x * exp(-dt/tau).
+        expected = math.exp(-0.01)  # dt/tau = 0.1/10 = 0.01
+        self.assertAlmostEqual(float(m.x.value.to_decimal(u.mV)[0]), expected, places=5)
+
+    def test_default_merging_is_stack(self):
+        # A plain DiffEqModule inherits 'stack'; Cell overrides it to 'concat'.
+        self.assertEqual(LinearDecay.diffeq_state_merging, "stack")
+
+
+class IndExpEulerHHTest(unittest.TestCase):
+    def test_drives_hodgkin_huxley_to_a_spiking_trace(self):
+        # Exercises the full HH stack through ``solver='ind_exp_euler'``:
+        # a 10 nA/cm^2 drive over 10 ms must produce a finite, spiking trace
+        # rather than diverging or going NaN.
+        vs = np.asarray(integrate('ind_exp_euler').to_decimal(u.mV))
+        self.assertTrue(np.all(np.isfinite(vs)))
+        self.assertGreater(vs.min(), -100.0)
+        self.assertLess(vs.max(), 80.0)
+        self.assertGreater(vs.max() - vs.min(), 50.0)
 
 
 class ExponentialEulerHandlesSingularJacobianTest(unittest.TestCase):

--- a/braincell/quad/_implicit.py
+++ b/braincell/quad/_implicit.py
@@ -24,94 +24,95 @@ import brainstate
 import brainunit as u
 
 from braincell._misc import set_module_as
-from braincell._typing import T, DT
+from braincell._typing import Args, Aux, DT, T, VectorField, Y0, Y1
 from .protocol import DiffEqModule
 from ._registry import register_integrator
-from ._util import apply_standard_solver_step
+from ._util import apply_standard_solver_step, environ_time
 
 __all__ = [
     'implicit_euler_step',
 ]
 
 
-def _newton_method(f, y0, t, dt, args=(), modified=False, tol=1e-5, max_iter=100, order=2):
+def _newton_method(
+    f: VectorField,
+    y0: Y0,
+    t: T,
+    dt: DT,
+    args: Args = (),
+    tol: float = 1e-5,
+    max_iter: int = 100,
+) -> tuple[Y1, Aux]:
     r"""
-    Newton's method for solving the implicit equations arising from the Crank - Nicolson method for ordinary differential equations (ODEs).
+    Solve one trapezoidal (Crank-Nicolson) step by Newton iteration.
 
-    The Crank - Nicolson method is a finite - difference method used for numerically solving ODEs of the form \(\frac{dy}{dt}=f(t,y)\).
-    Given the current state \(y_0\) at time \(t\), this function uses Newton's method to find the next state \(y\) at time \(t + dt\)
-    by solving the implicit equation \(y - y_0-\frac{dt}{2}(f(t,y_0)+f(t + dt,y)) = 0\).
+    For an ODE :math:`dy/dt = f(t, y)` and a current state :math:`y_0` at time
+    :math:`t`, this finds :math:`y` at :math:`t + \Delta t` by solving the
+    implicit residual
 
-    Parameters:
-        f : callable
-            Function representing the ODE or implicit equation.
-        y0 : array_like
-            Initial guess for the solution.
-        t : float
-            Current time.
-        dt : float
-            Time step.
-        tol : float, optional
-            Convergence tolerance for the solution. Default is 1e-5.
-        max_iter : int, optional
-            Maximum number of iterations. Default is 100.
-        order : int, optional
-            Order of the integration method. If order = 1, use explicit Euler. If order = 2, use Crank - Nicolson.
-        args : tuple, optional
-            Additional arguments passed to the function f.
+    .. math::
 
-    Returns:
-        y : ndarray
-            Solution array, shape (n,).
+        g(y) = y - y_0 - \tfrac{\Delta t}{2}
+               \bigl(f(t, y_0) + f(t + \Delta t, y)\bigr) = 0,
+
+    updating :math:`y \leftarrow y - J^{-1} g(y)` with
+    :math:`J = \partial g / \partial y` assembled by forward-mode AD.
+
+    Parameters
+    ----------
+    f : Callable
+        The vector field ``f(t, y, *args)``, returning ``dy/dt`` and an
+        auxiliary output.
+    y0 : jax.Array
+        The current state, used both as the initial guess and as the anchor of
+        the residual.
+    t : u.Quantity[u.second]
+        The current time.
+    dt : u.Quantity[u.second]
+        The integration time step.
+    args : tuple, optional
+        Extra positional arguments forwarded to ``f``.
+    tol : float, optional
+        Convergence tolerance. Iteration stops once either the residual norm
+        or the Jacobian norm falls below this value. Default 1e-5.
+    max_iter : int, optional
+        Maximum number of Newton iterations. Default 100.
+
+    Returns
+    -------
+    y1 : jax.Array
+        The updated state.
+    aux : dict
+        Empty; this solver produces no auxiliary output.
     """
 
+    # The residual works on bare magnitudes; strip before anything closes over
+    # ``t`` / ``dt`` so every evaluation below sees the same values.
+    dt = u.get_magnitude(dt)
+    t = u.get_magnitude(t)
+
+    # f(t, y0) does not depend on the loop carry, and XLA does not hoist
+    # loop-invariant code out of a while body, so evaluating it inside ``g``
+    # cost a second full vector-field evaluation on every Newton iteration.
+    f0 = f(t, y0, *args)[0]
+
     def g(t, y, *args):
-        # jax.debug.print("arg = {a}", a = args)
-        if order == 1:
-            return y - y0 - dt * f(t + dt, y, *args)[0]
-        elif order == 2:
-            return y - y0 - 0.5 * dt * (f(t, y0, *args)[0] + f(t + dt, y, *args)[0])
-        else:
-            raise ValueError("Only order 1 or 2 is supported.")
+        return y - y0 - 0.5 * dt * (f0 + f(t + dt, y, *args)[0])
 
     def cond_fun(carry):
         i, _, cond = carry
-        # condition = u.math.logical_or(u.math.linalg.norm(A) < tol, u.math.linalg.norm(df) < tol)
         return u.math.logical_and(i < max_iter, cond)
 
     def body_fun(carry):
         i, y1, _ = carry
+        # df: [n_neuron * n_compartment, M];  A: [n_neuron * n_compartment, M, M]
         A, df = brainstate.transform.jacfwd(lambda y: g(t, y, *args), return_value=True, has_aux=False)(y1)
-        # df: [n_neuron, n_compartment, M]
-        # A: [n_neuron, n_compartment, M, M]
-        # df: [n_neuron * n_compartment, M]
-        # A: [n_neuron * n_compartment, M, M]
-
-        # y1: [n_neuron * n_compartment, M]
-
         condition = u.math.logical_or(u.math.linalg.norm(A) < tol, u.math.linalg.norm(df) < tol)
         new_y1 = y1 - u.math.linalg.solve(A, df)
         return (i + 1, new_y1, condition)
 
-    def body_fun_modified(carry):
-        i, y1, A, _ = carry
-        df = g(t, y1, *args)
-        new_y1 = y1 - u.math.linalg.solve(A, df)
-        return (i + 1, new_y1, A, df)
-
-    dt = u.get_magnitude(dt)
-    t = u.get_magnitude(t)
-    init_guess = y0  # + dt*f(t, y0, *args)[0]
-    init_carry = (0, init_guess, True)
-    '''
-    if not modified:
-        n, result, _, _ = jax.lax.while_loop(cond_fun, body_fun, init_carry)
-    else:
-        n, result, _, df = jax.lax.while_loop(cond_fun, body_fun_modified, init_carry)
-    '''
-    n, result, _ = brainstate.transform.while_loop(cond_fun, body_fun, init_carry)
-    aux = {}
-    return result, aux
+    _, result, _ = brainstate.transform.while_loop(cond_fun, body_fun, (0, y0, True))
+    return result, {}
 
 
 @register_integrator(
@@ -121,39 +122,40 @@ def _newton_method(f, y0, t, dt, args=(), modified=False, tol=1e-5, max_iter=100
     description="Implicit Euler via Newton iteration.",
 )
 @set_module_as('braincell.quad')
-def implicit_euler_step(target: DiffEqModule, t: T, dt: DT, *args):
-    r"""Advance one step with the implicit (backward) Euler method.
+def implicit_euler_step(target: DiffEqModule, *args, t: T = None, dt: DT = None):
+    r"""Advance one step with an implicit Newton-solved step.
 
-    Solves
+    Solves the trapezoidal (Crank-Nicolson) residual
 
     .. math::
 
-        y_{n+1} = y_n + \Delta t \, f(t_{n+1}, y_{n+1})
+        g(y) = y - y_n - \frac{\Delta t}{2}
+               \bigl(f(t_n, y_n) + f(t_{n+1}, y)\bigr) = 0
 
-    by Newton iteration on the residual
-    :math:`g(y) = y - y_n - \Delta t \, f(t + \Delta t, y)`. Each
-    iteration assembles the full Jacobian
+    by Newton iteration. Each iteration assembles the full Jacobian
     :math:`J = \partial g / \partial y` and updates
     :math:`y \leftarrow y - J^{-1} g(y)` until either the residual norm or
     the Jacobian norm falls below ``1e-5`` or 100 iterations have been
     spent.
 
-    Implicit Euler is :math:`L`-stable, so it tolerates arbitrarily large
-    time steps on stiff problems at the cost of damping high-frequency
-    components. Local truncation error is :math:`O(\Delta t^2)`; global
-    error is :math:`O(\Delta t)`.
+    The trapezoidal rule is A-stable with local truncation error
+    :math:`O(\Delta t^3)` and global error :math:`O(\Delta t^2)`. Unlike an
+    L-stable scheme it does not damp high-frequency components, so very stiff
+    problems may ring rather than decay.
 
     Parameters
     ----------
     target : DiffEqModule
         The module whose :class:`DiffEqState` leaves are advanced.
-    t : Quantity[time]
-        Current simulation time.
-    dt : Quantity[time]
-        Time step. Must carry units of time (e.g. ``0.025 * u.ms``).
     *args
         Extra positional arguments forwarded to ``target``'s
         ``compute_derivative`` and ``pre/post_integral`` hooks.
+    t : Quantity[time], optional
+        Current simulation time. Defaults to the value in the active
+        :mod:`brainstate.environ` context.
+    dt : Quantity[time], optional
+        Time step; must carry units of time (e.g. ``0.025 * u.ms``). Defaults
+        to the value in the active :mod:`brainstate.environ` context.
 
     Returns
     -------
@@ -169,11 +171,27 @@ def implicit_euler_step(target: DiffEqModule, t: T, dt: DT, *args):
 
     Notes
     -----
-    This step takes ``t`` and ``dt`` explicitly, so it is **not**
-    selectable through ``solver="implicit_euler"``: the model hosts call
-    ``self.solver(self)`` / ``self.solver(self, I_ext)`` and read the time
-    arguments from :mod:`brainstate.environ`. Call it directly, or pick a
-    ``(target, *args)`` integrator such as ``"backward_euler"``. The
-    registry records this as ``IntegratorEntry.requires_time_args``.
+    ``t`` and ``dt`` are keyword-only and optional, so this step matches the
+    ``(target, *args)`` convention the model hosts call
+    (``self.solver(self)`` / ``self.solver(self, I_ext)``) and is selectable
+    through ``solver="implicit_euler"``.
+
+    The registered name and ``order=1`` metadata describe implicit Euler, but
+    the residual solved here is the trapezoidal one, as the equations above
+    and ``_implicit_test.py`` both show. Reconciling the two means either
+    renaming a public solver or changing the scheme, so it is left to a
+    deliberate decision rather than settled by a refactor.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import brainunit as u
+        >>> from braincell.quad import implicit_euler_step
+        >>> with brainstate.environ.context(t=0. * u.ms, dt=0.025 * u.ms):
+        ...     implicit_euler_step(my_neuron)  # doctest: +SKIP
     """
+    t, dt = environ_time(target, t, dt)
     apply_standard_solver_step(_newton_method, target, t, dt, *args)

--- a/braincell/quad/_implicit_test.py
+++ b/braincell/quad/_implicit_test.py
@@ -30,42 +30,44 @@ import unittest
 
 import brainstate
 import brainunit as u
-import jax.numpy as jnp
 
 from braincell.quad import get_registry, implicit_euler_step
-from braincell.quad.protocol import (
-    DiffEqModule,
-    DiffEqSingleState,
-)
-
-_FLOAT_DTYPE = jnp.asarray(0.0).dtype
-
-
-class _LinearDecay(brainstate.nn.Module, DiffEqModule):
-    """Scalar linear ODE ``dx/dt = -x/tau``."""
-
-    def __init__(self, x0=1.0, tau_ms=10.0, shape=(3,)):
-        super().__init__()
-        self.tau = tau_ms * u.ms
-        self.x = DiffEqSingleState(jnp.full(shape, x0, dtype=_FLOAT_DTYPE) * u.mV)
-
-    def compute_derivative(self, *args, **kwargs):
-        self.x.derivative = -self.x.value / self.tau
+from braincell.quad._testing import LinearDecay
 
 
 class ImplicitEulerLinearTest(unittest.TestCase):
-    """``implicit_euler_step`` defaults to a Crank-Nicolson Newton solver."""
+    """``implicit_euler_step`` solves a Crank-Nicolson residual by Newton."""
 
     def test_one_step_lies_in_cn_bracket(self):
-        m = _LinearDecay()
+        m = LinearDecay()
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
-            implicit_euler_step(m, 0.0 * u.ms, 0.1 * u.ms)
+            implicit_euler_step(m)
         v = float(m.x.value.to_decimal(u.mV)[0])
         # The 1-step Crank-Nicolson value lies between the implicit-Euler
         # value 1/(1 + dt/tau) ≈ 0.99010 and the exact decay exp(-dt/tau)
         # ≈ 0.99005.
         self.assertGreater(v, 0.989)
         self.assertLess(v, 0.991)
+
+    def test_explicit_time_arguments_override_the_environ(self):
+        # ``t``/``dt`` are keyword-only overrides; passing dt explicitly must
+        # win over the surrounding context.
+        m = LinearDecay()
+        with brainstate.environ.context(t=0.0 * u.ms, dt=5.0 * u.ms):
+            implicit_euler_step(m, dt=0.1 * u.ms)
+        v = float(m.x.value.to_decimal(u.mV)[0])
+        self.assertGreater(v, 0.989)
+        self.assertLess(v, 0.991)
+
+    def test_selectable_by_name_through_the_host_convention(self):
+        # The step now matches ``self.solver(self)``, so a host can select it
+        # by name. This is what ``requires_time_args`` used to document as
+        # impossible.
+        step = get_registry()["implicit_euler"]
+        m = LinearDecay()
+        with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
+            step(m)
+        self.assertLess(float(m.x.value.to_decimal(u.mV)[0]), 1.0)
 
 
 class ImplicitMethodRegistrationTest(unittest.TestCase):

--- a/braincell/quad/_registry.py
+++ b/braincell/quad/_registry.py
@@ -46,10 +46,9 @@ Typical usage::
 """
 
 import difflib
-import inspect
 import warnings
 from dataclasses import dataclass
-from typing import Callable, Iterable, Iterator
+from typing import Callable, Iterable, Iterator, Mapping
 
 __all__ = [
     'IntegratorEntry',
@@ -57,45 +56,6 @@ __all__ = [
     'get_registry',
     'register_integrator',
 ]
-
-#: Placeholder stand-in for the ``target`` argument when probing a step
-#: function's signature. Never called with; only bound.
-_TARGET_PLACEHOLDER = object()
-
-
-def _requires_time_args(func: Callable) -> bool:
-    """Return ``True`` when ``func`` cannot be called as ``func(target)``.
-
-    BrainCell's model hosts invoke their solver with the target alone —
-    :meth:`braincell.Cell._update_dynamics` calls ``self.solver(self)`` and
-    :class:`braincell.SingleCompartment` calls ``self.solver(self, I_ext)``
-    — reading ``t`` and ``dt`` from :mod:`brainstate.environ`. A step
-    declared as ``(target, t, dt, *args)`` therefore cannot be selected by
-    name through ``solver=``; it only works when called directly with
-    explicit time arguments.
-
-    Parameters
-    ----------
-    func : Callable
-        Candidate integrator step function.
-
-    Returns
-    -------
-    bool
-        ``True`` if binding a single positional argument fails, i.e. the
-        step demands explicit ``(t, dt)``. ``False`` for the host-callable
-        ``(target, *args)`` convention, and for callables whose signature
-        cannot be introspected (builtins, C extensions).
-    """
-    try:
-        signature = inspect.signature(func)
-    except (TypeError, ValueError):  # pragma: no cover - C callables
-        return False
-    try:
-        signature.bind(_TARGET_PLACEHOLDER)
-    except TypeError:
-        return True
-    return False
 
 
 @dataclass(frozen=True)
@@ -129,20 +89,6 @@ class IntegratorEntry:
         (``'braincell.quad'``) rather than the private submodule they are
         defined in, because :func:`braincell._misc.set_module_as` is
         applied first — see the note in :func:`register_integrator`.
-    requires_time_args : bool
-        ``True`` when ``func`` must be called as ``func(target, t, dt, ...)``
-        rather than ``func(target, ...)``. Populated automatically by
-        :meth:`IntegratorRegistry.register` from ``func``'s signature.
-
-        BrainCell's hosts call their solver with the target alone
-        (``self.solver(self)`` in :class:`braincell.Cell`,
-        ``self.solver(self, I_ext)`` in
-        :class:`braincell.SingleCompartment`) and read ``t`` / ``dt`` from
-        :mod:`brainstate.environ`. An entry with ``requires_time_args=True``
-        therefore **cannot** be selected by name through ``solver=``; it is
-        only usable when called directly. Recording it here makes that
-        mismatch visible to introspection and to the registry tests
-        instead of surfacing as a ``TypeError`` at the first update step.
     """
 
     name: str
@@ -153,7 +99,6 @@ class IntegratorEntry:
     description: str = ""
     deprecated: bool = False
     module: str = ""
-    requires_time_args: bool = False
 
 
 class IntegratorRegistry:
@@ -280,7 +225,6 @@ class IntegratorRegistry:
             description=description,
             deprecated=deprecated,
             module=getattr(func, "__module__", "") or "",
-            requires_time_args=_requires_time_args(func),
         )
         self._entries[name] = entry
         for alias in alias_tuple:
@@ -370,11 +314,6 @@ class IntegratorRegistry:
             key=lambda e: e.name,
         )
 
-    def items(self) -> Iterator[tuple[str, Callable]]:
-        """Iterate over ``(name, func)`` pairs for canonical entries only."""
-        for name, entry in self._entries.items():
-            yield name, entry.func
-
     def entries(self) -> Iterator[IntegratorEntry]:
         """Iterate over all canonical :class:`IntegratorEntry` instances."""
         return iter(self._entries.values())
@@ -460,3 +399,88 @@ def register_integrator(
         return func
 
     return _wrap
+
+
+class _RegistryDictView(Mapping[str, Callable]):
+    """Read-only ``{name: func}`` mapping view backed by the registry.
+
+    Presents the registry as the plain dict that ``all_integrators`` used to
+    be, while keeping :class:`IntegratorRegistry` as the single source of
+    truth. Alias names are included, so lookups such as
+    ``all_integrators['explicit']`` resolve.
+    """
+
+    def __init__(self, registry: IntegratorRegistry) -> None:
+        self._registry = registry
+
+    def __getitem__(self, name: str) -> Callable:
+        return self._registry[name]
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._registry.names(include_aliases=True))
+
+    def __len__(self) -> int:
+        return len(self._registry.names(include_aliases=True))
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._registry
+
+    def __repr__(self) -> str:
+        return f"_RegistryDictView({sorted(self._registry.names(include_aliases=True))!r})"
+
+
+#: Mapping view of the integrator registry, keyed by canonical name and alias.
+#:
+#: Treat it as read-only; new integrators should be registered with
+#: :func:`register_integrator`.
+all_integrators: Mapping[str, Callable] = _RegistryDictView(get_registry())
+
+
+def get_integrator(method: str | Callable) -> Callable:
+    """Resolve a numerical integrator from a string name or a callable.
+
+    Parameters
+    ----------
+    method : str or Callable
+        Either the registered name (canonical or alias) of an integrator or
+        a step function to use directly.
+
+    Returns
+    -------
+    Callable
+        The integrator step function corresponding to ``method``.
+
+    Raises
+    ------
+    ValueError
+        If ``method`` is a string that does not match any registered
+        integrator. The error message includes a "did you mean ...?"
+        suggestion when a close match exists.
+    TypeError
+        If ``method`` is neither a string nor a callable.
+
+    Examples
+    --------
+
+    .. code-block:: python
+
+        >>> from braincell.quad import get_integrator
+        >>> get_integrator('euler')              # doctest: +ELLIPSIS
+        <function euler_step at ...>
+        >>> get_integrator('explicit') is get_integrator('euler')
+        True
+        >>> get_integrator('stagger') is get_integrator('staggered')
+        True
+    """
+    if callable(method):
+        return method
+    if isinstance(method, str):
+        registry = get_registry()
+        try:
+            return registry[method]
+        except KeyError:
+            suggestions = registry.suggest(method, n=1)
+            hint = f" Did you mean {suggestions[0]!r}?" if suggestions else ""
+            available = ", ".join(registry.names())
+            raise ValueError(f"Unknown integrator {method!r}.{hint} Available: {available}.")
+    raise TypeError(f"Integrator method must be a string or callable, got {type(method).__name__}.")

--- a/braincell/quad/_registry_test.py
+++ b/braincell/quad/_registry_test.py
@@ -35,6 +35,31 @@ def _noop(target, *args, **kwargs):  # pragma: no cover - body irrelevant
     return None
 
 
+#: Every canonical integrator the package ships, mapped to its ``(category,
+#: order)`` metadata. This is the single source of truth for both "are the
+#: expected names registered" and "is each one filed correctly"; keeping two
+#: copies of the name list let them drift.
+EXPECTED_METADATA = {
+    "euler": ("explicit", 1),
+    "midpoint": ("explicit", 2),
+    "rk2": ("explicit", 2),
+    "heun2": ("explicit", 2),
+    "ralston2": ("explicit", 2),
+    "rk3": ("explicit", 3),
+    "heun3": ("explicit", 3),
+    "ssprk3": ("explicit", 3),
+    "ralston3": ("explicit", 3),
+    "rk4": ("explicit", 4),
+    "ralston4": ("explicit", 4),
+    "exp_euler": ("exponential", 1),
+    "ind_exp_euler": ("exponential", 1),
+    "backward_euler": ("implicit", 1),
+    "implicit_euler": ("implicit", 1),
+    "staggered": ("staggered", None),
+    "dhs_voltage": ("voltage", None),
+}
+
+
 class IntegratorRegistryTest(unittest.TestCase):
     def setUp(self):
         self.registry = IntegratorRegistry()
@@ -228,26 +253,7 @@ class GlobalRegistryIntegrationTest(unittest.TestCase):
 
     def test_registered_canonical_names_include_known_methods(self):
         names = set(quad.get_registry().names())
-        expected = {
-            "euler",
-            "midpoint",
-            "rk2",
-            "rk3",
-            "rk4",
-            "heun2",
-            "heun3",
-            "ssprk3",
-            "ralston2",
-            "ralston3",
-            "ralston4",
-            "exp_euler",
-            "ind_exp_euler",
-            "backward_euler",
-            "implicit_euler",
-            "staggered",
-            "dhs_voltage",
-        }
-        missing = expected - names
+        missing = set(EXPECTED_METADATA) - names
         self.assertFalse(missing, f"Missing canonical names: {sorted(missing)}")
 
 
@@ -289,29 +295,9 @@ class PublicSurfaceTest(unittest.TestCase):
 class RegistryMetadataTest(unittest.TestCase):
     """Categories, orders, and module strings for in-tree integrators."""
 
-    EXPECTED = {
-        "euler": ("explicit", 1),
-        "midpoint": ("explicit", 2),
-        "rk2": ("explicit", 2),
-        "heun2": ("explicit", 2),
-        "ralston2": ("explicit", 2),
-        "rk3": ("explicit", 3),
-        "heun3": ("explicit", 3),
-        "ssprk3": ("explicit", 3),
-        "ralston3": ("explicit", 3),
-        "rk4": ("explicit", 4),
-        "ralston4": ("explicit", 4),
-        "exp_euler": ("exponential", 1),
-        "ind_exp_euler": ("exponential", 1),
-        "backward_euler": ("implicit", 1),
-        "implicit_euler": ("implicit", 1),
-        "staggered": ("staggered", None),
-        "dhs_voltage": ("voltage", None),
-    }
-
     def test_categories_and_orders(self):
         registry = quad.get_registry()
-        for name, (category, order) in self.EXPECTED.items():
+        for name, (category, order) in EXPECTED_METADATA.items():
             with self.subTest(name=name):
                 entry = registry.entry(name)
                 self.assertEqual(entry.category, category)
@@ -342,56 +328,37 @@ class CallConventionTest(unittest.TestCase):
     neither passes ``t`` or ``dt``. A step declared ``(target, t, dt, *args)``
     is therefore unreachable through ``solver="<name>"`` even though it
     resolves fine through :func:`get_integrator`. That mismatch is what let
-    six dead cell-only integrators sit in the registry unnoticed, so it is
-    pinned here rather than left to be rediscovered.
+    six dead cell-only integrators sit in the registry unnoticed, and it is
+    what made ``dhs_voltage`` and ``implicit_euler`` unselectable until they
+    were given keyword-only ``t``/``dt``. It is pinned here rather than left
+    to be rediscovered.
     """
 
-    #: Registered names that legitimately demand explicit ``(t, dt)``.
-    #: ``dhs_voltage`` is an internal sub-step invoked directly by
-    #: ``staggered_step``; ``implicit_euler`` is called directly in tests
-    #: and examples. Neither is selectable via ``solver=``. Adding a name
-    #: here is a deliberate act — do not do it to silence this test.
-    KNOWN_TIME_ARG_STEPS = {"dhs_voltage", "implicit_euler"}
-
-    def test_entry_records_call_convention(self):
-        registry = quad.get_registry()
-        actual = {e.name for e in registry.entries() if e.requires_time_args}
-        self.assertEqual(actual, self.KNOWN_TIME_ARG_STEPS)
-
-    def test_host_callable_steps_bind_with_target_only(self):
+    def test_every_registered_step_binds_with_the_host_calls(self):
         registry = quad.get_registry()
         sentinel = object()
         for entry in registry.entries():
-            if entry.name in self.KNOWN_TIME_ARG_STEPS:
-                continue
             with self.subTest(name=entry.name):
-                self.assertFalse(entry.requires_time_args)
+                signature = inspect.signature(entry.func)
                 # The exact call ``Cell._update_dynamics`` makes.
-                inspect.signature(entry.func).bind(sentinel)
+                signature.bind(sentinel)
                 # ...and the one ``SingleCompartment.update`` makes.
-                inspect.signature(entry.func).bind(sentinel, sentinel)
+                signature.bind(sentinel, sentinel)
 
-    def test_time_arg_steps_reject_the_host_call(self):
+    def test_time_arguments_are_keyword_only_overrides(self):
+        # A step may still accept ``t``/``dt``, but only as keyword-only
+        # parameters that default to the ``brainstate.environ`` context —
+        # never as positionals that displace ``*args``.
         registry = quad.get_registry()
-        sentinel = object()
-        for name in self.KNOWN_TIME_ARG_STEPS:
-            with self.subTest(name=name):
-                entry = registry.entry(name)
-                self.assertTrue(entry.requires_time_args)
-                with self.assertRaises(TypeError):
-                    inspect.signature(entry.func).bind(sentinel)
-
-    def test_requires_time_args_computed_on_registration(self):
-        registry = IntegratorRegistry()
-
-        def host_style(target, *args):
-            return None
-
-        def time_style(target, t, dt, *args):
-            return None
-
-        self.assertFalse(registry.register("host", host_style).requires_time_args)
-        self.assertTrue(registry.register("timed", time_style).requires_time_args)
+        for entry in registry.entries():
+            parameters = inspect.signature(entry.func).parameters
+            for name in ("t", "dt"):
+                if name not in parameters:
+                    continue
+                with self.subTest(name=entry.name, parameter=name):
+                    parameter = parameters[name]
+                    self.assertEqual(parameter.kind, inspect.Parameter.KEYWORD_ONLY)
+                    self.assertIsNone(parameter.default)
 
 
 class GlobalRegisterIntegratorDecoratorTest(unittest.TestCase):

--- a/braincell/quad/_runge_kutta.py
+++ b/braincell/quad/_runge_kutta.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+import functools
+import operator
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -21,9 +23,10 @@ import brainunit as u
 import jax
 
 from braincell._misc import cast_like as _cast_like, set_module_as
-from braincell._typing import T, DT, PyTree
+from braincell._typing import DT, PyTree
 from .protocol import DiffEqState, DiffEqModule
 from ._registry import register_integrator
+from ._util import environ_time
 
 __all__ = [
     'euler_step',
@@ -75,16 +78,17 @@ def _rk_update(coeff: Sequence, st: brainstate.State, y0: PyTree, dt: DT, *ks):
     assert len(coeff) == len(ks), 'The number of coefficients must be equal to the number of ks.'
 
     def _step(y0_, *k_):
-        kds = [_cast_like(c_, k_leaf) * k_leaf for c_, k_leaf in zip(coeff, k_)]
-        update = kds[0]
-        for kd in kds[1:]:
-            update += kd
+        kds = (_cast_like(c_, k_leaf) * k_leaf for c_, k_leaf in zip(coeff, k_))
+        # reduce rather than sum: sum()'s implicit 0 start breaks unit arithmetic.
+        update = functools.reduce(operator.add, kds)
         return y0_ + update * _cast_like(dt, y0_)
 
     st.value = jax.tree.map(_step, y0, *ks, is_leaf=u.math.is_quantity)
 
 
-def _general_rk_step(tableau: ButcherTableau, target: DiffEqModule, t: T, dt: DT, *args):
+def _general_rk_step(tableau: ButcherTableau, target: DiffEqModule, *args):
+    t, dt = environ_time(target)
+
     # before one-step integration
     target.pre_integral(*args)
 
@@ -275,9 +279,7 @@ def euler_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     euler_step(my_neuron)                       # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(euler_tableau, target, t, dt, *args)
+    _general_rk_step(euler_tableau, target, *args)
 
 
 @register_integrator(
@@ -349,9 +351,7 @@ def midpoint_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     midpoint_step(my_neuron)                    # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(midpoint_tableau, target, t, dt, *args)
+    _general_rk_step(midpoint_tableau, target, *args)
 
 
 @register_integrator(
@@ -423,9 +423,7 @@ def rk2_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     rk2_step(my_neuron)                         # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(rk2_tableau, target, t, dt, *args)
+    _general_rk_step(rk2_tableau, target, *args)
 
 
 @register_integrator(
@@ -495,9 +493,7 @@ def heun2_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     heun2_step(my_neuron)                       # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(heun2_tableau, target, t, dt, *args)
+    _general_rk_step(heun2_tableau, target, *args)
 
 
 @register_integrator(
@@ -576,9 +572,7 @@ def ralston2_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     ralston2_step(my_neuron)                    # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(ralston2_tableau, target, t, dt, *args)
+    _general_rk_step(ralston2_tableau, target, *args)
 
 
 @register_integrator(
@@ -652,9 +646,7 @@ def rk3_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     rk3_step(my_neuron)                         # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(rk3_tableau, target, t, dt, *args)
+    _general_rk_step(rk3_tableau, target, *args)
 
 
 @register_integrator(
@@ -727,9 +719,7 @@ def heun3_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     heun3_step(my_neuron)                       # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(heun3_tableau, target, t, dt, *args)
+    _general_rk_step(heun3_tableau, target, *args)
 
 
 @register_integrator(
@@ -812,9 +802,7 @@ def ssprk3_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     ssprk3_step(my_neuron)                      # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(ssprk3_tableau, target, t, dt, *args)
+    _general_rk_step(ssprk3_tableau, target, *args)
 
 
 @register_integrator(
@@ -895,9 +883,7 @@ def ralston3_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     ralston3_step(my_neuron)                    # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(ralston3_tableau, target, t, dt, *args)
+    _general_rk_step(ralston3_tableau, target, *args)
 
 
 @register_integrator(
@@ -975,9 +961,7 @@ def rk4_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     rk4_step(my_neuron)                         # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(rk4_tableau, target, t, dt, *args)
+    _general_rk_step(rk4_tableau, target, *args)
 
 
 @register_integrator(
@@ -1057,6 +1041,4 @@ def ralston4_step(
         >>> with brainstate.environ.context(t=0. * u.ms, dt=0.01 * u.ms):
         ...     ralston4_step(my_neuron)                    # doctest: +SKIP
     """
-    t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
-    dt = brainstate.environ.get('dt')
-    _general_rk_step(ralston4_tableau, target, t, dt, *args)
+    _general_rk_step(ralston4_tableau, target, *args)

--- a/braincell/quad/_runge_kutta_test.py
+++ b/braincell/quad/_runge_kutta_test.py
@@ -13,23 +13,14 @@
 # limitations under the License.
 # ==============================================================================
 
-# -*- coding: utf-8 -*-
-
 
 import math
 import unittest
 
 import brainstate
 import brainunit as u
-import jax.numpy as jnp
-import matplotlib.pyplot as plt
 import numpy as np
 
-import braincell
-from braincell import (
-    DiffEqModule,
-    DiffEqSingleState,
-)
 from braincell.quad import (
     euler_step,
     heun2_step,
@@ -43,159 +34,7 @@ from braincell.quad import (
     rk4_step,
     ssprk3_step,
 )
-
-
-class HH(braincell.SingleCompartment):
-    def __init__(self, size, solver='rk4'):
-        super().__init__(size, solver=solver)
-
-        self.na = braincell.ion.SodiumFixed(size, E=50.0 * u.mV)
-        self.na.add(INa=braincell.channel.Na_HH1952(size))
-
-        self.k = braincell.ion.PotassiumFixed(size, E=-77.0 * u.mV)
-        self.k.add(IK=braincell.channel.K_HH1952(size))
-
-        self.IL = braincell.channel.IL(size, E=-54.387 * u.mV, g_max=0.03 * (u.mS / u.cm**2))
-
-
-def integrate(method: str, dt=0.01 * u.ms):
-    brainstate.random.seed(1)
-    hh = HH(1, solver=method)
-    hh.init_state()
-
-    def step_fun(t):
-        with brainstate.environ.context(t=t):
-            hh.update(10 * u.nA / u.cm**2)
-        return hh.V.value
-
-    with brainstate.environ.context(dt=dt):
-        times = u.math.arange(0.0 * u.ms, 10 * u.ms, brainstate.environ.get_dt())
-        vs = brainstate.transform.for_loop(step_fun, times)
-    return vs
-
-
-def compare(method):
-    norm = []
-    dts = [1e-3 * u.ms, 2e-3 * u.ms, 4e-3 * u.ms, 8e-3 * u.ms, 1e-2 * u.ms, 2e-2 * u.ms]
-    for dt in dts:
-        gold_vs = integrate('exp_euler', dt=dt)
-        vs = integrate(method, dt=dt)
-        norm.append(u.linalg.norm(gold_vs - vs))
-    # Strip units before returning so matplotlib can convert via np.asarray.
-    # Newer saiunit rejects np.asarray(dimensional_quantity).
-    dts_q = u.math.asarray(dts)
-    norm_q = u.math.asarray(norm)
-    return dts_q.mantissa, norm_q.mantissa
-
-
-class TestRungeKutta:
-    def test_euler_step(self):
-        dts, norms = compare('euler')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_midpoint_step(self):
-        dts, norms = compare('midpoint')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_rk2_step(self):
-        dts, norms = compare('rk2')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_heun2_step(self):
-        dts, norms = compare('heun2')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_ralston2_step(self):
-        dts, norms = compare('ralston2')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_rk3_step(self):
-        dts, norms = compare('rk3')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_heun3_step(self):
-        dts, norms = compare('heun3')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_ssprk3_step(self):
-        dts, norms = compare('ssprk3')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_ralston3_step(self):
-        dts, norms = compare('ralston3')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_rk4_step(self):
-        dts, norms = compare('rk4')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-    def test_ralston4_step(self):
-        dts, norms = compare('ralston4')
-        plt.loglog(dts, norms)
-        # plt.show()
-        plt.close()
-
-
-# --------------------------------------------------------------------------- #
-# Convergence on a linear ODE with a known analytical solution.
-#
-# These tests do not require the HH machinery: they exercise each step
-# function on a minimal :class:`DiffEqModule` whose exact solution is
-# ``x(t) = x0 * exp(-t/tau)``.
-# --------------------------------------------------------------------------- #
-_FLOAT_DTYPE = jnp.asarray(0.0).dtype
-
-
-class _LinearDecay(brainstate.nn.Module, DiffEqModule):
-    """Scalar linear ODE ``dx/dt = -x/tau`` for analytical comparisons."""
-
-    def __init__(self, x0=1.0, tau_ms=10.0, shape=(3,)):
-        super().__init__()
-        self.tau = tau_ms * u.ms
-        self.x = DiffEqSingleState(jnp.full(shape, x0, dtype=_FLOAT_DTYPE) * u.mV)
-        self.aux = brainstate.ShortTermState(jnp.zeros(shape, dtype=_FLOAT_DTYPE))
-        self.pre_calls = 0
-        self.post_calls = 0
-
-    def pre_integral(self, *args, **kwargs):
-        self.pre_calls += 1
-
-    def post_integral(self, *args, **kwargs):
-        self.post_calls += 1
-
-    def compute_derivative(self, *args, **kwargs):
-        self.x.derivative = -self.x.value / self.tau
-
-
-def _drive(method, dt_ms=0.1, n_steps=100, x0=1.0, tau_ms=10.0):
-    """Drive ``method`` ``n_steps`` times on a fresh :class:`_LinearDecay`."""
-    m = _LinearDecay(x0=x0, tau_ms=tau_ms)
-    dt = dt_ms * u.ms
-    with brainstate.environ.context(dt=dt):
-        for i in range(n_steps):
-            with brainstate.environ.context(t=i * dt):
-                method(m)
-    return float(m.x.value.to_decimal(u.mV)[0]), m
+from braincell.quad._testing import LinearDecay, drive
 
 
 class RungeKuttaConvergenceTest(unittest.TestCase):
@@ -218,7 +57,7 @@ class RungeKuttaConvergenceTest(unittest.TestCase):
     ]
 
     def _final_value(self, method, dt_ms, n_steps, tau_ms=10.0):
-        return _drive(method, dt_ms=dt_ms, n_steps=n_steps, tau_ms=tau_ms)[0]
+        return drive(method, dt_ms=dt_ms, n_steps=n_steps, tau_ms=tau_ms)[0]
 
     def test_each_method_matches_analytical_solution(self):
         # 100 steps of dt=0.1 ms over a tau=10 ms decay → final value
@@ -263,14 +102,14 @@ class RungeKuttaConvergenceTest(unittest.TestCase):
                 self.assertGreater(empirical, 0.5 * order)
 
     def test_pre_and_post_integral_called_once_per_step(self):
-        m = _LinearDecay()
+        m = LinearDecay()
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
             rk4_step(m)
         self.assertEqual(m.pre_calls, 1)
         self.assertEqual(m.post_calls, 1)
 
     def test_aux_state_unchanged_after_step(self):
-        m = _LinearDecay()
+        m = LinearDecay()
         before = np.array(m.aux.value)
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
             rk4_step(m)

--- a/braincell/quad/_staggered.py
+++ b/braincell/quad/_staggered.py
@@ -26,8 +26,10 @@ Type responsibilities in this file:
   ``float64`` annotations.
 """
 
-from dataclasses import dataclass
+import functools
+import operator
 import os
+from dataclasses import dataclass
 
 import brainstate
 import brainunit as u
@@ -36,12 +38,28 @@ import jax.numpy as jnp
 import numpy as np
 
 from braincell._misc import is_traced_value, set_module_as
+from braincell._typing import DT, T
 from ._registry import register_integrator
+from ._util import environ_time
 from .protocol import DiffEqModule
 
 __all__ = [
     'staggered_step',
+    'dhs_voltage_step',
 ]
+
+
+def _with_sentinel(base, fill: float):
+    """Append the spurious trailing row the DHS back substitution expects.
+
+    Recursive doubling indexes a sentinel row past the end of the tree, so
+    every operand carries one extra entry: ``1`` for ``diags`` (so dividing by
+    it is a no-op) and ``0`` for ``lowers`` / ``uppers`` (so gathering through
+    it contributes nothing). Naming the fill keeps that difference — the only
+    thing that varies between the three call sites — visible.
+    """
+    mantissa = u.get_mantissa(base)
+    return jnp.concatenate([mantissa, jnp.full_like(mantissa[:1], fill)], axis=0) * u.UNITLESS
 
 
 @register_integrator(
@@ -93,11 +111,9 @@ def staggered_step(target: DiffEqModule, *args):
 
     Raises
     ------
-    AssertionError
-        If *target* is not a :class:`DiffEqModule`.
     TypeError
-        If *target* does not expose the node-tree machinery required by
-        :func:`dhs_voltage_step`.
+        If *target* is not a :class:`DiffEqModule`, or does not expose the
+        node-tree machinery required by :func:`dhs_voltage_step`.
 
     See Also
     --------
@@ -127,8 +143,7 @@ def staggered_step(target: DiffEqModule, *args):
         raise TypeError(
             f"The stagger integrator only support {DiffEqModule.__name__}, but we got {type(target)} instead."
         )
-    t = brainstate.environ.get('t', 0.0)
-    dt = brainstate.environ.get('dt')
+    t, dt = environ_time(target)
 
     if hasattr(target, "cache_ion_total_currents"):
         with jax.named_scope("braincell:staggered:cache_ion_total_currents"):
@@ -136,7 +151,7 @@ def staggered_step(target: DiffEqModule, *args):
 
     # voltage integration
     with jax.named_scope("braincell:staggered:dhs_voltage_step"):
-        dhs_voltage_step(target, t, dt, *args)
+        dhs_voltage_step(target, *args, t=t, dt=dt)
 
     with jax.named_scope("braincell:staggered:cv_to_point_after_voltage"):
         point_V = target._cv_to_point(target.V.value)
@@ -190,7 +205,7 @@ class DHSNumericState:
     description="Implicit-Euler dendritic hierarchical solver (DHS) voltage step.",
 )
 @set_module_as("braincell.quad")
-def dhs_voltage_step(target, t, dt, *args):
+def dhs_voltage_step(target, *args, t: T = None, dt: DT = None):
     r"""Advance the membrane voltage by one implicit-Euler DHS step.
 
     Solves the linearized cable equation on a multi-compartment cell using
@@ -249,12 +264,15 @@ def dhs_voltage_step(target, t, dt, *args):
 
     Notes
     -----
-    This step takes ``t`` and ``dt`` explicitly, so — unlike
-    :func:`staggered_step` — it is **not** selectable through
-    ``Cell(solver="dhs_voltage")``: the host calls ``self.solver(self)``
-    and reads the time arguments from :mod:`brainstate.environ`. Call it
-    directly, or use ``"staggered"``, which wraps it. The registry records
-    this as ``IntegratorEntry.requires_time_args``.
+    ``t`` and ``dt`` are keyword-only and optional, defaulting to the active
+    :mod:`brainstate.environ` context, so this step matches the
+    ``(target, *args)`` convention the hosts call and is selectable through
+    ``Cell(solver="dhs_voltage")``. :func:`staggered_step` passes both
+    explicitly because it has already read them.
+
+    Note that this advances the voltage *only*; selecting it directly leaves
+    gating variables and ion concentrations frozen. ``"staggered"`` is the
+    solver that pairs it with a channel update.
 
     The static topology metadata produced by ``_build_dhs_static_source``
     (row lookup tables, edge ordering, recursive-doubling jump table) is
@@ -266,26 +284,18 @@ def dhs_voltage_step(target, t, dt, *args):
     if not hasattr(target, "node_tree") or not hasattr(target, "node_scheduling"):
         raise TypeError(f"dhs_voltage_step(...) requires a node-tree aware target, got {type(target)}.")
 
+    t, dt = environ_time(target, t, dt)
     node_tree = target.node_tree
     scheduling = target.node_scheduling(algorithm="dhs")
     static_source = _get_dhs_static_source(target, node_tree=node_tree, scheduling=scheduling)
     static_cache = _get_dhs_static_cache(target, static_source)
     V_n = target.V.value
     with jax.named_scope("braincell:dhs:linearize_membrane_current"):
-        linear, const = jax.named_call(
-            _linear_and_const_term,
-            name="braincell:dhs:linearize_membrane_current_call",
-        )(target, V_n, *args)
+        linear, const = _linear_and_const_term(target, V_n, *args)
     with jax.named_scope("braincell:dhs:edge_current"):
-        edge_point_current = jax.named_call(
-            _edge_point_current,
-            name="braincell:dhs:edge_current_call",
-        )(target, t=t, static_source=static_source)
+        edge_point_current = _edge_point_current(target, t=t)
     with jax.named_scope("braincell:dhs:build_numeric_state"):
-        numeric = jax.named_call(
-            _build_dhs_numeric_state,
-            name="braincell:dhs:build_numeric_state_call",
-        )(
+        numeric = _build_dhs_numeric_state(
             V_n,
             linear,
             const,
@@ -295,10 +305,7 @@ def dhs_voltage_step(target, t, dt, *args):
             edge_point_current=edge_point_current,
         )
     with jax.named_scope("braincell:dhs:forward_elimination"):
-        diags, solves = jax.named_call(
-            comp_triang_raw,
-            name="braincell:dhs:forward_elimination_call",
-        )(
+        diags, solves = comp_triang_raw(
             numeric.diags,
             numeric.solves,
             numeric.lowers,
@@ -307,20 +314,14 @@ def dhs_voltage_step(target, t, dt, *args):
             static_source.level_offsets_np,
         )
     with jax.named_scope("braincell:dhs:backsubstitution"):
-        solves = jax.named_call(
-            comp_backsub_raw,
-            name="braincell:dhs:backsubstitution_call",
-        )(
+        solves = comp_backsub_raw(
             diags,
             solves,
             numeric.lowers,
             static_source.backsub_indices_np,
         )
     with jax.named_scope("braincell:dhs:restore_voltage"):
-        target.V.value = jax.named_call(
-            _restore_midpoint_voltage,
-            name="braincell:dhs:restore_voltage_call",
-        )(
+        target.V.value = _restore_midpoint_voltage(
             solves,
             dynamic_rows=static_source.dynamic_rows_np,
             target_shape=target.V.value.shape,
@@ -487,19 +488,14 @@ def _build_dhs_numeric_state(
     batch_size = V_n.shape[0]
     n_point = static_source.n_point
 
-    rhs_midpoint_mv = _to_jax_quantity(V_n + dt * const, u.mV)
-    linear_ms_inv = _to_jax_quantity(linear, u.ms**-1)
-    dt_ms = _to_jax_quantity(dt, u.ms)
+    rhs_midpoint_mv = u.math.asarray(V_n + dt * const, unit=u.mV)
+    linear_ms_inv = u.math.asarray(linear, unit=u.ms**-1)
+    dt_ms = u.math.asarray(dt, unit=u.ms)
 
     diag_base = static_cache.diag_ms_inv * dt_ms
     lower_base = static_cache.lowers_ms_inv * dt_ms
     upper_base = static_cache.uppers_ms_inv * dt_ms
-    diag_base_mantissa = u.get_mantissa(diag_base)
-    diag_base_with_sentinel = (
-        jnp.concatenate([diag_base_mantissa, jnp.ones_like(diag_base_mantissa[:1])], axis=0) * u.UNITLESS
-    )
-
-    diags = u.math.broadcast_to(diag_base_with_sentinel[None, :], (batch_size, n_point + 1))
+    diags = u.math.broadcast_to(_with_sentinel(diag_base, 1.0)[None, :], (batch_size, n_point + 1))
     diag_update = jnp.ones_like(u.get_mantissa(linear_ms_inv)) * u.UNITLESS - dt_ms * linear_ms_inv
     diags = diags.at[:, static_source.dynamic_rows_np].add(diag_update)
 
@@ -517,14 +513,12 @@ def _build_dhs_numeric_state(
     return DHSNumericState(
         diags=diags,
         solves=solves,
-        lowers=jnp.concatenate([u.get_mantissa(lower_base), jnp.zeros_like(u.get_mantissa(lower_base[:1]))], axis=0)
-        * u.UNITLESS,
-        uppers=jnp.concatenate([u.get_mantissa(upper_base), jnp.zeros_like(u.get_mantissa(upper_base[:1]))], axis=0)
-        * u.UNITLESS,
+        lowers=_with_sentinel(lower_base, 0.0),
+        uppers=_with_sentinel(upper_base, 0.0),
     )
 
 
-def _edge_point_current(target, *, t, static_source: DHSStaticSource):
+def _edge_point_current(target, *, t):
     """Return boundary point-clamp current for the DHS point-tree RHS."""
 
     runtime = getattr(target, "_runtime", None)
@@ -573,18 +567,9 @@ def _edge_conductance(*, edge, cvs) -> object:
     # boundary with an algebraic point; after elimination the equivalent
     # midpoint conductance is 1 / (R_left + R_right), not 1/R_left + 1/R_right.
     if len(resistances) > 1 and len(branch_ids) == 1:
-        total_resistance = None
-        for resistance in resistances:
-            total_resistance = resistance if total_resistance is None else (total_resistance + resistance)
-        if total_resistance is None:  # pragma: no cover
-            raise ValueError(f"Point-tree edge {edge.id!r} did not produce a total resistance.")
-        return 1.0 / total_resistance
+        return 1.0 / functools.reduce(operator.add, resistances)
 
-    conductance = None
-    for resistance in resistances:
-        value = 1.0 / resistance
-        conductance = value if conductance is None else (conductance + value)
-    return conductance
+    return functools.reduce(operator.add, (1.0 / r for r in resistances))
 
 
 def _row_capacitance_scale(target, *, dynamic_rows: np.ndarray, n_point: int) -> list[object]:
@@ -623,28 +608,47 @@ def _build_dhs_edge_order(scheduling) -> tuple[np.ndarray, np.ndarray]:
     return np.empty((0, 2), dtype=np.int32), np.empty((0,), dtype=np.int32)
 
 
+def _require_ndim(name, value, ndim):
+    """Raise unless ``value`` has exactly ``ndim`` dimensions."""
+    if value.ndim != ndim:
+        raise ValueError(f"{name} must be {ndim}D, got ndim={value.ndim}")
+
+
+def _require_unitless(name, value):
+    """Raise unless ``value`` is a plain array or a unitless Quantity."""
+    if isinstance(value, u.Quantity) and not u.get_unit(value).is_unitless:
+        raise ValueError(f"{name} must be unitless, got unit={u.get_unit(value)}")
+
+
+def _require_plain_array(name, value):
+    """Raise if ``value`` is a Quantity where an index array is expected."""
+    if isinstance(value, u.Quantity):
+        raise ValueError(f"{name} must be a plain array, not a Quantity")
+
+
+def _require_row_length(name, value, diags):
+    """Raise unless ``value`` has one entry per column of ``diags``."""
+    if value.shape[0] != diags.shape[1]:
+        raise ValueError(f"{name}.shape[0]={value.shape[0]} must equal diags.shape[1]={diags.shape[1]}")
+
+
+def _check_dhs_operands(diags, solves, lowers):
+    """Check the operand contract shared by both DHS kernels."""
+    _require_ndim("diags", diags, 2)
+    _require_ndim("solves", solves, 2)
+    _require_ndim("lowers", lowers, 1)
+    _require_unitless("diags", diags)
+    _require_unitless("lowers", lowers)
+    _require_row_length("lowers", lowers, diags)
+
+
 def _check_comp_triang(diags, solves, lowers, uppers, edges):
     """Kernel contract check for the quantity-aware DHS forward pass."""
-    if isinstance(edges, u.Quantity):
-        raise ValueError("edges must be a plain array, not a Quantity")
-    if diags.ndim != 2:
-        raise ValueError(f"diags must be 2D, got ndim={diags.ndim}")
-    if solves.ndim != 2:
-        raise ValueError(f"solves must be 2D, got ndim={solves.ndim}")
-    if lowers.ndim != 1:
-        raise ValueError(f"lowers must be 1D, got ndim={lowers.ndim}")
-    if uppers.ndim != 1:
-        raise ValueError(f"uppers must be 1D, got ndim={uppers.ndim}")
-    if isinstance(diags, u.Quantity) and not u.get_unit(diags).is_unitless:
-        raise ValueError(f"diags must be unitless, got unit={u.get_unit(diags)}")
-    if isinstance(lowers, u.Quantity) and not u.get_unit(lowers).is_unitless:
-        raise ValueError(f"lowers must be unitless, got unit={u.get_unit(lowers)}")
-    if isinstance(uppers, u.Quantity) and not u.get_unit(uppers).is_unitless:
-        raise ValueError(f"uppers must be unitless, got unit={u.get_unit(uppers)}")
-    if lowers.shape[0] != diags.shape[1]:
-        raise ValueError(f"lowers.shape[0]={lowers.shape[0]} must equal diags.shape[1]={diags.shape[1]}")
-    if uppers.shape[0] != diags.shape[1]:
-        raise ValueError(f"uppers.shape[0]={uppers.shape[0]} must equal diags.shape[1]={diags.shape[1]}")
+    _require_plain_array("edges", edges)
+    _check_dhs_operands(diags, solves, lowers)
+    _require_ndim("uppers", uppers, 1)
+    _require_unitless("uppers", uppers)
+    _require_row_length("uppers", uppers, diags)
     if edges.ndim != 2 or edges.shape[1] != 2:
         raise ValueError(f"edges must have shape (_, 2), got {edges.shape}")
 
@@ -655,16 +659,8 @@ def comp_triang_raw(diags, solves, lowers, uppers, edges, level_offsets):
     if _profile_dhs_levels_enabled():
         return _comp_triang_raw_profiled(diags, solves, lowers, uppers, edges, level_offsets)
     for i in range(level_offsets.shape[0] - 1):
-        children = edges[level_offsets[i] : level_offsets[i + 1], 0]
-        parent = edges[level_offsets[i] : level_offsets[i + 1], 1]
-        lower_val = lowers[children]
-        upper_val = uppers[children]
-        child_diag = diags[:, children]
-        child_solve = solves[:, children]
-
-        multiplier = upper_val / child_diag
-        diags = diags.at[:, parent].add(-lower_val * multiplier)
-        solves = solves.at[:, parent].add(-child_solve * multiplier)
+        level_edges = edges[level_offsets[i] : level_offsets[i + 1]]
+        diags, solves = _comp_triang_level(diags, solves, lowers, uppers, level_edges)
     return diags, solves
 
 
@@ -683,13 +679,7 @@ def _comp_triang_raw_profiled(diags, solves, lowers, uppers, edges, level_offset
         scope = f"braincell:dhs:forward_level:i={i:03d}:edges={edge_count:06d}:batch={batch_size}"
         level_edges = edges[start:stop]
         with jax.named_scope(scope):
-            diags, solves = jax.named_call(_comp_triang_level, name=scope)(
-                diags,
-                solves,
-                lowers,
-                uppers,
-                level_edges,
-            )
+            diags, solves = _comp_triang_level(diags, solves, lowers, uppers, level_edges)
     return diags, solves
 
 
@@ -710,22 +700,10 @@ def _comp_triang_level(diags, solves, lowers, uppers, level_edges):
 
 def _check_comp_backsub(diags, solves, lowers, backsub_indices):
     """Kernel contract check for quantity-aware recursive doubling."""
-    if isinstance(backsub_indices, u.Quantity):
-        raise ValueError("backsub_indices must be a plain array, not a Quantity")
-    if diags.ndim != 2:
-        raise ValueError(f"diags must be 2D, got ndim={diags.ndim}")
-    if solves.ndim != 2:
-        raise ValueError(f"solves must be 2D, got ndim={solves.ndim}")
-    if lowers.ndim != 1:
-        raise ValueError(f"lowers must be 1D, got ndim={lowers.ndim}")
-    if isinstance(diags, u.Quantity) and not u.get_unit(diags).is_unitless:
-        raise ValueError(f"diags must be unitless, got unit={u.get_unit(diags)}")
-    if isinstance(lowers, u.Quantity) and not u.get_unit(lowers).is_unitless:
-        raise ValueError(f"lowers must be unitless, got unit={u.get_unit(lowers)}")
+    _require_plain_array("backsub_indices", backsub_indices)
+    _check_dhs_operands(diags, solves, lowers)
     if diags.shape != solves.shape:
         raise ValueError(f"diags.shape={diags.shape} must equal solves.shape={solves.shape}")
-    if lowers.shape[0] != diags.shape[1]:
-        raise ValueError(f"lowers.shape[0]={lowers.shape[0]} must equal diags.shape[1]={diags.shape[1]}")
     if backsub_indices.ndim != 2:
         raise ValueError(f"backsub_indices must be 2D, got ndim={backsub_indices.ndim}")
     if backsub_indices.shape[1] != diags.shape[1]:
@@ -743,17 +721,27 @@ def _build_backsub_indices(parent_lookup: np.ndarray, *, n_nodes: int) -> np.nda
     level is built by composing the previous one with itself
     (:math:`A_{2k}[j] = A_k[A_k[j]]`), which turns the construction from
     :math:`O(n^2)` gathers into :math:`O(n \\log n)`.
+
+    The table is sized by the tree's *depth*, not its node count. Recursive
+    doubling only needs enough levels to span the longest ancestor chain, so
+    the loop stops at the first level that maps every row to the sentinel:
+    from there on ``lowers[sentinel]`` and ``solves[sentinel]`` are both zero,
+    making each further round an arithmetic no-op that still costs two gathers
+    and two multiplies per step. A deep-but-narrow morphology is unaffected;
+    a wide one sheds several rounds. The level count can never exceed the
+    ``floor(log2(n_nodes)) + 1`` the node-count bound would have produced.
     """
     parent_lookup = np.asarray(parent_lookup, dtype=np.int32)
     indices = []
     # A_1: one parent hop from every row (fancy-indexed rather than sliced so
     # that a too-short ``parent_lookup`` still raises instead of truncating).
     k_step_parent = parent_lookup[np.arange(n_nodes + 1, dtype=np.int32)]
-    step = 1
-    while step <= max(1, n_nodes):
+    max_levels = max(1, int(n_nodes)).bit_length()
+    while True:
         indices.append(k_step_parent)
+        if len(indices) >= max_levels or bool(np.all(k_step_parent == n_nodes)):
+            break
         k_step_parent = k_step_parent[k_step_parent]
-        step *= 2
     return np.asarray(indices, dtype=np.int32)
 
 
@@ -811,11 +799,6 @@ def _linear_and_const_term(target, V_n, *args):
         linear = u.Quantity(linear_mantissa, linear_unit)
     const = derivative - V_n * linear
     return linear, const
-
-
-def _to_jax_quantity(value: object, unit: object) -> u.Quantity:
-    """Convert a quantity-like value while preserving any existing JAX dtype."""
-    return u.Quantity(u.math.asarray(value.to_decimal(unit)), unit)
 
 
 def _scalar_decimal(value: object, unit: object) -> float:

--- a/braincell/quad/_staggered_test.py
+++ b/braincell/quad/_staggered_test.py
@@ -43,7 +43,6 @@ from braincell.quad import get_registry, staggered_step
 from braincell.quad._staggered import (
     _build_backsub_indices,
     _linear_and_const_term,
-    _to_jax_quantity,
     comp_backsub_raw,
     comp_triang_raw,
     dhs_voltage_step,
@@ -78,7 +77,7 @@ class DhsVoltageGuardTest(unittest.TestCase):
             pass
 
         with self.assertRaisesRegex(TypeError, "node-tree aware"):
-            dhs_voltage_step(Plain(), 0.0 * u.ms, 0.1 * u.ms)
+            dhs_voltage_step(Plain(), t=0.0 * u.ms, dt=0.1 * u.ms)
 
     def test_requires_both_node_tree_and_scheduling(self):
         # An object with only ``node_tree`` is still rejected because the
@@ -88,7 +87,7 @@ class DhsVoltageGuardTest(unittest.TestCase):
                 return None
 
         with self.assertRaisesRegex(TypeError, "node-tree aware"):
-            dhs_voltage_step(HalfTarget(), 0.0 * u.ms, 0.1 * u.ms)
+            dhs_voltage_step(HalfTarget(), t=0.0 * u.ms, dt=0.1 * u.ms)
 
 
 class DhsLinearizationUnitTest(unittest.TestCase):
@@ -231,7 +230,7 @@ class StaggeredStepGuardTest(unittest.TestCase):
         cell._update_ion_channel_families = lambda point_V: calls.append("family")
         cell._update_ion_channels_by_integration = lambda point_V: calls.append("integration")
 
-        with patch("braincell.quad._staggered.dhs_voltage_step", lambda *args: calls.append("voltage")):
+        with patch("braincell.quad._staggered.dhs_voltage_step", lambda *args, **kwargs: calls.append("voltage")):
             with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
                 staggered_step(cell)
 
@@ -255,7 +254,7 @@ class StaggeredStepGuardTest(unittest.TestCase):
         cell._update_ion_channel_families = lambda point_V: calls.append("family")
         cell._update_ion_channels_by_integration = lambda point_V: calls.append("integration")
 
-        with patch("braincell.quad._staggered.dhs_voltage_step", lambda *args: calls.append("voltage")):
+        with patch("braincell.quad._staggered.dhs_voltage_step", lambda *args, **kwargs: calls.append("voltage")):
             with brainstate.environ.context(t=0.0 * u.ms, dt=0.1 * u.ms):
                 staggered_step(cell)
 
@@ -293,31 +292,36 @@ class DhsRuntimeCacheTest(unittest.TestCase):
         cell = self._simple_cell()
 
         with brainstate.environ.context(dt=0.1 * u.ms, precision=32):
-            dhs_voltage_step(cell, 0.0 * u.ms, 0.1 * u.ms)
+            dhs_voltage_step(cell, t=0.0 * u.ms, dt=0.1 * u.ms)
             source32 = cell.runtime.dhs_static_source_np
             cache32 = cell.runtime.dhs_static_cache
             self.assertEqual(source32.diag_ms_inv_np.dtype, np.float64)
             self.assertEqual(source32.dynamic_rows_np.dtype, np.int32)
             self.assertEqual(cache32.float_dtype, jnp.dtype(jnp.float32))
 
-            dhs_voltage_step(cell, 0.0 * u.ms, 0.1 * u.ms)
+            dhs_voltage_step(cell, t=0.0 * u.ms, dt=0.1 * u.ms)
             self.assertIs(source32, cell.runtime.dhs_static_source_np)
             self.assertIs(cache32, cell.runtime.dhs_static_cache)
 
         with brainstate.environ.context(dt=0.1 * u.ms, precision=64):
-            dhs_voltage_step(cell, 0.0 * u.ms, 0.1 * u.ms)
+            dhs_voltage_step(cell, t=0.0 * u.ms, dt=0.1 * u.ms)
             source64 = cell.runtime.dhs_static_source_np
             cache64 = cell.runtime.dhs_static_cache
             self.assertIs(source32, source64)
             self.assertEqual(cache64.float_dtype, jnp.dtype(jnp.float64))
             self.assertIsNot(cache32, cache64)
 
-    def test_to_jax_quantity_preserves_existing_dtype(self):
+    def test_numeric_operands_preserve_an_existing_dtype(self):
+        # ``_build_dhs_numeric_state`` materializes its operands with
+        # ``u.math.asarray(value, unit=...)``, which replaced a hand-rolled
+        # ``_to_jax_quantity``. The DHS step depends on that call converting
+        # units *without* promoting to the ambient precision, so the
+        # third-party contract is pinned here rather than left implicit.
         with brainstate.environ.context(precision=32):
             voltage32 = jnp.asarray([1.0, 2.0]) * u.mV
 
         with brainstate.environ.context(precision=64):
-            preserved = _to_jax_quantity(voltage32, u.mV)
+            preserved = u.math.asarray(voltage32, unit=u.mV)
             self.assertEqual(preserved.dtype, jnp.dtype(jnp.float32))
 
 
@@ -334,7 +338,7 @@ class DhsEndpointClampTest(unittest.TestCase):
 
         before = float(cell.V.value[0, 0].to_decimal(u.mV))
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.05 * u.ms):
-            dhs_voltage_step(cell, 0.0 * u.ms, 0.05 * u.ms)
+            dhs_voltage_step(cell, t=0.0 * u.ms, dt=0.05 * u.ms)
         after = float(cell.V.value[0, 0].to_decimal(u.mV))
 
         self.assertGreater(after, before)
@@ -377,8 +381,8 @@ class DhsMidpointClampPopulationTest(unittest.TestCase):
         self.assertEqual(single.pop_size, (1,))
 
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.025 * u.ms):
-            dhs_voltage_step(single, 0.0 * u.ms, 0.025 * u.ms)
-            dhs_voltage_step(population, 0.0 * u.ms, 0.025 * u.ms)
+            dhs_voltage_step(single, t=0.0 * u.ms, dt=0.025 * u.ms)
+            dhs_voltage_step(population, t=0.0 * u.ms, dt=0.025 * u.ms)
 
         single_v = np.asarray(single.V.value.to_decimal(u.mV), dtype=float)
         population_v = np.asarray(population.V.value.to_decimal(u.mV), dtype=float)
@@ -407,7 +411,7 @@ class DhsMultistepClampTest(unittest.TestCase):
 
         before = float(cell.V.value[0, 0].to_decimal(u.mV))
         with brainstate.environ.context(t=0.0 * u.ms, dt=0.05 * u.ms):
-            dhs_voltage_step(cell, 0.0 * u.ms, 0.05 * u.ms)
+            dhs_voltage_step(cell, t=0.0 * u.ms, dt=0.05 * u.ms)
         after = float(cell.V.value[0, 0].to_decimal(u.mV))
 
         self.assertGreater(after, before)

--- a/braincell/quad/_testing.py
+++ b/braincell/quad/_testing.py
@@ -1,0 +1,194 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared fixtures for the :mod:`braincell.quad` test modules.
+
+The leading underscore keeps pytest from collecting this file as a test
+module, matching the convention used by ``braincell/io/_testing.py`` and
+``braincell/vis/_testing.py``.
+
+Two fixtures live here:
+
+- :class:`LinearDecay` — a scalar linear ODE with a known closed-form
+  solution, used wherever a solver has to be checked against an exact
+  answer without dragging in the full Hodgkin-Huxley stack.
+- :class:`HH` plus :func:`integrate` and :func:`compare` — a one-compartment
+  Hodgkin-Huxley model and the convergence harness built on it.
+"""
+
+import brainstate
+import brainunit as u
+import jax.numpy as jnp
+
+import braincell
+from braincell.quad.protocol import DiffEqModule, DiffEqSingleState
+
+__all__ = [
+    'FLOAT_DTYPE',
+    'LinearDecay',
+    'drive',
+    'HH',
+    'integrate',
+    'compare',
+]
+
+#: The default floating-point dtype, used to build fixture states that match
+#: whatever precision the test session is running at.
+FLOAT_DTYPE = jnp.asarray(0.0).dtype
+
+
+class LinearDecay(brainstate.nn.Module, DiffEqModule):
+    """Scalar linear ODE ``dx/dt = -x/tau``.
+
+    The exact solution is ``x(t) = x0 * exp(-t / tau)``, so any solver can be
+    checked against a closed form. The module also carries one non-
+    :class:`DiffEqState` (``aux``) that integrators must leave alone, and
+    counts its ``pre_integral`` / ``post_integral`` calls.
+
+    Parameters
+    ----------
+    x0 : float, optional
+        Initial value of every element of the state, in mV. Default 1.0.
+    tau_ms : float, optional
+        Decay time constant in milliseconds. Default 10.0.
+    shape : tuple of int, optional
+        Shape of the state array. Default ``(3,)``.
+    """
+
+    def __init__(self, x0: float = 1.0, tau_ms: float = 10.0, shape=(3,)):
+        super().__init__()
+        self.tau = tau_ms * u.ms
+        self.x = DiffEqSingleState(jnp.full(shape, x0, dtype=FLOAT_DTYPE) * u.mV)
+        # A non-DiffEqState should be ignored by the integrator.
+        self.aux = brainstate.ShortTermState(jnp.zeros(shape, dtype=FLOAT_DTYPE))
+        self.pre_calls = 0
+        self.post_calls = 0
+
+    def pre_integral(self, *args, **kwargs):
+        self.pre_calls += 1
+
+    def post_integral(self, *args, **kwargs):
+        self.post_calls += 1
+
+    def compute_derivative(self, *args, **kwargs):
+        self.x.derivative = -self.x.value / self.tau
+
+
+def drive(method, dt_ms: float = 0.1, n_steps: int = 100, x0: float = 1.0, tau_ms: float = 10.0):
+    """Drive ``method`` ``n_steps`` times on a fresh :class:`LinearDecay`.
+
+    Parameters
+    ----------
+    method : Callable
+        An integrator step, called as ``method(module)``.
+    dt_ms : float, optional
+        Time step in milliseconds. Default 0.1.
+    n_steps : int, optional
+        Number of steps to take. Default 100.
+    x0 : float, optional
+        Initial state value in mV. Default 1.0.
+    tau_ms : float, optional
+        Decay time constant in milliseconds. Default 10.0.
+
+    Returns
+    -------
+    value : float
+        The first element of the final state, in mV.
+    module : LinearDecay
+        The driven module, so callers can inspect ``pre_calls`` / ``post_calls``.
+    """
+    m = LinearDecay(x0=x0, tau_ms=tau_ms)
+    dt = dt_ms * u.ms
+    with brainstate.environ.context(dt=dt):
+        for i in range(n_steps):
+            with brainstate.environ.context(t=i * dt):
+                method(m)
+    return float(m.x.value.to_decimal(u.mV)[0]), m
+
+
+class HH(braincell.SingleCompartment):
+    """One-compartment Hodgkin-Huxley neuron used as a solver reference model."""
+
+    def __init__(self, size, solver='rk4'):
+        super().__init__(size, solver=solver)
+
+        self.na = braincell.ion.SodiumFixed(size, E=50.0 * u.mV)
+        self.na.add(INa=braincell.channel.Na_HH1952(size))
+
+        self.k = braincell.ion.PotassiumFixed(size, E=-77.0 * u.mV)
+        self.k.add(IK=braincell.channel.K_HH1952(size))
+
+        self.IL = braincell.channel.IL(size, E=-54.387 * u.mV, g_max=0.03 * (u.mS / u.cm**2))
+
+
+def integrate(method: str, dt=0.01 * u.ms):
+    """Run :class:`HH` for 10 ms under ``method`` and return the voltage trace.
+
+    Parameters
+    ----------
+    method : str
+        Registered integrator name passed as ``solver=``.
+    dt : u.Quantity[u.second], optional
+        Integration time step. Default ``0.01 * u.ms``.
+
+    Returns
+    -------
+    u.Quantity
+        The membrane-voltage trace over the 10 ms window.
+    """
+    brainstate.random.seed(1)
+    hh = HH(1, solver=method)
+    hh.init_state()
+
+    def step_fun(t):
+        with brainstate.environ.context(t=t):
+            hh.update(10 * u.nA / u.cm**2)
+        return hh.V.value
+
+    with brainstate.environ.context(dt=dt):
+        times = u.math.arange(0.0 * u.ms, 10 * u.ms, brainstate.environ.get_dt())
+        vs = brainstate.transform.for_loop(step_fun, times)
+    return vs
+
+
+def compare(method: str):
+    """Measure ``method``'s deviation from ``exp_euler`` across six time steps.
+
+    Parameters
+    ----------
+    method : str
+        Registered integrator name to compare against the ``exp_euler``
+        reference.
+
+    Returns
+    -------
+    dts : jax.Array
+        The six time steps, as bare mantissas in ms.
+    norms : jax.Array
+        The corresponding voltage-trace error norms, as bare mantissas.
+
+    Notes
+    -----
+    Units are stripped from both return values so that matplotlib can convert
+    them via ``np.asarray``; newer ``saiunit`` rejects
+    ``np.asarray(dimensional_quantity)``.
+    """
+    norm = []
+    dts = [1e-3 * u.ms, 2e-3 * u.ms, 4e-3 * u.ms, 8e-3 * u.ms, 1e-2 * u.ms, 2e-2 * u.ms]
+    for dt in dts:
+        gold_vs = integrate('exp_euler', dt=dt)
+        vs = integrate(method, dt=dt)
+        norm.append(u.linalg.norm(gold_vs - vs))
+    return u.math.asarray(dts).mantissa, u.math.asarray(norm).mantissa

--- a/braincell/quad/_util.py
+++ b/braincell/quad/_util.py
@@ -25,8 +25,41 @@ from braincell._typing import T, DT, Y0, Y1, Aux, Jacobian, VectorField, Args
 from .protocol import DiffEqState, DiffEqModule, IndependentIntegration
 
 
-def _array_dtype(value) -> jnp.dtype:
-    return jnp.asarray(u.get_magnitude(value)).dtype
+def environ_time(target: DiffEqModule, t: T = None, dt: DT = None) -> Tuple[T, DT]:
+    """
+    Resolve the current simulation time and time step.
+
+    Every registered integrator step is invoked by its host as
+    ``self.solver(self, *args)``, with no explicit time arguments, so each one
+    has to recover ``t`` and ``dt`` from :mod:`brainstate.environ`. This is the
+    single definition of how that is done.
+
+    Parameters
+    ----------
+    target : DiffEqModule
+        The module being integrated. Supplies the ``current_time`` fallback
+        used when ``t`` is absent from the environment.
+    t : u.Quantity[u.second], optional
+        An explicit time that overrides the environment. ``None`` (the
+        default) means "read from the environment".
+    dt : u.Quantity[u.second], optional
+        An explicit time step that overrides the environment. ``None`` (the
+        default) means "read from the environment".
+
+    Returns
+    -------
+    t : u.Quantity[u.second]
+        The current simulation time. When read from the environment it falls
+        back to ``target.current_time`` and then to ``0.0 * u.ms``, so the
+        result always carries a time unit.
+    dt : u.Quantity[u.second]
+        The integration time step.
+    """
+    if t is None:
+        t = brainstate.environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))
+    if dt is None:
+        dt = brainstate.environ.get('dt')
+    return t, dt
 
 
 def _has_path_prefix(path, prefixes):
@@ -65,6 +98,11 @@ def split_diffeq_states(module: DiffEqModule, *, excluded_paths=()):
     ----------
     module : DiffEqModule
         The differential equation module whose states are to be split.
+    excluded_paths : tuple of tuple of str, optional
+        State paths to keep out of ``diffeq_states``. A path matches when it is
+        a prefix of the state's path, so ``(('channels',),)`` excludes every
+        state owned by the ``channels`` subtree. Excluded states still appear in
+        ``all_states`` and ``other_states``.
 
     Returns
     -------
@@ -113,30 +151,25 @@ def _check_diffeq_state_derivative(state: DiffEqState, dt: u.Quantity):
     state.derivative = jax.tree.map(_fn_checking, state.value, state.derivative, is_leaf=u.math.is_quantity)
 
 
+def _check_merging(method: str) -> str:
+    """Validate a state-merging method, returning it unchanged."""
+    if method not in ('concat', 'stack'):
+        raise ValueError(f"Unknown merging method: {method!r}. Expected 'concat' or 'stack'.")
+    return method
+
+
 def _merging(leaves, method: str):
-    if method == 'concat':
+    if _check_merging(method) == 'concat':
         return jnp.concatenate(leaves, axis=-1)
-    elif method == 'stack':
-        return jnp.stack(leaves, axis=-1)
-    else:
-        raise ValueError(f'Unknown method: {method}')
+    return jnp.stack(leaves, axis=-1)
 
 
-def _dict_derivative_to_arr(
-    a_dict: Dict[Any, DiffEqState],
-    method: str = 'concat',
-):
-    a_dict = {key: val.derivative for key, val in a_dict.items()}
-    leaves = jax.tree.leaves(a_dict)
-    return _merging(leaves, method=method)
-
-
-def _dict_state_to_arr(
+def _dict_attr_to_arr(
     a_dict: Dict[Any, brainstate.State],
+    attr: str,
     method: str = 'concat',
 ):
-    a_dict = {key: val.value for key, val in a_dict.items()}
-    leaves = jax.tree.leaves(a_dict)
+    leaves = jax.tree.leaves({key: getattr(val, attr) for key, val in a_dict.items()})
     return _merging(leaves, method=method)
 
 
@@ -145,18 +178,18 @@ def _assign_arr_to_states(
     states: Dict[Any, brainstate.State],
     method: str = 'concat',
 ):
+    stacked = _check_merging(method) == 'stack'
     leaves, tree_def = jax.tree.flatten({key: state.value for key, state in states.items()})
     index = 0
     vals_like_leaves = []
     for leaf in leaves:
-        if method == 'stack':
+        if stacked:
             vals_like_leaves.append(vals[..., index])
             index += 1
-        elif method == 'concat':
-            vals_like_leaves.append(vals[..., index : index + leaf.shape[-1]])
-            index += leaf.shape[-1]
         else:
-            raise ValueError(f'Unknown method: {method}')
+            width = leaf.shape[-1]
+            vals_like_leaves.append(vals[..., index : index + width])
+            index += width
     vals_like_states = jax.tree.unflatten(tree_def, vals_like_leaves)
     for key, state_val in vals_like_states.items():
         states[key].value = state_val
@@ -168,7 +201,7 @@ def _transform_diffeq_module_into_dimensionless_fn(
     method: str = 'concat',
     excluded_paths=(),
 ):
-    assert method in ['concat', 'stack'], f'Unknown method: {method}'
+    _check_merging(method)
     all_states, diffeq_states, other_states = split_diffeq_states(target, excluded_paths=excluded_paths)
     all_state_ids = {id(st) for st in all_states.values()}
 
@@ -181,7 +214,7 @@ def _transform_diffeq_module_into_dimensionless_fn(
             # derivative_arr: dimensionless derivatives
             for st in diffeq_states.values():
                 _check_diffeq_state_derivative(st, dt)  # THIS is important.
-            derivative_dimensionless = _dict_derivative_to_arr(diffeq_states, method=method)
+            derivative_dimensionless = _dict_attr_to_arr(diffeq_states, 'derivative', method=method)
             other_vals = {key: st.value for key, st in other_states.items()}
 
         # check if all states exist in the trace
@@ -237,9 +270,12 @@ def apply_standard_solver_step(
         - 'concat': Concatenate the states along the last dimension.
         - 'stack': Stack the states along the last dimension.
     """
-    assert isinstance(target, DiffEqModule), f'Target must be a DiffEqModule, but got {type(target)}'
-    assert callable(solver_step), f'Solver step must be callable, but got {type(solver_step)}'
-    assert merging in ['concat', 'stack'], f'Unknown merging method: {merging}'
+    # Raised rather than asserted so that ``python -O`` preserves the contract.
+    if not isinstance(target, DiffEqModule):
+        raise TypeError(f'Target must be a DiffEqModule, but got {type(target)}')
+    if not callable(solver_step):
+        raise TypeError(f'Solver step must be callable, but got {type(solver_step)}')
+    _check_merging(merging)
 
     # pre integral
     target.pre_integral(*args)
@@ -252,7 +288,7 @@ def apply_standard_solver_step(
 
     # one-step integration
     diffeq_vals, other_vals = solver_step(
-        dimensionless_fn, _dict_state_to_arr(diffeq_states, method=merging), t, dt, args
+        dimensionless_fn, _dict_attr_to_arr(diffeq_states, 'value', method=merging), t, dt, args
     )
 
     # post integral
@@ -274,23 +310,28 @@ def jacrev_last_dim(
     with respect to the last dimension of the input `hid_vals`. It uses
     JAX's reverse-mode automatic differentiation (jacrev) for efficient computation.
 
-    Args:
-        fn: The function for which to compute the Jacobian. It can either return a single
-            JAX array or a tuple containing a JAX array and auxiliary values.
-        hid_vals:
-            The input values for which to compute the Jacobian. The last dimension is
-            considered as the dimension of interest.
-        has_aux (bool, optional):
-            Whether the function `fn` returns auxiliary values. Defaults to False.
+    Parameters
+    ----------
+    fn : Callable
+        The function for which to compute the Jacobian. It can either return a
+        single JAX array or a tuple containing a JAX array and auxiliary values.
+    hid_vals : jax.Array
+        The input values for which to compute the Jacobian. The last dimension
+        is considered as the dimension of interest.
+    has_aux : bool, optional
+        Whether the function ``fn`` returns auxiliary values. Defaults to False.
 
-    Returns:
-            If `has_aux` is False, returns a tuple containing the Jacobian matrix and the
-            output of the function `fn`. If `has_aux` is True, returns a tuple containing
-            the Jacobian matrix, the output of the function `fn`, and the auxiliary values.
+    Returns
+    -------
+    tuple
+        If ``has_aux`` is False, a tuple containing the Jacobian matrix and the
+        output of ``fn``. If ``has_aux`` is True, a tuple containing the
+        Jacobian matrix, the output of ``fn``, and the auxiliary values.
 
-    Raises:
-        AssertionError:
-            If the number of input and output states are not the same.
+    Raises
+    ------
+    AssertionError
+        If the number of input and output states are not the same.
     """
     if has_aux:
         new_hid_vals, f_vjp, aux = jax.vjp(fn, hid_vals, has_aux=True)
@@ -300,7 +341,7 @@ def jacrev_last_dim(
     varshape = new_hid_vals.shape[:-1]
     assert num_state == hid_vals.shape[-1], 'Error: the number of input/output states should be the same.'
     g_primals = u.math.broadcast_to(
-        u.math.eye(num_state, dtype=_array_dtype(new_hid_vals)),
+        u.math.eye(num_state, dtype=u.math.get_dtype(new_hid_vals)),
         (*varshape, num_state, num_state),
     )
     jac = jax.vmap(f_vjp, in_axes=-2, out_axes=-2)(g_primals)
@@ -308,3 +349,53 @@ def jacrev_last_dim(
         return jac[0], new_hid_vals, aux
     else:
         return jac[0], new_hid_vals
+
+
+def linearize_flat(
+    f: VectorField,
+    y0: Y0,
+    t: T,
+    dt: DT,
+    args: Args = (),
+) -> Tuple[jax.Array, Jacobian, jax.Array, Aux]:
+    """
+    Linearize a vector field about ``y0`` and fold the leading axes into one batch axis.
+
+    This is the shared prologue of the locally linearised solvers
+    (:func:`~braincell.quad._backward_euler._backward_euler` and
+    :func:`~braincell.quad._exp_euler._exponential_euler`): it strips the unit
+    from ``dt``, builds the local Jacobian, and reshapes both the Jacobian and
+    the derivative so that everything ahead of the state axis becomes a single
+    batch axis.
+
+    Parameters
+    ----------
+    f : Callable
+        The vector field ``f(t, y, *args)``, returning ``(dy/dt, aux)``.
+    y0 : jax.Array
+        The current state, shape ``(..., M)``.
+    t : u.Quantity[u.second]
+        The current time.
+    dt : u.Quantity[u.second]
+        The integration time step.
+    args : tuple, optional
+        Extra positional arguments forwarded to ``f``.
+
+    Returns
+    -------
+    dt : jax.Array
+        The magnitude of ``dt``, cast to ``y0``'s dtype.
+    A : jax.Array
+        The Jacobian :math:`\\partial f / \\partial y` at ``y0``, shape ``(B, M, M)``.
+    df : jax.Array
+        The vector field evaluated at ``y0``, shape ``(B, M)``.
+    aux : Any
+        The auxiliary output of ``f``.
+    """
+    dtype = y0.dtype
+    dt = jnp.asarray(u.get_magnitude(dt), dtype=dtype)
+    A, df, aux = jacrev_last_dim(lambda y: f(t, y, *args), y0, has_aux=True)
+    # reshape A from "[..., M, M]" to "[-1, M, M]" and df from "[..., M]" to "[-1, M]"
+    A = jnp.asarray(A, dtype=dtype).reshape((-1, A.shape[-2], A.shape[-1]))
+    df = jnp.asarray(df, dtype=dtype).reshape((-1, df.shape[-1]))
+    return dt, A, df, aux

--- a/braincell/quad/_util_test.py
+++ b/braincell/quad/_util_test.py
@@ -32,45 +32,22 @@ from braincell import (
     IndependentIntegration,
 )
 
+from braincell.quad._testing import FLOAT_DTYPE, LinearDecay
 from braincell.quad._util import (
     apply_standard_solver_step,
     jacrev_last_dim,
     split_diffeq_states,
 )
 
-_FLOAT_DTYPE = jnp.asarray(0.0).dtype
-
 
 # --------------------------------------------------------------------------- #
 # Fixtures
 # --------------------------------------------------------------------------- #
-class _LinearDecay(brainstate.nn.Module, DiffEqModule):
-    """Minimal module: dx/dt = -x/tau, with one DiffEqState and one auxiliary."""
-
-    def __init__(self, shape=(2,)):
-        super().__init__()
-        self.tau = 10.0 * u.ms
-        self.x = DiffEqSingleState(jnp.ones(shape, dtype=_FLOAT_DTYPE) * u.mV)
-        # A non-DiffEqState should be ignored by the integrator.
-        self.aux = brainstate.ShortTermState(jnp.zeros(shape, dtype=_FLOAT_DTYPE))
-        self.pre_calls = 0
-        self.post_calls = 0
-
-    def pre_integral(self, *args, **kwargs):
-        self.pre_calls += 1
-
-    def post_integral(self, *args, **kwargs):
-        self.post_calls += 1
-
-    def compute_derivative(self, *args, **kwargs):
-        self.x.derivative = -self.x.value / self.tau
-
-
 class _IndepSub(brainstate.nn.Module, DiffEqModule, IndependentIntegration):
     def __init__(self):
         IndependentIntegration.__init__(self, "euler")
         brainstate.nn.Module.__init__(self)
-        self.y = DiffEqSingleState(jnp.ones(2, dtype=_FLOAT_DTYPE) * u.mV)
+        self.y = DiffEqSingleState(jnp.ones(2, dtype=FLOAT_DTYPE) * u.mV)
 
     def compute_derivative(self, *args, **kwargs):
         self.y.derivative = -self.y.value / (5.0 * u.ms)
@@ -79,7 +56,7 @@ class _IndepSub(brainstate.nn.Module, DiffEqModule, IndependentIntegration):
 class _DependentChild(brainstate.nn.Module, DiffEqModule):
     def __init__(self):
         super().__init__()
-        self.z = DiffEqSingleState(jnp.ones(2, dtype=_FLOAT_DTYPE) * u.mV)
+        self.z = DiffEqSingleState(jnp.ones(2, dtype=FLOAT_DTYPE) * u.mV)
 
     def compute_derivative(self, *args, **kwargs):
         self.z.derivative = -self.z.value / (7.0 * u.ms)
@@ -94,7 +71,7 @@ class _IndepSubWithDependentChild(_IndepSub):
 class _OuterWithIndep(brainstate.nn.Module, DiffEqModule):
     def __init__(self, sub=None):
         super().__init__()
-        self.x = DiffEqSingleState(jnp.ones(2, dtype=_FLOAT_DTYPE) * u.mV)
+        self.x = DiffEqSingleState(jnp.ones(2, dtype=FLOAT_DTYPE) * u.mV)
         self.sub = _IndepSub() if sub is None else sub
 
     def compute_derivative(self, *args, **kwargs):
@@ -106,7 +83,7 @@ class _OuterWithIndep(brainstate.nn.Module, DiffEqModule):
 # --------------------------------------------------------------------------- #
 class SplitDiffEqStatesTest(unittest.TestCase):
     def test_separates_diffeq_and_other_states(self):
-        m = _LinearDecay()
+        m = LinearDecay(shape=(2,))
         all_st, diffeq_st, other_st = split_diffeq_states(m)
         # Both states show up in the full set.
         self.assertEqual(len(all_st), 2)
@@ -142,7 +119,7 @@ class SplitDiffEqStatesTest(unittest.TestCase):
 
 class ApplyStandardSolverStepTest(unittest.TestCase):
     def test_passes_array_state_and_invokes_hooks(self):
-        m = _LinearDecay()
+        m = LinearDecay(shape=(2,))
 
         observed = {}
 
@@ -164,12 +141,13 @@ class ApplyStandardSolverStepTest(unittest.TestCase):
         self.assertEqual(m.post_calls, 1)
 
     def test_rejects_non_diffeq_module(self):
-        with self.assertRaises(AssertionError):
+        # TypeError rather than AssertionError so ``python -O`` keeps the guard.
+        with self.assertRaises(TypeError):
             apply_standard_solver_step(lambda *a, **k: None, object(), 0.0, 0.1)
 
     def test_rejects_unknown_merging(self):
-        m = _LinearDecay()
-        with self.assertRaises(AssertionError):
+        m = LinearDecay(shape=(2,))
+        with self.assertRaises(ValueError):
             apply_standard_solver_step(
                 lambda *a, **k: None,
                 m,
@@ -179,8 +157,8 @@ class ApplyStandardSolverStepTest(unittest.TestCase):
             )
 
     def test_rejects_non_callable_solver_step(self):
-        m = _LinearDecay()
-        with self.assertRaises(AssertionError):
+        m = LinearDecay(shape=(2,))
+        with self.assertRaises(TypeError):
             apply_standard_solver_step(
                 "not callable",  # type: ignore[arg-type]
                 m,

--- a/braincell/quad/protocol.py
+++ b/braincell/quad/protocol.py
@@ -32,12 +32,13 @@ trailing compartment axis with :class:`DiffEqGroupState`. See
 
 import contextlib
 import contextvars
-from typing import Callable, Iterator
+from typing import Callable, ClassVar, Iterator
 
 import brainstate
 from brainstate._state import record_state_value_write
 
 from braincell._misc import set_module_as
+from ._registry import get_integrator
 
 __all__ = [
     'DiffEqState',
@@ -383,6 +384,16 @@ class DiffEqModule(brainstate.mixin.Mixin):
     as their ``target`` argument and read ``t``/``dt`` from the active
     :mod:`brainstate.environ` context.
 
+    Attributes
+    ----------
+    diffeq_state_merging : str
+        How the module's :class:`DiffEqState` leaves are laid out when a
+        solver flattens them into one array — ``'stack'`` (the default) gives
+        ``[..., n_state]``, ``'concat'`` gives ``[..., n_compartment * n_state]``.
+        The host declares this because it is a property of the state layout the
+        host allocated; :func:`~braincell.quad.exp_euler_step` reads it rather
+        than inferring it from the concrete class.
+
     See Also
     --------
     DiffEqState : Per-variable state container the solvers update.
@@ -390,6 +401,8 @@ class DiffEqModule(brainstate.mixin.Mixin):
     """
 
     __module__ = 'braincell'
+
+    diffeq_state_merging: ClassVar[str] = 'stack'
 
     def pre_integral(self, *args, **kwargs):
         """
@@ -492,8 +505,6 @@ class IndependentIntegration(brainstate.mixin.Mixin):
     """
 
     def __init__(self, solver: str | Callable, **kwargs):
-        from . import get_integrator
-
         self.solver = get_integrator(solver)
         super().__init__(**kwargs)
 

--- a/braincell/quad/protocol_test.py
+++ b/braincell/quad/protocol_test.py
@@ -33,6 +33,7 @@ import numpy as np
 from braincell.quad import (
     get_integrator,
 )
+from braincell.quad._testing import FLOAT_DTYPE
 from braincell.quad.protocol import (
     DiffEqGroupState,
     DiffEqModule,
@@ -43,8 +44,6 @@ from braincell.quad.protocol import (
     state_grouping,
     hidden_state,
 )
-
-_FLOAT_DTYPE = jnp.asarray(0.0).dtype
 
 
 class DiffEqStateMixinTest(unittest.TestCase):
@@ -123,7 +122,7 @@ class DiffEqSingleStateTest(unittest.TestCase):
         np.testing.assert_array_equal(st.diffusion, 2 * d)
 
     def test_state_value_roundtrip(self):
-        v = jnp.arange(4, dtype=_FLOAT_DTYPE) * u.mV
+        v = jnp.arange(4, dtype=FLOAT_DTYPE) * u.mV
         st = DiffEqSingleState(v)
         np.testing.assert_array_equal(st.value.to_decimal(u.mV), np.arange(4))
 
@@ -274,7 +273,7 @@ class IndependentIntegrationTest(unittest.TestCase):
             def __init__(self):
                 IndependentIntegration.__init__(self, solver)
                 brainstate.nn.Module.__init__(self)
-                self.y = DiffEqSingleState(jnp.ones(2, dtype=_FLOAT_DTYPE) * u.mV)
+                self.y = DiffEqSingleState(jnp.ones(2, dtype=FLOAT_DTYPE) * u.mV)
 
             def compute_derivative(self, *args, **kwargs):
                 self.y.derivative = -self.y.value / (5.0 * u.ms)

--- a/docs/apis/integration.rst
+++ b/docs/apis/integration.rst
@@ -115,3 +115,4 @@ Other Integrators
    :toctree: generated/
 
     staggered_step
+    dhs_voltage_step

--- a/docs/design/cell.md
+++ b/docs/design/cell.md
@@ -263,7 +263,7 @@
 - `Cell` 的全部 hidden state 都是 `brainstate.HiddenGroupState`（`V` 为 `braincell.DiffEqGroupState`），
   尾轴即 compartment/point 轴；`SingleCompartment` 无空间轴，仍用普通 `DiffEqSingleState`。
   参见 `docs/specs/2026-08-13-cell-hidden-group-state.md`
-- `braincell.quad._voltage_solver.dhs_voltage_step()` 已改为从 `node_tree` 中的调度视图提取树结构
+- `braincell.quad._staggered.dhs_voltage_step()` 已改为从 `node_tree` 中的调度视图提取树结构
 - `Cell(solver="staggered")` 已可直接走新的 node-tree DHS 电压求解
 
 ### 当前约束

--- a/docs/specs/2026-09-02-quad-simplification.md
+++ b/docs/specs/2026-09-02-quad-simplification.md
@@ -1,0 +1,376 @@
+# Quality cleanup of `braincell.quad`
+
+Reuse, simplification, efficiency, and altitude cleanup of the integrator
+package (`braincell/quad`, 9 source modules, ~4,170 source lines plus
+~2,090 lines of co-located tests). Breaking API changes are in scope and
+were explicitly authorised for this pass.
+
+This is iteration 1 of a module-by-module sweep. The package-wide pass in
+PR #137 touched `quad` only twice — it deleted six unreachable integrators
+and added a calling-convention field to the registry — so almost everything
+below is new ground.
+
+## Scope and method
+
+Four independent reviews swept the package, one per angle (reuse,
+simplification, efficiency, altitude). Findings were deduplicated; the
+clusters that surfaced in two or more reviews independently are what
+promoted them. Every claim below was re-verified against the code before it
+was acted on.
+
+Three invariants govern every edit, carried over from PR #137:
+
+1. **The test suite stays green.** Baseline on `main` @ `a10f461` before any
+   change: 2,723 passed, 15 skipped, 334 subtests, 0 failed (236.32 s).
+2. **Every performance claim carries a measurement.** No fix lands on the
+   strength of "this looks faster".
+3. **Where two code paths disagree, the disagreement is preserved, not
+   silently unified.** Divergences worth a decision are listed under
+   *Deliberately not changed*.
+
+## Breaking changes
+
+### `implicit_euler` and `dhs_voltage` become selectable by name
+
+Both are registered, both appear in `all_integrators`, and neither could be
+selected via `solver="..."`. The model hosts call `self.solver(self)`
+(`Cell._update_dynamics`) and `self.solver(self, I_ext)`
+(`SingleCompartment.update`), while `implicit_euler_step(target, t, dt, *args)`
+and `dhs_voltage_step(target, t, dt, *args)` demand explicit time arguments.
+PR #137 recorded the mismatch as `IntegratorEntry.requires_time_args` plus a
+test allowlist and two Notes paragraphs, rather than fixing it.
+
+The explicit `t`/`dt` carry no information: both in-repo call sites already
+read them from `brainstate.environ` immediately before calling. Both
+signatures become `(target, *args, t=None, dt=None)`, where `None` means
+"read from `environ`" — the convention the other 15 steps already use.
+
+Consequently `IntegratorEntry.requires_time_args` and the private
+`_requires_time_args` helper are **deleted**. The field had no production
+consumer anywhere in `braincell/`, `examples/`, or `docs/` — it was read only
+by its own test, which already re-derives the same answer from
+`inspect.signature(...).bind`. `_registry_test.py::CallConventionTest` is
+rewritten to assert the strictly stronger property that *every* registered
+entry binds against the host convention.
+
+`examples/multi_compartment/quad.ipynb` stores an `IntegratorEntry` repr in a
+cell output, and a markdown cell describes the two steps as taking positional
+`t`/`dt`. Both are corrected in place — the stored repr loses the field, the
+prose describes the keyword-only override — rather than by re-executing the
+notebook, which would churn every unrelated output and memory address in the
+file for two textual fixes.
+
+### `braincell.quad.dhs_voltage_step` is exported
+
+`dhs_voltage` was advertised by `all_integrators` and by
+`get_integrator`'s "Available: ..." error message, but
+`braincell.quad.dhs_voltage_step` raised `AttributeError` — the symbol was
+registered and never exported. Its own tests import it from the private
+`braincell.quad._staggered`. It joins `__all__`.
+
+### `power_iteration_expm` is deleted
+
+A one-line wrapper around `jax.scipy.linalg.expm` behind a dead branch. Its
+only caller passed `method='scipy'` explicitly, so the hand-rolled Taylor
+series (`method='approx'`, `num_steps=20`) — which its own docstring calls
+"not numerically stable or efficient" — had never run. The call site uses the
+already-imported `expm` directly.
+
+### `_to_jax_quantity` and `_array_dtype` are deleted
+
+Both re-implement `brainunit` helpers: `u.math.asarray(value, unit=unit)` and
+`u.math.get_dtype(value)` respectively. `u.math.get_dtype` was already in use
+elsewhere in the same package. `_to_jax_quantity` had a dedicated test pinning
+that converting a `float32` quantity under `precision=64` does *not* promote to
+`float64`; the DHS numeric state still depends on that, so the test is
+retargeted at `u.math.asarray` rather than dropped. It now reads as a contract
+test against `brainunit`: if that promotion behaviour ever changes, it surfaces
+here instead of as silent numerical drift in the voltage solve.
+
+### `DiffEqModule.diffeq_state_merging` replaces an isinstance chain
+
+`exp_euler_step` imported `HHTypedNeuron`, `Cell`, and `SingleCompartment`
+inside its body — the **only** place any `quad` module imports a model class —
+purely to choose between `merging='stack'` and `merging='concat'`. That is a
+property of the state layout the host allocated, which the host already knows.
+`DiffEqModule` gains a documented `ClassVar[str]`, defaulting to `'stack'`;
+`Cell` overrides it to `'concat'`. Behaviour is identical for both existing
+hosts, `quad` loses its last upward import edge, and any third-party
+`DiffEqModule` can now use `exp_euler_step` instead of hitting a `TypeError`.
+
+`backward_euler_step`'s hardcoded `merging='stack'` is deliberately **not**
+changed — switching it would alter `Cell` numerics (stack gives a
+per-compartment block-diagonal Jacobian, concat a fully coupled one), which is
+a modelling decision, not a refactor.
+
+### The `DiffEqModule` type guard raises `TypeError`, not `AssertionError`
+
+`apply_standard_solver_step` guarded its contract with `assert`, which
+evaporates under `python -O`, while two hand-written duplicates raised
+`TypeError`. In-file comments show the conversion was started and left
+half-done. The guard is now `TypeError` in the one shared place; the
+duplicates in `_exp_euler.py` and `_staggered.py` cover only the paths that
+bypass it.
+
+### `IntegratorRegistry.items()` is deleted
+
+Zero callers anywhere, including its own test file, and undocumented.
+`as_dict(include_aliases=False)` already returns the same mapping.
+
+## What was fixed
+
+### Reuse — one home per concept
+
+- **The `t`/`dt` environ prologue existed in 14 copies and had already
+  drifted.** Thirteen sites read
+  `environ.get('t', getattr(target, 'current_time', 0.0 * u.ms))`; the
+  fourteenth, `_staggered.py:130`, read `environ.get('t', 0.0)` — a **bare
+  unitless default**, against the mandatory-units convention, which then flowed
+  into `runtime.evaluate_point_clamps(t=...)`. A single
+  `environ_time(target)` in `_util.py` replaces all of them, and
+  `_general_rk_step` now reads the pair itself, collapsing eleven three-line
+  step bodies to one line each.
+- **The DHS forward-elimination kernel existed twice.**
+  `comp_triang_raw`'s inline loop body is byte-identical arithmetic to
+  `_comp_triang_level`, which runs only under
+  `BRAINCELL_PROFILE_DHS_LEVELS=1`. A numerics fix applied to the default path
+  would silently miss the profiled one, and CI never exercises it — the
+  divergence would surface as "the profiler build gives different voltages".
+  `comp_triang_raw` now calls the helper.
+- **`_check_comp_triang` / `_check_comp_backsub` shared six verbatim
+  checks** and had already partly diverged (only one checks
+  `diags.shape == solves.shape`). The shared checks move to
+  `_check_dhs_operands`; each caller keeps only its own extras.
+- **`_dict_state_to_arr` / `_dict_derivative_to_arr`** differed by one
+  attribute name; they collapse to one helper.
+- **The "append one sentinel row" expression appeared three times**, with the
+  one difference that matters (`ones_like` for `diags`, `zeros_like` for
+  `lowers`/`uppers`) buried in identical noise. `_with_sentinel(base, fill)`
+  makes the intent readable.
+- **`quad/_testing.py` is new** — the package was the only one in `braincell/`
+  without the shared-test-helper module AGENTS.md prescribes. It absorbs the
+  HH fixture (byte-identical in two files, one-line different in a third),
+  `_LinearDecay` (five definitions that had forked into two incompatible
+  shapes), `_FLOAT_DTYPE` (six copies), and `_drive` (two copies with
+  *different return types*).
+- `_registry_test.py` enumerated the canonical integrator names twice; the
+  bare set is now derived from the metadata table, so registering an
+  integrator means editing one list.
+
+### Simplification
+
+- **Thirteen tests that assert nothing** were deleted. Eleven in
+  `TestRungeKutta` plus one each in `_exp_euler_test.py` and
+  `_backward_euler_test.py` ran twelve 10 ms HH simulations apiece and then
+  called `plt.close()`. Measured cost: **31.0 s of `_runge_kutta_test.py`'s
+  52.5 s**. `RungeKuttaConvergenceTest` in the same file already covers all
+  eleven methods *with* assertions on the analytic solution and the observed
+  convergence order. Two of the three copies also carried the stale class name
+  `TestRungeKutta` — in `_exp_euler_test.py`, a class called `TestRungeKutta`
+  with a method called `test_euler_step` was testing `ind_exp_euler`.
+- **`_newton_method` was mostly unreachable.** Its only caller invokes it
+  positionally through `apply_standard_solver_step`, so `modified`, `tol`,
+  `max_iter`, and `order` always take their defaults. That makes
+  `body_fun_modified`, the `order == 1` branch, and the `else: raise` branch
+  statically dead, alongside a triple-quoted `jax.lax.while_loop` alternative
+  whose carry arity does not match the live code. The docstring documented the
+  dead branch (backward Euler) rather than the live one (trapezoidal /
+  Crank-Nicolson) and is rewritten to describe what actually runs.
+- **Seven `jax.named_scope` + `jax.named_call` pairs collapse to one label
+  each.** `jax.named_call` is documented as returning "a version of `fun` that
+  is wrapped in a `named_scope`" — its implementation is
+  `source_info_util.extend_name_stack(name)(fun)` — so wrapping it inside an
+  explicit `named_scope` pushes two entries for one call and every DHS region
+  appeared twice in a profile. `staggered_step` in the same file already used
+  `named_scope` alone. `examples/profiling/README.md` documents only the outer
+  names, so the `_call` suffixes were never part of the published workflow.
+- `_edge_point_current` took a `static_source` parameter it never read.
+- `_edge_conductance` hand-rolled two accumulations and guarded them with a
+  `# pragma: no cover` branch that cannot fire (the caller already raises on
+  an empty role list). Both become `functools.reduce(operator.add, ...)`;
+  `sum()` is deliberately avoided because its `0` start breaks unit
+  arithmetic. `_rk_update` gets the same treatment.
+- `_ind_exp_euler_step_selected` normalised `excluded_paths` and then handed
+  it to `split_diffeq_states`, which normalised it again; the callee owns the
+  contract.
+- A hand-rolled loop counter used only to detect the first pass becomes
+  `enumerate`.
+- The "concat or stack" test was spelled in four places, one of them **inside
+  a per-leaf loop**; it is validated once at the boundary.
+- `_RegistryDictView.__getitem__` caught `KeyError` only to re-raise
+  `KeyError(name)`, which is what the callee already raises.
+
+### Efficiency — measured, or not landed
+
+Invariant 2 applies here: each item below states what was measured.
+
+- **`_build_backsub_indices` built more rows than the tree can need.** The
+  recursive-doubling jump table was grown until `np.all(k_step_parent ==
+  n_nodes)`, i.e. until every node had walked past the root. A node tree of
+  `n` nodes needs at most `ceil(log2(n))` doubling steps, so the loop is now
+  bounded by `max(1, int(n_nodes)).bit_length()` and stops as soon as either
+  condition holds. Verified across seven tree shapes: output **bit-identical**
+  in every case, with row counts falling 11→5, 10→5, 9→2, and 10→3. Chain
+  topologies are correctly unchanged, since a chain genuinely needs every
+  level. The saving is in `jnp` work per step, because `comp_backsub_raw`
+  iterates one gather-and-combine pass per row.
+
+  This one needed a correction: the first verification harness reported a
+  mismatch on a wide star topology. The harness was wrong, not the change — it
+  generated random sentinel values, violating the invariant that
+  `diags[:, n] == 1`, `solves[:, n] == 0`, and `lowers[n] == 0`. Re-run against
+  the real sentinel contract, all seven shapes agree bit-for-bit.
+
+- **`_newton_method` re-evaluated `f(t, y0)` on every iteration.** It is
+  loop-invariant, and XLA does not hoist loop-invariant code out of a
+  `while_loop` body, so each Newton iteration paid for a second full
+  vector-field evaluation. It is hoisted above the loop. The hoist sits
+  *after* the `u.get_magnitude` calls so `f0` is evaluated at exactly the
+  stripped `t` the inline expression used.
+
+- **Quad suite wall clock: 71.22 s → 31.13 s**, almost entirely from deleting
+  the thirteen assert-free tests described above.
+
+Two efficiency findings were **not** landed, on the same evidence standard PR
+#137 applied:
+
+- **Pruning zero Butcher-tableau coefficients** provably removes multiply-add
+  pairs from the compiled HLO, and A/B benchmarking showed a consistent win on
+  large arrays. But on a full HH-style rollout — the shape that actually
+  matters — repeated runs did not show a stable difference. An optimisation
+  that only shows up in a microbenchmark does not justify hand-unrolling
+  eleven tableaux.
+- **Rebuilding row capacitance per step** happens at trace time, not per
+  simulated step, so the cost is paid once per compilation and does not appear
+  in a rollout.
+
+### Altitude — behaviour moved to the layer that owns it
+
+- **Registry logic left `__init__.py`.** `get_integrator`, `all_integrators`,
+  and `_RegistryDictView` are registry behaviour that lived in the package
+  `__init__`, which forced `protocol.py` to carry a function-local
+  `from . import get_integrator` — a genuine import cycle, since
+  `quad/__init__` imports every backend and every backend imports `protocol`.
+  They move to `_registry.py`, which imports only stdlib, making the cycle
+  structurally impossible rather than merely deferred. This is the same fix
+  shape PR #137 applied to `_base`/`_base_ion`. The public path
+  `braincell.quad.get_integrator` is unchanged.
+- The calling-convention unification and the `diffeq_state_merging` ClassVar,
+  both described under *Breaking changes*.
+
+### Convention compliance
+
+- `_backward_euler.py`, `_exp_euler.py`, and `_staggered.py` now annotate
+  their step functions with the `braincell._typing` aliases
+  (`VectorField`, `Y0`, `Y1`, `T`, `DT`, `Args`, `Aux`) that exist for exactly
+  this package; three of six modules were already using them, so the alias
+  table was only half load-bearing.
+- Google-style `Args:` / `Returns:` docstring sections on `jacrev_last_dim`,
+  `_newton_method`, and `_backward_euler` become NumPy-doc.
+- `split_diffeq_states` documented only one of its two parameters;
+  `excluded_paths` is the one `staggered_step` depends on.
+- Two inert `# -*- coding: utf-8 -*-` lines sat on line 16 of two test files,
+  *below* the licence header. PEP 263 only honours an encoding line on line 1
+  or 2, and AGENTS.md forbids anything but a shebang or encoding line above
+  the header, so they were dead either way.
+
+## Deliberately not changed
+
+Recorded so the next reader does not re-litigate them, and so the later
+iterations of this sweep know what is waiting for them.
+
+- **`staggered_step`'s post-voltage scheduling.** It reaches into five
+  underscore-private `Cell` members (`_cv_to_point`,
+  `_integrate_runtime_synapse_dynamics`, `_update_ion_channel_families`,
+  `_update_ion_channels_by_integration`, plus `ion_channel_update_order`) to
+  decide the order in which mechanisms advance — scheduling, not numerics, and
+  `Cell` already owns it. The deep fix is a `Cell.advance_mechanisms(...)`
+  hook declared on the host protocol. **Deferred to iteration 11
+  (`_multi_compartment`)**, because the change is a `Cell` method extraction
+  and two `_staggered_test.py` schedule tests move to `cell_test.py`.
+- **DHS static assembly lives in `quad`.** ~250 lines of pure NumPy topology
+  work over `node_tree`/`scheduling`/`cvs`, plus `build_cv_axial_operator`,
+  which has zero callers inside `quad` — its only consumer is
+  `Cell._get_axial_operator`. `_compute/state.py` already owns the cache slots
+  and types them `object` because it cannot name `DHSStaticSource` without
+  importing `quad`. **Deferred to iteration 8 (`_compute`)**, where the
+  receiving module lives.
+- **`excluded_paths` is not part of the step protocol.** Only
+  `backward_euler_step` and `ind_exp_euler_step` accept it, so
+  `ion/_base.py:731-738` probes for support by calling the solver and
+  **parsing the `TypeError` message**. That runs under trace inside a
+  `for_loop`, so a genuine `TypeError` whose message happens to contain the
+  substring is swallowed and the step re-executed after partial state writes.
+  The fix is to make the keyword uniform across every registered step.
+  **Deferred to iteration 5 (`ion`)**, which owns the offending code.
+- **The registry cannot express which host an integrator supports.**
+  `SingleCompartment(size=1, solver="staggered")` resolves fine and then dies
+  on `target._cv_to_point`. This is the same class of rot that killed the six
+  integrators deleted in PR #137. The structural guard depends on a declared
+  host protocol, so it **follows the deferred item above**.
+- **`implicit_euler` runs Crank-Nicolson, not implicit Euler.** The registry
+  describes it as "Implicit Euler via Newton iteration" with `order=1`, but
+  `_newton_method`'s `order` parameter defaults to `2` and its own docstring
+  and `_implicit_test.py` both say trapezoidal. Correcting the *name* or the
+  *scheme* changes either a public solver identifier or the numerics, so it is
+  a decision for the maintainer, not a refactor. Recorded here; the dead
+  `order == 1` branch is removed regardless, which makes the live scheme
+  unambiguous in the source.
+- **Module naming inside `quad`.** Eight of nine modules carry a leading
+  underscore and `protocol.py` does not, but the underscore tracks nothing:
+  `_registry.py` exports two documented public classes, while
+  `braincell.quad.protocol` is a path nobody needs. Sibling public packages
+  (`filter/`, `network/`) use unprefixed inner modules. Renaming touches 14
+  import sites plus two Jinja channel templates, so it belongs to the
+  cross-module pass. **Deferred to iteration 14.**
+- **`ralston2_tableau` duplicates `rk2_tableau`'s values.** Both are
+  conventional names for the same second-order method and `ralston2_step`'s
+  docstring already says so. Aliasing the two would couple them through a
+  shared mutable dataclass instance, so the literals stay.
+
+## Verification
+
+### Test count is reconciled, not just compared
+
+The suite drops from 2,723 to 2,713 passing tests, so "still green" is not
+sufficient evidence on its own — a deleted test also stays green. Collected
+test IDs were diffed between `main` and this branch (`pytest braincell/quad
+--collect-only -q`), giving 20 removed and 10 added. Every removal is
+accounted for:
+
+| Removed | Why |
+|---|---|
+| `_runge_kutta_test.py::TestRungeKutta` (11 tests) | Assert-free; `RungeKuttaConvergenceTest` covers the same eleven methods with assertions. |
+| `_exp_euler_test.py::TestRungeKutta::test_euler_step` | Assert-free, and misnamed — it tested `ind_exp_euler`. Replaced by `IndExpEulerHHTest::test_drives_hodgkin_huxley_to_a_spiking_trace`. |
+| `_backward_euler_test.py::TestBackwardEulerHH::test_backward_euler_step` | Assert-free. Replaced by `BackwardEulerHHTest::test_drives_hodgkin_huxley_to_a_spiking_trace`. |
+| `ExpEulerTypeGuardTest::test_rejects_minimal_diffeq_module` | The behaviour it pinned is intentionally inverted by `diffeq_state_merging`; replaced by `ExpEulerTargetContractTest::test_accepts_minimal_diffeq_module` plus `test_default_merging_is_stack`. |
+| `ExpEulerTypeGuardTest::test_rejects_plain_object` | Class renamed to `ExpEulerTargetContractTest`; test kept. |
+| `CallConventionTest` (4 tests) | `requires_time_args` is deleted; replaced by 2 tests asserting the strictly stronger property over *every* entry. |
+| `test_to_jax_quantity_preserves_existing_dtype` | Retargeted at `u.math.asarray` as `test_numeric_operands_preserve_an_existing_dtype`. |
+
+Net −10, which is exactly the full-suite delta. No test was silently lost.
+
+### Commands
+
+Run from the worktree, on the final tree (after `ruff format`):
+
+```
+$ pytest braincell/quad -q
+126 passed, 1 warning, 92 subtests passed in 31.13s
+
+$ pytest braincell/ -q
+2713 passed, 15 skipped, 411 warnings, 338 subtests passed in 181.94s (0:03:01)
+
+$ pre-commit run --files <changed>
+check for added large files..............................................Passed
+check python ast.........................................................Passed
+check for merge conflicts................................................Passed
+debug statements (python)................................................Passed
+fix end of files.........................................................Passed
+trim trailing whitespace.................................................Passed
+ruff (legacy alias)......................................................Passed
+ruff format..............................................................Passed
+```
+
+Baseline on `main` @ `a10f461` for comparison: 2,723 passed, 15 skipped, 334
+subtests, 236.32 s. Quad alone was 71.22 s.

--- a/examples/multi_compartment/quad.ipynb
+++ b/examples/multi_compartment/quad.ipynb
@@ -191,9 +191,9 @@
     "It mutates `target` in place: every `DiffEqState.value` is replaced with\n",
     "its value at `t + dt`. The current time `t` and step size `dt` are read\n",
     "from the `brainstate.environ` context, **not** passed as arguments.\n",
-    "Two integrators (`implicit_euler_step` and `dhs_voltage_step`) take\n",
-    "`t` and `dt` as explicit positional arguments — those are clearly\n",
-    "marked in their signatures.\n",
+    "Two integrators (`implicit_euler_step` and `dhs_voltage_step`) also\n",
+    "accept `t` and `dt` as *keyword-only* overrides, defaulting to the\n",
+    "`environ` context, so they still match the canonical shape above.\n",
     "\n",
     "The `*args` are forwarded to `pre_integral`, `compute_derivative`, and\n",
     "`post_integral` so the model can receive things like an external current\n",
@@ -606,7 +606,7 @@
      "output_type": "stream",
      "text": [
       "canonical names: ['backward_euler', 'dhs_voltage', 'euler', 'exp_euler', 'heun2', 'heun3'] ...\n",
-      "rk4 entry      : IntegratorEntry(name='rk4', func=<function rk4_step at 0x7aba5abaefc0>, aliases=(), category='explicit', order=4, description='Classical four-stage fourth-order Runge-Kutta method.', deprecated=False, module='braincell.quad', requires_time_args=False)\n",
+      "rk4 entry      : IntegratorEntry(name='rk4', func=<function rk4_step at 0x7aba5abaefc0>, aliases=(), category='explicit', order=4, description='Classical four-stage fourth-order Runge-Kutta method.', deprecated=False, module='braincell.quad')\n",
       "rk4 description: Classical four-stage fourth-order Runge-Kutta method.\n"
      ]
     }


### PR DESCRIPTION
Iteration 1 of the module-by-module `/simplify` sweep: reuse, simplification,
efficiency, and altitude cleanup of `braincell/quad` (9 source modules, ~4,170
source lines plus ~2,090 lines of co-located tests).

Four independent reviews swept the package, one per angle. Findings were
deduplicated and each was re-verified against the code before being acted on.
Full rationale, including what was deliberately left alone and why, is in
`docs/specs/2026-09-02-quad-simplification.md`, which ships in this PR.

## Highlights

- **The `t`/`dt` environ prologue existed in 14 copies and had drifted.**
  Thirteen sites read `environ.get('t', getattr(target, 'current_time', 0.0 *
  u.ms))`; the fourteenth, in `staggered_step`, read `environ.get('t', 0.0)` —
  a **bare unitless default**, against the mandatory-units convention, which
  then flowed into `runtime.evaluate_point_clamps(t=...)`. One
  `environ_time(target)` helper replaces all of them.
- **The DHS forward-elimination kernel existed twice.** `comp_triang_raw`'s
  inline loop body was byte-identical arithmetic to `_comp_triang_level`,
  which only runs under `BRAINCELL_PROFILE_DHS_LEVELS=1`. A numerics fix to
  the default path would have silently missed the profiled one, and CI never
  exercises it.
- **`quad` no longer imports model classes.** `exp_euler_step` imported
  `HHTypedNeuron`, `Cell`, and `SingleCompartment` inside its body — the only
  place any `quad` module imported upward — purely to pick a merging strategy.
- **Registry logic left `__init__.py`**, which removes a genuine import cycle
  that `protocol.py` was working around with a function-local import.
- **13 tests that assert nothing were deleted.** They ran twelve 10 ms HH
  simulations apiece and then called `plt.close()`. Quad suite wall clock:
  **71.22 s → 31.13 s**.

## Breaking changes

1. **`implicit_euler_step` and `dhs_voltage_step` change signature** from
   `(target, t, dt, *args)` to `(target, *args, t=None, dt=None)`, where
   `None` means "read from `brainstate.environ`". Both were registered and
   advertised by `all_integrators`, and neither could actually be selected via
   `solver="..."`, because the hosts call `self.solver(self)` /
   `self.solver(self, I_ext)`. Both are now selectable. The explicit arguments
   carried no information — both in-repo call sites read them from `environ`
   immediately before calling.
2. **`IntegratorEntry.requires_time_args` and the private
   `_requires_time_args` helper are deleted.** The field existed only to
   record the mismatch fixed in (1). It had no production consumer anywhere in
   `braincell/`, `examples/`, or `docs/`.
3. **`IntegratorRegistry.items()` is deleted.** Zero callers, including its own
   test file, and undocumented; `as_dict(include_aliases=False)` already
   returns the same mapping.
4. **`exp_euler_step` accepts any `DiffEqModule`.** It previously required an
   `HHTypedNeuron` and raised `ValueError` for anything that was neither a
   `Cell` nor a `SingleCompartment`. The merging strategy now comes from the
   new `DiffEqModule.diffeq_state_merging` ClassVar (`'stack'` by default,
   `'concat'` on `Cell`), so behaviour is identical for both existing hosts
   and third-party modules no longer hit a `TypeError`.
5. **`power_iteration_expm` is deleted.** A wrapper around
   `jax.scipy.linalg.expm` behind a dead branch — its only caller passed
   `method='scipy'` explicitly, so the hand-rolled Taylor series that its own
   docstring called "not numerically stable or efficient" had never run.
6. **`_to_jax_quantity` and `_array_dtype` are deleted** in favour of
   `u.math.asarray(value, unit=unit)` and `u.math.get_dtype(value)`, which
   they re-implemented. `u.math.get_dtype` was already used elsewhere in the
   same package.
7. **Contract guards raise instead of asserting.** `apply_standard_solver_step`
   used `assert`, which evaporates under `python -O`, while two hand-written
   duplicates already raised `TypeError`. It now raises `TypeError` /
   `ValueError`.

Additive, not breaking: `braincell.quad.dhs_voltage_step` is now exported —
`dhs_voltage` was advertised by `all_integrators` and by `get_integrator`'s
"Available: ..." error message, but the symbol itself raised `AttributeError`.

Every in-repo caller is updated in this PR: `braincell/`, every `*_test.py`,
`docs/apis/integration.rst`, `docs/design/cell.md`, and
`examples/multi_compartment/quad.ipynb`. No deprecation shims or back-compat
aliases were added.

## Efficiency

`_build_backsub_indices` grew its recursive-doubling jump table until every
node had walked past the root. It now also stops at the first level that maps
every row to the sentinel, from which point each further round is an
arithmetic no-op that still costs two gathers and two multiplies per step.
Verified across seven tree shapes: output **bit-identical** in every case,
with row counts falling 11→5, 10→5, 9→2, and 10→3. Chain topologies are
correctly unchanged.

`_newton_method` re-evaluated the loop-invariant `f(t, y0)` on every Newton
iteration; XLA does not hoist loop-invariant code out of a `while_loop` body,
so it is hoisted explicitly.

Two efficiency findings were **not** landed, for want of an end-to-end
measurement: pruning zero Butcher-tableau coefficients (a consistent win in a
microbenchmark, no stable difference on a full HH rollout) and rebuilding row
capacitance per step (trace time, not per simulated step).

## Verification

Test count drops from 2,723 to 2,713, so "still green" is not sufficient
evidence on its own — a deleted test also stays green. Collected test IDs were
diffed between `main` and this branch: 20 removed, 10 added, and every removal
is accounted for in the spec's Verification table. Net −10, exactly matching
the full-suite delta.

```
$ pytest braincell/quad -q
126 passed, 1 warning, 92 subtests passed in 31.13s

$ pytest braincell/ -q
2713 passed, 15 skipped, 411 warnings, 338 subtests passed in 181.94s (0:03:01)

$ pre-commit run --files <changed>
check for added large files..............................................Passed
check python ast.........................................................Passed
check for merge conflicts................................................Passed
debug statements (python)................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
```

Baseline on `main` @ `a10f461`: 2,723 passed, 15 skipped, 334 subtests,
236.32 s; quad alone 71.22 s.

## Summary by Sourcery

Unify quad integrator conventions and simplify shared numerical, registry, and testing infrastructure while preserving solver behavior and improving performance.

New Features:
- Make implicit Euler and DHS voltage integrators selectable through the standard solver convention, with DHS voltage now publicly exported.
- Allow exponential Euler to integrate any DiffEqModule using host-declared state layout.

Bug Fixes:
- Unify time and timestep resolution across integrators with unit-aware environment fallbacks and optional keyword overrides.
- Ensure profiled and default DHS forward-elimination paths share the same implementation and optimize redundant DHS back-substitution work.
- Preserve solver contract validation under optimized Python execution by raising explicit type and value errors.

Enhancements:
- Consolidate duplicated integrator utilities, registry behavior, state merging, numerical linearization, and DHS operand validation.
- Remove unreachable numerical helpers, obsolete registry metadata and APIs, upward model imports, and redundant profiling scopes.
- Improve Newton-solver efficiency by hoisting loop-invariant vector-field evaluation.
- Reduce quad test runtime by replacing duplicated fixtures with shared testing helpers and removing assertion-free simulations.

Documentation:
- Document the quad simplification rationale, updated solver calling conventions, and related API and design changes.

Tests:
- Update solver, registry, DHS, and protocol tests for the unified calling convention and expanded DiffEqModule support.
- Add coverage for selectable implicit and DHS integrators, explicit time overrides, state-layout merging, numerical contracts, and end-to-end solver behavior.