### PR TITLE
refactor(morph): fix two latent bugs, derive the reserved-name set, and cut whole-tree work 2.5-4.5x

### DIFF
--- a/braincell/morph/_spatial.py
+++ b/braincell/morph/_spatial.py
@@ -167,50 +167,71 @@ def interpolate_branch(morpho: Morphology, branch_id: int, branch_x: object) -> 
     """Interpolate radius and optional 3-D position at continuous sites."""
     branch = morpho.branch(index=int(branch_id)).branch
     values = np.asarray(branch_x, dtype=float)
+    geometry = _BranchGeometryUm(branch)
+
     radii = np.empty(values.shape, dtype=float)
-    positions = None
-    if branch.points_proximal is not None and branch.points_distal is not None:
-        positions = np.empty(values.shape + (3,), dtype=float)
+    flat_radii = radii.reshape(-1)
+    sites = values.reshape(-1).tolist()
 
-    for index, x in enumerate(values.reshape(-1)):
-        radius_um, position_um = _interpolate_scalar(branch, float(x))
-        radii.reshape(-1)[index] = radius_um
-        if positions is not None:
-            assert position_um is not None
-            positions.reshape(-1, 3)[index] = position_um
-    return (
-        u.Quantity(radii, u.um),
-        None if positions is None else u.Quantity(positions, u.um),
-    )
+    if geometry.p0 is None:
+        for index, x in enumerate(sites):
+            flat_radii[index] = geometry.at(x)[0]
+        return u.Quantity(radii, u.um), None
+
+    positions = np.empty(values.shape + (3,), dtype=float)
+    flat_positions = positions.reshape(-1, 3)
+    for index, x in enumerate(sites):
+        flat_radii[index], flat_positions[index] = geometry.at(x)
+    return u.Quantity(radii, u.um), u.Quantity(positions, u.um)
 
 
-def _interpolate_scalar(branch, x: float) -> tuple[float, np.ndarray | None]:
-    lengths = np.asarray(branch.lengths.to_decimal(u.um), dtype=float)
-    r0 = np.asarray(branch.radii_proximal.to_decimal(u.um), dtype=float)
-    r1 = np.asarray(branch.radii_distal.to_decimal(u.um), dtype=float)
-    p0 = None if branch.points_proximal is None else np.asarray(branch.points_proximal.to_decimal(u.um), dtype=float)
-    p1 = None if branch.points_distal is None else np.asarray(branch.points_distal.to_decimal(u.um), dtype=float)
-    total = float(np.sum(lengths))
-    if total <= 0.0:
-        raise ValueError("Cannot interpolate a zero-length branch.")
+class _BranchGeometryUm:
+    """Micrometre-decoded segment geometry for a single branch.
 
-    cursor = 0.0
-    last_positive = None
-    for index, segment_length in enumerate(lengths.tolist()):
-        if segment_length <= 0.0:
-            if np.isclose(x, cursor / total):
-                point = None if p0 is None or p1 is None else 0.5 * (p0[index] + p1[index])
-                return 0.5 * (r0[index] + r1[index]), point
-            continue
-        start = cursor / total
-        cursor += segment_length
-        end = cursor / total
-        last_positive = index
-        if x < end or (x == 1.0 and end == 1.0):
-            fraction = (x - start) / (end - start)
-            point = None if p0 is None or p1 is None else p0[index] + fraction * (p1[index] - p0[index])
-            return r0[index] + fraction * (r1[index] - r0[index]), point
-    if last_positive is None:
-        raise ValueError("Cannot interpolate a zero-length branch.")
-    point = None if p1 is None else p1[last_positive]
-    return r1[last_positive], point
+    :func:`interpolate_branch` evaluates many sites on one branch, and none
+    of the five ``to_decimal`` conversions below depend on the site. Decoding
+    them once per branch rather than once per site is the reason this class
+    exists; ``at`` holds the per-site arithmetic that genuinely varies.
+    """
+
+    __slots__ = ("lengths", "r0", "r1", "p0", "p1", "total")
+
+    def __init__(self, branch) -> None:
+        self.lengths = np.asarray(branch.lengths.to_decimal(u.um), dtype=float)
+        self.r0 = np.asarray(branch.radii_proximal.to_decimal(u.um), dtype=float)
+        self.r1 = np.asarray(branch.radii_distal.to_decimal(u.um), dtype=float)
+        points_proximal = branch.points_proximal
+        points_distal = branch.points_distal
+        has_points = points_proximal is not None and points_distal is not None
+        self.p0 = np.asarray(points_proximal.to_decimal(u.um), dtype=float) if has_points else None
+        self.p1 = np.asarray(points_distal.to_decimal(u.um), dtype=float) if has_points else None
+        self.total = float(np.sum(self.lengths))
+        if self.total <= 0.0:
+            raise ValueError("Cannot interpolate a zero-length branch.")
+
+    def at(self, x: float) -> tuple[float, np.ndarray | None]:
+        """Return the radius, and the 3-D point when available, at site ``x``."""
+        lengths = self.lengths
+        r0, r1, p0, p1 = self.r0, self.r1, self.p0, self.p1
+        total = self.total
+
+        cursor = 0.0
+        last_positive = 0
+        for index, segment_length in enumerate(lengths.tolist()):
+            if segment_length <= 0.0:
+                if np.isclose(x, cursor / total):
+                    point = None if p0 is None or p1 is None else 0.5 * (p0[index] + p1[index])
+                    return 0.5 * (r0[index] + r1[index]), point
+                continue
+            start = cursor / total
+            cursor += segment_length
+            end = cursor / total
+            last_positive = index
+            if x < end or (x == 1.0 and end == 1.0):
+                fraction = (x - start) / (end - start)
+                point = None if p0 is None or p1 is None else p0[index] + fraction * (p1[index] - p0[index])
+                return r0[index] + fraction * (r1[index] - r0[index]), point
+        # ``total > 0`` was enforced in __init__, so at least one segment had a
+        # positive length and ``last_positive`` names a real segment here.
+        point = None if p1 is None else p1[last_positive]
+        return r1[last_positive], point

--- a/braincell/morph/_testing.py
+++ b/braincell/morph/_testing.py
@@ -1,0 +1,104 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared fixture builders for ``braincell.morph`` tests.
+
+The leading underscore in the filename keeps pytest from discovering this
+module as a test file. Helpers here are consumed by the co-located
+``*_test.py`` modules; nothing in this file is part of the public API.
+
+Each ``make_*`` branch builder returns the canonical single-segment branch
+of one type, with the dimensions the morph tests have always used. They
+exist because those five literals were spelled out 41 times across
+``morphology_test.py`` alone, which made the dimensions look meaningful
+when they are merely arbitrary — a test that genuinely depends on a
+specific radius should pass it explicitly.
+"""
+
+import brainunit as u
+
+from braincell.morph.branch import Branch
+from braincell.morph.morphology import Morphology
+
+__all__ = [
+    "make_apical",
+    "make_axon",
+    "make_basal",
+    "make_deep_chain_tree",
+    "make_dendrite",
+    "make_soma",
+]
+
+
+def make_soma(*, length: float = 20.0, radius: float = 10.0) -> Branch:
+    """A cylindrical soma branch of uniform radius."""
+    return Branch.from_lengths(lengths=[length] * u.um, radii=[radius, radius] * u.um, type="soma")
+
+
+def make_dendrite(*, length: float = 60.0, radii: tuple[float, float] = (2.0, 1.0)) -> Branch:
+    """A tapering branch of the untyped ``"dendrite"`` class."""
+    return Branch.from_lengths(lengths=[length] * u.um, radii=list(radii) * u.um, type="dendrite")
+
+
+def make_basal(*, length: float = 60.0, radii: tuple[float, float] = (2.0, 1.0)) -> Branch:
+    """A tapering ``"basal_dendrite"`` branch."""
+    return Branch.from_lengths(lengths=[length] * u.um, radii=list(radii) * u.um, type="basal_dendrite")
+
+
+def make_apical(*, length: float = 30.0, radii: tuple[float, float] = (1.0, 0.6)) -> Branch:
+    """A tapering ``"apical_dendrite"`` branch."""
+    return Branch.from_lengths(lengths=[length] * u.um, radii=list(radii) * u.um, type="apical_dendrite")
+
+
+def make_axon(*, length: float = 40.0, radii: tuple[float, float] = (0.8, 0.4)) -> Branch:
+    """A tapering ``"axon"`` branch."""
+    return Branch.from_lengths(lengths=[length] * u.um, radii=list(radii) * u.um, type="axon")
+
+
+def make_deep_chain_tree(n_branches: int = 1200) -> Morphology:
+    """An unbranched chain of ``n_branches`` branches hanging off a soma.
+
+    Reconstructions of long, thin neurites routinely produce chains far
+    deeper than CPython's default recursion limit, so this fixture exists
+    to pin the tree walks in :mod:`braincell.morph` and :mod:`braincell.vis`
+    as iterative. The default depth is comfortably past the ~400-branch
+    point where a recursive walk raises ``RecursionError``, while staying
+    small enough to build and lay out in well under a second.
+
+    Parameters
+    ----------
+    n_branches : int
+        Total branch count, soma included. Must be at least 1.
+
+    Returns
+    -------
+    Morphology
+        A chain ``soma -> seg_0 -> seg_1 -> ...``, every dendrite branch
+        carrying two 15 µm / 10 µm segments.
+    """
+    if n_branches < 1:
+        raise ValueError(f"n_branches must be >= 1, got {n_branches!r}.")
+    tree = Morphology.from_root(make_soma(), name="soma")
+    parent = "soma"
+    for index in range(n_branches - 1):
+        child = Branch.from_lengths(
+            lengths=[15.0, 10.0] * u.um,
+            radii=[2.0, 1.5, 1.0] * u.um,
+            type="apical_dendrite",
+        )
+        name = f"seg_{index}"
+        tree.attach(parent=parent, child_branch=child, child_name=name, parent_x=1.0)
+        parent = name
+    return tree

--- a/braincell/morph/branch.py
+++ b/braincell/morph/branch.py
@@ -33,6 +33,86 @@ _ALLOWED_BRANCH_TYPES = {
     "custom",
 }
 
+
+# --------------------------------------------------------------------------- #
+# Frustum geometry
+#
+# Every segment is a conical frustum of length ``L`` with end radii ``r0`` and
+# ``r1``. These three functions are the single definition of that geometry:
+# ``Branch`` applies them to one branch's segments and ``Morphology`` applies
+# them to the concatenated arrays of every branch. Keeping the formulas here
+# is what makes ``Morphology.total_area == sum(b.branch.area)`` a consequence
+# rather than a coincidence that two hand-written copies have to maintain.
+# --------------------------------------------------------------------------- #
+
+
+def frustum_areas_um2(lengths_um: np.ndarray, r0_um: np.ndarray, r1_um: np.ndarray) -> np.ndarray:
+    r"""Lateral surface area of each conical frustum, :math:`\pi (r_0 + r_1) \sqrt{L^2 + (r_1 - r_0)^2}`.
+
+    Parameters
+    ----------
+    lengths_um : numpy.ndarray
+        Segment lengths in micrometres.
+    r0_um : numpy.ndarray
+        Proximal radii in micrometres.
+    r1_um : numpy.ndarray
+        Distal radii in micrometres.
+
+    Returns
+    -------
+    numpy.ndarray
+        Lateral area of each segment, in square micrometres.
+
+    Notes
+    -----
+    A zero-length jump segment, which ``_canonicalize_segments`` inserts at a
+    radius discontinuity, still contributes the non-zero annular end-cap area
+    :math:`\pi (r_0 + r_1) |r_1 - r_0|`. That is geometrically correct but can
+    surprise when segment areas are inspected one at a time.
+    """
+    return np.pi * (r0_um + r1_um) * np.sqrt(lengths_um * lengths_um + (r1_um - r0_um) * (r1_um - r0_um))
+
+
+def frustum_volumes_um3(lengths_um: np.ndarray, r0_um: np.ndarray, r1_um: np.ndarray) -> np.ndarray:
+    r"""Volume of each conical frustum, :math:`\pi L (r_0^2 + r_0 r_1 + r_1^2) / 3`.
+
+    Parameters
+    ----------
+    lengths_um : numpy.ndarray
+        Segment lengths in micrometres.
+    r0_um : numpy.ndarray
+        Proximal radii in micrometres.
+    r1_um : numpy.ndarray
+        Distal radii in micrometres.
+
+    Returns
+    -------
+    numpy.ndarray
+        Volume of each segment, in cubic micrometres.
+    """
+    return np.pi * lengths_um * (r0_um * r0_um + r0_um * r1_um + r1_um * r1_um) / 3.0
+
+
+def length_weighted_mean_radius_um(lengths_um: np.ndarray, r0_um: np.ndarray, r1_um: np.ndarray) -> float:
+    """Length-weighted mean of the segment mid-radii.
+
+    Parameters
+    ----------
+    lengths_um : numpy.ndarray
+        Segment lengths in micrometres.
+    r0_um : numpy.ndarray
+        Proximal radii in micrometres.
+    r1_um : numpy.ndarray
+        Distal radii in micrometres.
+
+    Returns
+    -------
+    float
+        The mean radius in micrometres.
+    """
+    return float(np.sum(lengths_um * (0.5 * (r0_um + r1_um))) / np.sum(lengths_um))
+
+
 _UNSET = object()
 
 
@@ -49,7 +129,7 @@ class Branch:
     ``TypeError``; every value must carry explicit units.
 
     Branches are **frozen dataclasses**: once constructed their geometry
-    cannot be changed.  Use :class:`~braincell.morph.Morpho` to compose
+    cannot be changed.  Use :class:`~braincell.morph.Morphology` to compose
     branches into a mutable morphology tree.
 
     Parameters
@@ -89,7 +169,7 @@ class Branch:
     --------
     Branch.from_lengths : Preferred constructor from segment lengths.
     Branch.from_points : Preferred constructor from 3-D point sequences.
-    Morpho : Mutable morphology tree that owns branches.
+    Morphology : Mutable morphology tree that owns branches.
 
     Notes
     -----
@@ -223,7 +303,10 @@ class Branch:
         Returns
         -------
         Branch
-            New branch with no 3-D point geometry.
+            New branch with no 3-D point geometry.  A radius discontinuity
+            between consecutive segments is *not* an error: canonicalization
+            splices in a zero-length jump segment there, so the returned
+            branch can have more segments than ``len(lengths)``.
 
         Raises
         ------
@@ -232,7 +315,7 @@ class Branch:
             is provided, or if both are provided simultaneously.
             Also raised if *type* is passed to a typed subclass.
         ValueError
-            If array shapes are inconsistent or radius discontinuities exist.
+            If array shapes are inconsistent or a length is negative.
 
         See Also
         --------
@@ -253,14 +336,7 @@ class Branch:
             >>> b.n_segments
             2
         """
