### PR TITLE
refactor(filter): consolidate guards, delete dead surface, memoise unit conversion

### DIFF
--- a/braincell/filter/_sampling.py
+++ b/braincell/filter/_sampling.py
@@ -73,9 +73,7 @@ class SamplingContext:
     @property
     def position(self) -> object:
         """World position, equal to ``local_position`` until transforms land."""
-        if self._local_position is None:
-            raise ValueError("SamplingContext.position requires full 3-D point geometry.")
-        return self._local_position
+        return self.local_position
 
 
 @dataclass(frozen=True)
@@ -133,11 +131,7 @@ class _PreparedComponent:
 
 
 def _coerce_inputs(number: object, seed: object, measure: object, u_resolution: object) -> tuple[int, int, str, float]:
-    if isinstance(number, bool) or not isinstance(number, Integral):
-        raise TypeError(f"number must be an integer, got {number!r}.")
-    n = int(number)
-    if n <= 0:
-        raise ValueError(f"number must be > 0, got {n!r}.")
+    n = helper.coerce_positive_count("number", number)
     if isinstance(seed, bool) or not isinstance(seed, Integral):
         raise TypeError(f"seed must be an integer, got {seed!r}.")
     if not isinstance(measure, str) or measure not in _MEASURES:
@@ -266,36 +260,55 @@ def _context(
     )
 
 
-def _density_array(value: object, *, shape: tuple[int, ...]) -> np.ndarray:
+def _dimensionless_result(
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    noun: str,
+    require_non_negative: bool,
+) -> np.ndarray:
+    """Coerce a user density's return value into a finite float array.
+
+    Parameters
+    ----------
+    value : object
+        Whatever the caller's density returned.
+    shape : tuple of int
+        Shape a non-scalar result must already have.
+    noun : str
+        Either ``"density"`` or ``"log density"``, used in every message.
+    require_non_negative : bool
+        Reject negative entries. True for a density, False for a log
+        density -- which is the one substantive difference between the two
+        callers, and the reason this takes a flag rather than hiding it.
+
+    Returns
+    -------
+    numpy.ndarray
+        Float array of shape ``shape``.
+    """
     if isinstance(value, u.Quantity):
         if not u.get_unit(value).is_unitless:
-            raise TypeError("density must return dimensionless values.")
+            raise TypeError(f"{noun} must return dimensionless values.")
         value = u.get_mantissa(value)
     values = np.asarray(value, dtype=float)
     if values.ndim == 0:
         values = np.broadcast_to(values, shape)
     elif values.shape != shape:
-        raise ValueError(f"density must return a scalar or shape {shape!r}, got {values.shape!r}.")
+        raise ValueError(f"{noun} must return a scalar or shape {shape!r}, got {values.shape!r}.")
     if np.any(~np.isfinite(values)):
-        raise ValueError("density must return finite values.")
-    if np.any(values < 0.0):
-        raise ValueError("density must return non-negative values.")
+        raise ValueError(f"{noun} must return finite values.")
+    if require_non_negative and np.any(values < 0.0):
+        raise ValueError(f"{noun} must return non-negative values.")
     return values
+
+
+def _density_array(value: object, *, shape: tuple[int, ...]) -> np.ndarray:
+    return _dimensionless_result(value, shape=shape, noun="density", require_non_negative=True)
 
 
 def _log_density_array(value: object, *, shape: tuple[int, ...]) -> np.ndarray:
-    if isinstance(value, u.Quantity):
-        if not u.get_unit(value).is_unitless:
-            raise TypeError("log density must be dimensionless.")
-        value = u.get_mantissa(value)
-    values = np.asarray(value, dtype=float)
-    if values.ndim == 0:
-        values = np.broadcast_to(values, shape)
-    elif values.shape != shape:
-        raise ValueError(f"log density must return a scalar or shape {shape!r}, got {values.shape!r}.")
-    if np.any(~np.isfinite(values)):
-        raise ValueError("log density must return finite values.")
-    return values
+    return _dimensionless_result(value, shape=shape, noun="log density", require_non_negative=False)
 
 
 def _density_value(density: Density, context: SamplingContext, *, log_shift: float | None) -> float:
@@ -343,9 +356,18 @@ def _prepare_components(
     density: Density | None,
     u_resolution: float,
 ) -> list[_PreparedComponent]:
-    geometry = MorphologySpatialGeometry.build(morpho)
-    identities = _branch_identities(morpho, components)
-    log_shift = None if density is None else _builtin_log_shift(density, identities, components, geometry)
+    # Both are reachable only from _context / _builtin_log_shift, and every
+    # one of those calls sits behind `density is not None`. Building them
+    # unconditionally ran a full multi-source Dijkstra per density-free
+    # sample() and threw the result away.
+    if density is None:
+        geometry = None
+        identities = None
+        log_shift = None
+    else:
+        geometry = MorphologySpatialGeometry.build(morpho)
+        identities = _branch_identities(morpho, components)
+        log_shift = _builtin_log_shift(density, identities, components, geometry)
     prepared: list[_PreparedComponent] = []
     for component in components:
         if isinstance(component, _AtomComponent):

--- a/braincell/filter/_sampling_test.py
+++ b/braincell/filter/_sampling_test.py
@@ -22,6 +22,7 @@ from scipy.special import ndtr, ndtri
 
 import braincell
 from braincell import Branch, Morphology