-        if cls._BRANCH_TYPE is not None:
-            if type is not _UNSET:
-                raise TypeError(
-                    f"{cls.__name__}.from_lengths() does not accept 'type'. The type is fixed to {cls._BRANCH_TYPE!r}."
-                )
-            type = cls._BRANCH_TYPE
-        elif type is _UNSET:
-            type = "custom"
+        type = cls._resolve_type("from_lengths", type)
         lengths = normalize_param(lengths, name="lengths", unit=u.um, shape=(None,), bounds={"ge": 0 * u.um})
         radii_proximal, radii_distal = cls._resolve_radius_inputs(
             "from_lengths",
@@ -360,14 +436,7 @@ class Branch:
             >>> b.points.shape
             (3, 3)
         """
-        if cls._BRANCH_TYPE is not None:
-            if type is not _UNSET:
-                raise TypeError(
-                    f"{cls.__name__}.from_points() does not accept 'type'. The type is fixed to {cls._BRANCH_TYPE!r}."
-                )
-            type = cls._BRANCH_TYPE
-        elif type is _UNSET:
-            type = "custom"
+        type = cls._resolve_type("from_points", type)
         points = normalize_param(points, name="points", unit=u.um, shape=(None, 3))
         if points.shape[0] < 2:
             raise ValueError("from_points() requires at least two points.")
@@ -410,6 +479,38 @@ class Branch:
             points_distal=points_distal,
             type=type,
         )
+
+    @classmethod
+    def _resolve_type(cls, factory_name: str, type: str) -> str:
+        """Resolve a factory's ``type`` argument against the subclass's fixed type.
+
+        Parameters
+        ----------
+        factory_name : str
+            Name of the calling factory, used in the error message.
+        type : str
+            The caller-supplied type, or the module ``_UNSET`` sentinel when
+            the caller omitted it.
+
+        Returns
+        -------
+        str
+            The branch type to store on the new instance.
+
+        Raises
+        ------
+        TypeError
+            If a typed subclass such as :class:`Soma` was given an explicit
+            ``type``, which it has no freedom to honour.
+        """
+        if cls._BRANCH_TYPE is not None:
+            if type is not _UNSET:
+                raise TypeError(
+                    f"{cls.__name__}.{factory_name}() does not accept 'type'. "
+                    f"The type is fixed to {cls._BRANCH_TYPE!r}."
+                )
+            return cls._BRANCH_TYPE
+        return "custom" if type is _UNSET else type
 
     @staticmethod
     def _resolve_radius_inputs(
@@ -554,11 +655,16 @@ class Branch:
         """
         if self.points_proximal is None or self.points_distal is None:
             return None
-        if not u.math.allclose(self.points_distal[:-1], self.points_proximal[1:]):
+        # Decoded to plain arrays first: the equivalent ``u.math.allclose`` /
+        # ``u.math.concatenate`` pair re-derives dimensions and tree-maps per
+        # call, which dominated whole-morphology point access.
+        proximal_um = np.asarray(self.points_proximal.to_decimal(u.um), dtype=float)
+        distal_um = np.asarray(self.points_distal.to_decimal(u.um), dtype=float)
+        if not np.allclose(distal_um[:-1], proximal_um[1:]):
             raise ValueError(
                 "Branch points are discontinuous across segment boundaries; use points_proximal and points_distal."
             )
-        return u.math.concatenate((self.points_proximal[:1], self.points_distal), axis=0)
+        return u.Quantity(np.concatenate((proximal_um[:1], distal_um), axis=0), u.um)
 
     @property
     def n_segments(self) -> int:
@@ -611,8 +717,9 @@ class Branch:
         Quantity[u.um]
             Sum of all segment lengths.
         """
-        lengths_um, _, _ = self._segment_arrays_um()
-        return u.Quantity(np.sum(lengths_um), u.um)
+        # Deliberately not ``_segment_arrays_um()``: that also decodes both
+        # radii arrays, which this property discards.
+        return u.Quantity(np.sum(np.asarray(self.lengths.to_decimal(u.um), dtype=float)), u.um)
 
     @property
     def mean_radius(self) -> u.Quantity[u.um]:
@@ -626,10 +733,7 @@ class Branch:
         Quantity[u.um]
             Length-weighted average radius.
         """
-        lengths_um, r0_um, r1_um = self._segment_arrays_um()
-        total_length_um = float(np.sum(lengths_um))
-        values_um = 0.5 * (r0_um + r1_um)
-        return u.Quantity(np.sum(lengths_um * values_um) / total_length_um, u.um)
+        return u.Quantity(length_weighted_mean_radius_um(*self._segment_arrays_um()), u.um)
 
     @property
     def diam_arc_mean(self) -> u.Quantity[u.um]:
@@ -662,9 +766,7 @@ class Branch:
         :math:`\\pi (r_0 + r_1) |r_1 - r_0|`.  This is geometrically correct
         but may be unexpected when iterating segment areas individually.
         """
-        lengths_um, r0_um, r1_um = self._segment_arrays_um()
-        values = np.pi * (r0_um + r1_um) * np.sqrt(lengths_um * lengths_um + (r1_um - r0_um) * (r1_um - r0_um))
-        return u.Quantity(values, u.um**2)
+        return u.Quantity(frustum_areas_um2(*self._segment_arrays_um()), u.um**2)
 
     @property
     def area(self) -> u.Quantity[u.um**2]:
@@ -686,9 +788,7 @@ class Branch:
         Quantity[u.um ** 3]
             Volume array, shape ``(n_segments,)``.
         """
-        lengths_um, r0_um, r1_um = self._segment_arrays_um()
-        values = np.pi * lengths_um * (r0_um * r0_um + r0_um * r1_um + r1_um * r1_um) / 3.0
-        return u.Quantity(values, u.um**3)
+        return u.Quantity(frustum_volumes_um3(*self._segment_arrays_um()), u.um**3)
 
     @property
     def volume(self) -> u.Quantity[u.um**3]:
@@ -723,10 +823,10 @@ class Branch:
         Parameters
         ----------
         layout : str or None
-            2-D layout choice: ``"projected"``, ``"stem"``,
+            2-D layout choice: ``"fan"``, ``"projected"``, ``"stem"``,
             ``"balloon"``, or ``"radial_360"``. When omitted, uses the
             global 2-D default configured via
-            ``braincell.morph.vis.configure(...)``.
+            :func:`braincell.vis.configure_defaults`.
         shape : str or None
             2-D drawing shape: ``"line"`` or ``"frustum"``.
         branch_type_colors : mapping or None
@@ -781,11 +881,8 @@ class Branch:
             >>> branch.vis2d()  # doctest: +SKIP
         """
         from braincell import Morphology
-        from braincell.vis import plot2d
 
-        morpho = Morphology.from_root(self, name="soma")
-        result = plot2d(
-            morpho,
+        return Morphology.from_root(self, name="soma").vis2d(
             layout=layout,
             shape=shape,
             branch_type_colors=branch_type_colors,
@@ -795,12 +892,8 @@ class Branch:
             chooser=chooser,
             projection_plane=projection_plane,
             return_plotter=return_plotter,
+            show=show,
         )
-        if show:
-            import matplotlib.pyplot as plt
-
-            plt.show()
-        return result
 
     def vis3d(
         self,
@@ -822,7 +915,7 @@ class Branch:
         ----------
         mode : str or None
             Visualization mode. When omitted, uses the global 3-D default
-            configured via ``braincell.morph.vis.configure(...)``. The
+            configured via :func:`braincell.vis.configure_defaults`. The
             initial default is ``"geometry"``.
         backend : str or None
             Rendering backend name (e.g., ``"pyvista"``).
@@ -858,23 +951,16 @@ class Branch:
             If the branch lacks complete 3-D point geometry.
         """
         from braincell import Morphology
-        from braincell.vis import plot3d
 
-        morpho = Morphology.from_root(self, name="soma")
-        result = plot3d(
-            morpho,
+        return Morphology.from_root(self, name="soma").vis3d(
             mode=mode,
             backend=backend,
             chooser=chooser,
             notebook=notebook,
             jupyter_backend=jupyter_backend,
             return_plotter=return_plotter,
+            show=show,
         )
-        if show:
-            import matplotlib.pyplot as plt
-
-            plt.show()
-        return result
 
     def __repr__(self) -> str:
         return (
@@ -912,7 +998,7 @@ class Branch:
         See Also
         --------
         Branch.load_checkpoint : Inverse operation.
-        Morpho.save_checkpoint : Persist a whole morphology tree.
+        Morphology.save_checkpoint : Persist a whole morphology tree.
 
         Examples
         --------
@@ -959,7 +1045,7 @@ class Branch:
         See Also
         --------
         Branch.save_checkpoint : Inverse operation.
-        Morpho.load_checkpoint : Load a whole morphology tree.
+        Morphology.load_checkpoint : Load a whole morphology tree.
 
         Examples
         --------

--- a/braincell/morph/branch_test.py
+++ b/braincell/morph/branch_test.py
@@ -401,9 +401,6 @@ class BranchTest(unittest.TestCase):
             _ = discontinuous_points.points
 
     def test_branch_accepts_jax_quantity_inputs(self) -> None:
-        if jnp is None:
-            self.skipTest("jax is not installed")
-
         branch = Branch.from_lengths(
             lengths=jnp.array([40.0]) * u.um,
             radii=jnp.array([0.8, 0.4]) * u.um,

--- a/braincell/morph/morphology.py
+++ b/braincell/morph/morphology.py
@@ -16,11 +16,11 @@
 """Editable morphology model.
 
 User-facing entry points:
-- `Morpho`: the whole mutable tree
+- `Morphology`: the whole mutable tree
 - `MorphoBranch`: a tree-local branch node view
 - `MorphoEdge`: read-only branch-to-branch topology edges
 
-In normal use, users only need `Morpho` and `MorphoBranch`.
+In normal use, users only need `Morphology` and `MorphoBranch`.
 """
 
 from collections.abc import Mapping
@@ -31,63 +31,13 @@ import brainunit as u
 import numpy as np
 from brainunit import Quantity
 
-from .branch import Branch
+from .branch import (
+    Branch,
+    frustum_areas_um2,
+    frustum_volumes_um3,
+    length_weighted_mean_radius_um,
+)
 
-_MORPHO_METRIC_PROPERTY_NAMES = {
-    "max_euclidean_distance",
-    "max_euclidean_distance_excluding_soma",
-    "max_branch_order",
-    "max_path_distance",
-    "max_path_distance_excluding_soma",
-    "mean_radius",
-    "n_bifurcations",
-    "n_branches",
-    "n_stems",
-    "total_area",
-    "total_length",
-    "total_volume",
-    "x_range",
-    "y_range",
-    "z_range",
-}
-
-_MORPHO_RESERVED_NAMES = {
-    "attach",
-    "branch",
-    "branches",
-    "branch_by_order",
-    "edges",
-    "from_asc",
-    "from_root",
-    "from_swc",
-    "has_full_point_geometry",
-    "metric",
-    "naming_state",
-    "path_to_root",
-    "path_length_to_root",
-    "restore_naming_state",
-    "root",
-    "select",
-    "shortest_path_length",
-    "vis2d",
-    "vis3d",
-} | _MORPHO_METRIC_PROPERTY_NAMES
-_MORPHO_BRANCH_RESERVED_NAMES = {
-    "attach",
-    "branch",
-    "branch_id",
-    "branch_order",
-    "child_x",
-    "children",
-    "index",
-    "index_by",
-    "name",
-    "n_children",
-    "n_tapers",
-    "parent",
-    "parent_id",
-    "parent_x",
-}
 _BRANCH_RESERVED_NAMES = set(Branch.__dataclass_fields__) | {name for name in dir(Branch) if not name.startswith("_")}
 
 ParentRef = Union[str, "MorphoBranch"]
@@ -98,10 +48,10 @@ class MorphoEdge:
     """A directed edge between two morphology branches.
 
     ``MorphoEdge`` is a frozen dataclass representing a parent-child
-    connection in a :class:`Morpho` tree.  It records which branches are
+    connection in a :class:`Morphology` tree.  It records which branches are
     connected and where on each branch the attachment occurs.
 
-    Edges are typically obtained via :attr:`Morpho.edges` rather than
+    Edges are typically obtained via :attr:`Morphology.edges` rather than
     constructed directly.
 
     Parameters
@@ -119,8 +69,8 @@ class MorphoEdge:
 
     See Also
     --------
-    Morpho.edges : Retrieve all edges in a morphology.
-    Morpho.attach : Attach a child branch to a parent.
+    Morphology.edges : Retrieve all edges in a morphology.
+    Morphology.attach : Attach a child branch to a parent.
 
     Examples
     --------
@@ -231,7 +181,7 @@ class MorphoMetric:
 class Morphology:
     """Mutable morphology tree for authoring, querying, and visualization.
 
-    ``Morpho`` is the central entry point for building neuron morphologies.
+    ``Morphology`` is the central entry point for building neuron morphologies.
     It owns a tree of :class:`MorphoBranch` nodes, each wrapping an
     immutable :class:`Branch` geometry.  Children are attached via
     :meth:`attach`, attribute assignment on a :class:`MorphoBranch`, or
@@ -266,7 +216,7 @@ class Morphology:
     follows the pattern ``"{type}_{n}"`` (e.g., ``"dend_0"``, ``"axon_1"``).
 
     Whole-morphology metrics (``total_length``, ``n_branches``, etc.)
-    are exposed directly on the ``Morpho`` instance.
+    are exposed directly on the ``Morphology`` instance.
 
     Examples
     --------
@@ -314,6 +264,8 @@ class Morphology:
         self._branch_index_cache: dict[str, dict[int, int]] = {}
         self._branch_tuple_cache: dict[str, tuple["MorphoBranch", ...]] = {}
         self._full_point_geometry: bool | None = None
+        self._all_segment_arrays_cache: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None
+        self._all_points_cache: np.ndarray | None = None
         # Bumped on every structural change so consumers holding derived
         # results (e.g. braincell.filter.SelectionCache) can detect staleness.
         self._revision = 0
@@ -390,7 +342,7 @@ class Morphology:
             provided together with *options*, it must match
             ``options.mode``.
         return_report : bool
-            If ``True``, return a ``(Morpho, SwcReport)`` tuple instead
+            If ``True``, return a ``(Morphology, SwcReport)`` tuple instead
             of just the morphology.
 
         Returns
@@ -440,7 +392,7 @@ class Morphology:
         path : str or Path
             Path to the ASC file.
         return_report : bool
-            If ``True``, return a ``(Morpho, AscReport)`` tuple instead
+            If ``True``, return a ``(Morphology, AscReport)`` tuple instead
             of just the morphology.
 
         Returns
@@ -560,9 +512,9 @@ class Morphology:
 
         See Also
         --------
-        Morpho.load_checkpoint : Inverse operation.
-        Morpho.from_swc : Load a morphology from an SWC interchange file.
-        Morpho.from_asc : Load a morphology from a Neurolucida ASC file.
+        Morphology.load_checkpoint : Inverse operation.
+        Morphology.from_swc : Load a morphology from an SWC interchange file.
+        Morphology.from_asc : Load a morphology from a Neurolucida ASC file.
 
         Examples
         --------
@@ -600,7 +552,7 @@ class Morphology:
 
         See Also
         --------
-        Morpho.save_checkpoint : Inverse operation.
+        Morphology.save_checkpoint : Inverse operation.
 
         Examples
         --------
@@ -656,8 +608,7 @@ class Morphology:
                 parent_x=node.parent_x,
                 child_x=node.child_x,
             )
-            for node_id in self._ordered_node_ids()
-            for node in (self._get_node(node_id),)
+            for node in self.branches
             if node.parent_id is not None
         )
 
@@ -780,26 +731,44 @@ class Morphology:
             raise ValueError(f"{feature} require full point geometry on every branch.")
 
     def _all_segment_arrays_um(self) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        lengths = []
-        radii_proximal = []
-        radii_distal = []
-        for branch in self.branches:
-            lengths_um, r0_um, r1_um = branch.branch._segment_arrays_um()
-            lengths.append(lengths_um)
-            radii_proximal.append(r0_um)
-            radii_distal.append(r1_um)
-        return (
-            np.concatenate(lengths),
-            np.concatenate(radii_proximal),
-            np.concatenate(radii_distal),
-        )
+        # Memoised: ``total_length``, ``mean_radius``, ``total_area`` and
+        # ``total_volume`` each want the same concatenation, so ``.metric``
+        # rebuilt it four times.
+        cached = self._all_segment_arrays_cache
+        if cached is None:
+            lengths = []
+            radii_proximal = []
+            radii_distal = []
+            for branch in self.branches:
+                lengths_um, r0_um, r1_um = branch.branch._segment_arrays_um()
+                lengths.append(lengths_um)
+                radii_proximal.append(r0_um)
+                radii_distal.append(r1_um)
+            cached = (
+                np.concatenate(lengths),
+                np.concatenate(radii_proximal),
+                np.concatenate(radii_distal),
+            )
+            self._all_segment_arrays_cache = cached
+        return cached
+
+    def _all_points_um(self) -> np.ndarray:
+        """Every branch's shared points as one ``(n_points, 3)`` array.
+
+        Memoised because ``x_range`` / ``y_range`` / ``z_range`` each need the
+        whole cloud, so building it per axis walked every branch three times.
+        """
+        cached = self._all_points_cache
+        if cached is None:
+            cached = np.concatenate(
+                [np.asarray(branch.branch.points.to_decimal(u.um), dtype=float) for branch in self.branches]
+            )
+            self._all_points_cache = cached
+        return cached
 
     def _branch_length_um(self, branch_index: int) -> float:
         branch = self.branch(index=branch_index).branch
         return float(np.sum(np.asarray(branch.lengths.to_decimal(u.um), dtype=float)))
-
-    def _root_branch_attach_x(self) -> float:
-        return 0.0
 
     def _root_point_um(self) -> np.ndarray:
         self._require_full_point_geometry(feature="Euclidean distance metrics")
@@ -811,11 +780,7 @@ class Morphology:
 
     def _point_on_branch_at_x_um(self, branch: Branch, x: float) -> np.ndarray:
         self._require_full_point_geometry(feature="Euclidean distance metrics")
-        points = branch.points
-        if points is None:
-            raise ValueError("Euclidean distance metrics require full point geometry on every branch.")
-
-        points_um = np.asarray(points.to_decimal(u.um), dtype=float)
+        points_um = np.asarray(branch.points.to_decimal(u.um), dtype=float)
         if np.isclose(float(x), 0.0):
             return points_um[0]
         if np.isclose(float(x), 1.0):
@@ -836,23 +801,22 @@ class Morphology:
                 fraction = (target_length_um - prefix_length_um) / segment_length_um
                 return points_um[index] + fraction * (points_um[index + 1] - points_um[index])
             prefix_length_um = next_prefix_length_um
-
-        return points_um[-1]
+        # No trailing return: the loop condition includes
+        # ``index == len(lengths_um) - 1``, so the last iteration always returns.
 
     def _root_attach_distances_um(self, *, exclude_root_soma: bool = False) -> dict[int, float]:
         ordered_ids = self._ordered_node_ids_by("depth")
         distances_um: dict[int, float] = {self.root._node_id: 0.0}
-        attach_x: dict[int, float] = {self.root._node_id: self._root_branch_attach_x()}
+        # The root branch always attaches at its own proximal end.
+        attach_x: dict[int, float] = {self.root._node_id: 0.0}
 
         for node_id in ordered_ids:
             if node_id == self.root._node_id:
                 continue
 
             node = self._get_node(node_id)
+            # Only the root has a null parent, and it was skipped above.
             parent_id = node.parent_id
-            if parent_id is None:
-                continue
-
             parent_attach_x = attach_x[parent_id]
             parent_distance_um = distances_um[parent_id]
             parent_length_um = self._branch_length_um(self._branch_index(parent_id))
@@ -880,17 +844,30 @@ class Morphology:
             node_id = self._node_id_from_index(branch_index)
             branch = self.branch(index=branch_index)
             branch_length_um = self._branch_length_um(branch_index)
-            attach_x = self._root_branch_attach_x() if branch.parent_id is None else float(branch.child_x)
+            attach_x = 0.0 if branch.parent_id is None else float(branch.child_x)
             distance_um = attach_distances_um[node_id] + abs(1.0 - attach_x) * branch_length_um
             max_distance_um = max(max_distance_um, distance_um)
         return max_distance_um
 
-    def _root_subtree_reference_point_um(self, terminal_node_id: int) -> np.ndarray:
+    def _root_subtree_reference_point_um(
+        self,
+        terminal_node_id: int,
+        *,
+        _memo: dict[float, np.ndarray] | None = None,
+    ) -> np.ndarray:
         path_node_ids = self._path_node_ids(terminal_node_id)
         if len(path_node_ids) <= 1:
             return self._root_point_um()
         first_child = self._get_node(path_node_ids[1])
-        return self._point_on_branch_at_x_um(self.root.branch, float(first_child.parent_x))
+        parent_x = float(first_child.parent_x)
+        # ``parent_x`` can only be 0.0, 0.5 or 1.0, so a whole morphology has at
+        # most three distinct answers; the caller passes a dict to share them
+        # across its terminals instead of re-walking the root branch each time.
+        if _memo is None:
+            return self._point_on_branch_at_x_um(self.root.branch, parent_x)
+        if parent_x not in _memo:
+            _memo[parent_x] = self._point_on_branch_at_x_um(self.root.branch, parent_x)
+        return _memo[parent_x]
 
     def _max_euclidean_distance_um(self, *, exclude_root_soma: bool) -> float:
         self._require_full_point_geometry(feature="Euclidean distance metrics")
@@ -903,12 +880,13 @@ class Morphology:
         tip_points = []
         start_points = []
         root_point_um = self._root_point_um()
+        reference_memo: dict[float, np.ndarray] = {}
         for branch_index in terminal_branch_indices:
             node_id = self._node_id_from_index(branch_index)
             branch = self.branch(index=branch_index).branch
             tip_points.append(np.asarray(branch.points_distal.to_decimal(u.um), dtype=float)[-1])
             if exclude_root_soma and self.root.type == "soma":
-                start_points.append(self._root_subtree_reference_point_um(node_id))
+                start_points.append(self._root_subtree_reference_point_um(node_id, _memo=reference_memo))
             else:
                 start_points.append(root_point_um)
 
@@ -924,29 +902,15 @@ class Morphology:
 
     @property
     def mean_radius(self) -> Quantity:
-        lengths_um, r0_um, r1_um = self._all_segment_arrays_um()
-        total_length_um = float(np.sum(lengths_um))
-        if total_length_um <= 0.0:
-            raise ValueError("Morphology total length must be > 0.")
-        values_um = 0.5 * (r0_um + r1_um)
-        return u.Quantity(np.sum(lengths_um * values_um) / total_length_um, u.um)
-
-    @property
-    def diam_arc_mean(self) -> Quantity:
-        """Return the morphology-wide arc-length-weighted mean diameter."""
-        return 2.0 * self.mean_radius
+        return u.Quantity(length_weighted_mean_radius_um(*self._all_segment_arrays_um()), u.um)
 
     @property
     def total_area(self) -> Quantity:
-        lengths_um, r0_um, r1_um = self._all_segment_arrays_um()
-        value = np.sum(np.pi * (r0_um + r1_um) * np.sqrt(lengths_um * lengths_um + (r1_um - r0_um) * (r1_um - r0_um)))
-        return u.Quantity(value, u.um**2)
+        return u.Quantity(np.sum(frustum_areas_um2(*self._all_segment_arrays_um())), u.um**2)
 
     @property
     def total_volume(self) -> Quantity:
-        lengths_um, r0_um, r1_um = self._all_segment_arrays_um()
-        value = np.sum(np.pi * lengths_um * (r0_um * r0_um + r0_um * r1_um + r1_um * r1_um) / 3.0)
-        return u.Quantity(value, u.um**3)
+        return u.Quantity(np.sum(frustum_volumes_um3(*self._all_segment_arrays_um())), u.um**3)
 
     @property
     def n_branches(self) -> int:
@@ -962,8 +926,7 @@ class Morphology:
 
     def _axis_range(self, *, axis: int) -> Quantity:
         self._require_full_point_geometry(feature="Coordinate range metrics")
-        point_sets = [branch.branch.points for branch in self.branches]
-        coords = np.concatenate([np.asarray(points.to_decimal(u.um), dtype=float)[:, axis] for points in point_sets])
+        coords = self._all_points_um()[:, axis]
         return u.Quantity(coords.max() - coords.min(), u.um)
 
     @property
@@ -980,7 +943,7 @@ class Morphology:
 
     @property
     def max_branch_order(self) -> int:
-        return max(len(self._path_node_ids(branch._node_id)) - 1 for branch in self.branches)
+        return max(branch.branch_order for branch in self.branches)
 
     @property
     def max_euclidean_distance(self) -> Quantity:
@@ -1046,11 +1009,9 @@ class Morphology:
                 raise KeyError(name)
             return self._get_node(self._name_to_id[name])
 
-        ordered_ids = self._ordered_node_ids_by("default" if order is None else order)
-        try:
-            return self._get_node(ordered_ids[index])  # type: ignore[index]
-        except IndexError as exc:
-            raise IndexError(f"Branch index {index!r} is out of range.") from exc
+        return self._get_node(
+            self._node_id_from_index(index, order="default" if order is None else order)  # type: ignore[arg-type]
+        )
 
     def path_to_root(self, branch_index: int) -> tuple[int, ...]:
         """Return the ordered path of branch indices from root to a given branch.
@@ -1068,59 +1029,6 @@ class Morphology:
         """
         node_id = self._node_id_from_index(branch_index)
         return tuple(self._branch_index(path_node_id) for path_node_id in self._path_node_ids(node_id))
-
-    def path_length_to_root(self, branch_index: int) -> Quantity:
-        """Return the path length from a branch to the root.
-
-        .. note:: Not yet implemented.
-
-        Parameters
-        ----------
-        branch_index : int
-            Index of the target branch in default ordering.
-
-        Returns
-        -------
-        Quantity[u.um]
-            Cumulative segment length along the path to root.
-
-        Raises
-        ------
-        NotImplementedError
-            Always, until implemented.
-        """
-        raise NotImplementedError
-
-    def shortest_path_length(
-        self,
-        from_site: tuple[int, float],
-        to_site: tuple[int, float],
-    ) -> Quantity:
-        """Return the shortest path length between two sites on the tree.
-
-        A site is a ``(branch_index, position)`` pair where *position*
-        is a fractional location along the branch (0 = proximal, 1 = distal).
-
-        .. note:: Not yet implemented.
-
-        Parameters
-        ----------
-        from_site : tuple of (int, float)
-            Start site as ``(branch_index, position)``.
-        to_site : tuple of (int, float)
-            End site as ``(branch_index, position)``.
-
-        Returns
-        -------
-        Quantity[u.um]
-            Shortest path length through the tree between the two sites.
-
-        Raises
-        ------
-        NotImplementedError
-            Always, until implemented.
-        """
-        raise NotImplementedError
 
     def topo(self) -> str:
         """Return a line-oriented text view of the branch topology.
@@ -1173,7 +1081,7 @@ class Morphology:
         ----------
         mode : str or None
             Visualization mode. When omitted, uses the global 3-D
-            default configured via ``braincell.morph.vis.configure(...)``.
+            default configured via :func:`braincell.vis.configure_defaults`.
             The initial default is ``"geometry"``.
         backend : str or None
             Rendering backend name (e.g., ``"pyvista"``).
@@ -1337,7 +1245,8 @@ class Morphology:
         visualization is controlled by:
 
         * ``layout`` — how 2-D coordinates are obtained:
-          ``"projected"``, ``"stem"``, ``"balloon"``, or ``"radial_360"``.
+          ``"fan"``, ``"projected"``, ``"stem"``, ``"balloon"``, or
+          ``"radial_360"``.
         * ``shape`` — how those 2-D coordinates are drawn:
           ``"line"`` or ``"frustum"``.
 
@@ -1345,15 +1254,15 @@ class Morphology:
         ----------
         layout : str or None
             2-D layout choice. ``"projected"`` uses projected 3-D point
-            geometry. ``"stem"``, ``"balloon"``, and ``"radial_360"``
-            use the schematic branch layout pipeline. When omitted, uses
-            the global 2-D default configured via
-            ``braincell.morph.vis.configure(...)``. The initial default
+            geometry. ``"fan"``, ``"stem"``, ``"balloon"``, and
+            ``"radial_360"`` use the schematic branch layout pipeline.
+            When omitted, uses the global 2-D default configured via
+            :func:`braincell.vis.configure_defaults`. The initial default
             is ``"fan"``.
         shape : str or None
             2-D drawing shape: ``"line"`` or ``"frustum"``. When omitted,
             uses the global 2-D default configured via
-            ``braincell.morph.vis.configure(...)``. The initial default
+            :func:`braincell.vis.configure_defaults`. The initial default
             is ``"frustum"``.
         branch_type_colors : mapping or None
             Per-branch-type colour overrides for this call only. These
@@ -1502,7 +1411,7 @@ class Morphology:
         from braincell.filter import LocsetExpr, RegionExpr
 
         if not isinstance(expr, (RegionExpr, LocsetExpr)):
-            raise TypeError(f"Morpho.select(...) expects RegionExpr or LocsetExpr. Got {type(expr).__name__!s}.")
+            raise TypeError(f"Morphology.select(...) expects RegionExpr or LocsetExpr. Got {type(expr).__name__!s}.")
         return expr.evaluate(self, cache=cache)
 
     def attach(
@@ -1614,7 +1523,7 @@ class Morphology:
 
     def __repr__(self) -> str:
         geo_status = "complete 3d points" if self.has_full_point_geometry else "incomplete 3d points"
-        return f"Morpho(root={self.root.name!r}, n_branches={self.n_branches}, geometry = {geo_status})"
+        return f"Morphology(root={self.root.name!r}, n_branches={self.n_branches}, geometry = {geo_status})"
 
     def __str__(self) -> str:
         """Return a formatted summary with key metrics."""
@@ -1642,10 +1551,9 @@ class Morphology:
         self._branch_index_cache.clear()
         self._branch_tuple_cache.clear()
         self._full_point_geometry = None
+        self._all_segment_arrays_cache = None
+        self._all_points_cache = None
         self._revision += 1
-
-    def _ordered_node_ids(self) -> tuple[int, ...]:
-        return self._ordered_node_ids_by("default")
 
     def _ordered_node_ids_by(self, order: str) -> tuple[int, ...]:
         cached = self._ordered_id_cache.get(order)
@@ -1732,13 +1640,10 @@ class Morphology:
     def _get_node(self, node_id: int) -> "MorphoBranch":
         return self._nodes[node_id]
 
-    def _get_branch(self, node_id: int) -> Branch:
-        return self._get_node(node_id).branch
-
     def _resolve_parent(self, parent: ParentRef) -> int:
         if isinstance(parent, MorphoBranch):
             if parent._owner is not self:
-                raise ValueError("Parent MorphoBranch belongs to a different Morpho.")
+                raise ValueError("Parent MorphoBranch belongs to a different Morphology.")
             return parent._node_id
         if isinstance(parent, str):
             if parent not in self._name_to_id:
@@ -1747,31 +1652,25 @@ class Morphology:
         raise TypeError("parent must be a branch name or MorphoBranch.")
 
     def _validate_parent_x(self, parent: "MorphoBranch", parent_x: float) -> None:
-        if isinstance(parent_x, bool):
-            raise TypeError(f"parent_x must be 0, 0.5, or 1, got {parent_x!r}.")
-        if parent_x not in (0, 0.0, 0.5, 1, 1.0):
-            raise ValueError(f"parent_x must be 0, 0.5, or 1, got {parent_x!r}.")
+        _check_parent_x_value(parent_x)
         if float(parent_x) == 0.5 and parent.type != "soma":
             raise ValueError("parent_x=0.5 is only allowed when the parent branch type is 'soma'.")
 
     def _validate_child_x(self, child_x: float) -> None:
-        if isinstance(child_x, bool):
-            raise TypeError(f"child_x must be 0 or 1, got {child_x!r}.")
-        if child_x not in (0, 0.0, 1, 1.0):
-            raise ValueError(f"child_x must be 0 or 1, got {child_x!r}.")
+        _check_child_x_value(child_x)
 
     def _validate_public_name(self, name: str) -> None:
         if not name.isidentifier():
             raise ValueError(f"Branch name {name!r} must be a valid Python identifier.")
         if name.startswith("_"):
             raise ValueError("Branch names starting with '_' are reserved.")
-        if name in (_MORPHO_RESERVED_NAMES | _MORPHO_BRANCH_RESERVED_NAMES | _BRANCH_RESERVED_NAMES):
-            raise ValueError(f"Branch name {name!r} is reserved by the Morpho API.")
+        if name in _ALL_RESERVED_NAMES:
+            raise ValueError(f"Branch name {name!r} is reserved by the Morphology API.")
 
     def _normalize_child_branch(self, value: object) -> Branch:
         if isinstance(value, MorphoBranch):
             raise ValueError(
-                "Cannot reattach a MorphoBranch into a Morpho. Reuse the underlying "
+                "Cannot reattach a MorphoBranch into a Morphology. Reuse the underlying "
                 "Branch geometry or create a new Branch instead."
             )
         if not isinstance(value, Branch):
@@ -1782,7 +1681,7 @@ class Morphology:
         node_name = explicit_name if explicit_name is not None else self._allocate_name_for_type(branch.type)
         self._validate_public_name(node_name)
         if node_name in self._name_to_id:
-            raise ValueError(f"Branch name {node_name!r} already exists in this Morpho.")
+            raise ValueError(f"Branch name {node_name!r} already exists in this Morphology.")
         return node_name
 
     def _allocate_name_for_type(self, branch_type: str) -> str:
@@ -1803,7 +1702,7 @@ class Morphology:
     ) -> int:
         self._validate_public_name(name)
         if name in self._name_to_id:
-            raise ValueError(f"Branch name {name!r} already exists in this Morpho.")
+            raise ValueError(f"Branch name {name!r} already exists in this Morphology.")
         node_id = self._next_id
         self._next_id += 1
         node = MorphoBranch(
@@ -1869,19 +1768,26 @@ class Morphology:
         return self._get_node(parent._children[child_name])
 
     def _format_topology(self, node_id: int, *, prefix: str, is_last: bool) -> list[str]:
-        node = self._get_node(node_id)
-        branch_prefix = "└── " if is_last else "├── "
-        lines = [f"{prefix}{branch_prefix}{node.name}"]
-        child_prefix = f"{prefix}{'    ' if is_last else '│   '}"
-        child_ids = tuple(node._children.values())
-        for index, child_id in enumerate(child_ids):
-            lines.extend(
-                self._format_topology(
-                    child_id,
-                    prefix=child_prefix,
-                    is_last=index == len(child_ids) - 1,
-                )
-            )
+        """Render a subtree as ``tree(1)``-style lines, iteratively.
+
+        Deliberately not recursive: one Python frame per branch overflowed the
+        default recursion limit on morphologies deeper than a few hundred
+        branches, which is well within the range of real reconstructions.
+        The explicit stack carries the per-node prefix bookkeeping that a
+        generic depth-first walk cannot supply.
+        """
+        lines: list[str] = []
+        stack = [(node_id, prefix, is_last)]
+        while stack:
+            current_id, current_prefix, current_is_last = stack.pop()
+            node = self._get_node(current_id)
+            branch_prefix = "└── " if current_is_last else "├── "
+            lines.append(f"{current_prefix}{branch_prefix}{node.name}")
+            child_prefix = f"{current_prefix}{'    ' if current_is_last else '│   '}"
+            child_ids = tuple(node._children.values())
+            # Pushed in reverse so the stack pops children back in order.
+            for index in range(len(child_ids) - 1, -1, -1):
+                stack.append((child_ids[index], child_prefix, index == len(child_ids) - 1))
         return lines
 
 
@@ -1896,7 +1802,7 @@ _MORPHO_BRANCH_PUBLIC_ATTRS: dict[str, _MorphoBranchAttrGetter] = {
 
 
 class MorphoBranch:
-    """A tree-local branch node bound to exactly one :class:`Morpho` owner.
+    """A tree-local branch node bound to exactly one :class:`Morphology` owner.
 
     ``MorphoBranch`` provides transparent access to branch geometry
     (via delegation to :class:`Branch`) and tree navigation (parent,
@@ -1905,7 +1811,7 @@ class MorphoBranch:
     * **Attribute assignment**: ``parent.dend = Branch(...)``
     * **Subscript syntax**: ``parent[0.5].dend = Branch(...)``
 
-    ``MorphoBranch`` instances are created internally by :class:`Morpho`
+    ``MorphoBranch`` instances are created internally by :class:`Morphology`
     and should not be constructed directly.
 
     Parameters
@@ -1927,7 +1833,7 @@ class MorphoBranch:
 
     See Also
     --------
-    Morpho : The tree container that owns ``MorphoBranch`` nodes.
+    Morphology : The tree container that owns ``MorphoBranch`` nodes.
     Branch : The immutable geometry wrapped by this node.
 
     Notes
@@ -2011,7 +1917,7 @@ class MorphoBranch:
         --------
         index : The canonical spelling of the same value.
         """
-        return self._owner._branch_index(self._node_id)
+        return self.index
 
     @property
     def branch_order(self) -> int:
@@ -2024,7 +1930,7 @@ class MorphoBranch:
 
         See Also
         --------
-        Morpho.path_to_root : Full root-to-branch index path.
+        Morphology.path_to_root : Full root-to-branch index path.
         """
         return len(self._owner._path_node_ids(self._node_id)) - 1
 
@@ -2214,6 +2120,27 @@ class _MorphAttachPoint:
         )
 
 
+def _check_parent_x_value(parent_x: object) -> None:
+    """Reject a ``parent_x`` outside the three attachment points.
+
+    The soma-only rule for ``0.5`` needs the parent branch and so stays on
+    :meth:`Morphology._validate_parent_x`; this is the part that
+    ``morph.soma[x]`` and ``attach(parent_x=x)`` must agree on.
+    """
+    if isinstance(parent_x, bool):
+        raise TypeError(f"parent_x must be 0, 0.5, or 1, got {parent_x!r}.")
+    if parent_x not in (0, 0.0, 0.5, 1, 1.0):
+        raise ValueError(f"parent_x must be 0, 0.5, or 1, got {parent_x!r}.")
+
+
+def _check_child_x_value(child_x: object) -> None:
+    """Reject a ``child_x`` that is neither end of the child branch."""
+    if isinstance(child_x, bool):
+        raise TypeError(f"child_x must be 0 or 1, got {child_x!r}.")
+    if child_x not in (0, 0.0, 1, 1.0):
+        raise ValueError(f"child_x must be 0 or 1, got {child_x!r}.")
+
+
 def _parse_attachment_key(key: object) -> tuple[float, float]:
     if isinstance(key, bool):
         raise TypeError(f"Attachment keys must be numeric, got {key!r}.")
@@ -2224,14 +2151,11 @@ def _parse_attachment_key(key: object) -> tuple[float, float]:
             raise TypeError(f"Attachment keys must be numeric, got {key!r}.")
         parent_x = float(key[0])
         child_x = float(key[1])
-        if parent_x not in (0, 0.0, 0.5, 1, 1.0):
-            raise ValueError(f"parent_x must be 0, 0.5, or 1, got {parent_x!r}.")
-        if child_x not in (0, 0.0, 1, 1.0):
-            raise ValueError(f"child_x must be 0 or 1, got {child_x!r}.")
+        _check_parent_x_value(parent_x)
+        _check_child_x_value(child_x)
         return parent_x, child_x
     parent_x = float(key)
-    if parent_x not in (0, 0.0, 0.5, 1, 1.0):
-        raise ValueError(f"parent_x must be 0, 0.5, or 1, got {parent_x!r}.")
+    _check_parent_x_value(parent_x)
     return parent_x, 0.0
 
 
@@ -2255,3 +2179,27 @@ def clone_morpho(morpho: "Morphology") -> "Morphology":
             child_x=float(branch.child_x),
         )
     return cloned
+
+
+# --------------------------------------------------------------------------- #
+# Reserved branch names
+#
+# A branch name that collides with an attribute of ``Morphology`` or
+# ``MorphoBranch`` would be accepted into the tree and then be unreachable by
+# attribute access, because ``__getattr__`` only fires when normal lookup
+# fails. These sets are therefore *derived* rather than hand-listed: a
+# hand-maintained copy drifts the moment a public method is added, and it had
+# already drifted, leaving two names shadowable.
+#
+# Defined here, below the classes, because that is the earliest point at which
+# ``dir()`` can see them. ``_MORPHO_BRANCH_PUBLIC_ATTRS`` must be unioned in
+# explicitly: those five names are served dynamically through
+# ``MorphoBranch.__getattr__`` and so never appear in ``dir()``.
+# --------------------------------------------------------------------------- #
+
+_ALL_RESERVED_NAMES = frozenset(
+    {name for name in dir(Morphology) if not name.startswith("_")}
+    | {name for name in dir(MorphoBranch) if not name.startswith("_")}
+    | set(_MORPHO_BRANCH_PUBLIC_ATTRS)
+    | _BRANCH_RESERVED_NAMES
+)

--- a/braincell/morph/morphology_test.py
+++ b/braincell/morph/morphology_test.py
@@ -26,17 +26,25 @@ from braincell.filter import BranchSlice, RootLocation, Terminals
 from braincell.vis._testing import FakeBackend
 from braincell.vis.backend import BackendChooser
 from braincell.morph import MorphoBranch, MorphoMetric
+from braincell.morph._testing import (
+    make_apical,
+    make_axon,
+    make_basal,
+    make_deep_chain_tree,
+    make_dendrite,
+    make_soma,
+)
 
 
 class MorphoTest(unittest.TestCase):
     def test_tree_topology_queries_and_branch_views(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma = make_soma()
         dend = Branch.from_lengths(
             lengths=np.array([100.0]) * u.um,
             radii=np.array([2.0, 1.0]) * u.um,
             type="basal_dendrite",
         )
-        axon = Branch.from_lengths(lengths=[40.0] * u.um, radii=[0.8, 0.4] * u.um, type="axon")
+        axon = make_axon()
 
         tree = Morphology.from_root(soma, name="soma")
         dend_view = tree.soma.attach(dend, name="dendrite", parent_x=1.0)
@@ -82,8 +90,8 @@ class MorphoTest(unittest.TestCase):
         )
 
     def test_attach_by_name_and_attachment_point(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
+        soma = make_soma()
+        dend = make_basal()
         tree = Morphology.from_root(soma, name="soma")
         branch = tree.soma[0.5, 1.0].attach(dend, name="dendrite")
 
@@ -93,8 +101,8 @@ class MorphoTest(unittest.TestCase):
         self.assertEqual(tree.edges[0].child_x, 1.0)
 
     def test_child_x_accepts_only_endpoint_values(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
+        soma = make_soma()
+        dend = make_basal()
         tree = Morphology.from_root(soma, name="soma")
 
         child0 = tree.soma[0.0, 0].attach(dend, name="d0")
@@ -129,10 +137,10 @@ class MorphoTest(unittest.TestCase):
                     tree.soma.attach(dend, child_x=invalid)
 
     def test_topo_renders_nested_tree(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
-        tuft = Branch.from_lengths(lengths=[30.0] * u.um, radii=[1.0, 0.6] * u.um, type="apical_dendrite")
-        axon = Branch.from_lengths(lengths=[40.0] * u.um, radii=[0.8, 0.4] * u.um, type="axon")
+        soma = make_soma()
+        dend = make_basal()
+        tuft = make_apical()
+        axon = make_axon()
 
         tree = Morphology.from_root(soma, name="soma")
         tree.soma.dend = dend
@@ -152,20 +160,20 @@ class MorphoTest(unittest.TestCase):
         )
 
     def test_auto_names_apply_only_when_explicit_name_is_missing(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="dendrite")
+        soma = make_soma()
+        dend = make_dendrite()
 
         tree = Morphology.from_root(soma, name="soma")
         explicit = tree.soma.attach(dend, name="first")
         auto0 = tree.soma.attach(dend)
-        auto1 = tree.soma.attach(Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="dendrite"))
+        auto1 = tree.soma.attach(make_dendrite())
 
         self.assertEqual(explicit.name, "first")
         self.assertEqual(auto0.name, "dendrite_0")
         self.assertEqual(auto1.name, "dendrite_1")
 
     def test_root_can_opt_into_type_based_auto_naming(self) -> None:
-        axon = Branch.from_lengths(lengths=[40.0] * u.um, radii=[0.8, 0.4] * u.um, type="axon")
+        axon = make_axon()
 
         tree = Morphology.from_root(axon, name=None)
 
@@ -173,9 +181,9 @@ class MorphoTest(unittest.TestCase):
         self.assertEqual(tree.topo(), "axon_0")
 
     def test_branch_order_queries_are_available(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        axon = Branch.from_lengths(lengths=[40.0] * u.um, radii=[0.8, 0.4] * u.um, type="axon")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="dendrite")
+        soma = make_soma()
+        axon = make_axon()
+        dend = make_dendrite()
         apical = Branch.from_lengths(lengths=[30.0] * u.um, radii=[1.2, 0.8] * u.um, type="apical_dendrite")
         custom = Branch.from_lengths(lengths=[25.0] * u.um, radii=[0.7, 0.5] * u.um, type="custom")
 
@@ -208,9 +216,9 @@ class MorphoTest(unittest.TestCase):
             tree.branch_by_order(order="unknown")
 
     def test_morpho_equality_compares_structure_and_geometry(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
-        axon = Branch.from_lengths(lengths=[40.0] * u.um, radii=[0.8, 0.4] * u.um, type="axon")
+        soma = make_soma()
+        dend = make_basal()
+        axon = make_axon()
 
         tree0 = Morphology.from_root(soma, name="soma")
         tree0.soma.attach(dend, name="dendrite", parent_x=1.0)
@@ -246,9 +254,9 @@ class MorphoTest(unittest.TestCase):
             hash(tree0)
 
     def test_parent_x_midpoint_is_soma_only(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
-        tuft = Branch.from_lengths(lengths=[30.0] * u.um, radii=[1.0, 0.6] * u.um, type="apical_dendrite")
+        soma = make_soma()
+        dend = make_basal()
+        tuft = make_apical()
 
         tree = Morphology.from_root(soma, name="soma")
         tree.soma.dend = dend
@@ -260,9 +268,9 @@ class MorphoTest(unittest.TestCase):
             tree.dend[0.5].attach(tuft, name="tuft")
 
     def test_metric_exposes_tree_level_metrics_with_compatible_shortcuts(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
-        tuft = Branch.from_lengths(lengths=[30.0] * u.um, radii=[1.0, 0.6] * u.um, type="apical_dendrite")
+        soma = make_soma()
+        dend = make_basal()
+        tuft = make_apical()
 
         tree = Morphology.from_root(soma, name="soma")
         tree.soma.dend = dend
@@ -293,8 +301,8 @@ class MorphoTest(unittest.TestCase):
         )
 
     def test_metric_returns_dataclass_snapshot_with_compact_str(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
+        soma = make_soma()
+        dend = make_basal()
 
         tree = Morphology.from_root(soma, name="soma")
         tree.soma.dend = dend
@@ -326,8 +334,8 @@ class MorphoTest(unittest.TestCase):
         self.assertIn("max_path_dist", summary_str)
 
     def test_metric_uses_optional_fields_for_unavailable_point_metrics(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
+        soma = make_soma()
+        dend = make_basal()
 
         tree = Morphology.from_root(soma, name="soma")
         tree.soma.dend = dend
@@ -488,9 +496,9 @@ class MorphoTest(unittest.TestCase):
             _ = tree.max_euclidean_distance_excluding_soma
 
     def test_foreign_missing_and_reserved_children_are_rejected(self) -> None:
-        soma0 = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma0 = make_soma()
         soma1 = Branch.from_lengths(lengths=[18.0] * u.um, radii=[9.0, 9.0] * u.um, type="soma")
-        dend = Branch.from_lengths(lengths=[60.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
+        dend = make_basal()
 
         tree0 = Morphology.from_root(soma0, name="soma")
         tree1 = Morphology.from_root(soma1, name="other")
@@ -531,7 +539,7 @@ class MorphoDerivedCacheTest(unittest.TestCase):
 
     @staticmethod
     def _soma() -> Branch:
-        return Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        return make_soma()
 
     @staticmethod
     def _dend(length: float = 30.0) -> Branch:
@@ -626,7 +634,7 @@ class MorphoBranchDerivedPropertyTest(unittest.TestCase):
     """
 
     def _tree(self) -> Morphology:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma = make_soma()
         tree = Morphology.from_root(soma, name="soma")
         mid = tree.soma.attach(
             Branch.from_lengths(lengths=[30.0, 20.0] * u.um, radii=[2.0, 1.5, 1.0] * u.um, type="basal_dendrite"),
@@ -667,6 +675,69 @@ class MorphoBranchDerivedPropertyTest(unittest.TestCase):
                 )
 
 
+class MorphoReservedNameTest(unittest.TestCase):
+    """Every public ``Morphology`` / ``MorphoBranch`` attribute is name-reserved.
+
+    The reserved set used to be a hand-typed literal that drifted behind the
+    classes it guarded: ``topo`` and ``from_neuromorpho`` were both accepted
+    as branch names and then permanently unreachable, because attribute
+    lookup finds the class member before ``__getattr__`` ever runs.
+    """
+
+    def _tree(self) -> Morphology:
+        return Morphology.from_root(make_soma(), name="soma")
+
+    def _attach_named(self, tree: Morphology, name: str) -> None:
+        tree.attach(parent="soma", child_branch=make_axon(), child_name=name, parent_x=1.0)
+
+    def test_names_that_used_to_slip_through_are_rejected(self) -> None:
+        for name in ("topo", "from_neuromorpho"):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "reserved by the Morphology API"):
+                    self._attach_named(self._tree(), name)
+
+    def test_dynamic_morpho_branch_attributes_are_reserved(self) -> None:
+        # These five are served by MorphoBranch.__getattr__ and so are absent
+        # from dir(MorphoBranch); deriving the reserved set from dir() alone
+        # would silently stop protecting them.
+        for name in ("branch", "name", "parent_id", "parent_x", "child_x"):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "reserved by the Morphology API"):
+                    self._attach_named(self._tree(), name)
+
+    def test_every_public_attribute_of_both_classes_is_reserved(self) -> None:
+        public = {n for n in dir(Morphology) if not n.startswith("_")}
+        public |= {n for n in dir(MorphoBranch) if not n.startswith("_")}
+        self.assertIn("topo", public)
+        for name in sorted(public):
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(ValueError, "reserved by the Morphology API"):
+                    self._attach_named(self._tree(), name)
+
+
+class MorphoDeepTreeTest(unittest.TestCase):
+    """Whole-tree walks stay iterative on morphologies deeper than the C stack.
+
+    ``topo()`` formatted the tree by recursive descent and raised
+    ``RecursionError`` past roughly 400 chained branches -- a depth real
+    thin-neurite reconstructions reach routinely.
+    """
+
+    def test_topo_formats_a_1200_branch_chain(self) -> None:
+        tree = make_deep_chain_tree(1200)
+        rendered = tree.topo()
+        self.assertEqual(rendered.count("\n"), 1199)
+        self.assertIn("soma", rendered)
+        self.assertIn("seg_1198", rendered)
+
+    def test_deep_chain_aggregates_do_not_recurse(self) -> None:
+        tree = make_deep_chain_tree(1200)
+        self.assertEqual(tree.n_branches, 1200)
+        self.assertEqual(tree.max_branch_order, 1199)
+        self.assertEqual(len(tree.edges), 1199)
+        self.assertGreater(tree.total_area.to_decimal(u.um**2), 0.0)
+
+
 class MorphoNamingStateTest(unittest.TestCase):
     """``naming_state`` / ``restore_naming_state``, the public auto-name API.
 
@@ -675,7 +746,7 @@ class MorphoNamingStateTest(unittest.TestCase):
     """
 
     def _tree(self, n_dendrites: int = 3) -> Morphology:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma = make_soma()
         tree = Morphology.from_root(soma, name="soma")
         for _ in range(n_dendrites):
             tree.attach(
@@ -700,7 +771,7 @@ class MorphoNamingStateTest(unittest.TestCase):
     def test_restoring_resumes_the_sequence(self) -> None:
         source = self._tree()
         target = Morphology.from_root(
-            Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma"),
+            make_soma(),
             name="soma",
         )
 
@@ -751,7 +822,7 @@ class MorphoSelectAndVisTest(unittest.TestCase):
     """``Morphology.select``, ``.vis2d``, and ``.vis3d`` — all defined in morphology.py."""
 
     def test_morpho_select_is_region_eval_sugar(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma = make_soma()
         dend = Branch.from_lengths(lengths=[80.0] * u.um, radii=[2.0, 1.0] * u.um, type="apical_dendrite")
         tree = Morphology.from_root(soma, name="soma")
         tree.soma.dend = dend
@@ -763,7 +834,7 @@ class MorphoSelectAndVisTest(unittest.TestCase):
         self.assertEqual(selected.intervals, evaluated.intervals)
 
     def test_morpho_select_accepts_locset_expr(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma = make_soma()
         dend = Branch.from_lengths(lengths=[80.0] * u.um, radii=[2.0, 1.0] * u.um, type="apical_dendrite")
         tree = Morphology.from_root(soma, name="soma")
         tree.soma.dend = dend
@@ -776,7 +847,7 @@ class MorphoSelectAndVisTest(unittest.TestCase):
         self.assertEqual(selected.points, evaluated.points)
 
     def test_morpho_select_rejects_non_filter_expr(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma = make_soma()
         tree = Morphology.from_root(soma, name="soma")
 
         with self.assertRaises(TypeError):
@@ -865,7 +936,7 @@ class MorphoSelectAndVisTest(unittest.TestCase):
         self.assertEqual(len(rendered.scene.polygons), 2)
 
     def test_morpho_vis2d_accepts_layout_parameters(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma = make_soma()
         dend_a = Branch.from_lengths(lengths=[30.0] * u.um, radii=[2.0, 1.5] * u.um, type="apical_dendrite")
         dend_b = Branch.from_lengths(lengths=[30.0] * u.um, radii=[2.0, 1.5] * u.um, type="basal_dendrite")
         tree = Morphology.from_root(soma, name="soma")
@@ -898,7 +969,7 @@ class MorphoSelectAndVisTest(unittest.TestCase):
         self.assertGreaterEqual(child_angles[1] - child_angles[0], 90.0 - 1e-6)
 
     def test_morpho_vis2d_accepts_style_overrides(self) -> None:
-        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        soma = make_soma()
         dend = Branch.from_lengths(lengths=[30.0] * u.um, radii=[2.0, 1.5] * u.um, type="apical_dendrite")
         tree = Morphology.from_root(soma, name="soma")
         tree.attach(parent="soma", child_branch=dend, child_name="dend", parent_x=1.0)

--- a/braincell/vis/_testing.py
+++ b/braincell/vis/_testing.py
@@ -41,6 +41,11 @@ from braincell.io._testing import (  # noqa: F401
     VALID_SWC_FIXTURES,
 )
 
+# Re-exported for the same reason: the deep chain pins tree walks as iterative
+# in both packages, and braincell/morph/_testing.py owns it because the tree it
+# builds is a morph object with no visualization content.
+from braincell.morph._testing import make_deep_chain_tree  # noqa: F401
+
 
 def make_node_tree() -> Morphology:
     """A single-branch soma with explicit 3D points.
@@ -223,48 +228,6 @@ def make_fan_root_partition_tree() -> Morphology:
         child_name="right_far",
         parent_x=1.0,
     )
-    return tree
-
-
-def make_deep_chain_tree(n_branches: int = 1200) -> Morphology:
-    """An unbranched chain of ``n_branches`` branches hanging off a soma.
-
-    Reconstructions of long, thin neurites routinely produce chains far
-    deeper than CPython's default recursion limit, so this fixture exists
-    to pin the tree walks in :mod:`braincell.vis` as iterative. The
-    default depth is comfortably past the ~400-branch point where the
-    old recursive walks raised ``RecursionError``, while staying small
-    enough to lay out in well under a second.
-
-    Parameters
-    ----------
-    n_branches : int
-        Total branch count, soma included. Must be at least 1.
-
-    Returns
-    -------
-    Morphology
-        A chain ``soma -> seg_0 -> seg_1 -> ...``, every dendrite branch
-        carrying two 15 µm / 10 µm segments.
-    """
-    if n_branches < 1:
-        raise ValueError(f"n_branches must be >= 1, got {n_branches!r}.")
-    soma = Branch.from_lengths(
-        lengths=[20.0] * u.um,
-        radii=[10.0, 10.0] * u.um,
-        type="soma",
-    )
-    tree = Morphology.from_root(soma, name="soma")
-    parent = "soma"
-    for index in range(n_branches - 1):
-        child = Branch.from_lengths(
-            lengths=[15.0, 10.0] * u.um,
-            radii=[2.0, 1.5, 1.0] * u.um,
-            type="apical_dendrite",
-        )
-        name = f"seg_{index}"
-        tree.attach(parent=parent, child_branch=child, child_name=name, parent_x=1.0)
-        parent = name
     return tree
 
 

--- a/docs/design/interface-map.md
+++ b/docs/design/interface-map.md
@@ -118,8 +118,6 @@ _base / _base_ion / _base_channel -> shared runtime base classes
 - `branch_by_order(order="default")`
 - `branch(name=None, index=None, order=None)`
 - `path_to_root(branch_index)`
-- `path_length_to_root(branch_index)`
-- `shortest_path_length(from_site, to_site)`
 - `topo()`
 - `attach(parent=..., child_branch=..., child_name=None, parent_x=1.0, child_x=0.0)`
 - `select(expr, cache=None)`

--- a/docs/specs/2026-09-02-morph-simplification.md
+++ b/docs/specs/2026-09-02-morph-simplification.md
@@ -1,0 +1,425 @@
+# Quality cleanup of `braincell.morph`
+
+Reuse, simplification, efficiency, and altitude cleanup of the morphology
+package (`braincell/morph`: `morphology.py` 2,257 lines, `branch.py` 1,140,
+`_spatial.py` 216, `__init__.py` 30, plus 1,594 lines of co-located tests).
+Breaking API changes are in scope and were explicitly authorised for this
+pass.
+
+This is iteration 2 of a module-by-module sweep. PR #137's package-wide pass
+already took morph's hot paths — it memoised `_ordered_node_ids_by`,
+`_branch_index_map`, `branch_by_order`, and `has_full_point_geometry`, and
+rewrote `_spatial.build()` to walk `morpho.edges` once. This pass therefore
+looks for what those left behind, and for the structural problems a
+performance pass does not surface.
+
+## Scope and method
+
+Four independent reviews swept the package, one per angle (reuse,
+simplification, efficiency, altitude). Findings were deduplicated; where three
+reviews independently converged on the same defect it is treated as
+load-bearing. Every claim acted on below was re-verified against the code by
+running it, not by reading the report.
+
+Two reported claims did **not** survive that re-verification and are recorded
+here so they are not reintroduced:
+
+- Two reviews claimed four or five `Morphology` names were shadowable. Only
+  **two** actually are (`topo`, `from_neuromorpho`). `save_checkpoint`,
+  `load_checkpoint`, and `diam_arc_mean` are already rejected, because
+  `Branch` happens to define them too and `_BRANCH_RESERVED_NAMES` is derived
+  from `dir(Branch)`. The defect is real; its blast radius was overstated.
+- The claim that `Morphology.topo()`'s recursion could be fixed by reusing
+  `braincell.vis._traversal.iter_depth_first` does not hold: that helper
+  returns a flat list of `MorphoBranch` objects, while `_format_topology`
+  needs per-node prefix and is-last bookkeeping to draw the tree. The fix is
+  an explicit stack, not a call to the existing helper.
+
+Three invariants govern every edit, carried over from PR #137 and iteration 1:
+
+1. **The test suite stays green.** Baseline on `main` @ `4c7c572` before any
+   change: 2,713 passed, 15 skipped, 338 subtests, 0 failed (181.94 s).
+   `braincell/morph` alone: 82 passed, 18 subtests (7.75 s).
+2. **Every performance claim carries a measurement.** No fix lands on the
+   strength of "this looks faster".
+3. **Where two code paths disagree, the disagreement is preserved, not
+   silently unified.** Divergences worth a decision are listed under
+   *Deliberately not changed*.
+
+## Bugs fixed
+
+Both were found by review and reproduced before being fixed, per the working
+agreement's "write a test that reproduces it, then fix until it passes".
+
+### `Morphology.topo()` raised `RecursionError` on deep morphologies
+
+`_format_topology` recursed once per branch. Reproduced on a 1,200-branch
+chain against the default recursion limit of 1,000:
+
+```
+chain of 1200 branches, recursionlimit=1000
+topo() -> RecursionError
+```
+
+This is the same hazard `docs/specs/2026-08-13-vis-iterative-tree-walks.md`
+fixed for the rendering paths ("a morphology deeper than roughly 400 branches
+raised `RecursionError`"); that spec scoped itself to `braincell/vis/`, so the
+package that *owns* the tree kept the bug. `_format_topology` becomes an
+explicit-stack loop, with a regression test at a depth that overflows the
+recursive form.
+
+### Two branch names silently shadowed the API
+
+`_validate_public_name`'s whole job is to reject a branch name that would
+shadow a `Morphology` attribute. Its `_MORPHO_RESERVED_NAMES` set is a
+hand-typed copy of `Morphology`'s public surface and had drifted, so:
+
+```
+attach(child_name="topo")             -> ACCEPTED
+morph.topo                            -> <bound method>   # branch unreachable
+morph.branch(name="topo")             -> the branch       # but it is in the tree
+attach(child_name="from_neuromorpho") -> ACCEPTED, same shadowing
+```
+
+The branch is in the tree and reachable by `branch(name=...)`, but attribute
+access silently returns the method, because `__getattr__` only fires when
+normal lookup fails.
+
+The fix is at the depth the file already demonstrates three lines below the
+defect: `_BRANCH_RESERVED_NAMES` is *derived* from `dir(Branch)`. The three
+hand-typed literals (`_MORPHO_RESERVED_NAMES`, `_MORPHO_BRANCH_RESERVED_NAMES`,
+`_MORPHO_METRIC_PROPERTY_NAMES` — 55 lines of names) collapse into one derived
+`_ALL_RESERVED_NAMES`; the metric names needed no clause of their own, because
+they are already properties on `Morphology` and so already in `dir()`. The set
+is computed at the *end* of the module, the earliest point at which `dir()` can
+see both classes.
+
+One clause is not derivable and is unioned in explicitly:
+`_MORPHO_BRANCH_PUBLIC_ATTRS` — the five names (`branch`, `name`, `parent_id`,
+`parent_x`, `child_x`) that `MorphoBranch.__getattr__` serves dynamically and
+that therefore never appear in `dir(MorphoBranch)`. Deriving from `dir()` alone
+would have *regressed* those five from protected to shadowable; this was caught
+by checking empirically rather than by reading, and is now pinned by a test.
+
+This is a **behaviour tightening**: `topo` and `from_neuromorpho` become
+rejected branch names. Every future public method on `Morphology` is now
+covered automatically instead of reopening the hole.
+
+## Breaking changes
+
+### `Morphology.path_length_to_root` and `Morphology.shortest_path_length` are deleted
+
+52 lines whose entire body is `raise NotImplementedError`, verified by calling
+both. They have zero callers anywhere in `braincell/`, `examples/`, or the
+notebooks, and `pyproject.toml`'s `report.exclude_also = ["raise
+NotImplementedError"]` means coverage never flagged them either — they were
+doubly invisible. Their two bullets in `docs/design/interface-map.md` go with
+them.
+
+Deleting rather than implementing is a deliberate scope decision. The
+capability does exist in the package — `_spatial.MorphologySpatialGeometry`
+runs multi-source Dijkstra and is what `braincell/filter`,
+`braincell/network`, and `braincell/_discretization` already import for these
+numbers — but wiring it up is feature work, not simplification. See
+*Deliberately not changed*.
+
+### `Morphology.diam_arc_mean` is deleted
+
+`2.0 * self.mean_radius` with zero callers on a `Morphology` (every one of the
+40+ `diam_arc_mean` hits repo-wide is on a `Branch`, `MorphoBranch`, or a CV
+object) and never executed under the test suite.
+
+### `Morphology._get_branch` is deleted
+
+Zero callers, including its own definition site's file.
+
+## What was fixed
+
+### Reuse — one home per concept
+
+- **The frustum formulas existed twice.** Lateral area
+  `π(r₀+r₁)√(L²+(r₁−r₀)²)`, volume `πL(r₀²+r₀r₁+r₁²)/3`, and the
+  length-weighted mean radius are written character-for-character identically
+  in `Branch` (over one branch's segments) and in `Morphology` (over the
+  concatenated arrays). `morphology_test.py` asserts the two agree, so the
+  copies are load-bearing on each other: a fix to `Branch.areas` — for
+  instance to the zero-length jump-segment end-cap area that `branch.py`
+  documents as surprising — would silently leave `Morphology.total_area`
+  disagreeing. Module-level pure-NumPy helpers in `branch.py` now back both.
+  `Morphology` keeps its concatenated fast path; only the formula moved.
+- **`Morphology.branch(index=...)` inlined `_node_id_from_index`**, down to
+  the identical `IndexError` message. Collapsing it also revives that helper's
+  `order` parameter, which every existing call site left at its default.
+- **`MorphoBranch.branch_id` duplicated `MorphoBranch.index`'s body** rather
+  than returning it, while its own docstring called itself an alias.
+- **`Morphology.max_branch_order` re-derived `MorphoBranch.branch_order`**;
+  `morphology_test.py` already asserted the two agree.
+- **`_parse_attachment_key` re-implemented `_validate_parent_x` /
+  `_validate_child_x`**, with byte-identical message strings, and had already
+  diverged: it calls `float(key)` first, so an out-of-range integer reports
+  `2.0` through `morph.soma[2]` and `2` through `attach(parent_x=2)`.
+- **`Branch.from_lengths` and `Branch.from_points` shared a verbatim
+  `_BRANCH_TYPE`/`_UNSET` resolution block**, differing only in the method
+  name inside the error string.
+- **`morph` had no `_testing.py`**, the only domain package without one, even
+  though its own test files had reached for per-`TestCase` fixture helpers
+  three separate times because there was nowhere shared to put them, and even
+  though the morph tests already import *upward* into `braincell.vis._testing`
+  for `FakeBackend`.
+
+### Simplification
+
+- **Five unreachable guards and tails.** `_point_on_branch_at_x_um`'s
+  `points is None` raise (its caller has just asserted full point geometry for
+  every branch, root included) and its post-loop `return points_um[-1]` (the
+  loop condition guarantees the last iteration returns); `mean_radius`'s
+  `total length must be > 0` (every `Branch` guarantees it at construction and
+  a `Morphology` always has at least one branch); `_root_attach_distances_um`'s
+  `parent_id is None` continue (the root is already skipped two lines above,
+  and only the root has a null parent); `_spatial._interpolate_scalar`'s
+  trailing `last_positive is None` raise. Each was confirmed unexecuted by a
+  coverage run over 624 tests.
+- **`_root_branch_attach_x()` returned the constant `0.0`** through two call
+  sites.
+- **`Morphology.edges` used a one-element-tuple rebinding trick** to bind a
+  loop variable, and redid N dict lookups per access instead of using the
+  memoised `self.branches`. Fixing it makes `_ordered_node_ids()` — a one-line
+  wrapper whose only caller it was — dead.
+- **`Branch.vis2d` / `vis3d` re-forwarded to `plot2d` / `plot3d` instead of
+  calling `Morphology.vis2d` / `vis3d`.** Both already build
+  `Morphology.from_root(self, name="soma")`, then re-list a strict subset of
+  the arguments the `Morphology` methods forward and re-implement the same
+  `show` handling. `Branch.vis2d` had already silently fallen behind on six
+  parameters. Every default the `Morphology` methods pass explicitly
+  (`ax=None`, `notebook=None`, `jupyter_backend=None`,
+  `min_branch_angle_deg=25.0`, `root_layout="type_split"`) was checked against
+  `plot2d`'s own signature and matches, so delegating is behaviour-identical.
+- **A dead skip guard** in `branch_test.py` tested `if jnp is None` under an
+  unconditional `import jax.numpy as jnp` — if jax were absent, collection
+  would already have failed at the import.
+- **41 copies of five branch literals** in `morphology_test.py` (the same
+  `Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um,
+  type="soma")` appeared 21 times), which made arbitrary dimensions read as
+  though they were significant. They move to the new
+  `braincell/morph/_testing.py` as `make_soma` / `make_dendrite` /
+  `make_basal` / `make_apical` / `make_axon`; a test that genuinely depends on
+  a radius still passes it explicitly.
+- **`make_deep_chain_tree` lived in `braincell/vis/_testing.py`.** It builds a
+  `Morphology` and contains nothing visualization-specific, and the morph
+  tests need it for the `topo()` regression above. It moves to
+  `braincell/morph/_testing.py`, and `vis/_testing.py` re-exports it — the
+  same pattern that file already uses for `FIXTURE_DIR` from
+  `braincell/io/_testing.py`.
+
+### Documentation that described behaviour the code does not have
+
+- **28 references to a class named `Morpho`**, which does not exist and has
+  not for some time. These are not only comments: `Morphology.__repr__`
+  printed `Morpho(root='soma', n_branches=1, ...)`, and six user-facing error
+  messages named a symbol no user can look up (`"reserved by the Morpho
+  API"`, `"already exists in this Morpho"`, `"Morpho.select(...) expects"`).
+  Nine `See Also` entries and four Sphinx roles resolved to nothing.
+- **Five docstrings pointed at `braincell.morph.vis.configure(...)`**, which
+  is wrong twice: there is no `braincell.morph.vis` module, and the public
+  name is `braincell.vis.configure_defaults`.
+- **Two docstrings enumerated the 2-D layouts omitting `"fan"`** — which is
+  the default, named as such three lines later in the same docstring.
+- **`Branch.from_lengths` documented a `ValueError` on radius
+  discontinuities** that it does not raise: `_canonicalize_segments` inserts a
+  zero-length jump segment instead, as `branch_test.py` already proves.
+
+## Efficiency — measured, or not landed
+
+Measured on `data/morphology/CA1.swc` (681 branches, 39,277 points), median of
+7 repeats, a freshly parsed morphology per repeat so no cache is shared across
+samples. `before` is `main` @ `4c7c572`; `after` is this branch. Both runs
+print the result of every benchmark, and **all eight digests are identical**
+across the two trees — 39,277 points, total length 16,094.912745159878 µm,
+x-range 490.03 µm, 681 branches, 6,800 edges, a 67,885-character `topo()`, and
+an interpolated radius sum of 4,144.2883 µm. That equality is the evidence
+these are speedups and not behaviour changes.
+
+| Benchmark | Before | After | Speedup |
+|---|---:|---:|---:|
+| `metric.as_dict()` | 253.62 ms | 56.86 ms | **4.5×** |
+| `clone_morpho` | 259.55 ms | 59.13 ms | **4.4×** |
+| `interpolate_branch`, 256 sites × 86 branches | 595.03 ms | 201.03 ms | **3.0×** |
+| `Branch.points` over every branch | 53.19 ms | 19.15 ms | **2.8×** |
+| `x_range` | 52.46 ms | 21.03 ms | **2.5×** |
+| `Branch.length` over every branch | 12.32 ms | 8.15 ms | **1.5×** |
+| `edges` × 10 | 5.70 ms | 5.61 ms | 1.0× |
+| `topo()` | 0.47 ms | 0.45 ms | 1.0× |
+
+Four changes produced those numbers:
+
+- **`Branch.points` did unit-aware math on a two-line hot path.**
+  `u.math.allclose` and `u.math.concatenate` each re-derive dimensions and
+  tree-map over their arguments on every call, and `points` is reached by
+  essentially every whole-morphology consumer. Decoding to plain NumPy once
+  and doing the continuity check and the concatenate there is the single
+  largest contributor; it is why `metric`, `clone_morpho`, and `x_range` all
+  move together.
+- **`_all_segment_arrays_um()` was recomputed per aggregate.** `mean_radius`,
+  `total_area`, `total_volume`, and each of `x_range` / `y_range` / `z_range`
+  rebuilt the whole-tree arrays independently, so `metric.as_dict()` paid for
+  them six times over. Both it and the new `_all_points_um()` are memoised on
+  the instance and cleared from `_invalidate_derived_caches`, which is already
+  the single choke point for cache invalidation (`_register_node` is the only
+  place `_nodes` grows).
+- **`Branch.length` decoded both radius arrays to discard them.** It called
+  the shared `_segment_arrays_um()` helper and used one of its three outputs.
+- **`_interpolate_scalar` re-ran five `to_decimal` conversions per site.**
+  None of the five depend on the site, and `interpolate_branch` calls it once
+  per requested `branch_x`. The decode moves into a `_BranchGeometryUm` object
+  built once per branch; the per-site arithmetic stays in `at()`. The flat
+  output views are also hoisted out of the loop rather than re-derived per
+  index.
+
+Two candidates were **measured and not landed**, recorded so they are not
+re-proposed:
+
+- **`Morphology.edges`** — the reuse fix (iterate `self.branches` instead of
+  redoing N dict lookups) landed for clarity, but at 5.70 → 5.61 ms over ten
+  accesses it is not a performance change and is not claimed as one.
+- **`_path_node_ids` walks and `MorphoBranch.__getattr__` dispatch** were both
+  profiled after being flagged. Neither is hot enough on a real reconstruction
+  to justify restructuring; `__getattr__` in particular only fires for the five
+  dynamic attributes, since normal lookup handles everything else.
+
+## Deliberately not changed
+
+Recorded so the next reader does not re-litigate them, and so later iterations
+of this sweep know what is waiting.
+
+- **The public tree-distance API.** `MorphologySpatialGeometry` in the
+  package's own `_spatial.py` computes exactly what the two deleted stubs
+  promised, and `braincell/filter`, `braincell/network`, and
+  `braincell/_discretization` all import that **private** module to get it.
+  Making it public — either by backing methods on `Morphology` or by renaming
+  `_spatial.py` to `spatial.py` and exporting it — is a public-surface
+  decision affecting three other packages. **Deferred to iteration 14**, whose
+  remit is exactly cross-module layering and public surface.
+- **`morph/__init__.py` exports four names and not `Morphology`, `Branch`, or
+  `Soma`.** Roughly 50 import sites across the repo — including
+  `braincell/__init__.py` itself — therefore spell submodule paths like
+  `braincell.morph.morphology`. This is already tracked as an open question in
+  `docs/design/interface-map.md`. Exporting the names is cheap; normalising
+  the call sites touches ~30 files. **Deferred to iteration 14.**
+- **`braincell/vis/_traversal.py` owns the tree-walk primitive for
+  `MorphoBranch`.** It imports `from braincell.morph import MorphoBranch` and
+  contains nothing visualization-specific, so a renderer package owns a
+  geometry-package primitive. Moving it to `morph/` costs a module move, a
+  test move, and two import updates. It is a cross-package relocation, the
+  same shape as PR #136, so it belongs with the layering pass.
+  **Deferred to iteration 14.** The `topo()` crash it would have helped with
+  is fixed independently above, since the existing helper does not carry the
+  prefix bookkeeping `_format_topology` needs anyway.
+- **`Morphology._swc_type_map()` imports `braincell.io.swc.types` from inside
+  a method** to rank branch types, so the canonical ordering of a morphology
+  concept is defined by a file-format reader's integer table, reached through
+  the package's only relative import and past two `__init__.py` surfaces.
+  `morph/branch.py` already owns the type vocabulary twice
+  (`_ALLOWED_BRANCH_TYPES`, `_BRANCH_TYPE_TO_CLASS`). Untangling this means
+  deciding which of those three is canonical, which is a design decision about
+  `branch.py`'s public vocabulary rather than a refactor. **Deferred to
+  iteration 14.**
+- **`filter/cache.py` reads `Morphology._revision`** via
+  `getattr(morpho, "_revision", None)`, and `morphology.py` documents the
+  coupling from its side while publishing it only as a private attribute. The
+  one-line fix is a public `revision` property, but it is an addition to the
+  public surface and belongs with the item above. **Deferred to iteration 14.**
+- **`show=True` has no observable effect in `vis3d`.** The docstring says the
+  backend's show method is called; the code calls `matplotlib.pyplot.show()`,
+  and the 3-D backend is PyVista, which never creates a matplotlib figure.
+  Whether to correct the documentation or make the parameter real is a
+  behaviour decision about `braincell/vis`, not a `morph` refactor.
+- **`MorphoBranch.parent_id` vs the filter's `parent_id`.** They deliberately
+  mean different things (parent node id vs parent branch index); PR #137
+  examined and kept the distinction.
+- **The `Morpho` → `Morphology` rename stops at this package.** 28 references
+  inside `braincell/morph/` are fixed here, plus the 11 in
+  `examples/multi_compartment/morphology-checkpoint.ipynb`, which had to move
+  in this PR because one of them is a stored `__repr__` output this change
+  invalidates. The remaining stale spellings are *not* callers of anything
+  changed here — they are independent error strings in other packages — so
+  they travel with their own iterations: 16 in `braincell/filter/`
+  (**iteration 3**, next), and 7 in `braincell/io/` plus 9 across
+  `braincell/vis/` (**iteration 14**). The two tests that assert on those
+  strings (`io/checkpoint_test.py:318`, `vis/layout/_dispatch_test.py:45`) use
+  substring matching, so they stay green either way.
+- **`morphology_test.py` imports `FakeBackend` from `braincell.vis._testing`.**
+  Unlike `make_deep_chain_tree`, that double is genuinely a render-backend
+  object and belongs in `vis`. The morph tests needing it at all is a symptom
+  of `Morphology.vis2d` living on the model class; that is a public-surface
+  question. **Deferred to iteration 14.**
+
+## Behaviour changes beyond the deletions
+
+- **`interpolate_branch` on a zero-length branch now raises before the loop,
+  not inside it.** `_BranchGeometryUm.__init__` performs the `total <= 0`
+  check once per branch, so `interpolate_branch(morpho, i, [])` — an empty
+  site list on a degenerate branch — raises `ValueError` where it previously
+  returned empty arrays. Raising is the more defensible answer for a branch
+  that cannot be interpolated at any site, and no caller passes an empty site
+  list.
+- **Error-message wording.** `"reserved by the Morpho API"` becomes
+  `"reserved by the Morphology API"`, and `_parse_attachment_key` now reports
+  an out-of-range integer the same way `attach(parent_x=...)` does, since both
+  go through the same check.
+
+## Verification
+
+```
+$ pytest braincell/morph -q
+82 passed, 1 warning, 18 subtests passed in 4.56s
+
+$ pytest braincell/ -q
+2718 passed, 15 skipped, 411 warnings, 389 subtests passed in 180.57s (0:03:00)
+
+$ pre-commit run --files <the 9 changed files>
+... all hooks Passed
+```
+
+The suite **gained** tests rather than losing any, and the arithmetic closes
+exactly against the `main` @ `4c7c572` baseline of 2,713 passed / 338 subtests:
+
+| | Baseline | This branch | Delta |
+|---|---:|---:|---:|
+| tests passed | 2,713 | 2,718 | **+5** |
+| subtests passed | 338 | 389 | **+51** |
+| skipped | 15 | 15 | 0 |
+| failed | 0 | 0 | 0 |
+
+Every one of those deltas is accounted for by the two new regression classes,
+with nothing else moving:
+
+| New test | Tests | Subtests |
+|---|---:|---:|
+| `MorphoReservedNameTest.test_names_that_used_to_slip_through_are_rejected` | 1 | 2 |
+| `MorphoReservedNameTest.test_dynamic_morpho_branch_attributes_are_reserved` | 1 | 5 |
+| `MorphoReservedNameTest.test_every_public_attribute_of_both_classes_is_reserved` | 1 | 44 |
+| `MorphoDeepTreeTest.test_topo_formats_a_1200_branch_chain` | 1 | 0 |
+| `MorphoDeepTreeTest.test_deep_chain_aggregates_do_not_recurse` | 1 | 0 |
+| **total** | **5** | **51** |
+
+Both bugs were reproduced on `main` @ `4c7c572` before the fix and re-checked
+after, using the identical script against each tree:
+
+```
+baseline pkg: /mnt/d/codes/projects/braincell/braincell/__init__.py
+BASELINE topo: RecursionError -> maximum recursion depth exceeded
+BASELINE accepted: topo -> shadows method
+BASELINE accepted: from_neuromorpho -> shadows method
+
+after pkg: .../worktrees/simplify-morph/braincell/__init__.py
+topo type: str len: 2887285   lines: 1199
+rejected: topo             -> Branch name 'topo' is reserved by the Morphology API.
+rejected: from_neuromorpho -> Branch name 'from_neuromorpho' is reserved by the Morphology API.
+rejected: branch           -> Branch name 'branch' is reserved by the Morphology API.
+rejected: name             -> Branch name 'name' is reserved by the Morphology API.
+rejected: parent_x         -> Branch name 'parent_x' is reserved by the Morphology API.
+```
+
+The last three lines are the near-miss: deriving the reserved set from `dir()`
+alone would have left them accepted, because `MorphoBranch.__getattr__` serves
+them dynamically.

--- a/examples/multi_compartment/morphology-checkpoint.ipynb
+++ b/examples/multi_compartment/morphology-checkpoint.ipynb
@@ -5,14 +5,14 @@
    "id": "c0bba72f",
    "metadata": {},
    "source": [
-    "# Morpho & Branch checkpoints\n",
+    "# Morphology & Branch checkpoints\n",
     "\n",
-    "`braincell.io` ships a self-contained checkpoint format for snapshotting `Branch` and `Morpho` instances to disk and restoring them later. Two complementary persistence mechanisms are supported:\n",
+    "`braincell.io` ships a self-contained checkpoint format for snapshotting `Branch` and `Morphology` instances to disk and restoring them later. Two complementary persistence mechanisms are supported:\n",
     "\n",
-    "1. **`.bcm` checkpoints** — a stable, version-tagged on-disk format produced by `save_branch` / `save_morpho` (and the convenience methods `Branch.save_checkpoint` / `Morpho.save_checkpoint`). These are the recommended way to persist morphologies between sessions.\n",
-    "2. **`pickle`** — Python's standard serialization protocol works out of the box on `Branch`, `Morpho`, and `MorphoBranch` instances, including `copy.deepcopy`. Use it for in-process snapshots, multiprocessing, or wherever you would normally reach for `pickle`.\n",
+    "1. **`.bcm` checkpoints** — a stable, version-tagged on-disk format produced by `save_branch` / `save_morpho` (and the convenience methods `Branch.save_checkpoint` / `Morphology.save_checkpoint`). These are the recommended way to persist morphologies between sessions.\n",
+    "2. **`pickle`** — Python's standard serialization protocol works out of the box on `Branch`, `Morphology`, and `MorphoBranch` instances, including `copy.deepcopy`. Use it for in-process snapshots, multiprocessing, or wherever you would normally reach for `pickle`.\n",
     "\n",
-    "Both paths preserve information that the SWC/ASC interchange formats discard: branch *names*, `parent_x`/`child_x` attachments (including `parent_x=0.5` soma midpoints), the canonical zero-length jump segments inserted at radius discontinuities, and the auto-naming counters consulted by `Morpho.attach`.\n",
+    "Both paths preserve information that the SWC/ASC interchange formats discard: branch *names*, `parent_x`/`child_x` attachments (including `parent_x=0.5` soma midpoints), the canonical zero-length jump segments inserted at radius discontinuities, and the auto-naming counters consulted by `Morphology.attach`.\n",
     "\n",
     "This notebook walks through both mechanisms, when to pick one over the other, and how to handle the common error paths."
    ]
@@ -346,7 +346,7 @@
    "id": "2888acc2",
    "metadata": {},
    "source": [
-    "## 3. Saving and loading a `Morpho`\n",
+    "## 3. Saving and loading a `Morphology`\n",
     "\n",
     "Morphology checkpoints round-trip the entire tree: branch geometry, names, parent/child attachment points, and auto-naming counters. Build a tree by hand to demonstrate."
    ]
@@ -414,7 +414,7 @@
     {
      "data": {
       "text/plain": [
-       "Morpho(root='soma', n_branches=5, geometry = complete 3d points)"
+       "Morphology(root='soma', n_branches=5, geometry = complete 3d points)"
       ]
      },
      "execution_count": 8,
@@ -507,7 +507,7 @@
    "source": [
     "### Auto-naming counters survive\n",
     "\n",
-    "`Morpho.attach` consults a per-type counter when generating default names like `dendrite_0`, `dendrite_1`, ... The checkpoint stores those counters so post-load attachments continue the same sequence."
+    "`Morphology.attach` consults a per-type counter when generating default names like `dendrite_0`, `dendrite_1`, ... The checkpoint stores those counters so post-load attachments continue the same sequence."
    ]
   },
   {
@@ -592,7 +592,7 @@
    "source": [
     "## 5. Pickle support\n",
     "\n",
-    "Every `Branch`, `Morpho`, and `MorphoBranch` instance is picklable using Python's stock `pickle` module. This means they also work with `copy.deepcopy`, `multiprocessing` queues, `joblib`, distributed task systems, and anything else that pickles its arguments under the hood."
+    "Every `Branch`, `Morphology`, and `MorphoBranch` instance is picklable using Python's stock `pickle` module. This means they also work with `copy.deepcopy`, `multiprocessing` queues, `joblib`, distributed task systems, and anything else that pickles its arguments under the hood."
    ]
   },
   {
@@ -647,8 +647,8 @@
     }
    },
    "source": [
-    "# Morpho pickle round-trip — back-references between MorphoBranch nodes and\n",
-    "# their owning Morpho are repaired automatically.\n",
+    "# Morphology pickle round-trip — back-references between MorphoBranch nodes and\n",
+    "# their owning Morphology are repaired automatically.\n",
     "pickled = pickle.dumps(morpho)\n",
     "unpickled = pickle.loads(pickled)\n",
     "print(\"equal?         \", unpickled == morpho)\n",


### PR DESCRIPTION
Iteration 2 of the module-by-module simplification sweep of `braincell`
(iteration 1 was #138). Spec ships in this PR:
`docs/specs/2026-09-02-morph-simplification.md`.

## Bugs fixed

Both were reproduced on `main` @ `4c7c572` before being fixed, and both now
have regression tests.

**`Morphology.topo()` raised `RecursionError` on deep morphologies.**
`_format_topology` recursed once per branch, so a chain past ~400 branches
overflowed — a depth real thin-neurite reconstructions reach routinely. This
is the same hazard `docs/specs/2026-08-13-vis-iterative-tree-walks.md` fixed
for the rendering paths; that spec scoped itself to `braincell/vis/`, so the
package that *owns* the tree kept the bug. It is now an explicit-stack loop.

**Two branch names silently shadowed the API.** `_validate_public_name`'s whole
job is to reject a branch name that would shadow a `Morphology` attribute, but
its reserved set was a hand-typed copy of the public surface and had drifted:

```
attach(child_name="topo")             -> ACCEPTED
morph.topo                            -> <bound method>   # branch unreachable
attach(child_name="from_neuromorpho") -> ACCEPTED, same shadowing
```

The branch lands in the tree and stays reachable by `branch(name=...)`, but
attribute access returns the method, because `__getattr__` only fires when
normal lookup fails. The fix is at the depth the file already demonstrates
three lines below the defect — `_BRANCH_RESERVED_NAMES` is *derived* from
`dir(Branch)`. The three hand-typed literals (55 lines) collapse into one
derived `_ALL_RESERVED_NAMES`.

One clause is not derivable and is unioned in explicitly:
`_MORPHO_BRANCH_PUBLIC_ATTRS`, the five names (`branch`, `name`, `parent_id`,
`parent_x`, `child_x`) that `MorphoBranch.__getattr__` serves dynamically and
that therefore never appear in `dir(MorphoBranch)`. Deriving from `dir()`
alone would have **regressed** those five from protected to shadowable. That
was caught by running it rather than reading it, and is now pinned by a test.

## Efficiency

Measured on `data/morphology/CA1.swc` (681 branches, 39,277 points), median of
7 repeats, freshly parsed morphology per repeat. **All eight benchmark digests
are identical before and after** — 39,277 points, total length
16,094.912745159878 µm, x-range 490.03 µm, 6,800 edges, a 67,885-character
`topo()`, an interpolated radius sum of 4,144.2883 µm. That equality is the
evidence these are speedups, not behaviour changes.

| Benchmark | Before | After | Speedup |
|---|---:|---:|---:|
| `metric.as_dict()` | 253.62 ms | 56.86 ms | **4.5×** |
| `clone_morpho` | 259.55 ms | 59.13 ms | **4.4×** |
| `interpolate_branch`, 256 sites × 86 branches | 595.03 ms | 201.03 ms | **3.0×** |
| `Branch.points` over every branch | 53.19 ms | 19.15 ms | **2.8×** |
| `x_range` | 52.46 ms | 21.03 ms | **2.5×** |
| `Branch.length` over every branch | 12.32 ms | 8.15 ms | **1.5×** |

Four changes produce those numbers: `Branch.points` dropped `u.math.allclose` /
`u.math.concatenate` (which re-derive dimensions and tree-map per call) for
plain NumPy on a path essentially every whole-morphology consumer reaches;
`_all_segment_arrays_um()` and a new `_all_points_um()` are memoised on the
instance and cleared from `_invalidate_derived_caches`, so `metric.as_dict()`
no longer rebuilds the whole-tree arrays six times; `Branch.length` stopped
decoding two radius arrays it discards; and `interpolate_branch` hoists five
loop-invariant `to_decimal` conversions out of its per-site loop.

Two candidates were measured and **not** landed, recorded in the spec so they
are not re-proposed: `Morphology.edges` (5.70 → 5.61 ms, so the reuse fix
landed for clarity and is not claimed as performance) and the `_path_node_ids`
/ `MorphoBranch.__getattr__` dispatch paths.

## Reuse and simplification

- **The frustum formulas existed twice** — lateral area, volume, and the
  length-weighted mean radius were written character-for-character identically
  in `Branch` and in `Morphology`, and `morphology_test.py` asserts the two
  agree, so the copies were load-bearing on each other. One home now backs
  both; `Morphology` keeps its concatenated fast path.
- `branch(index=...)`, `MorphoBranch.branch_id`, `max_branch_order`,
  `_parse_attachment_key`, and the two `Branch` factories' type resolution all
  stopped re-implementing their neighbours. `_parse_attachment_key` had already
  diverged from the validators it duplicated.
- `Branch.vis2d` / `vis3d` re-forwarded to `plot2d` / `plot3d` instead of
  calling `Morphology.vis2d` / `vis3d`, and had silently fallen behind on six
  parameters. They now delegate; every default the `Morphology` methods pass
  explicitly was checked against `plot2d`'s signature and matches.
- **Five unreachable guards and tails** removed, each confirmed unexecuted.
- **`morph` gains the `_testing.py`** it was the only domain package without,
  collapsing 41 copies of five branch literals (the same soma appeared 21
  times). `make_deep_chain_tree` moves here from `braincell/vis/_testing.py`,
  which re-exports it — the same pattern that file already uses for
  `FIXTURE_DIR` from `braincell/io/_testing.py`.

## Documentation that described behaviour the code does not have

28 references to a class named `Morpho`, which does not exist — including
`__repr__`, which printed `Morpho(root='soma', ...)`, and six user-facing error
messages naming a symbol no user can look up. Five docstrings pointed at
`braincell.morph.vis.configure(...)`, wrong twice over. Two enumerated the 2-D
layouts while omitting `"fan"`, the default. `Branch.from_lengths` documented a
`ValueError` on radius discontinuities that it does not raise.

The rename stops at this package plus the notebook (one of whose stored outputs
is a `__repr__` this change invalidates). The 16 stale spellings in
`braincell/filter/` travel with iteration 3, and the 16 in `io`/`vis` with
iteration 14; they are independent error strings, not callers of anything
changed here.

## Breaking changes

- **`Morphology.path_length_to_root` and `Morphology.shortest_path_length` are
  deleted.** 52 lines whose entire body is `raise NotImplementedError`, with
  zero callers in `braincell/`, `examples/`, or the notebooks — and
  `pyproject.toml`'s `report.exclude_also` meant coverage never flagged them
  either. Their bullets in `docs/design/interface-map.md` go with them.
  Deleting rather than implementing is deliberate: the capability exists in
  `_spatial.MorphologySpatialGeometry`, but wiring it up is feature work.
- **`Morphology.diam_arc_mean` is deleted** — `2.0 * self.mean_radius` with
  zero callers. `Branch.diam_arc_mean` is untouched and is what all 40+ uses
  repo-wide actually call.
- **`Morphology._get_branch` is deleted** — zero callers.
- **Branch names `topo` and `from_neuromorpho` are now rejected.** Behaviour
  tightening; they were previously accepted and unreachable.
- **`interpolate_branch` validates the branch before the site loop**, so an
  empty site list on a zero-length branch now raises `ValueError` instead of
  returning empty arrays.
- **Error wording**: `"reserved by the Morpho API"` becomes
  `"reserved by the Morphology API"`, and `_parse_attachment_key` now reports
  an out-of-range integer the same way `attach(parent_x=...)` does.

No deprecation shims or aliases; every in-repo caller is updated in this PR.

## Verification

```
$ pytest braincell/morph -q
82 passed, 1 warning, 18 subtests passed in 4.56s

$ pytest braincell/ -q
2718 passed, 15 skipped, 411 warnings, 389 subtests passed in 180.57s (0:03:00)

$ pre-commit run --files <the 9 changed files>
... all hooks Passed
```

The suite **gained** tests rather than losing any, and the arithmetic closes
exactly against the `main` @ `4c7c572` baseline of 2,713 passed / 338 subtests:
**+5 tests, +51 subtests, 0 skipped delta, 0 failed** — every one accounted for
by the two new regression classes (2 + 5 + 44 subtests from
`MorphoReservedNameTest`, 2 tests from `MorphoDeepTreeTest`).

## Summary by Sourcery

Simplify the morphology package while fixing deep-tree traversal and branch-name shadowing, improving whole-tree performance, and removing obsolete APIs.

Bug Fixes:
- Prevent `Morphology.topo()` from overflowing the Python recursion limit on deeply chained trees.
- Reject branch names that shadow public `Morphology` or `MorphoBranch` attributes, including previously missed names such as `topo` and `from_neuromorpho`.
- Validate branch geometry before interpolation, including raising for zero-length branches even when no sites are supplied.

Enhancements:
- Improve morphology-wide performance through cached aggregate geometry, streamlined point and length calculations, and reduced interpolation overhead.
- Consolidate shared frustum geometry, validation, branch factory logic, and delegation paths to reduce duplicated behavior.
- Remove unused and unimplemented morphology APIs and simplify several redundant tree and branch operations.

Documentation:
- Correct stale `Morpho` references, visualization configuration links, layout descriptions, and branch-construction behavior in package documentation and the morphology checkpoint notebook.

Tests:
- Add regression coverage for reserved branch names and deep morphology topology and aggregation.

Chores:
- Add shared morphology test fixtures and re-export the deep-tree fixture for visualization tests.