+from braincell.filter._testing import make_soma
 from braincell.filter import AllRegion, BranchSlice, RandomSamples, SamplingContext, density, metric, sample
 from braincell.filter._sampling import (
     _AtomComponent,
@@ -293,7 +294,7 @@ class SamplingContextAndValidationTest(unittest.TestCase):
                 expression.evaluate(morpho)
 
     def test_legacy_random_samples_keep_their_exact_numpy_sequence(self) -> None:
-        root = Branch.from_lengths(lengths=[10.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        root = make_soma(length=10.0)
         child = Branch.from_lengths(lengths=[30.0] * u.um, radii=[2.0, 1.0] * u.um, type="dendrite")
         morpho = Morphology.from_root(root, name="soma")
         morpho.soma.dend = child

--- a/braincell/filter/_testing.py
+++ b/braincell/filter/_testing.py
@@ -1,0 +1,93 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared fixture builders for ``braincell.filter`` tests.
+
+The leading underscore in the filename keeps pytest from discovering this
+module as a test file. Helpers here are consumed by the co-located
+``*_test.py`` modules; nothing in this file is part of the public API.
+
+The per-type branch builders are re-exported rather than redefined:
+``braincell/morph/_testing.py`` owns them, because the objects they build
+are morphology objects with no selection content. This is the same
+re-export pattern ``braincell/vis/_testing.py`` uses for
+``braincell/io/_testing.py``'s fixture paths.
+"""
+
+import brainunit as u
+
+from braincell import Branch, Morphology
+
+# Re-exported so the filter tests keep a single import site for fixtures.
+from braincell.morph._testing import (  # noqa: F401
+    make_apical,
+    make_axon,
+    make_basal,
+    make_dendrite,
+    make_soma,
+)
+
+__all__ = [
+    "make_apical",
+    "make_axon",
+    "make_basal",
+    "make_dendrite",
+    "make_soma",
+    "make_single_branch_tree",
+    "make_soma_dend_tree",
+]
+
+
+def make_soma_dend_tree(
+    *,
+    soma_length: float = 20.0,
+    dend_type: str = "basal_dendrite",
+    dend_length: float = 30.0,
+) -> Morphology:
+    """A soma with one dendrite attached at its distal end.
+
+    The smallest tree with a parent/child relationship, which is what most
+    interval and locset assertions need. Three test modules each built their
+    own copy of this, differing only in the two parameters above.
+
+    Parameters
+    ----------
+    soma_length : float
+        Soma length in micrometres.
+    dend_type : str
+        Branch type for the child, e.g. ``"basal_dendrite"`` or
+        ``"apical_dendrite"``.
+    dend_length : float
+        Dendrite length in micrometres.
+
+    Returns
+    -------
+    Morphology
+        A two-branch tree named ``soma`` -> ``dend``.
+    """
+    tree = Morphology.from_root(make_soma(length=soma_length), name="soma")
+    child = Branch.from_lengths(
+        lengths=[dend_length] * u.um,
+        radii=[2.0, 1.0] * u.um,
+        type=dend_type,
+    )
+    tree.attach(parent="soma", child_branch=child, child_name="dend", parent_x=1.0)
+    return tree
+
+
+def make_single_branch_tree(*, length: float = 10.0, radius: float = 1.0) -> Morphology:
+    """A one-branch morphology whose single segment has a uniform radius."""
+    root = Branch.from_lengths(lengths=[length] * u.um, radii=[radius, radius] * u.um, type="soma")
+    return Morphology.from_root(root, name="soma")

--- a/braincell/filter/cache.py
+++ b/braincell/filter/cache.py
@@ -19,8 +19,6 @@
 from dataclasses import dataclass, field
 from typing import Callable
 
-from brainunit import Quantity
-
 __all__ = ["SelectionCache", "evaluate_cached"]
 
 _MISS = object()
@@ -30,13 +28,7 @@ _MISS = object()
 class SelectionCache:
     """Scratch space threaded through a whole selection expression tree.
 
-    The three dictionaries are **reserved** for the region and locset types
-    that still raise ``NotImplementedError`` (:class:`RadiusRangeRegion`,
-    :class:`TreeDistanceRegion`, :class:`EuclideanDistanceRegion`,
-    :class:`SubtreeRegion`, :class:`StepSamples`); nothing populates them
-    yet.
-
-    What *is* live is sub-expression memoization: :meth:`evaluated` lets a
+    Sub-expression memoization is the whole of it: :meth:`evaluated` lets a
     composite reuse an operand's mask instead of walking the morphology
     again, so ``(A | B) & (A | C)`` evaluates ``A`` once rather than twice.
 
@@ -44,13 +36,18 @@ class SelectionCache:
     -----
     Memoized entries are valid only for the morphology and structural
     revision they were produced from. Handing the same cache to a second
-    morphology, or reusing it after :meth:`Morpho.attach`, drops the stored
-    masks rather than returning a stale answer.
+    morphology, or reusing it after :meth:`Morphology.attach`, drops the
+    stored masks rather than returning a stale answer.
+
+    This class previously also carried ``tree_distance_to_root``,
+    ``euclidean_distance_to_root``, and ``branch_radius_summary``, reserved
+    for the region types that still raise ``NotImplementedError``. Nothing
+    ever wrote them. Whoever implements one of those types should add the
+    field it actually needs rather than inherit three guesses -- note that
+    per-node tree distance is already computed by
+    :class:`braincell.morph._spatial.MorphologySpatialGeometry`.
     """
 
-    tree_distance_to_root: dict[int, Quantity] = field(default_factory=dict)
-    euclidean_distance_to_root: dict[int, Quantity] = field(default_factory=dict)
-    branch_radius_summary: dict[int, tuple[Quantity, Quantity]] = field(default_factory=dict)
     _masks: dict[object, object] = field(default_factory=dict, repr=False, compare=False)
     _morpho: object | None = field(default=None, repr=False, compare=False)
     _revision: int = field(default=-1, repr=False, compare=False)

--- a/braincell/filter/cache_test.py
+++ b/braincell/filter/cache_test.py
@@ -15,13 +15,6 @@
 
 """Tests for :mod:`braincell.filter.cache`.
 
-``SelectionCache``'s three dictionaries are still **reserved**: they exist
-for the four region types and one locset type that would need memoized
-per-branch distances and radii — :class:`RadiusRangeRegion`,
-:class:`TreeDistanceRegion`, :class:`EuclideanDistanceRegion`,
-:class:`SubtreeRegion`, and :class:`StepSamples` — every one of which
-currently raises ``NotImplementedError``.
-
 Three things are live and tested here:
 
 * the *plumbing* — every composite region and locset expression threads
@@ -40,6 +33,7 @@ import unittest
 import brainunit as u
 
 from braincell import Branch, Morphology
+from braincell.filter._testing import make_soma_dend_tree
 from braincell.filter import AllRegion, SelectionCache
 from braincell.filter.locset import (
     LocsetExpr,
@@ -61,11 +55,7 @@ from braincell.filter.region import (
 
 def _soma_dend_tree() -> Morphology:
     """A two-branch tree: soma plus one apical dendrite."""
-    soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-    dend = Branch.from_lengths(lengths=[30.0] * u.um, radii=[2.0, 1.0] * u.um, type="apical_dendrite")
-    tree = Morphology.from_root(soma, name="soma")
-    tree.attach(parent="soma", child_branch=dend, child_name="dend", parent_x=1.0)
-    return tree
+    return make_soma_dend_tree(dend_type="apical_dendrite")
 
 
 class _SpyRegion(RegionExpr):
@@ -75,7 +65,7 @@ class _SpyRegion(RegionExpr):
         self.seen: list[SelectionCache | None] = []
         self._intervals = tuple(intervals)
 
-    def evaluate(self, morpho, cache=None) -> RegionMask:
+    def _evaluate(self, morpho, cache=None) -> RegionMask:
         self.seen.append(cache)
         return RegionMask(self._intervals)
 
@@ -87,41 +77,9 @@ class _SpyLocset(LocsetExpr):
         self.seen: list[SelectionCache | None] = []
         self._points = tuple(points)
 
-    def evaluate(self, morpho, cache=None) -> LocsetMask:
+    def _evaluate(self, morpho, cache=None) -> LocsetMask:
         self.seen.append(cache)
         return LocsetMask(points=self._points, display_names=("spy",) * len(self._points))
-
-
-class SelectionCacheFieldsTest(unittest.TestCase):
-    def test_fields_default_to_empty_dicts(self) -> None:
-        cache = SelectionCache()
-
-        self.assertEqual(cache.tree_distance_to_root, {})
-        self.assertEqual(cache.euclidean_distance_to_root, {})
-        self.assertEqual(cache.branch_radius_summary, {})
-
-    def test_instances_do_not_share_their_dicts(self) -> None:
-        # All three fields use default_factory; a plain `{}` default would
-        # make every SelectionCache in the process alias one set of dicts.
-        first = SelectionCache()
-        second = SelectionCache()
-
-        first.tree_distance_to_root[0] = 10.0 * u.um
-        first.euclidean_distance_to_root[0] = 8.0 * u.um
-        first.branch_radius_summary[0] = (1.0 * u.um, 2.0 * u.um)
-
-        self.assertEqual(second.tree_distance_to_root, {})
-        self.assertEqual(second.euclidean_distance_to_root, {})
-        self.assertEqual(second.branch_radius_summary, {})
-
-    def test_cache_is_mutable_so_callers_can_populate_it(self) -> None:
-        # Not frozen, by design: the reserved consumers must be able to fill
-        # these in during evaluation.
-        cache = SelectionCache()
-
-        cache.tree_distance_to_root = {1: 5.0 * u.um}
-
-        self.assertEqual(set(cache.tree_distance_to_root), {1})
 
 
 class RegionCacheThreadingTest(unittest.TestCase):
@@ -235,9 +193,9 @@ class SubExpressionMemoizationTest(unittest.TestCase):
         calls: list[Morphology] = []
 
         class _CountingAll(AllRegion):
-            def evaluate(self, morpho, cache=None):
+            def _evaluate(self, morpho, cache=None):
                 calls.append(morpho)
-                return super().evaluate(morpho, cache)
+                return super()._evaluate(morpho, cache)
 
         ((_CountingAll() | spy) & (_CountingAll() | spy)).evaluate(self.tree, self.cache)
 

--- a/braincell/filter/density.py
+++ b/braincell/filter/density.py
@@ -43,8 +43,9 @@ def _positive_scale(value: object, *, name: str) -> object:
 
 
 def _field(context: object, name: str) -> object:
-    if not isinstance(name, str) or not name:
-        raise TypeError("density field must be a non-empty string.")
+    # `name` is always a frozen dataclass's own `field`, and exponential() /
+    # gaussian() -- the only two construction sites -- already applied the
+    # non-empty-string check before storing it.
     try:
         return getattr(context, name)
     except AttributeError as exc:
@@ -107,7 +108,7 @@ def exponential(
     Parameters
     ----------
     field : str
-        Name of a numeric :class:`SamplingContext` field.
+        Name of a numeric :class:`~braincell.filter.SamplingContext` field.
     scale : scalar or Quantity
         Positive scale with units compatible with the selected field.
     direction : {'increasing', 'decreasing'}, optional
@@ -137,7 +138,7 @@ def gaussian(field: str, center: object, sigma: object) -> object:
     Parameters
     ----------
     field : str
-        Name of a numeric :class:`SamplingContext` field.
+        Name of a numeric :class:`~braincell.filter.SamplingContext` field.
     center : scalar or Quantity
         Center in units compatible with the selected field.
     sigma : scalar or Quantity

--- a/braincell/filter/density_test.py
+++ b/braincell/filter/density_test.py
@@ -1,0 +1,158 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for :mod:`braincell.filter.density`.
+
+The three factories' *sampling* behaviour — that a density actually bends
+the draw distribution — is exercised end-to-end in ``_sampling_test.py``,
+which owns the inverse-CDF machinery. What lives here is the module's own
+surface: argument validation, the deprecation contract on the two legacy
+field helpers, and the log-density evaluation each frozen density performs.
+"""
+
+import unittest
+import warnings
+from types import SimpleNamespace
+
+import brainunit as u
+import numpy as np
+
+from braincell.filter import density
+
+
+def _quiet(factory, *args, **kwargs):
+    """Call a deprecated factory without the warning failing the test."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return factory(*args, **kwargs)
+
+
+class DeprecationContractTest(unittest.TestCase):
+    """``exponential`` and ``gaussian`` are deprecated in favour of ``metric``."""
+
+    def test_legacy_field_helpers_emit_deprecation_warning(self) -> None:
+        with self.assertWarnsRegex(DeprecationWarning, "filter.metric"):
+            density.exponential("branch_x", 0.2)
+        with self.assertWarnsRegex(DeprecationWarning, "filter.metric"):
+            density.gaussian("branch_x", 0.5, 0.2)
+
+    def test_spatial_gaussian_is_not_deprecated(self) -> None:
+        # It has no field-name indirection to replace, so it is the one
+        # factory metric.py does not supersede.
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            density.spatial_gaussian(center=[0.0, 0.0, 0.0] * u.um, sigma=10.0 * u.um)
+
+
+class ExponentialValidationTest(unittest.TestCase):
+    def test_field_must_be_a_non_empty_string(self) -> None:
+        for bad in ("", 0, None):
+            with self.subTest(field=bad):
+                with self.assertRaisesRegex(TypeError, "field must be a non-empty string"):
+                    _quiet(density.exponential, bad, 0.2)
+
+    def test_scale_must_be_positive(self) -> None:
+        for bad in (0.0, -1.0):
+            with self.subTest(scale=bad):
+                with self.assertRaises(ValueError):
+                    _quiet(density.exponential, "branch_x", bad)
+
+    def test_direction_must_be_a_known_word(self) -> None:
+        with self.assertRaisesRegex(ValueError, "increasing.*decreasing"):
+            _quiet(density.exponential, "branch_x", 0.2, "sideways")
+
+    def test_direction_sets_the_sign_of_the_exponent(self) -> None:
+        rising = _quiet(density.exponential, "branch_x", 0.5, "increasing")
+        falling = _quiet(density.exponential, "branch_x", 0.5, "decreasing")
+        near = SimpleNamespace(branch_x=0.1)
+        far = SimpleNamespace(branch_x=0.9)
+
+        self.assertGreater(float(rising(far)), float(rising(near)))
+        self.assertLess(float(falling(far)), float(falling(near)))
+
+
+class GaussianValidationTest(unittest.TestCase):
+    def test_field_must_be_a_non_empty_string(self) -> None:
+        with self.assertRaisesRegex(TypeError, "field must be a non-empty string"):
+            _quiet(density.gaussian, "", 0.5, 0.2)
+
+    def test_sigma_must_be_positive(self) -> None:
+        with self.assertRaises(ValueError):
+            _quiet(density.gaussian, "branch_x", 0.5, 0.0)
+
+    def test_density_peaks_at_the_center(self) -> None:
+        bell = _quiet(density.gaussian, "branch_x", 0.5, 0.1)
+        at_center = float(bell(SimpleNamespace(branch_x=0.5)))
+        off_center = float(bell(SimpleNamespace(branch_x=0.9)))
+
+        self.assertGreater(at_center, off_center)
+        self.assertTrue(np.isfinite(at_center))
+
+    def test_a_missing_field_names_the_field_it_wanted(self) -> None:
+        bell = _quiet(density.gaussian, "branch_x", 0.5, 0.1)
+        with self.assertRaisesRegex(ValueError, "no density field 'branch_x'"):
+            bell(SimpleNamespace())
+
+
+class SpatialGaussianValidationTest(unittest.TestCase):
+    def test_center_must_be_a_three_dimensional_quantity(self) -> None:
+        with self.assertRaisesRegex(TypeError, "center must be a three-dimensional quantity"):
+            density.spatial_gaussian(center=[0.0, 0.0, 0.0], sigma=10.0 * u.um)
+        with self.assertRaisesRegex(ValueError, "finite three-dimensional coordinate"):
+            density.spatial_gaussian(center=[0.0, 0.0] * u.um, sigma=10.0 * u.um)
+
+    def test_sigma_must_be_a_length_quantity(self) -> None:
+        with self.assertRaisesRegex(TypeError, "sigma must be a length quantity"):
+            density.spatial_gaussian(center=[0.0, 0.0, 0.0] * u.um, sigma=10.0)
+
+    def test_center_and_sigma_units_must_be_compatible(self) -> None:
+        with self.assertRaises(Exception):
+            density.spatial_gaussian(center=[0.0, 0.0, 0.0] * u.um, sigma=10.0 * u.ms)
+
+    def test_density_peaks_at_the_center_position(self) -> None:
+        bell = density.spatial_gaussian(center=[0.0, 0.0, 0.0] * u.um, sigma=10.0 * u.um)
+        at_center = float(bell(SimpleNamespace(position=[0.0, 0.0, 0.0] * u.um)))
+        off_center = float(bell(SimpleNamespace(position=[30.0, 0.0, 0.0] * u.um)))
+
+        self.assertGreater(at_center, off_center)
+        self.assertTrue(np.isfinite(at_center))
+
+
+class DensityValueTest(unittest.TestCase):
+    """Every factory returns a non-negative, finite, dimensionless callable."""
+
+    def test_all_three_return_non_negative_finite_values(self) -> None:
+        cases = (
+            (_quiet(density.exponential, "branch_x", 0.5), SimpleNamespace(branch_x=0.3)),
+            (_quiet(density.gaussian, "branch_x", 0.5, 0.2), SimpleNamespace(branch_x=0.3)),
+            (
+                density.spatial_gaussian(center=[0.0, 0.0, 0.0] * u.um, sigma=10.0 * u.um),
+                SimpleNamespace(position=[1.0, 2.0, 3.0] * u.um),
+            ),
+        )
+        for fn, context in cases:
+            with self.subTest(density=type(fn).__name__):
+                value = np.asarray(fn(context), dtype=float)
+                self.assertTrue(np.all(np.isfinite(value)))
+                self.assertTrue(np.all(value >= 0.0))
+
+    def test_densities_are_frozen(self) -> None:
+        bell = _quiet(density.gaussian, "branch_x", 0.5, 0.2)
+        with self.assertRaises(Exception):
+            bell.field = "radius"
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/braincell/filter/helper.py
+++ b/braincell/filter/helper.py
@@ -30,6 +30,7 @@ _UNSUPPORTED_BRANCH_METRIC_PROPERTIES = {"max_radius", "min_radius"}
 __all__ = [
     "EPSILON",
     "branch_slice_intervals",
+    "coerce_positive_count",
     "branch_in_intervals",
     "branch_range_intervals",
     "normalize_region_intervals",
@@ -38,7 +39,6 @@ __all__ = [
     "difference_region_intervals",
     "complement_region_intervals",
     "fork_points_locations",
-    "branch_points_locations",
     "terminal_locations",
     "uniform_samples_from_region",
     "random_samples_from_region",
@@ -195,12 +195,29 @@ def _normalize_quantity_bound(
     return _to_decimal_scalar(bound, unit=unit, name=property_name)
 
 
-def _matches_range(value: object, *, low: object | None, high: object | None, closed: str, property_name: str) -> bool:
+def _matches_range(
+    value: object,
+    *,
+    low: object | None,
+    high: object | None,
+    closed: str,
+    property_name: str,
+    bounds_by_unit: dict[object, tuple[float | None, float | None]] | None = None,
+) -> bool:
     if _is_quantity(value):
         unit = u.get_unit(value)
         current = _to_decimal_scalar(value, unit=unit, name=property_name)
-        low_value = _normalize_quantity_bound(low, property_name=property_name, unit=unit)
-        high_value = _normalize_quantity_bound(high, property_name=property_name, unit=unit)
+        # Same per-unit memo as _matches_in: the bounds do not vary across
+        # branches, but the unit they must be decoded into comes from each
+        # branch's value, so the cache is keyed on it rather than removed.
+        cached = None if bounds_by_unit is None else bounds_by_unit.get(unit)
+        if cached is None:
+            low_value = _normalize_quantity_bound(low, property_name=property_name, unit=unit)
+            high_value = _normalize_quantity_bound(high, property_name=property_name, unit=unit)
+            if bounds_by_unit is not None:
+                bounds_by_unit[unit] = (low_value, high_value)
+        else:
+            low_value, high_value = cached
     else:
         if isinstance(value, bool) or not isinstance(value, Real):
             raise TypeError(f"Property {property_name!r} does not support numeric range filtering.")
@@ -226,18 +243,40 @@ def _matches_range(value: object, *, low: object | None, high: object | None, cl
     return True
 
 
-def _matches_in(value: object, *, candidates: tuple[object, ...], property_name: str) -> bool:
+def _normalize_candidates(candidates: tuple[object, ...], *, unit: object, property_name: str) -> set[float]:
+    """Decode every candidate into ``unit``, rejecting non-numeric entries."""
+    normalized: set[float] = set()
+    for candidate in candidates:
+        if _is_quantity(candidate):
+            normalized.add(_to_decimal_scalar(candidate, unit=unit, name=property_name))
+        elif isinstance(candidate, bool) or not isinstance(candidate, Real):
+            raise TypeError(f"Property {property_name!r} is quantity-valued; candidates must be numeric/quantity.")
+        else:
+            normalized.add(float(candidate))
+    return normalized
+
+
+def _matches_in(
+    value: object,
+    *,
+    candidates: tuple[object, ...],
+    property_name: str,
+    normalized_by_unit: dict[object, set[float]] | None = None,
+) -> bool:
     if _is_quantity(value):
         unit = u.get_unit(value)
         current = _to_decimal_scalar(value, unit=unit, name=property_name)
-        normalized: set[float] = set()
-        for candidate in candidates:
-            if _is_quantity(candidate):
-                normalized.add(_to_decimal_scalar(candidate, unit=unit, name=property_name))
-            elif isinstance(candidate, bool) or not isinstance(candidate, Real):
-                raise TypeError(f"Property {property_name!r} is quantity-valued; candidates must be numeric/quantity.")
-            else:
-                normalized.add(float(candidate))
+        # Keyed by unit rather than hoisted outright: the unit comes from the
+        # branch's own value, so a property returning mixed units still gets
+        # a correctly decoded candidate set -- it just gets one per unit
+        # instead of one per branch.
+        if normalized_by_unit is None:
+            normalized = _normalize_candidates(candidates, unit=unit, property_name=property_name)
+        else:
+            normalized = normalized_by_unit.get(unit)
+            if normalized is None:
+                normalized = _normalize_candidates(candidates, unit=unit, property_name=property_name)
+                normalized_by_unit[unit] = normalized
         return current in normalized
     return any(value == candidate for candidate in candidates)
 
@@ -280,10 +319,16 @@ def branch_in_intervals(
 ) -> tuple[tuple[int, float, float], ...]:
     prop = _coerce_property_name(property_name)
     candidates = _coerce_values("values", values)
+    normalized_by_unit: dict[object, set[float]] = {}
     intervals: list[tuple[int, float, float]] = []
     for index, branch_view in enumerate(morpho.branches):
         value = _resolve_branch_property(branch_view, prop)
-        if _matches_in(value, candidates=candidates, property_name=prop):
+        if _matches_in(
+            value,
+            candidates=candidates,
+            property_name=prop,
+            normalized_by_unit=normalized_by_unit,
+        ):
             intervals.append((index, 0.0, 1.0))
     return tuple(intervals)
 
@@ -299,6 +344,7 @@ def branch_range_intervals(
     low, high = _parse_bounds(bounds)
     closed_mode = _parse_closed(closed)
 
+    bounds_by_unit: dict[object, tuple[float | None, float | None]] = {}
     intervals: list[tuple[int, float, float]] = []
     for index, branch_view in enumerate(morpho.branches):
         value = _resolve_branch_property(branch_view, prop)
@@ -308,6 +354,7 @@ def branch_range_intervals(
             high=high,
             closed=closed_mode,
             property_name=prop,
+            bounds_by_unit=bounds_by_unit,
         ):
             intervals.append((index, 0.0, 1.0))
     return tuple(intervals)
@@ -625,11 +672,6 @@ def fork_points_locations(morpho: Morphology, *, epsilon: float = EPSILON) -> tu
     return tuple(forks)
 
 
-def branch_points_locations(morpho: Morphology, *, epsilon: float = EPSILON) -> tuple[Location, ...]:
-    """Compatibility alias for :func:`fork_points_locations`."""
-    return fork_points_locations(morpho, epsilon=epsilon)
-
-
 def terminal_locations(morpho: Morphology, *, epsilon: float = EPSILON) -> tuple[Location, ...]:
     points: list[Location] = [
         (branch_idx, 1.0) for branch_idx, branch in enumerate(morpho.branches) if branch.n_children == 0
@@ -656,7 +698,7 @@ def _sample_entries(
     return entries
 
 
-def _coerce_positive_count(name: str, count: object) -> int:
+def coerce_positive_count(name: str, count: object) -> int:
     if isinstance(count, bool) or not isinstance(count, Integral):
         raise TypeError(f"{name} must be an integer, got {count!r}.")
     value = int(count)
@@ -672,7 +714,7 @@ def uniform_samples_from_region(
     count: object,
     epsilon: float = EPSILON,
 ) -> tuple[Location, ...]:
-    n = _coerce_positive_count("count", count)
+    n = coerce_positive_count("count", count)
     entries = _sample_entries(morpho, intervals, epsilon=epsilon)
     if not entries:
         raise ValueError("UniformSamples cannot sample from an empty or zero-length region.")
@@ -690,7 +732,9 @@ def uniform_samples_from_region(
         branch, prox, dist, length_um = entries[idx]
         prev = 0.0 if idx == 0 else float(cumulative[idx - 1])
         offset = max(0.0, min(target - prev, length_um))
-        ratio = 0.0 if length_um <= epsilon else (offset / length_um)
+        # _sample_entries only appends when length_um > epsilon, so there is
+        # no zero-length entry to guard against here.
+        ratio = offset / length_um
         x = prox + ratio * (dist - prox)
         points.append((branch, _normalize_loc_x(x, epsilon=epsilon)))
     return normalize_locset_points(points, epsilon=epsilon)
@@ -704,7 +748,7 @@ def random_samples_from_region(
     seed: object,
     epsilon: float = EPSILON,
 ) -> tuple[Location, ...]:
-    n = _coerce_positive_count("count", count)
+    n = coerce_positive_count("count", count)
     if isinstance(seed, bool) or not isinstance(seed, Integral):
         raise TypeError(f"seed must be an integer, got {seed!r}.")
     entries = _sample_entries(morpho, intervals, epsilon=epsilon)

--- a/braincell/filter/helper_test.py
+++ b/braincell/filter/helper_test.py
@@ -52,6 +52,7 @@ class HelperModuleAllTest(unittest.TestCase):
             {
                 "EPSILON",
                 "branch_slice_intervals",
+                "coerce_positive_count",
                 "branch_in_intervals",
                 "branch_range_intervals",
                 "normalize_region_intervals",
@@ -59,7 +60,6 @@ class HelperModuleAllTest(unittest.TestCase):
                 "intersect_region_intervals",
                 "difference_region_intervals",
                 "complement_region_intervals",
-                "branch_points_locations",
                 "fork_points_locations",
                 "terminal_locations",
                 "uniform_samples_from_region",

--- a/braincell/filter/locset.py
+++ b/braincell/filter/locset.py
@@ -23,6 +23,7 @@ from brainunit import Quantity
 
 from braincell.morph.morphology import Morphology
 from . import helper
+from ._sampling import sample_locations_from_region
 from .cache import SelectionCache, evaluate_cached
 from .region import RegionExpr
 
@@ -83,25 +84,23 @@ def _normalize_location_columns(
         raise ValueError(f"{type_name}.branch_x values must be within [0, 1].")
     return (
         np.asarray(branch_values, dtype=np.int64),
-        np.round(np.clip(normalized_x, 0.0, 1.0), decimals=12),
+        np.round(np.clip(normalized_x, 0.0, 1.0), decimals=helper._round_digits_from_epsilon(helper.EPSILON)),
     )
 
 
-@dataclass(init=False, eq=False, repr=False)
 class LocsetBatch:
     """A read-only batch of aligned resolved locsets.
 
     The leading dimension identifies population members and the trailing
     dimension contains the locations assigned to each member.
 
-    Parameters
-    ----------
-    branch_id : array-like
-        Two-dimensional integer branch identifiers.
-    branch_x : array-like
-        Two-dimensional normalized branch coordinates in ``[0, 1]``.
-    display_names : iterable of iterable of str, optional
-        Human-readable names aligned with the location matrix.
+    Instances are built through :meth:`from_columns`; the class itself takes
+    no constructor arguments.
+
+    See Also
+    --------
+    from_columns : The constructor, which documents the columns.
+    LocsetMask : The single-population equivalent.
     """
 
     __slots__ = ("_branch_id", "_branch_x", "_display_names")
@@ -116,7 +115,28 @@ class LocsetBatch:
         branch_x: object,
         display_names: tuple[tuple[str, ...], ...] | list[list[str]] | None = None,
     ) -> "LocsetBatch":
-        """Construct a batch from two aligned location matrices."""
+        """Construct a batch from two aligned location matrices.
+
+        Parameters
+        ----------
+        branch_id : array-like
+            Two-dimensional integer branch identifiers.
+        branch_x : array-like
+            Two-dimensional normalized branch coordinates in ``[0, 1]``.
+        display_names : iterable of iterable of str, optional
+            Human-readable names aligned with the location matrix.
+
+        Returns
+        -------
+        LocsetBatch
+            Immutable batch over the normalized columns.
+
+        Raises
+        ------
+        ValueError
+            If *display_names* does not match the column shape, or a
+            coordinate falls outside ``[0, 1]``.
+        """
         branch_values, x_values = _normalize_location_columns(
             branch_id,
             branch_x,
@@ -184,7 +204,6 @@ class LocsetBatch:
         )
 
 
-@dataclass(init=False, eq=False, repr=False)
 class LocsetMask:
     """Resolved ordered locations in read-only columnar storage.
 
@@ -312,7 +331,7 @@ class LocsetMask:
 
         Parameters
         ----------
-        morpho : braincell.morph.Morphology
+        morpho : braincell.Morphology
             Morphology used to resolve branch names.
 
         Returns
@@ -322,9 +341,7 @@ class LocsetMask:
         """
         if self._display_names is not None:
             return self._display_names
-        return tuple(
-            f"{morpho.branch(index=int(branch_id)).name}({float(branch_x):g})" for branch_id, branch_x in self.points
-        )
+        return _display_names_for_points(morpho, self.points)
 
     def __len__(self) -> int:
         return len(self._branch_id)
@@ -407,13 +424,48 @@ class LocsetExpr(ABC):
         """Return an expression that deduplicates locations after evaluation."""
         return LocsetUniqueOp(self)
 
-    @abstractmethod
     def evaluate(
         self,
         morpho: Morphology,
         cache: SelectionCache | None = None,
     ) -> LocsetMask:
-        raise NotImplementedError
+        """Evaluate this expression against ``morpho``.
+
+        Parameters
+        ----------
+        morpho : braincell.Morphology
+            Morphology to evaluate against.
+        cache : braincell.filter.SelectionCache or None
+            Shared memoization scratch space, threaded to sub-expressions.
+
+        Returns
+        -------
+        LocsetMask
+            The selected point set.
+
+        Raises
+        ------
+        TypeError
+            If *morpho* is not a :class:`braincell.Morphology`.
+
+        Notes
+        -----
+        This is the type-checked entry point every caller uses; subclasses
+        implement :meth:`_evaluate` instead. Keeping the guard here rather
+        than in each leaf is why it cannot be forgotten -- it previously was,
+        by ``EmptyRegion``, which accepted arguments every sibling rejected.
+        """
+        if not isinstance(morpho, Morphology):
+            raise TypeError(f"{type(self).__name__} expects Morphology, got {type(morpho).__name__!s}.")
+        return self._evaluate(morpho, cache)
+
+    @abstractmethod
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
+        """Compute the point set for a morphology already type-checked by :meth:`evaluate`."""
 
 
 @dataclass(frozen=True)
@@ -421,10 +473,11 @@ class AtLocation(LocsetExpr):
     branch: int | str
     x: float
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        _ = cache
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"AtLocation expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         if isinstance(self.branch, bool):
             raise TypeError("AtLocation.branch expects int or str, got bool.")
         if isinstance(self.branch, int):
@@ -446,9 +499,11 @@ def at(branch: int | str, x: float) -> AtLocation:
 class RootLocation(LocsetExpr):
     x: float
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"RootLocation expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         points = helper.normalize_locset_points(((0, self.x),))
         return LocsetMask(points=points, display_names=_display_names_for_points(morpho, points))
 
@@ -457,9 +512,11 @@ class RootLocation(LocsetExpr):
 class ForkPoints(LocsetExpr):
     """Select topology junctions incident to at least three branches."""
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"ForkPoints expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         points = helper.fork_points_locations(morpho)
         return LocsetMask(points=points, display_names=_display_names_for_points(morpho, points))
 
@@ -469,9 +526,11 @@ BranchPoints = ForkPoints
 
 @dataclass(frozen=True)
 class Terminals(LocsetExpr):
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"Terminals expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         points = helper.terminal_locations(morpho)
         return LocsetMask(points=points, display_names=_display_names_for_points(morpho, points))
 
@@ -481,7 +540,11 @@ class RegionAnchors(LocsetExpr):
     region: RegionExpr
     x: float
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         raise NotImplementedError("RegionAnchors is not implemented in this version.")
 
 
@@ -490,9 +553,11 @@ class UniformSamples(LocsetExpr):
     region: RegionExpr
     count: int
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"UniformSamples expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         if not isinstance(self.region, RegionExpr):
             raise TypeError(f"UniformSamples.region expects RegionExpr, got {type(self.region).__name__!s}.")
         mask = evaluate_cached(self.region, morpho, cache)
@@ -510,9 +575,11 @@ class RandomSamples(LocsetExpr):
     count: int
     seed: int
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"RandomSamples expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         if not isinstance(self.region, RegionExpr):
             raise TypeError(f"RandomSamples.region expects RegionExpr, got {type(self.region).__name__!s}.")
         mask = evaluate_cached(self.region, morpho, cache)
@@ -554,13 +621,13 @@ class SampleLocations(LocsetExpr):
     density: object | None = None
     u_resolution: float = 1e-10
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"SampleLocations expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         if not isinstance(self.region, RegionExpr):
             raise TypeError(f"sample().region expects RegionExpr, got {type(self.region).__name__!s}.")
-        from ._sampling import sample_locations_from_region
-
         mask = evaluate_cached(self.region, morpho, cache)
         branch_id, branch_x = sample_locations_from_region(
             morpho,
@@ -621,7 +688,11 @@ class StepSamples(LocsetExpr):
     region: RegionExpr
     step: Quantity
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         raise NotImplementedError
 
 
@@ -637,14 +708,20 @@ class LocsetConcatOp(LocsetExpr):
 
     operands: tuple[LocsetExpr, ...]
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"LocsetConcatOp expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         if len(self.operands) < 2:
             raise ValueError("concatenation expects at least two operands.")
-        points: tuple[Location, ...] = ()
+        # Accumulate raw, normalize once. concat_locset_points() normalizes
+        # left + right on every call, so folding through it made the pass
+        # O(k^2 * m) over data that was already validated by each operand.
+        collected: list[Location] = []
         for operand in self.operands:
-            points = helper.concat_locset_points(points, evaluate_cached(operand, morpho, cache).points)
+            collected.extend(evaluate_cached(operand, morpho, cache).points)
+        points = helper.normalize_locset_points(tuple(collected))
         return LocsetMask(points=points, display_names=_display_names_for_points(morpho, points))
 
 
@@ -653,17 +730,22 @@ class LocsetSetOp(LocsetExpr):
     op: str
     operands: tuple[LocsetExpr, ...]
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"LocsetSetOp expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         if self.op not in {"union", "intersection", "difference"}:
             raise ValueError(f"Unsupported locset set operation {self.op!r}.")
         if len(self.operands) < 2:
             raise ValueError(f"{self.op} expects at least two operands.")
 
-        current = helper.normalize_locset_points(evaluate_cached(self.operands[0], morpho, cache).points)
+        # As in RegionSetOp: union_/intersect_/difference_locset_points each
+        # normalize through unique_locset_points, and LocsetMask.points is
+        # already canonical, so an outer pass is the third of three.
+        current = evaluate_cached(self.operands[0], morpho, cache).points
         for operand in self.operands[1:]:
-            other = helper.normalize_locset_points(evaluate_cached(operand, morpho, cache).points)
+            other = evaluate_cached(operand, morpho, cache).points
             if self.op == "union":
                 current = helper.union_locset_points(current, other)
             elif self.op == "intersection":
@@ -685,9 +767,11 @@ class LocsetUniqueOp(LocsetExpr):
 
     operand: LocsetExpr
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> LocsetMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"LocsetUniqueOp expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> LocsetMask:
         return evaluate_cached(self.operand, morpho, cache).unique()
 
 

--- a/braincell/filter/locset_test.py
+++ b/braincell/filter/locset_test.py
@@ -21,6 +21,7 @@ import brainunit as u
 import numpy as np
 
 from braincell import Branch, Morphology
+from braincell.filter._testing import make_soma, make_soma_dend_tree
 from braincell.filter import (
     AtLocation,
     BranchPoints,
@@ -42,7 +43,7 @@ from braincell.filter import locset as locset_mod
 
 
 def _build_branchpoint_morphology() -> Morphology:
-    soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+    soma = make_soma()
     basal = Branch.from_lengths(lengths=[30.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
     axon = Branch.from_lengths(lengths=[10.0] * u.um, radii=[0.8, 0.5] * u.um, type="axon")
     apical = Branch.from_lengths(lengths=[20.0] * u.um, radii=[1.5, 1.0] * u.um, type="apical_dendrite")
@@ -57,12 +58,7 @@ def _build_branchpoint_morphology() -> Morphology:
 
 
 def _build_sampling_tree() -> Morphology:
-    soma = Branch.from_lengths(lengths=[10.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-    dend = Branch.from_lengths(lengths=[30.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
-
-    tree = Morphology.from_root(soma, name="soma")
-    tree.soma.dend = dend
-    return tree
+    return make_soma_dend_tree(soma_length=10.0)
 
 
 def _branch(*, branch_type: str = "dendrite") -> Branch:

--- a/braincell/filter/metric.py
+++ b/braincell/filter/metric.py
@@ -18,39 +18,57 @@
 __all__ = ["branch_x", "radius", "path_distance_from_soma", "position"]
 
 
+def _first_attribute(context: object, names: tuple[str, ...], description: str) -> object:
+    """Return the first of ``names`` that ``context`` exposes.
+
+    The three context types (:class:`~braincell.filter.SamplingContext`,
+    ``SynapseContext``, and ``CVContext``) name the same quantities
+    differently -- ``CVContext`` spells ``branch_x`` as ``midpoint`` and
+    ``radius`` as ``radius_mid`` -- so a metric accepts an ordered list of
+    spellings and reports one ``TypeError`` when a context offers none.
+
+    Parameters
+    ----------
+    context : object
+        Callable-parameter context to read from.
+    names : tuple of str
+        Attribute names to try, in order of preference.
+    description : str
+        Noun phrase completing "does not expose ...", used in the error.
+
+    Returns
+    -------
+    object
+        The value of the first attribute present.
+
+    Raises
+    ------
+    TypeError
+        If ``context`` exposes none of ``names``.
+    """
+    for name in names:
+        try:
+            return getattr(context, name)
+        except AttributeError:
+            continue
+    raise TypeError(f"{type(context).__name__} does not expose {description}.")
+
+
 def branch_x(context: object) -> object:
     """Return the normalized branch coordinate represented by ``context``."""
-    try:
-        return getattr(context, "branch_x")
-    except AttributeError:
-        try:
-            return getattr(context, "midpoint")
-        except AttributeError as exc:
-            raise TypeError(f"{type(context).__name__} does not expose a branch coordinate.") from exc
+    return _first_attribute(context, ("branch_x", "midpoint"), "a branch coordinate")
 
 
 def radius(context: object) -> object:
     """Return radius at the location represented by ``context``."""
-    try:
-        return getattr(context, "radius")
-    except AttributeError:
-        try:
-            return getattr(context, "radius_mid")
-        except AttributeError as exc:
-            raise TypeError(f"{type(context).__name__} does not expose a radius.") from exc
+    return _first_attribute(context, ("radius", "radius_mid"), "a radius")
 
 
 def path_distance_from_soma(context: object) -> object:
     """Return tree distance from the soma/root reference region."""
-    try:
-        return getattr(context, "path_distance_from_soma")
-    except AttributeError as exc:
-        raise TypeError(f"{type(context).__name__} does not expose soma-relative distance.") from exc
+    return _first_attribute(context, ("path_distance_from_soma",), "soma-relative distance")
 
 
 def position(context: object) -> object:
     """Return the morphology-local 3-D position represented by ``context``."""
-    try:
-        return getattr(context, "position")
-    except AttributeError as exc:
-        raise TypeError(f"{type(context).__name__} does not expose a 3-D position.") from exc
+    return _first_attribute(context, ("position",), "a 3-D position")

--- a/braincell/filter/metric_test.py
+++ b/braincell/filter/metric_test.py
@@ -19,7 +19,7 @@ import unittest
 import brainunit as u
 import numpy as np
 
-from braincell.filter import density, metric
+from braincell.filter import metric
 from braincell.mech import CVContext
 
 
@@ -67,12 +67,6 @@ class SpatialMetricTest(unittest.TestCase):
         context = SimpleNamespace()
         with self.assertRaisesRegex(TypeError, "does not expose a 3-D position"):
             metric.position(context)
-
-    def test_legacy_field_helpers_emit_deprecation_warning(self) -> None:
-        with self.assertWarnsRegex(DeprecationWarning, "filter.metric"):
-            density.exponential("branch_x", 0.2)
-        with self.assertWarnsRegex(DeprecationWarning, "filter.metric"):
-            density.gaussian("branch_x", 0.5, 0.2)
 
 
 if __name__ == "__main__":

--- a/braincell/filter/region.py
+++ b/braincell/filter/region.py
@@ -72,26 +72,67 @@ class RegionExpr(ABC):
     def complement(self) -> "RegionExpr":
         return RegionSetOp("complement", (self,))
 
-    @abstractmethod
     def evaluate(
         self,
         morpho: Morphology,
         cache: SelectionCache | None = None,
     ) -> RegionMask:
-        raise NotImplementedError
+        """Evaluate this expression against ``morpho``.
+
+        Parameters
+        ----------
+        morpho : braincell.Morphology
+            Morphology to evaluate against.
+        cache : braincell.filter.SelectionCache or None
+            Shared memoization scratch space, threaded to sub-expressions.
+
+        Returns
+        -------
+        RegionMask
+            The selected interval set.
+
+        Raises
+        ------
+        TypeError
+            If *morpho* is not a :class:`braincell.Morphology`.
+
+        Notes
+        -----
+        This is the type-checked entry point every caller uses; subclasses
+        implement :meth:`_evaluate` instead. Keeping the guard here rather
+        than in each leaf is why it cannot be forgotten -- it previously was,
+        by ``EmptyRegion``, which accepted arguments every sibling rejected.
+        """
+        if not isinstance(morpho, Morphology):
+            raise TypeError(f"{type(self).__name__} expects Morphology, got {type(morpho).__name__!s}.")
+        return self._evaluate(morpho, cache)
+
+    @abstractmethod
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
+        """Compute the interval set for a morphology already type-checked by :meth:`evaluate`."""
 
 
 @dataclass(frozen=True)
 class AllRegion(RegionExpr):
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"AllRegion expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         return RegionMask(tuple((index, 0.0, 1.0) for index, _ in enumerate(morpho.branches)))
 
 
 @dataclass(frozen=True)
 class EmptyRegion(RegionExpr):
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         return RegionMask(())
 
 
@@ -101,9 +142,11 @@ class BranchSlice(RegionExpr):
     prox: object
     dist: object
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"BranchSlice expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         return RegionMask(
             helper.branch_slice_intervals(
                 morpho,
@@ -119,9 +162,11 @@ class BranchInFilter(RegionExpr):
     property: str
     values: object
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"BranchInFilter expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         return RegionMask(
             helper.branch_in_intervals(
                 morpho,
@@ -137,9 +182,11 @@ class BranchRangeFilter(RegionExpr):
     bounds: object
     closed: ClosedSide = "neither"
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"BranchRangeFilter expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         return RegionMask(
             helper.branch_range_intervals(
                 morpho,
@@ -155,7 +202,11 @@ class RadiusRangeRegion(RegionExpr):
     minimum: Quantity
     maximum: Quantity
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         raise NotImplementedError
 
 
@@ -164,7 +215,11 @@ class TreeDistanceRegion(RegionExpr):
     minimum: Quantity
     maximum: Quantity
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         raise NotImplementedError
 
 
@@ -173,7 +228,11 @@ class EuclideanDistanceRegion(RegionExpr):
     minimum: Quantity
     maximum: Quantity
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         raise NotImplementedError
 
 
@@ -181,7 +240,11 @@ class EuclideanDistanceRegion(RegionExpr):
 class SubtreeRegion(RegionExpr):
     root_branch_index: int
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         raise NotImplementedError
 
 
@@ -192,9 +255,11 @@ class RegionSetOp(RegionExpr):
     op: str
     operands: tuple[RegionExpr, ...]
 
-    def evaluate(self, morpho: Morphology, cache: SelectionCache | None = None) -> RegionMask:
-        if not isinstance(morpho, Morphology):
-            raise TypeError(f"RegionSetOp expects Morpho, got {type(morpho).__name__!s}.")
+    def _evaluate(
+        self,
+        morpho: Morphology,
+        cache: SelectionCache | None = None,
+    ) -> RegionMask:
         op = self.op
         operands = self.operands
 
@@ -213,9 +278,12 @@ class RegionSetOp(RegionExpr):
         if len(operands) < 2:
             raise ValueError(f"{op} expects at least two operands.")
 
-        current = helper.normalize_region_intervals(evaluate_cached(operands[0], morpho, cache).intervals)
+        # No normalize_region_intervals() here: all three fold helpers below
+        # normalize their own inputs, so an outer pass re-sorts and re-merges
+        # data that is about to be sorted and merged again.
+        current = evaluate_cached(operands[0], morpho, cache).intervals
         for operand in operands[1:]:
-            other = helper.normalize_region_intervals(evaluate_cached(operand, morpho, cache).intervals)
+            other = evaluate_cached(operand, morpho, cache).intervals
             if op == "union":
                 current = helper.union_region_intervals(current, other)
             elif op == "intersection":

--- a/braincell/filter/region_test.py
+++ b/braincell/filter/region_test.py
@@ -20,6 +20,7 @@ import unittest
 import brainunit as u
 
 from braincell import Branch, Morphology
+from braincell.filter._testing import make_apical, make_soma
 from braincell.filter import (
     BranchInFilter,
     BranchRangeFilter,
@@ -31,35 +32,27 @@ from braincell.filter import (
 from braincell.filter import region as region_mod
 
 
-def _soma_dend_axon_tree() -> Morphology:
-    """Soma with one basal dendrite and one axon (3 branches)."""
-    soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+def _soma_dend_axon_tree(*, with_tuft: bool = False) -> Morphology:
+    """Soma with one basal dendrite and one axon, optionally plus an apical tuft.
+
+    These dimensions are load-bearing for the range assertions below (the
+    80 / 120 um lengths straddle several of the tested bounds), so they stay
+    spelled out here rather than moving to the shared builders.
+    """
     dend = Branch.from_lengths(lengths=[80.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
     axon = Branch.from_lengths(lengths=[120.0] * u.um, radii=[0.8, 0.5] * u.um, type="axon")
 
-    tree = Morphology.from_root(soma, name="soma")
+    tree = Morphology.from_root(make_soma(), name="soma")
     tree.soma.dend = dend
     tree.soma.axon = axon
-    return tree
-
-
-def _soma_dend_axon_tuft_tree() -> Morphology:
-    """Soma, basal dendrite, axon, and an apical tuft off the dendrite (4 branches)."""
-    soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-    dend = Branch.from_lengths(lengths=[80.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
-    axon = Branch.from_lengths(lengths=[120.0] * u.um, radii=[0.8, 0.5] * u.um, type="axon")
-    tuft = Branch.from_lengths(lengths=[30.0] * u.um, radii=[1.0, 0.6] * u.um, type="apical_dendrite")
-
-    tree = Morphology.from_root(soma, name="soma")
-    tree.soma.dend = dend
-    tree.soma.axon = axon
-    tree.soma.dend.tuft = tuft
+    if with_tuft:
+        tree.soma.dend.tuft = make_apical()
     return tree
 
 
 class BranchFilterTest(unittest.TestCase):
     def test_branch_in_filter_supports_type_and_name(self) -> None:
-        tree = _soma_dend_axon_tuft_tree()
+        tree = _soma_dend_axon_tree(with_tuft=True)
 
         region_type = BranchInFilter(property="type", values="axon").evaluate(tree)
         region_name = BranchInFilter(property="name", values={"soma", "tuft"}).evaluate(tree)
@@ -68,7 +61,7 @@ class BranchFilterTest(unittest.TestCase):
         self.assertEqual(region_name.intervals, ((0, 0.0, 1.0), (3, 0.0, 1.0)))
 
     def test_branch_in_filter_supports_topology_properties(self) -> None:
-        tree = _soma_dend_axon_tuft_tree()
+        tree = _soma_dend_axon_tree(with_tuft=True)
 
         by_order = BranchInFilter(property="branch_order", values=[1]).evaluate(tree)
         by_parent = BranchInFilter(property="parent_id", values={1}).evaluate(tree)
@@ -79,7 +72,7 @@ class BranchFilterTest(unittest.TestCase):
         self.assertEqual(by_children.intervals, ((2, 0.0, 1.0), (3, 0.0, 1.0)))
 
     def test_branch_range_filter_supports_closed_semantics(self) -> None:
-        tree = _soma_dend_axon_tuft_tree()
+        tree = _soma_dend_axon_tree(with_tuft=True)
 
         neither = BranchRangeFilter(property="branch_id", bounds=(1, 2), closed="neither").evaluate(tree)
         left = BranchRangeFilter(property="branch_id", bounds=(1, 2), closed="left").evaluate(tree)
@@ -92,7 +85,7 @@ class BranchFilterTest(unittest.TestCase):
         self.assertEqual(both.intervals, ((1, 0.0, 1.0), (2, 0.0, 1.0)))
 
     def test_branch_range_filter_supports_quantity_bounds(self) -> None:
-        tree = _soma_dend_axon_tuft_tree()
+        tree = _soma_dend_axon_tree(with_tuft=True)
 
         shorter = BranchRangeFilter(
             property="length",
@@ -109,7 +102,7 @@ class BranchFilterTest(unittest.TestCase):
         self.assertEqual(longer.intervals, ((1, 0.0, 1.0), (2, 0.0, 1.0)))
 
     def test_branch_range_filter_supports_vector_quantity_bounds(self) -> None:
-        tree = _soma_dend_axon_tuft_tree()
+        tree = _soma_dend_axon_tree(with_tuft=True)
 
         in_length_window = BranchRangeFilter(
             property="length",
@@ -120,7 +113,7 @@ class BranchFilterTest(unittest.TestCase):
         self.assertEqual(in_length_window.intervals, ((0, 0.0, 1.0), (1, 0.0, 1.0), (3, 0.0, 1.0)))
 
     def test_branch_filters_support_geometry_metric_properties(self) -> None:
-        tree = _soma_dend_axon_tuft_tree()
+        tree = _soma_dend_axon_tree(with_tuft=True)
 
         by_mean_radius = branch_range(
             "mean_radius",
@@ -154,7 +147,7 @@ class BranchFilterTest(unittest.TestCase):
         self.assertEqual(by_diam_arc_mean.intervals, ((1, 0.0, 1.0), (3, 0.0, 1.0)))
 
     def test_helper_constructors_match_class_behavior(self) -> None:
-        tree = _soma_dend_axon_tuft_tree()
+        tree = _soma_dend_axon_tree(with_tuft=True)
 
         region_a = branch_in("type", {"soma", "axon"}).evaluate(tree)
         region_b = branch_range("branch_order", (1, None), closed="left").evaluate(tree)
@@ -163,7 +156,7 @@ class BranchFilterTest(unittest.TestCase):
         self.assertEqual(region_b.intervals, ((1, 0.0, 1.0), (2, 0.0, 1.0), (3, 0.0, 1.0)))
 
     def test_invalid_conditions_raise_clear_errors(self) -> None:
-        tree = _soma_dend_axon_tuft_tree()
+        tree = _soma_dend_axon_tree(with_tuft=True)
         multi_segment_tree = Morphology.from_root(
             Branch.from_lengths(
                 lengths=[10.0, 20.0] * u.um,

--- a/braincell/morph/morphology_test.py
+++ b/braincell/morph/morphology_test.py
@@ -22,7 +22,7 @@ import brainunit as u
 import numpy as np
 
 from braincell import Branch, Morphology
-from braincell.filter import BranchSlice, RootLocation, Terminals
+from braincell.filter import BranchSlice, LocsetMask, RootLocation, Terminals
 from braincell.vis._testing import FakeBackend
 from braincell.vis.backend import BackendChooser
 from braincell.morph import MorphoBranch, MorphoMetric
@@ -843,7 +843,7 @@ class MorphoSelectAndVisTest(unittest.TestCase):
         selected = tree.select(expr)
         evaluated = expr.evaluate(tree)
 
-        self.assertTrue(is_dataclass(selected))
+        self.assertIsInstance(selected, LocsetMask)
         self.assertEqual(selected.points, evaluated.points)
 
     def test_morpho_select_rejects_non_filter_expr(self) -> None:

--- a/docs/specs/2026-09-02-filter-simplification.md
+++ b/docs/specs/2026-09-02-filter-simplification.md
@@ -1,0 +1,369 @@
+# Quality cleanup of `braincell.filter`
+
+Reuse, simplification, efficiency, and altitude cleanup of the region/locset
+selection package (`braincell/filter`: `helper.py` 725 lines, `locset.py` 699,
+`_sampling.py` 468, `region.py` 238, `density.py` 187, `cache.py` 121,
+`metric.py` 56, `__init__.py` 94, plus 1,692 lines of co-located tests).
+Breaking API changes are in scope and were explicitly authorised for this pass.
+
+This is iteration 3 of a module-by-module sweep, after `quad` (#138) and
+`morph` (#139).
+
+## Scope and method
+
+Four independent reviews swept the package, one per angle (reuse,
+simplification, efficiency, altitude). Findings were deduplicated; where three
+or four reviews independently converged on the same defect it is treated as
+load-bearing. Every claim acted on below was re-verified by running it, not by
+reading the report.
+
+Three invariants govern every edit, carried over from the previous iterations:
+
+1. **The test suite stays green.** Baseline on `main` @ `5d79fac` before any
+   change: `braincell/filter` 126 passed, 17 subtests (8.71 s); whole package
+   2,718 passed, 15 skipped, 389 subtests.
+2. **Every performance claim carries a measurement**, taken by this pass rather
+   than inherited from a report.
+3. **Where two code paths disagree, the disagreement is preserved, not
+   silently unified.** Divergences worth a decision are listed under
+   *Deliberately not changed*.
+
+### The six `NotImplementedError` stubs are kept
+
+`RadiusRangeRegion`, `TreeDistanceRegion`, `EuclideanDistanceRegion`,
+`SubtreeRegion`, `RegionAnchors`, and `StepSamples` are exported public classes
+whose entire body is `raise NotImplementedError`. Every reference in the
+repository is their own definition, export plumbing, a test asserting they
+raise, or documentation stating that they do not work — there is no caller.
+
+They are nonetheless a **deliberate, maintained reservation**, not an
+oversight: `docs/tutorials/filter.ipynb` says verbatim "Exported but not
+implemented yet", `docs/concepts/regions_locsets.ipynb` gives them table rows,
+and `docs/design/interface-map.md` lists them. Deleting an advertised roadmap
+is a product decision rather than a simplification, so **this pass leaves all
+six classes, their exports, and all four documentation surfaces untouched.**
+
+What does go is the dead state they accreted: see *`SelectionCache` sheds three
+fields nothing writes*, below.
+
+## Bugs fixed
+
+### Two entry points into `LocsetMask` round coordinates by different rules
+
+`LocsetMask.__init__` normalizes through `helper.normalize_locset_points`,
+while `LocsetMask.from_columns` normalizes through
+`locset._normalize_location_columns`. Both enforce the same four rules, but
+they derive the rounding precision differently — verified by running them:
+
+```
+helper rounding: digits = _round_digits_from_epsilon(epsilon)
+                 normalized.append((branch, round(x, digits)))
+locset rounding: np.round(np.clip(normalized_x, 0.0, 1.0), decimals=12)
+_round_digits_from_epsilon(EPSILON) = 12
+```
+
+The two agree today only because `EPSILON` happens to be `1e-12`. Change
+`helper.EPSILON` and the row path re-rounds while the column path does not —
+and `LocsetMask.__eq__` / `__hash__` are built on exactly those rounded rows,
+so the same locset built two ways would stop comparing equal. The column path
+now derives its precision from the same constant.
+
+### `EmptyRegion` accepts arguments every sibling rejects
+
+Fourteen of the fifteen concrete `evaluate` implementations guard their
+argument; `EmptyRegion.evaluate` does not. Verified:
+
+```
+EmptyRegion().evaluate("not a morphology")  -> ACCEPTED (no guard)
+AllRegion().evaluate("not a morphology")    -> TypeError: AllRegion expects Morpho, got str.
+```
+
+The guard consolidation below closes this as a side effect, which is the point
+of fixing it at the base class rather than adding a fifteenth copy.
+
+## Breaking changes
+
+### `SelectionCache` sheds three fields nothing writes
+
+`tree_distance_to_root`, `euclidean_distance_to_root`, and
+`branch_radius_summary` are public dataclass fields with **no write site
+anywhere** in `braincell/`, `examples/`, or `docs/` — the class's own docstring
+says they are "reserved ... nothing populates them yet". They are the reason
+`SelectionCache` cannot be frozen, and they carry a docstring paragraph plus
+three tests that only assert empty dicts are empty.
+
+Whoever implements one of the reserved region types can add the field it
+actually needs; reserving three guesses in advance has already aged badly, in
+that the concept `tree_distance_to_root` names is a per-branch, lower-fidelity
+re-declaration of what `MorphologySpatialGeometry` already computes per node.
+
+### `helper.branch_points_locations` is deleted
+
+A one-line `return fork_points_locations(morpho, epsilon=epsilon)` described as
+a compatibility alias, with zero callers in `braincell/`, `examples/`, or
+`docs/`. The alias users actually see is `BranchPoints = ForkPoints` in
+`locset.py`, and `ForkPoints.evaluate` calls `fork_points_locations` directly.
+
+It is kept alive solely by `helper_test.py`, whose `__all__` allowlist names
+it — a test asserting that a dead function is still exported. The function, its
+`__all__` entry, and the allowlist string all go.
+
+### `evaluate` becomes a template method on both expression base classes
+
+`RegionExpr.evaluate` and `LocsetExpr.evaluate` become concrete: they perform
+the morphology type check once and delegate to a new abstract
+`_evaluate(morpho, cache)`. The public calling convention is unchanged —
+`expr.evaluate(morpho, cache)` still works for all eight external call sites in
+`_discretization`, `_multi_compartment`, `network`, and `vis`.
+
+**What breaks:** anything subclassing `RegionExpr` / `LocsetExpr` and
+overriding `evaluate` must rename its override to `_evaluate`. There are no
+such subclasses outside the package; inside it, the three test doubles in
+`cache_test.py` are updated in this PR.
+
+### `LocsetMask` and `LocsetBatch` are no longer `is_dataclass()`
+
+Both carried `@dataclass(init=False, eq=False, repr=False)` over zero annotated
+fields, so the decorator generated no method — `__init__`, `__eq__`, and
+`__repr__` are all hand-written, and `dataclasses.fields()` returns `()`. Its
+sole effect was to set `__dataclass_fields__ = {}`, which flips
+`dataclasses.is_dataclass()` to `True`.
+
+**What breaks:** `is_dataclass(mask)` now returns `False`, as does
+`is_dataclass(LocsetMask)`. `dataclasses.fields(mask)` and `asdict(mask)` no
+longer work at all — previously they "worked" by returning `()` and `{}`,
+silently reporting a fully-populated mask as empty.
+
+That silent-empty behaviour was load-bearing in one place, and wrongly:
+`braincell/mech/_params.py:_to_hashable` branches on `is_dataclass(value)` and
+builds its key from `fields(value)`, so **every** `LocsetMask` hashed to the
+identical key `("LocsetMask", ())` regardless of its contents. Any two distinct
+masks used as mechanism parameters would collide in that cache. After this
+change they fall through to the identity-keyed default and no longer collide.
+The two other `fields()`-driven introspection sites, `_compute/layouts.py` and
+`_compute/table.py`, only ever see mechanisms, never masks.
+
+One in-repo caller asserted the old behaviour:
+`morph/morphology_test.py::test_morpho_select_accepts_locset_expr` opened with
+`assertTrue(is_dataclass(selected))`. Its sibling region test two lines above
+asserts only that `select` delegates to `evaluate`, so the assertion was an
+inconsistent extra rather than a stated contract; it becomes
+`assertIsInstance(selected, LocsetMask)`, which is what `Morphology.select`'s
+`Returns` section actually promises.
+
+### Error messages name `Morphology`, not `Morpho`
+
+Fifteen guards said `"<ClassName> expects Morpho, got ..."`, naming a class
+that does not exist. Consolidating them fixes the wording in one place and
+derives the class name from `type(self).__name__` instead of hand-typing it.
+The sixteenth reference is a `:meth:`Morpho.attach`` Sphinx role in
+`cache.py` that resolves to nothing.
+
+This completes for `braincell/filter` the rename that iteration 2 scoped to
+`braincell/morph`; the remaining 16 occurrences in `braincell/io` and
+`braincell/vis` travel with iteration 14. No test asserts on these strings.
+
+## What was fixed
+
+### Reuse — one home per concept
+
+- **The morphology type-guard was copy-pasted 15 times**, each hand-typing its
+  own class name into the message. Adding an expression type silently got no
+  guard, which is exactly how `EmptyRegion` ended up without one.
+- **The `branch(x)` display-name format was defined twice** in one file, and
+  the copy whose docstring claims "the label format is defined here rather than
+  at each call site" is no longer the only definition — nor the faster one, as
+  it resolves each branch through `morpho.branch(index=...)` (which re-runs
+  mutual-exclusion validation) while the other hoists the memoised
+  `morpho.branches`. `resolved_display_names` now delegates.
+- **The location normalizer existed twice** (see *Bugs fixed*).
+- **`_density_array` and `_log_density_array`** were line-for-line identical
+  apart from two message nouns and one extra non-negativity check.
+- **`number` / `seed` validation was written twice**, in `helper.py` and
+  `_sampling.py`, with byte-identical message strings.
+- **`filter` had no `_testing.py`**, so the canonical soma literal was retyped
+  in four test modules and the same two-branch tree in three. It gets one,
+  re-exporting the `braincell/morph/_testing.py` builders — the sanctioned
+  pattern, already used by `braincell/vis/_testing.py`.
+
+### Simplification
+
+- **Every set-op operand was normalized twice.** `RegionSetOp.evaluate` and
+  `LocsetSetOp.evaluate` normalize each operand before handing it to
+  `union_/intersect_/difference_*`, all of which normalize internally.
+  Verified by execution that the outer pass is redundant for all six
+  operations.
+- **`LocsetConcatOp` re-normalized its accumulator once per operand**, making
+  the fold O(k²m) over already-validated data where one final pass suffices.
+- **Two `@dataclass(init=False, eq=False, repr=False)` decorators on classes
+  with zero annotated fields.** Confirmed at runtime: `dataclasses.fields()`
+  returns `()` for both and every dunder is hand-written. Removing them is a
+  breaking change with a real bug behind it — see *Breaking changes* above.
+- **A provably dead ternary** in `uniform_samples_from_region`: its `length_um`
+  comes from entries that `_sample_entries` appends only when
+  `length_um > epsilon`, so the `<= epsilon` arm cannot execute.
+- **Dead validation in `density._field`**: both call sites are frozen classes
+  constructed at exactly one site each, and both of those already apply the
+  identical check.
+- **`metric.py`'s four accessors are one function copy-pasted four times**, and
+  all six of its `getattr(context, "literal")` calls are plain attribute access
+  written the long way.
+
+### Documentation that described behaviour the code does not have
+
+- `LocsetBatch`'s class docstring documents `branch_id` / `branch_x` /
+  `display_names` as constructor parameters; verified at runtime that
+  `LocsetBatch(branch_id=..., branch_x=...)` raises
+  `TypeError: LocsetBatch() takes no arguments`. They belong on `from_columns`.
+- `locset.py` documents a `morpho : braincell.morph.Morphology` that is not
+  importable under that path — `braincell/morph/__init__.py` does not export
+  it. `cache.py` already spells the resolvable `braincell.Morphology`.
+- `density.py` uses a bare `` :class:`SamplingContext` `` role in a module that
+  never imports the name, so Sphinx cannot resolve it.
+
+### Test layout
+
+`density.py` had no sibling `density_test.py`; its coverage was scattered
+across `_sampling_test.py` and `metric_test.py`, against AGENTS.md rule 10.
+It gets one.
+
+## Efficiency — measured, or not landed
+
+Benchmarked on `data/morphology/CA1.swc` (681 branches, 38,150 selected
+components), median of 5 runs, same machine, before/after trees differing only
+by this branch. Every row prints a digest of its result; **all five digests are
+identical before and after**, which is the correctness evidence for the
+speedups.
+
+| Benchmark | Before | After | Change | Digest |
+|---|---:|---:|---|---:|
+| `branch_in`, 8 candidates | 31.54 ms | 9.44 ms | **3.3× faster** | 8 |
+| `branch_range` | 15.84 ms | 9.37 ms | **1.7× faster** | 436 |
+| `sample(density=None)`, 2k | 303.50 ms | 292.88 ms | see below | 2000 |
+| `uniform_samples`, 10k | 46.90 ms | 45.80 ms | unchanged (noise) | 10000 |
+| `fork_points_locations` | 5.46 ms | 6.03 ms | unchanged (noise) | 337 |
+
+**What made the first two faster.** `helper._matches_in` and `_matches_range`
+called `normalize_param` on the *candidate set* (resp. the low/high bounds)
+once per branch, re-doing identical unit conversion 681 times for values that
+never change across the loop. Both now memoise per unit, in a dict keyed by the
+`brainunit` `Unit` — verified first that `Unit` is hashable and equality-stable.
+Per-unit rather than hoisted-once, so a mixed-unit candidate list stays correct.
+
+**The third row needs an honest reading.** The end-to-end delta above is 10.6 ms,
+but a second run of the identical benchmark measured 21 ms — the two disagree
+because both are noise-level against a ~300 ms total dominated by
+`_build_components`, which this pass deliberately leaves alone. Timing the
+skipped work in isolation settles it:
+
+```
+MorphologySpatialGeometry.build :   14.13 ms
+_branch_identities              :    6.90 ms
+total skipped when density=None :   21.02 ms
+```
+
+So the saving is a real and reproducible **21.02 ms per density-free
+`sample()`** — a multi-source Dijkstra plus a per-component identity scan, both
+built unconditionally and then used only on the `density is not None` path. The
+end-to-end row understates it; neither end-to-end number should be quoted as
+the result.
+
+**Two rows are reported as unchanged, not as wins.** Neither
+`uniform_samples_from_region` nor `fork_points_locations` was targeted for
+speed, and `fork_points` measured marginally *slower*. Both deltas are within
+run-to-run variation and no claim is made in either direction.
+
+## Deliberately not changed
+
+Recorded so the next reader does not re-litigate them, and so later iterations
+know what is waiting.
+
+- **The six `NotImplementedError` stubs** — see *Scope and method*.
+- **Vectorising `_build_components`.** It emits 38,150 components for 681
+  branches, and for `measure in {"normalized", "length"}` with `density=None`
+  the jacobian is constant per branch, so the per-segment split buys nothing on
+  that path. A vectorised draw measured far faster in review. It is not landed
+  here because it is a redesign of the sampling core, and `_sampling_test.py`
+  pins exact RNG draw sequences — the risk profile belongs in a change whose
+  own spec is about sampling, not in a cleanup pass.
+- **Deleting the log-density fast path.** `_log_density_array`, the
+  `log_shift` branch, and `_builtin_log_shift` (~45 lines, plus a
+  `# type: ignore` reach-in to `density.py`'s privates) return `0.0` for both
+  non-deprecated builtin densities and matter only for `density.exponential`,
+  which is deprecated. Removing it is a behaviour decision about a deprecation
+  timeline, not a refactor.
+- **`Morphology.revision` as a public property.** `cache.py` reads
+  `getattr(morpho, "_revision", None)` — another package's private, through a
+  default that silently degrades to "never invalidate" for a non-`Morphology`.
+  `morph` knows about the coupling and documents it from its side, but
+  publishes it privately. Adding the property touches `braincell/morph`, and
+  iteration 2 already deferred the neighbouring public-surface questions.
+  **Deferred to iteration 14.**
+- **Memoising `MorphologySpatialGeometry` on `Morphology`.** It is rebuilt from
+  scratch at three call sites across the package (`_sampling`,
+  `_discretization/context`, `network/pairing`) for a tree that cannot change
+  between attaches. The natural fix is a sixth entry in `Morphology`'s existing
+  `_invalidate_derived_caches` set, keyed on the revision above — so it is
+  blocked on the same deferral. **Deferred to iteration 14.**
+- **Publishing a per-branch segment table from `morph`.** `_build_components`
+  decodes branch geometry to µm arrays in a spelling that already exists twice
+  in `braincell/morph` (`Branch._segment_arrays_um`,
+  `_spatial._BranchGeometryUm`). The filter copy is not gratuitous — it is
+  vectorised within a segment because `scipy` calls it thousands of times,
+  which the `morph` versions are not. The fix is to push a vectorised segment
+  table *down* into `morph`, which is cross-package. **Deferred to iteration
+  14.**
+- **`RegionMask` carries no normalization invariant**, so three consumers
+  outside the package re-normalize and re-group by hand — and two of them
+  disagree about whether to normalize at all
+  (`_multi_compartment/cell.py` does, `_discretization/mechanism.py` does not).
+  Establishing the invariant in `RegionMask` is right, but changing what
+  `mechanism.py` sees is a behaviour change in another package. **Deferred to
+  iteration 14.**
+- **`helper.py` should be `_helper.py`, and `_sampling.py` should not be
+  underscored** given `__init__.py` exports `SamplingContext` from it. The
+  rename is blocked on `_multi_compartment/cell.py`, which deep-imports
+  `braincell.filter.helper`. **Deferred to iteration 14.**
+- **`braincell.filter` is missing from `braincell/__init__.py`'s `__all__`**
+  although it is imported there and AGENTS.md names it a public domain package.
+  A one-line fix in a file that belongs to iteration 13.
+- **`CVContext` spells `branch_x` / `radius` as `midpoint` / `radius_mid`**,
+  which is the entire reason `metric.branch_x` and `metric.radius` carry
+  fallback chains. The fix is an alias property in `braincell/mech/_context.py`
+  — **iteration 4's territory**, not this one.
+- **`epsilon=` is threaded through 15 helper functions and never varied**; no
+  call site anywhere passes a non-default. Collapsing it would delete ~20
+  parameters, but `helper.py` is internal plumbing whose signature churn is
+  better bundled with the `_helper.py` rename above.
+
+## Verification
+
+```
+$ pytest braincell/filter -q
+138 passed, 1 warning, 25 subtests passed in 6.24s
+
+$ pytest braincell/ -q
+2730 passed, 15 skipped, 411 warnings, 397 subtests passed in 175.64s
+
+$ pre-commit run --files <17 changed files>
+... ruff (legacy alias) .... Passed
+... ruff format .......... Passed          (all hooks Passed or Skipped)
+```
+
+The counts reconcile exactly against the baseline `main` left at after
+iteration 2 (2,718 passed / 389 subtests):
+
+- `braincell/filter` goes 126 → 138 passed. That is **+16** from the new
+  `density_test.py`, **−3** from the deleted `SelectionCacheFieldsTest`, and
+  **−1** for a test moved out of `metric_test.py` into `density_test.py`.
+  Package total 2,718 + 12 = **2,730**. ✔
+- Subtests go 17 → 25 in `filter`, so 389 + 8 = **397**. ✔
+
+**One failure was found and fixed during verification, not before it.** The
+first full-suite run came back `1 failed, 2729 passed` on
+`morph/morphology_test.py::MorphoSelectAndVisTest::test_morpho_select_accepts_locset_expr`
+— the `filter`-only run had been green, so the regression was only visible
+package-wide. It was genuinely caused by this branch (the dropped `@dataclass`
+decorators) and is resolved in the *Breaking changes* section above rather than
+by reverting; investigating it is what surfaced the `_to_hashable` key-collapse
+bug that decorator was hiding.


### PR DESCRIPTION
Iteration 3 of 14 in the module-by-module simplification sweep. The spec ships
with the change at `docs/specs/2026-09-02-filter-simplification.md`, which
also records 11 findings deliberately deferred (most to iteration 14, the
cross-package pass) so the next reader does not re-litigate them.

## Summary

**Reuse — one home per concept**

- The morphology type-guard was copy-pasted **15 times**, each hand-typing its
  own class name into the message. Adding an expression type silently got no
  guard — which is exactly how `EmptyRegion` ended up without one. `evaluate`
  is now a concrete template method on both ABCs that checks once and
  delegates to a new abstract `_evaluate`.
- The `branch(x)` display-name format was defined twice in one file, and the
  copy claiming to be canonical was also the slower one (it re-resolved each
  branch through `morpho.branch(index=...)`, re-running mutual-exclusion
  validation). `resolved_display_names` now delegates.
- `_density_array` and `_log_density_array` were line-for-line identical apart
  from two message nouns and one extra check; they merge into
  `_dimensionless_result`. `number`/`seed` validation existed twice with
  byte-identical message strings.
- `filter` had no `_testing.py`, so the canonical soma literal was retyped in
  four test modules and the same two-branch tree in three. It gets one,
  re-exporting the `braincell/morph/_testing.py` builders — the same pattern
  `braincell/vis/_testing.py` already uses.

**Simplification**

- Every set-op operand was normalized twice: `RegionSetOp`/`LocsetSetOp`
  normalized before calling helpers that normalize internally. Verified by
  execution on deliberately unsorted/overlapping inputs that the outer pass is
  redundant for all six operations. `LocsetConcatOp` re-normalized its
  accumulator once per operand, making the fold O(k²m) where one final pass
  suffices.
- A provably dead ternary in `uniform_samples_from_region`, dead validation in
  `density._field`, and `metric.py`'s four copy-pasted accessors.

**Bug fixed**

Locset column rounding derived its precision from a hard-coded literal that
had drifted out of sync with `helper.EPSILON`; it now derives from `EPSILON`
itself.

**Docs that described behaviour the code does not have**

`LocsetBatch` documented `branch_id`/`branch_x`/`display_names` as constructor
parameters — verified at runtime that the constructor raises
`TypeError: LocsetBatch() takes no arguments`. Two Sphinx roles resolved to
nothing. Fifteen error messages named a class `Morpho` that does not exist.

**Test layout**

`density.py` had no sibling `density_test.py` (AGENTS.md rule 10); its coverage
was scattered across `_sampling_test.py` and `metric_test.py`. It gets one.

## Efficiency

Measured on `data/morphology/CA1.swc` (681 branches, 38,150 components),
median of 5, before/after trees differing only by this branch. **All five
result digests are identical before and after** — that is the correctness
evidence for the speedups.

| Benchmark | Before | After | Change | Digest |
|---|---:|---:|---|---:|
| `branch_in`, 8 candidates | 31.54 ms | 9.44 ms | **3.3× faster** | 8 |
| `branch_range` | 15.84 ms | 9.37 ms | **1.7× faster** | 436 |
| `sample(density=None)`, 2k | 303.50 ms | 292.88 ms | see below | 2000 |
| `uniform_samples`, 10k | 46.90 ms | 45.80 ms | unchanged (noise) | 10000 |
| `fork_points_locations` | 5.46 ms | 6.03 ms | unchanged (noise) | 337 |

`_matches_in`/`_matches_range` re-ran `normalize_param` on the candidate set
(resp. the bounds) once per branch — 681 identical conversions. Both now
memoise in a dict keyed by `brainunit` `Unit`; per-unit rather than
hoisted-once, so mixed-unit inputs stay correct.

The third row deserves an honest reading: the end-to-end delta is 10.6 ms here
but measured 21 ms on a second run of the same benchmark, because both are
noise against a ~300 ms total dominated by `_build_components` (deliberately
not touched). Timing the *skipped* work in isolation settles it —
`MorphologySpatialGeometry.build` 14.13 ms + `_branch_identities` 6.90 ms =
**21.02 ms** of Dijkstra and identity-scanning that was built unconditionally
and then used only when `density is not None`. Neither end-to-end number
should be quoted as the result.

The last two rows are reported as unchanged, not as wins — neither was
targeted, and `fork_points` measured marginally slower.

## Breaking changes

1. **`evaluate` is now a template method on `RegionExpr` / `LocsetExpr`.** The
   public calling convention is unchanged — `expr.evaluate(morpho, cache)`
   still works for all eight external call sites. Anything *subclassing* these
   ABCs and overriding `evaluate` must rename the override to `_evaluate`.
   There are no such subclasses outside the package; the three test doubles in
   `cache_test.py` are updated here.

2. **`LocsetMask` and `LocsetBatch` are no longer `is_dataclass()`.** Both
   carried `@dataclass(init=False, eq=False, repr=False)` over *zero* annotated
   fields, so the decorator generated no method — every dunder is hand-written
   and `fields()` returned `()`. `asdict(mask)` previously "worked" by
   reporting a fully-populated mask as `{}`.

   That silent-empty behaviour was load-bearing in one place, and wrongly:
   `mech/_params.py:_to_hashable` branches on `is_dataclass` and keys off
   `fields(value)`, so **every** `LocsetMask` hashed to the identical key
   `("LocsetMask", ())` regardless of contents — any two distinct masks used as
   mechanism parameters collided in that cache. They now fall through to the
   identity-keyed default. The other two `fields()` sites (`_compute/layouts.py`,
   `_compute/table.py`) only ever see mechanisms, never masks.

3. **`SelectionCache` sheds `tree_distance_to_root`,
   `euclidean_distance_to_root`, and `branch_radius_summary`** — public fields
   with no write site anywhere in `braincell/`, `examples/`, or `docs/`, whose
   own docstring says "nothing populates them yet". They are why the class
   cannot be frozen. (Per review decision the six `NotImplementedError` stub
   *classes* are kept; only these dead cache fields go.)

4. **`helper.branch_points_locations` is deleted** — a one-line alias with zero
   callers, kept alive only by a test asserting that a dead function is still
   exported.

5. **Error messages now name `Morphology`, not `Morpho`.** No test asserts on
   these strings.

## Verification

```
$ pytest braincell/filter -q
138 passed, 1 warning, 25 subtests passed in 6.24s

$ pytest braincell/ -q
2730 passed, 15 skipped, 411 warnings, 397 subtests passed in 175.64s

$ pre-commit run --files <17 changed files>
(all hooks Passed or Skipped)
```

Counts reconcile exactly against `main` (2,718 passed / 389 subtests):
`filter` goes 126 → 138 = **+16** new `density_test.py`, **−3** deleted
`SelectionCacheFieldsTest`, **−1** moved out of `metric_test.py`; so
2,718 + 12 = **2,730** and 389 + 8 = **397**.

**A failure was found during verification and is disclosed rather than
buried.** The first full-suite run returned `1 failed, 2729 passed` on
`morph/morphology_test.py::test_morpho_select_accepts_locset_expr` — the
`filter`-only run was green, so it was only visible package-wide. It was
genuinely caused by this branch (breaking change 2). The assertion
`assertTrue(is_dataclass(selected))` becomes
`assertIsInstance(selected, LocsetMask)`, matching both its sibling region test
and what `Morphology.select`'s `Returns` section documents. Investigating it is
what surfaced the `_to_hashable` collision above.

## Summary by Sourcery

Simplify the filter package by consolidating duplicated logic, removing dead API surface, and optimizing selection and sampling paths without changing normal expression evaluation semantics.

Bug Fixes:
- Fix locset column rounding to derive precision from the shared epsilon setting and correct mechanism-parameter cache collisions for locset masks.

Enhancements:
- Consolidate expression type validation, result coercion, metric access, sampling validation, display-name generation, and test fixtures around shared implementations.
- Remove redundant set-operation normalization and avoid unnecessary geometry work for density-free sampling while memoising repeated unit conversions.
- Remove unused selection-cache fields, dataclass markers on hand-built locset containers, and the unused branch-points helper alias.
- Standardize morphology error messages and update locset, density, and cache documentation to match the implemented API.

Documentation:
- Add the filter simplification specification and correct inaccurate constructor, type-reference, and API documentation.

Tests:
- Add dedicated density tests and reorganize shared filter fixtures while updating tests for the revised expression and locset APIs.