### PR TITLE
refactor(mech): fix two silent bugs, delete dead API, cache Params hashing

### DIFF
--- a/braincell/_discretization/_testing.py
+++ b/braincell/_discretization/_testing.py
@@ -25,7 +25,10 @@ import brainunit as u
 import numpy as np
 
 from braincell._discretization.geometry import build_cv_geometry
-from braincell.mech import CableProperty
+
+# Re-exported: ``CableProperty`` is a ``braincell.mech`` type, so its
+# builder lives with the package that owns it.
+from braincell.mech._testing import make_cable  # noqa: F401
 from braincell.morph.branch import Branch
 from braincell.morph.morphology import Morphology
 
@@ -36,15 +39,6 @@ __all__ = [
     "make_single_branch_morpho",
     "make_two_branch_morpho",
 ]
-
-
-def make_cable(cm: float = 1.0, ra: float = 100.0, v: float = -65.0) -> CableProperty:
-    """Build a :class:`CableProperty` from bare floats in the usual units."""
-    return CableProperty(
-        resting_potential=v * u.mV,
-        membrane_capacitance=cm * (u.uF / u.cm**2),
-        axial_resistivity=ra * (u.ohm * u.cm),
-    )
 
 
 def make_branch(lengths: list[float], radii: list[float], type: str = "dendrite") -> Branch:

--- a/braincell/_discretization/context.py
+++ b/braincell/_discretization/context.py
@@ -87,7 +87,6 @@ def build_cv_contexts(
             radius_prox=_source_quantity(source, "radius_prox", "r_prox_um", u.um),
             radius_mid=radius_mid,
             radius_dist=_source_quantity(source, "radius_dist", "r_dist_um", u.um),
-            diam_mid=2.0 * radius_mid,
             diam_arc_mean=_source_quantity(
                 source,
                 "diam_arc_mean",

--- a/braincell/filter/metric_test.py
+++ b/braincell/filter/metric_test.py
@@ -51,7 +51,6 @@ class SpatialMetricTest(unittest.TestCase):
             radius_prox=1.2 * u.um,
             radius_mid=1.0 * u.um,
             radius_dist=0.8 * u.um,
-            diam_mid=2.0 * u.um,
             diam_arc_mean=2.0 * u.um,
             path_distance_to_root=30.0 * u.um,
             path_distance_from_soma=20.0 * u.um,
@@ -60,6 +59,9 @@ class SpatialMetricTest(unittest.TestCase):
 
         self.assertEqual(metric.branch_x(context), 0.5)
         self.assertEqual(metric.radius(context), 1.0 * u.um)
+        # ``diam_mid`` is derived from ``radius_mid`` rather than stored,
+        # so the two can no longer disagree.
+        self.assertEqual(context.diam_mid, 2.0 * u.um)
         self.assertEqual(metric.path_distance_from_soma(context), 20.0 * u.um)
         np.testing.assert_array_equal(metric.position(context).to_decimal(u.um), [1.0, 2.0, 3.0])
 

--- a/braincell/mech/__init__.py
+++ b/braincell/mech/__init__.py
@@ -82,7 +82,6 @@ from ._point import (
     ProbeMechanism,
     SineClamp,
     StateProbe,
-    Synapse,
     SynapseSpec,
 )
 from ._registry import (
@@ -126,7 +125,6 @@ __all__ = [
     "ProbeMechanism",
     "SineClamp",
     "StateProbe",
-    "Synapse",
     "SynapseSpec",
     # Registry
     "MechanismEntry",

--- a/braincell/mech/_base.py
+++ b/braincell/mech/_base.py
@@ -37,7 +37,10 @@ class Mechanism:
     :class:`~braincell.mech.Ion`, and :class:`~braincell.mech.Point` and
     its concrete subclasses :class:`~braincell.mech.CurrentClamp` /
     :class:`~braincell.mech.SineClamp` / :class:`~braincell.mech.FunctionClamp`
-    / :class:`~braincell.mech.Probe` / :class:`~braincell.mech.SynapseSpec` /
+    / :class:`~braincell.mech.StateProbe` /
+    :class:`~braincell.mech.MechanismProbe` /
+    :class:`~braincell.mech.CurrentProbe` /
+    :class:`~braincell.mech.SynapseSpec` /
     :class:`~braincell.mech.Junction`) inherit from this class.
 
     :class:`Mechanism` exists only to support

--- a/braincell/mech/_cable.py
+++ b/braincell/mech/_cable.py
@@ -22,7 +22,7 @@ by ``Cell.paint(region, CableProperty(...))`` and lowered into per-CV
 cable defaults during :class:`braincell.Cell` rebuild.
 """
 
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from typing import Any
 
 import brainunit as u
@@ -90,28 +90,21 @@ class CableProperty:
             _coerce_temperature(self.temperature, name="temperature"),
         )
 
-    def with_updates(self, **kwargs: Any) -> "CableProperty":
-        """Return a copy with ``kwargs`` applied.
-
-        Parameters
-        ----------
-        **kwargs
-            Fields to override.
-
-        Returns
-        -------
-        CableProperty
-            A new instance. ``self`` is unchanged.
-        """
-        return replace(self, **kwargs)
-
 
 def _coerce_temperature(value: Any, *, name: str) -> Any:
     if callable(value):
         return value
-    if not hasattr(value, "to_decimal") or not callable(getattr(value, "to_decimal")):
+    # A brand-new ``CableProperty`` is built for *every* control volume by
+    # the paint lowering pass, from fields that pass have already
+    # canonicalized to exactly this form. Recognising that form and
+    # returning it untouched skips a decimal conversion, an ``asarray``,
+    # and a fresh Quantity allocation per CV.
+    if type(value) is u.Quantity and value.unit is u.kelvin and type(value.mantissa) is float:
+        return value
+    to_decimal = getattr(value, "to_decimal", None)
+    if not callable(to_decimal):
         raise TypeError(f"CableProperty.{name} must be a temperature Quantity, got {value!r}.")
-    decimal = np.asarray(value.to_decimal(u.kelvin), dtype=float)
+    decimal = np.asarray(to_decimal(u.kelvin), dtype=float)
     if decimal.ndim != 0:
         raise TypeError(f"CableProperty.{name} must be a scalar temperature Quantity, got shape {decimal.shape!r}.")
     return u.Quantity(float(decimal), u.kelvin)

--- a/braincell/mech/_cable_test.py
+++ b/braincell/mech/_cable_test.py
@@ -17,28 +17,22 @@ import unittest
 
 import brainunit as u
 
+import numpy as np
+
 from braincell.mech import CableProperty
+from braincell.mech._testing import make_cable
 
 
 class CablePropertyTest(unittest.TestCase):
     def test_fields_round_trip(self) -> None:
-        cp = CableProperty(
-            resting_potential=-65.0 * u.mV,
-            membrane_capacitance=1.0 * (u.uF / u.cm**2),
-            axial_resistivity=100.0 * (u.ohm * u.cm),
-        )
+        cp = make_cable()
         self.assertEqual(cp.resting_potential.to_decimal(u.mV), -65.0)
         self.assertEqual(cp.membrane_capacitance.to_decimal(u.uF / u.cm**2), 1.0)
         self.assertEqual(cp.axial_resistivity.to_decimal(u.ohm * u.cm), 100.0)
 
     def test_default_temperature_is_309_15K(self) -> None:
-        cp = CableProperty(
-            resting_potential=-65.0 * u.mV,
-            membrane_capacitance=1.0 * (u.uF / u.cm**2),
-            axial_resistivity=100.0 * (u.ohm * u.cm),
-        )
         self.assertAlmostEqual(
-            cp.temperature.to_decimal(u.kelvin),
+            make_cable().temperature.to_decimal(u.kelvin),
             u.celsius2kelvin(36.0).to_decimal(u.kelvin),
             places=12,
         )
@@ -56,49 +50,35 @@ class CablePropertyTest(unittest.TestCase):
             places=12,
         )
 
-    def test_temperature_not_quantity_raises(self) -> None:
-        with self.assertRaises(TypeError):
-            CableProperty(
-                resting_potential=-65.0 * u.mV,
-                membrane_capacitance=1.0 * (u.uF / u.cm**2),
-                axial_resistivity=100.0 * (u.ohm * u.cm),
-                temperature=310.0,  # type: ignore[arg-type]
-            )
+    def test_bad_temperature_raises(self) -> None:
+        for bad in (310.0, np.array([310.0, 311.0]) * u.kelvin):
+            with self.subTest(temperature=type(bad).__name__):
+                with self.assertRaises(TypeError):
+                    CableProperty(
+                        resting_potential=-65.0 * u.mV,
+                        membrane_capacitance=1.0 * (u.uF / u.cm**2),
+                        axial_resistivity=100.0 * (u.ohm * u.cm),
+                        temperature=bad,  # type: ignore[arg-type]
+                    )
 
-    def test_non_scalar_temperature_raises(self) -> None:
-        import numpy as np
-
-        with self.assertRaises(TypeError):
-            CableProperty(
-                resting_potential=-65.0 * u.mV,
-                membrane_capacitance=1.0 * (u.uF / u.cm**2),
-                axial_resistivity=100.0 * (u.ohm * u.cm),
-                temperature=np.array([310.0, 311.0]) * u.kelvin,
-            )
-
-    def test_with_updates_non_mutating(self) -> None:
-        original = CableProperty(
+    def test_already_canonical_temperature_is_passed_through(self) -> None:
+        # The paint lowering pass rebuilds a CableProperty per control
+        # volume from fields it has already canonicalized, so the
+        # coercion recognises that form and returns it untouched.
+        canonical = make_cable().temperature
+        rebuilt = CableProperty(
             resting_potential=-65.0 * u.mV,
             membrane_capacitance=1.0 * (u.uF / u.cm**2),
             axial_resistivity=100.0 * (u.ohm * u.cm),
+            temperature=canonical,
         )
-        updated = original.with_updates(resting_potential=-70.0 * u.mV)
-        self.assertEqual(original.resting_potential.to_decimal(u.mV), -65.0)
-        self.assertEqual(updated.resting_potential.to_decimal(u.mV), -70.0)
+        self.assertIs(rebuilt.temperature, canonical)
 
     def test_equality_and_hash(self) -> None:
-        a = CableProperty(
-            resting_potential=-65.0 * u.mV,
-            membrane_capacitance=1.0 * (u.uF / u.cm**2),
-            axial_resistivity=100.0 * (u.ohm * u.cm),
-        )
-        b = CableProperty(
-            resting_potential=-65.0 * u.mV,
-            membrane_capacitance=1.0 * (u.uF / u.cm**2),
-            axial_resistivity=100.0 * (u.ohm * u.cm),
-        )
+        a, b = make_cable(), make_cable()
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))
+        self.assertNotEqual(a, make_cable(cm=2.0))
 
 
 if __name__ == "__main__":

--- a/braincell/mech/_context.py
+++ b/braincell/mech/_context.py
@@ -48,8 +48,6 @@ class CVContext:
         Control-volume lateral membrane area.
     radius_prox, radius_mid, radius_dist : Quantity
         Radius at the proximal boundary, midpoint, and distal boundary.
-    diam_mid : Quantity
-        Diameter at the control-volume midpoint.
     diam_arc_mean : Quantity
         Arc-length-weighted mean diameter over the control volume.
     path_distance_to_root : Quantity
@@ -75,11 +73,15 @@ class CVContext:
     radius_prox: u.Quantity
     radius_mid: u.Quantity
     radius_dist: u.Quantity
-    diam_mid: u.Quantity
     diam_arc_mean: u.Quantity
     path_distance_to_root: u.Quantity
     path_distance_from_soma: u.Quantity
     _local_position: u.Quantity | None = None
+
+    @property
+    def diam_mid(self) -> u.Quantity:
+        """Diameter at the control-volume midpoint, i.e. ``2 * radius_mid``."""
+        return 2.0 * self.radius_mid
 
     @property
     def local_position(self) -> u.Quantity:
@@ -91,6 +93,4 @@ class CVContext:
     @property
     def position(self) -> u.Quantity:
         """World position, equal to ``local_position`` until transforms land."""
-        if self._local_position is None:
-            raise ValueError("CVContext.position requires full 3-D point geometry.")
-        return self._local_position
+        return self.local_position

--- a/braincell/mech/_density.py
+++ b/braincell/mech/_density.py
@@ -45,17 +45,14 @@ from typing import Any, Callable, ClassVar, Mapping
 
 from ._base import Mechanism
 from ._params import Params
-from ._registry import get_registry
+from ._registry import _CATEGORY_CHANNEL, _CATEGORY_ION, get_registry
+from ._validate import require_fraction, require_str
 
 __all__ = [
     "Density",
     "Channel",
     "Ion",
 ]
-
-
-_CHANNEL = "channel"
-_ION = "ion"
 
 
 class Density(Mechanism):
@@ -77,16 +74,20 @@ class Density(Mechanism):
         through :func:`braincell.mech.get_registry` at construction
         time; the stored :attr:`class_name` is always a string.
     params : Mapping or None
-        Parameter mapping. ``None`` (the default) produces an empty
-        :class:`Params`.
+        Parameter mapping, supplied by the concrete subclass from its own
+        ``**params`` capture. This is an internal contract between
+        :class:`Density` and its subclasses -- **callers pass parameters
+        as keyword arguments**, and ``Channel(..., params={...})`` is
+        rejected with :exc:`TypeError` rather than silently creating a
+        parameter named ``"params"``.
     name : str or None
         Optional instance label. When ``None``, :attr:`class_name` is
         used as the display label (see :attr:`instance_name`).
     coverage_area_fraction : float
         Fraction in ``[0, 1]`` of the target control volume's lateral
-        area covered by this declaration. Set by the control-volume
-        lowering pipeline (:mod:`braincell.cv._lower`) when a paint
-        region only partially overlaps a CV. Defaults to ``1.0``.
+        area covered by this declaration. Set by the paint lowering pass
+        in :mod:`braincell._discretization` when a paint region only
+        partially overlaps a CV. Defaults to ``1.0``.
     solver : str or Callable or None
         Optional declaration-local integrator override. It is applied only
         to Markov channels and kinetic ions and must be supplied together
@@ -124,6 +125,32 @@ class Density(Mechanism):
     #: or ``"ion"``. Instances of the abstract base have an empty string.
     category: ClassVar[str] = ""
 
+    #: Field names in declaration order, derived once per subclass from
+    #: ``__slots__`` along the MRO. See :meth:`__init_subclass__`.
+    _FIELDS: ClassVar[tuple[str, ...]] = ()
+
+    #: Per-field coercions applied to every *incoming* value, whether it
+    #: arrives through ``__init__`` or through :meth:`_replace`. Stored
+    #: values are already normalized, so they are never re-coerced. Each
+    #: entry is called as ``normalizer(value, owner_class_name)``.
+    _NORMALIZERS: ClassVar[Mapping[str, Callable[[Any, str], Any]]] = {
+        "params": lambda value, owner: Params.coerce(value),
+        "coverage_area_fraction": lambda value, owner: require_fraction(value, owner, "coverage_area_fraction"),
+    }
+
+    #: Per-field ``repr`` overrides for fields whose stored form differs
+    #: from the form the constructor accepts.
+    _REPRS: ClassVar[Mapping[str, Callable[[Any], str]]] = {}
+
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        names: list[str] = []
+        for klass in reversed(cls.__mro__):
+            for slot in getattr(klass, "__slots__", ()):
+                if slot not in names:
+                    names.append(slot)
+        cls._FIELDS = tuple(names)
+
     def __init__(
         self,
         class_name: Any,
@@ -136,14 +163,16 @@ class Density(Mechanism):
         substeps: int | None = None,
     ) -> None:
         cls = type(self)
-        if cls is Density or not cls.category:
+        if not cls.category:
             raise TypeError(f"{cls.__name__} is an abstract base; instantiate Channel or Ion instead.")
+        if isinstance(params, Mapping) and "params" in params:
+            raise TypeError(
+                f"{cls.__name__} parameters must be passed as keyword arguments, not as params={{...}}. "
+                f"Write {cls.__name__}(..., g_max=value) rather than "
+                f"{cls.__name__}(..., params={{'g_max': value}})."
+            )
         resolved = _resolve_class_name(cls.category, class_name)
-        if name is not None and not isinstance(name, str):
-            raise TypeError(f"{cls.__name__}.name must be a string or None, got {type(name).__name__!r}.")
-        coverage = float(coverage_area_fraction)
-        if not (0.0 <= coverage <= 1.0):
-            raise ValueError(f"{cls.__name__}.coverage_area_fraction must lie in [0, 1], got {coverage!r}.")
+        require_str(name, cls.__name__, "name", optional=True)
         solver, substeps = _normalize_integration_override(
             solver,
             substeps,
@@ -152,7 +181,11 @@ class Density(Mechanism):
         object.__setattr__(self, "class_name", resolved)
         object.__setattr__(self, "params", Params.coerce(params))
         object.__setattr__(self, "name", name)
-        object.__setattr__(self, "coverage_area_fraction", coverage)
+        object.__setattr__(
+            self,
+            "coverage_area_fraction",
+            require_fraction(coverage_area_fraction, cls.__name__, "coverage_area_fraction"),
+        )
         object.__setattr__(self, "solver", solver)
         object.__setattr__(self, "substeps", substeps)
 
@@ -178,70 +211,35 @@ class Density(Mechanism):
         """
         return self.name if self.name is not None else self.class_name
 
-    @property
-    def identity(self) -> tuple[str, str]:
-        """Return ``(instance_name, class_name)`` for table views."""
-        return (self.instance_name, self.class_name)
-
     # ------------------------------------------------------------------
     # equality / hashing: structural, type-exact
+    #
+    # All three dunders below, and ``_replace``, walk ``_FIELDS`` rather
+    # than naming the fields. A subclass therefore declares ``__slots__``
+    # and nothing else -- it does not re-implement any of them.
     # ------------------------------------------------------------------
 
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
             return NotImplemented
-        return (
-            self.class_name == other.class_name
-            and self.params == other.params
-            and self.name == other.name
-            and self.coverage_area_fraction == other.coverage_area_fraction
-            and self.solver == other.solver
-            and self.substeps == other.substeps
-        )
+        # ``params`` is the only field whose comparison walks contents
+        # (and may hold arrays), so let the cheap scalars reject first.
+        for field in type(self)._FIELDS:
+            if field != "params" and getattr(self, field) != getattr(other, field):
+                return False
+        return self.params == other.params
 
     def __hash__(self) -> int:
-        return hash(
-            (
-                type(self).__name__,
-                self.class_name,
-                self.params,
-                self.name,
-                self.coverage_area_fraction,
-                self.solver,
-                self.substeps,
-            )
-        )
+        return hash((type(self).__name__, *(getattr(self, field) for field in type(self)._FIELDS)))
 
     def __repr__(self) -> str:
-        return (
-            f"{type(self).__name__}("
-            f"class_name={self.class_name!r}, "
-            f"params={self.params!r}, "
-            f"name={self.name!r}, "
-            f"coverage_area_fraction={self.coverage_area_fraction!r}, "
-            f"solver={self.solver!r}, "
-            f"substeps={self.substeps!r})"
-        )
+        cls = type(self)
+        fields = ", ".join(f"{field}={cls._REPRS.get(field, repr)(getattr(self, field))}" for field in cls._FIELDS)
+        return f"{cls.__name__}({fields})"
 
     # ------------------------------------------------------------------
     # non-mutating updates
     # ------------------------------------------------------------------
-
-    def with_params(self, **updates: Any) -> "Density":
-        """Return a copy with ``updates`` merged into ``params``.
-
-        Parameters
-        ----------
-        **updates
-            Parameters to add or replace.
-
-        Returns
-        -------
-        Density
-            A new instance of the same concrete subclass. ``self`` is
-            unchanged.
-        """
-        return self._replace(params=self.params.with_updates(**updates))
 
     def with_coverage(self, fraction: float) -> "Density":
         """Return a copy with a new ``coverage_area_fraction``.
@@ -256,31 +254,15 @@ class Density(Mechanism):
         Density
             A new instance of the same concrete subclass. ``self`` is
             unchanged.
+
+        Raises
+        ------
+        ValueError
+            If ``fraction`` lies outside ``[0, 1]`` -- the same check
+            :meth:`__init__` applies, reached through the shared
+            normalization in :meth:`_replace`.
         """
-        return self._replace(coverage_area_fraction=float(fraction))
-
-    def with_name(self, name: str | None) -> "Density":
-        """Return a copy with a new instance label."""
-        return self._replace(name=name)
-
-    def with_integration(
-        self,
-        *,
-        solver: str | Callable | None = None,
-        substeps: int | None = None,
-    ) -> "Density":
-        """Return a copy with a declaration-local integration override.
-
-        ``solver`` and ``substeps`` form one atomic override. Passing both
-        as ``None`` clears the override so the declaration inherits the
-        enclosing :class:`braincell.Cell` configuration.
-        """
-        solver, substeps = _normalize_integration_override(
-            solver,
-            substeps,
-            owner=type(self).__name__,
-        )
-        return self._replace(solver=solver, substeps=substeps)
+        return self._replace(coverage_area_fraction=fraction)
 
     # ------------------------------------------------------------------
     # internals
@@ -290,20 +272,21 @@ class Density(Mechanism):
         """Return a copy with selected fields overridden.
 
         Constructs a new instance of the exact concrete subclass via
-        :meth:`object.__new__`, bypassing ``__init__`` so callers do
-        not have to re-validate unchanged fields.
+        :meth:`object.__new__`, bypassing ``__init__`` so unchanged
+        fields are not re-validated. Fields that *are* being replaced go
+        through the same :attr:`_NORMALIZERS` entry ``__init__`` uses, so
+        a copy cannot hold a value the constructor would have rejected.
         """
-        new = object.__new__(type(self))
-        object.__setattr__(new, "class_name", updates.get("class_name", self.class_name))
-        object.__setattr__(new, "params", Params.coerce(updates.get("params", self.params)))
-        object.__setattr__(new, "name", updates.get("name", self.name))
-        object.__setattr__(
-            new,
-            "coverage_area_fraction",
-            float(updates.get("coverage_area_fraction", self.coverage_area_fraction)),
-        )
-        object.__setattr__(new, "solver", updates.get("solver", self.solver))
-        object.__setattr__(new, "substeps", updates.get("substeps", self.substeps))
+        cls = type(self)
+        new = object.__new__(cls)
+        for field in cls._FIELDS:
+            if field in updates:
+                normalizer = cls._NORMALIZERS.get(field)
+                value = updates[field]
+                value = normalizer(value, cls.__name__) if normalizer is not None else value
+            else:
+                value = getattr(self, field)
+            object.__setattr__(new, field, value)
         return new
 
 
@@ -360,7 +343,16 @@ class Channel(Density):
     """
 
     __slots__ = ("ion_name", "ion_names")
-    category: ClassVar[str] = _CHANNEL
+    category: ClassVar[str] = _CATEGORY_CHANNEL
+    _NORMALIZERS: ClassVar[Mapping[str, Callable[[Any, str], Any]]] = {
+        **Density._NORMALIZERS,
+        "ion_names": lambda value, owner: _normalize_ion_names(value),
+    }
+    #: ``ion_names`` is stored as a sorted tuple of pairs but accepted as
+    #: a mapping, so echo the constructor's form.
+    _REPRS: ClassVar[Mapping[str, Callable[[Any], str]]] = {
+        "ion_names": lambda value: repr(dict(value) if value is not None else None),
+    }
 
     def __init__(
         self,
@@ -383,41 +375,12 @@ class Channel(Density):
             solver=solver,
             substeps=substeps,
         )
-        if ion_name is not None and (not isinstance(ion_name, str) or not ion_name):
-            raise TypeError(f"Channel.ion_name must be a non-empty string or None, got {ion_name!r}.")
+        require_str(ion_name, "Channel", "ion_name", optional=True)
         normalized_ion_names = _normalize_ion_names(ion_names)
         if ion_name is not None and normalized_ion_names is not None:
             raise ValueError("Channel cannot define both ion_name and ion_names.")
         object.__setattr__(self, "ion_name", ion_name)
         object.__setattr__(self, "ion_names", normalized_ion_names)
-
-    def __eq__(self, other: object) -> bool:
-        result = super().__eq__(other)
-        if result is NotImplemented:
-            return result
-        return result and self.ion_name == other.ion_name and self.ion_names == other.ion_names
-
-    def __hash__(self) -> int:
-        return hash((super().__hash__(), self.ion_name, self.ion_names))
-
-    def __repr__(self) -> str:
-        base = super().__repr__()
-        base = base[:-1]
-        return (
-            f"{base}, "
-            f"ion_name={self.ion_name!r}, "
-            f"ion_names={dict(self.ion_names) if self.ion_names is not None else None!r})"
-        )
-
-    def _replace(self, **updates: Any) -> "Channel":
-        new = super()._replace(**updates)
-        object.__setattr__(new, "ion_name", updates.get("ion_name", self.ion_name))
-        object.__setattr__(
-            new,
-            "ion_names",
-            _normalize_ion_names(updates["ion_names"]) if "ion_names" in updates else self.ion_names,
-        )
-        return new
 
 
 class Ion(Density):
@@ -468,7 +431,7 @@ class Ion(Density):
     """
 
     __slots__ = ()
-    category: ClassVar[str] = _ION
+    category: ClassVar[str] = _CATEGORY_ION
 
     def __init__(
         self,

--- a/braincell/mech/_density_test.py
+++ b/braincell/mech/_density_test.py
@@ -145,12 +145,10 @@ class DensityIdentityTest(unittest.TestCase):
     def test_default_instance_name_is_class_name(self) -> None:
         spec = Channel("IL")
         self.assertEqual(spec.instance_name, "IL")
-        self.assertEqual(spec.identity, ("IL", "IL"))
 
     def test_override_instance_name(self) -> None:
         spec = Channel("Na_HH1952", name="na_main")
         self.assertEqual(spec.instance_name, "na_main")
-        self.assertEqual(spec.identity, ("na_main", "Na_HH1952"))
 
 
 class DensityEqualityTest(unittest.TestCase):
@@ -196,14 +194,6 @@ class DensityEqualityTest(unittest.TestCase):
 
 
 class DensityUpdatesTest(unittest.TestCase):
-    def test_with_params_non_mutating(self) -> None:
-        original = Channel("IL", g_max=0.1 * (u.mS / u.cm**2))
-        updated = original.with_params(g_max=0.2 * (u.mS / u.cm**2), E=-70 * u.mV)
-        self.assertEqual(original.params["g_max"], 0.1 * (u.mS / u.cm**2))
-        self.assertEqual(updated.params["g_max"], 0.2 * (u.mS / u.cm**2))
-        self.assertEqual(updated.params["E"], -70 * u.mV)
-        self.assertIsInstance(updated, Channel)
-
     def test_with_coverage_non_mutating(self) -> None:
         original = Channel("IL", g_max=0.1 * (u.mS / u.cm**2))
         updated = original.with_coverage(0.5)
@@ -211,28 +201,54 @@ class DensityUpdatesTest(unittest.TestCase):
         self.assertEqual(updated.coverage_area_fraction, 0.5)
         self.assertIsInstance(updated, Channel)
 
-    def test_with_name_non_mutating(self) -> None:
-        original = Channel("IL")
-        updated = original.with_name("leak_soma")
-        self.assertIsNone(original.name)
-        self.assertEqual(updated.name, "leak_soma")
-        self.assertIsInstance(updated, Channel)
-
     def test_updates_preserve_ion_subclass(self) -> None:
         original = Ion("SodiumFixed", Ci=12.0 * u.mM)
-        updated = original.with_params(Ci=15.0 * u.mM)
+        updated = original.with_coverage(0.25)
         self.assertIsInstance(updated, Ion)
-        self.assertEqual(updated.params["Ci"], 15.0 * u.mM)
+        self.assertEqual(updated.params["Ci"], 12.0 * u.mM)
+        self.assertEqual(updated.coverage_area_fraction, 0.25)
 
-    def test_with_integration_sets_and_clears_override(self) -> None:
-        original = Channel("IL", name="leak")
-        updated = original.with_integration(solver="rk4", substeps=4)
-        inherited = updated.with_integration()
-        self.assertIsNone(original.solver)
-        self.assertEqual((updated.solver, updated.substeps), ("rk4", 4))
-        self.assertEqual((inherited.solver, inherited.substeps), (None, None))
-        self.assertEqual(updated.name, "leak")
-        self.assertIsInstance(updated, Channel)
+    def test_copy_preserves_subclass_fields(self) -> None:
+        # ``_replace`` walks ``_FIELDS``, so a subclass slot survives a
+        # copy without the subclass overriding ``_replace``.
+        original = Channel("Kca1p1_MA2020_GoC", ion_names={"ca": "ca_local"})
+        self.assertEqual(original.with_coverage(0.5).ion_names, (("ca", "ca_local"),))
+
+    def test_with_coverage_rejects_out_of_range_fraction(self) -> None:
+        # Regression: ``with_coverage`` routed around the ``[0, 1]`` check
+        # that ``__init__`` advertises, so a copy could hold a value the
+        # constructor would have rejected.
+        spec = Channel("IL", g_max=0.1 * (u.mS / u.cm**2))
+        for bad in (7.0, -0.5):
+            with self.subTest(fraction=bad):
+                with self.assertRaisesRegex(ValueError, r"coverage_area_fraction must lie in \[0, 1\]"):
+                    spec.with_coverage(bad)
+
+
+class DensityParamsKeywordTest(unittest.TestCase):
+    """``params={...}`` is rejected rather than silently mis-stored.
+
+    ``Density.__init__`` captures ``**params``, so ``Channel("IL",
+    params={"g_max": ...})`` used to create a parameter literally named
+    ``"params"`` and leave ``g_max`` unset -- with no error.
+    """
+
+    def test_channel_rejects_params_mapping(self) -> None:
+        with self.assertRaisesRegex(TypeError, "must be passed as keyword arguments"):
+            Channel("IL", params={"g_max": 0.1 * (u.mS / u.cm**2)})
+
+    def test_ion_rejects_params_mapping(self) -> None:
+        with self.assertRaisesRegex(TypeError, "must be passed as keyword arguments"):
+            Ion("SodiumFixed", params={"Ci": 12.0 * u.mM})
+
+    def test_rejected_even_when_mixed_with_real_parameters(self) -> None:
+        with self.assertRaisesRegex(TypeError, "must be passed as keyword arguments"):
+            Channel("IL", E=-70 * u.mV, params={"g_max": 0.1 * (u.mS / u.cm**2)})
+
+    def test_keyword_form_is_the_supported_spelling(self) -> None:
+        spec = Channel("IL", g_max=0.1 * (u.mS / u.cm**2))
+        self.assertEqual(spec.params["g_max"], 0.1 * (u.mS / u.cm**2))
+        self.assertNotIn("params", spec.params)
 
 
 class DensityImmutabilityTest(unittest.TestCase):

--- a/braincell/mech/_event_contract.py
+++ b/braincell/mech/_event_contract.py
@@ -77,11 +77,21 @@ class ScalarEventInput(EventInput):
         object.__setattr__(self, "unit", unit)
 
     def validate_payload(self, payload):
-        """Validate and return a payload without forcing host materialization."""
+        """Validate and return a payload without forcing host materialization.
+
+        The check is purely dimensional, so it compares dimension
+        metadata rather than converting the payload. The previous
+        implementation called ``payload.to_decimal(self.unit)`` and threw
+        the result away, which emitted a real array multiply on every
+        call -- dead work that only XLA's DCE removed, and only on the
+        jitted run paths.
+        """
         if not isinstance(payload, u.Quantity):
             raise TypeError(f"Scalar event payload must be a quantity compatible with {self.unit}.")
         try:
-            payload.to_decimal(self.unit)
+            compatible = payload.dim == u.get_dim(self.unit)
         except Exception as exc:
             raise ValueError(f"Scalar event payload has units incompatible with {self.unit}.") from exc
+        if not compatible:
+            raise ValueError(f"Scalar event payload has units incompatible with {self.unit}.")
         return payload

--- a/braincell/mech/_params.py
+++ b/braincell/mech/_params.py
@@ -70,8 +70,9 @@ def _to_hashable(value: object) -> object:
         return ("__list__",) + tuple(_to_hashable(v) for v in value)
     if isinstance(value, dict):
         return ("__dict__",) + tuple((k, _to_hashable(v)) for k, v in sorted(value.items(), key=lambda kv: kv[0]))
-    if isinstance(value, np.ndarray):
-        return ("__array__", str(value.dtype), value.shape, tuple(value.reshape(-1).tolist()))
+    # ``np.ndarray`` needs no branch of its own: ``np.asarray`` returns it
+    # unchanged and cannot raise, so the generic array branch below
+    # produces a byte-identical key for it.
     if hasattr(value, "shape") and hasattr(value, "dtype"):
         try:
             array = np.asarray(value)
@@ -145,7 +146,7 @@ class Params(Mapping[str, Any]):
         True
     """
 
-    __slots__ = ("_items",)
+    __slots__ = ("_items", "_hashable", "_hash")
 
     def __init__(self, data: object = None, /, **kwargs: Any) -> None:
         merged: dict[str, Any] = {}
@@ -172,45 +173,39 @@ class Params(Mapping[str, Any]):
                 merged[str(key)] = value
         for key, value in kwargs.items():
             merged[str(key)] = value
+        # The converted view is needed here anyway to validate that every
+        # value is hashable, so keep it rather than recomputing the same
+        # walk on every ``__hash__`` and ``__eq__`` for the lifetime of
+        # this (immutable) mapping.
+        hashable: dict[str, Any] = {}
         for key, value in merged.items():
+            converted = _to_hashable(value)
             try:
-                hash(_to_hashable(value))
+                hash(converted)
             except TypeError as exc:
                 raise TypeError(
                     f"Params value for {key!r} must be hashable or a concrete array; got {type(value).__name__!r}."
                 ) from exc
+            hashable[key] = converted
         object.__setattr__(self, "_items", merged)
+        object.__setattr__(self, "_hashable", hashable)
+        object.__setattr__(self, "_hash", hash(frozenset(hashable.items())))
 
     # ------------------------------------------------------------------
     # Mapping protocol
     # ------------------------------------------------------------------
 
+    # ``keys``/``values``/``items``/``get``/``__contains__`` are supplied
+    # by the ``Mapping`` ABC on top of the three methods below.
+
     def __getitem__(self, key: str) -> Any:
-        try:
-            return self._items[key]
-        except KeyError:
-            raise KeyError(key) from None
+        return self._items[key]
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._items)
 
     def __len__(self) -> int:
         return len(self._items)
-
-    def __contains__(self, key: object) -> bool:
-        return key in self._items
-
-    def keys(self):  # type: ignore[override]
-        return self._items.keys()
-
-    def values(self):  # type: ignore[override]
-        return self._items.values()
-
-    def items(self):  # type: ignore[override]
-        return self._items.items()
-
-    def get(self, key: str, default: Any = None) -> Any:
-        return self._items.get(key, default)
 
     # ------------------------------------------------------------------
     # immutability: block accidental mutation
@@ -227,23 +222,20 @@ class Params(Mapping[str, Any]):
     # ------------------------------------------------------------------
 
     def __eq__(self, other: object) -> bool:
+        # ``Params`` is a ``Mapping``, so the two former branches (one
+        # reaching into ``other._items``, one calling ``other.items()``)
+        # were the same comparison written twice.
         if isinstance(other, Params):
-            return {key: _to_hashable(value) for key, value in self._items.items()} == {
-                key: _to_hashable(value) for key, value in other._items.items()
-            }
+            return self._hashable == other._hashable
         if isinstance(other, Mapping):
-            return {key: _to_hashable(value) for key, value in self._items.items()} == {
+            return len(self._items) == len(other) and self._hashable == {
                 key: _to_hashable(value) for key, value in other.items()
             }
         return NotImplemented
 
     def __hash__(self) -> int:
-        try:
-            return hash(frozenset((k, _to_hashable(v)) for k, v in self._items.items()))
-        except TypeError as exc:
-            raise TypeError(
-                f"Params values must be hashable to hash the mapping; unhashable entry encountered ({exc})."
-            ) from exc
+        # ``__init__`` rejects unhashable values, so this cannot fail.
+        return self._hash
 
     # ------------------------------------------------------------------
     # repr: stable declared order
@@ -278,27 +270,6 @@ class Params(Mapping[str, Any]):
         for key, value in kwargs.items():
             merged[str(key)] = value
         return Params(merged)
-
-    def without(self, *keys: str) -> "Params":
-        """Return a copy with the given keys removed.
-
-        Unknown keys are silently ignored.
-
-        Parameters
-        ----------
-        *keys : str
-            Keys to drop.
-
-        Returns
-        -------
-        Params
-            A new :class:`Params` instance.
-        """
-        if not keys:
-            return self
-        to_drop = {str(k) for k in keys}
-        remaining = {key: value for key, value in self._items.items() if key not in to_drop}
-        return Params(remaining)
 
     # ------------------------------------------------------------------
     # construction

--- a/braincell/mech/_params_test.py
+++ b/braincell/mech/_params_test.py
@@ -140,16 +140,6 @@ class ParamsUpdatesTest(unittest.TestCase):
         updated = original.with_updates(b=2)
         self.assertEqual(list(updated), ["a", "b"])
 
-    def test_without_drops_keys(self) -> None:
-        original = Params(a=1, b=2, c=3)
-        pruned = original.without("b")
-        self.assertEqual(dict(pruned), {"a": 1, "c": 3})
-
-    def test_without_ignores_unknown_keys(self) -> None:
-        original = Params(a=1)
-        pruned = original.without("missing")
-        self.assertEqual(pruned, original)
-
 
 class ParamsCoerceTest(unittest.TestCase):
     def test_coerce_passes_through_params(self) -> None:

--- a/braincell/mech/_point.py
+++ b/braincell/mech/_point.py
@@ -38,7 +38,7 @@ inherits from :class:`Point` but lives in its own module
 """
 
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Callable, ClassVar, Mapping
 import warnings
 
 import brainunit as u
@@ -46,6 +46,7 @@ import numpy as np
 
 from ._base import Mechanism
 from ._params import Params, quantity_hashable
+from ._validate import require_str
 
 __all__ = [
     "Point",
@@ -56,7 +57,6 @@ __all__ = [
     "CurrentProbe",
     "ProbeMechanism",
     "SineClamp",
-    "Synapse",
     "SynapseSpec",
 ]
 
@@ -96,17 +96,13 @@ class CurrentClamp(Point):
         Single-segment duration or multi-segment durations.
     amplitudes : Quantity[nA] or sequence of Quantity[nA]
         Single-segment amplitude or multi-segment amplitudes.
-    target_index : array-like of int or None, optional
-        Reserved sparse target indices over the flattened placement target
-        axis. ``None`` keeps dense/broadcast semantics.
 
     Raises
     ------
     TypeError
         If ``delay``, ``durations`` or ``amplitudes`` are not quantities.
     ValueError
-        If any duration is non-positive, or if ``target_index`` is not a
-        one-dimensional non-negative integer array.
+        If any duration is non-positive.
 
     Examples
     --------
@@ -125,19 +121,16 @@ class CurrentClamp(Point):
     delay: Any = field(default_factory=lambda: 0.0 * u.ms)
     durations: Any = field(default_factory=lambda: 1.0 * u.ms)
     amplitudes: Any = field(default_factory=lambda: 0.0 * u.nA)
-    target_index: Any = None
 
     def __post_init__(self) -> None:
-        delay = _coerce_quantity(self.delay, unit=u.ms, field_name="CurrentClamp.delay")
-        durations = _coerce_quantity(self.durations, unit=u.ms, field_name="CurrentClamp.durations")
-        amplitudes = _coerce_quantity(self.amplitudes, unit=u.nA, field_name="CurrentClamp.amplitudes")
-        _raise_if_nonpositive_duration(durations)
-        target_index = _normalize_target_index(self.target_index)
-
-        object.__setattr__(self, "delay", delay)
-        object.__setattr__(self, "durations", durations)
-        object.__setattr__(self, "amplitudes", amplitudes)
-        object.__setattr__(self, "target_index", target_index)
+        for name, unit in (("delay", u.ms), ("durations", u.ms), ("amplitudes", u.nA)):
+            coerced = _coerce_quantity(
+                getattr(self, name),
+                unit=unit,
+                field_name=f"CurrentClamp.{name}",
+            )
+            object.__setattr__(self, name, coerced)
+        _raise_if_nonpositive_duration(self.durations)
 
 
 @quantity_hashable
@@ -169,43 +162,32 @@ class SineClamp(Point):
     delay: Any = field(default_factory=lambda: 0.0 * u.ms)
     duration: Any = field(default_factory=lambda: 1.0 * u.ms)
 
+    #: Quantity field -> unit. ``phase`` is dimensionless and handled
+    #: separately.
+    _UNITS: ClassVar[Mapping[str, Any]] = {
+        "amplitude": u.nA,
+        "frequency": u.Hz,
+        "offset": u.nA,
+        "delay": u.ms,
+        "duration": u.ms,
+    }
+    #: Fields that must additionally be strictly positive.
+    _POSITIVE: ClassVar[tuple[str, ...]] = ("frequency", "duration")
+
     def __post_init__(self) -> None:
-        frequency = _coerce_scalar_quantity(
-            self.frequency,
-            unit=u.Hz,
-            field_name="SineClamp.frequency",
-        )
-        if float(frequency.to_decimal(u.Hz)) <= 0.0:
-            raise ValueError(f"SineClamp.frequency must be > 0, got {self.frequency!r}.")
-        duration = _coerce_scalar_quantity(
-            self.duration,
-            unit=u.ms,
-            field_name="SineClamp.duration",
-        )
-        if float(duration.to_decimal(u.ms)) <= 0.0:
-            raise ValueError(f"SineClamp.duration must be > 0, got {self.duration!r}.")
         if not isinstance(self.phase, (int, float)) or isinstance(self.phase, bool):
             raise TypeError(f"SineClamp.phase must be a real number, got {type(self.phase).__name__!r}.")
-        amplitude = _coerce_scalar_quantity(
-            self.amplitude,
-            unit=u.nA,
-            field_name="SineClamp.amplitude",
-        )
-        offset = _coerce_scalar_quantity(
-            self.offset,
-            unit=u.nA,
-            field_name="SineClamp.offset",
-        )
-        delay = _coerce_scalar_quantity(
-            self.delay,
-            unit=u.ms,
-            field_name="SineClamp.delay",
-        )
-        object.__setattr__(self, "amplitude", amplitude)
-        object.__setattr__(self, "frequency", frequency)
-        object.__setattr__(self, "offset", offset)
-        object.__setattr__(self, "delay", delay)
-        object.__setattr__(self, "duration", duration)
+        for name, unit in self._UNITS.items():
+            original = getattr(self, name)
+            coerced = _coerce_quantity(
+                original,
+                unit=unit,
+                field_name=f"SineClamp.{name}",
+                allow_sequence=False,
+            )
+            if name in self._POSITIVE and float(coerced.to_decimal(unit)) <= 0.0:
+                raise ValueError(f"SineClamp.{name} must be > 0, got {original!r}.")
+            object.__setattr__(self, name, coerced)
 
 
 @quantity_hashable
@@ -249,62 +231,72 @@ class FunctionClamp(Point):
 
 
 @dataclass(frozen=True)
-class StateProbe(Point):
+class _LegacyProbe(Point):
+    """Shared preamble for the deprecated probe declarations.
+
+    The four probe classes each opened ``__post_init__`` with the same
+    deprecation warning -- passing their own class name as a string
+    literal, which a rename would silently desync -- followed by the same
+    optional-``name`` check. Both now happen once, here, and each
+    subclass implements only :meth:`_validate` for its own fields.
+    """
+
+    def __post_init__(self) -> None:
+        warnings.warn(
+            f"{type(self).__name__} is deprecated; use Cell.record(..., braincell.observe.*) for new code.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        require_str(getattr(self, "name", None), type(self).__name__, "name", optional=True)
+        self._validate()
+
+    def _validate(self) -> None:
+        """Validate subclass-specific fields. Overridden as needed."""
+
+
+@dataclass(frozen=True)
+class StateProbe(_LegacyProbe):
     """Probe for cell-owned state at one placed location."""
 
     name: str | None = None
     field: str = "v"
 
-    def __post_init__(self) -> None:
-        _warn_legacy_probe("StateProbe")
-        if self.name is not None and (not isinstance(self.name, str) or not self.name):
-            raise ValueError(f"StateProbe.name must be a non-empty string or None, got {self.name!r}.")
-        if not isinstance(self.field, str) or not self.field:
-            raise ValueError(f"StateProbe.field must be a non-empty string, got {self.field!r}.")
+    def _validate(self) -> None:
+        require_str(self.field, "StateProbe", "field")
         if self.field != "v":
             raise ValueError(f"Unsupported StateProbe field {self.field!r}; only 'v' is supported.")
 
 
 @dataclass(frozen=True)
-class MechanismProbe(Point):
+class MechanismProbe(_LegacyProbe):
     """Probe for runtime state on a named mechanism."""
 
     mechanism: str
     field: str
     name: str | None = None
 
-    def __post_init__(self) -> None:
-        _warn_legacy_probe("MechanismProbe")
-        if self.name is not None and (not isinstance(self.name, str) or not self.name):
-            raise ValueError(f"MechanismProbe.name must be a non-empty string or None, got {self.name!r}.")
-        for field_name in ("mechanism", "field"):
-            value = getattr(self, field_name)
-            if not isinstance(value, str) or not value:
-                raise ValueError(f"MechanismProbe.{field_name} must be a non-empty string, got {value!r}.")
+    def _validate(self) -> None:
+        require_str(self.mechanism, "MechanismProbe", "mechanism")
+        require_str(self.field, "MechanismProbe", "field")
 
 
 @dataclass(frozen=True)
-class CurrentProbe(Point):
+class CurrentProbe(_LegacyProbe):
     """Probe for current at a placed location."""
 
     ion: str | None = None
     mechanism: str | None = None
     name: str | None = None
 
-    def __post_init__(self) -> None:
-        _warn_legacy_probe("CurrentProbe")
-        if self.name is not None and (not isinstance(self.name, str) or not self.name):
-            raise ValueError(f"CurrentProbe.name must be a non-empty string or None, got {self.name!r}.")
-        if self.ion is not None and (not isinstance(self.ion, str) or not self.ion):
-            raise ValueError(f"CurrentProbe.ion must be a non-empty string or None, got {self.ion!r}.")
-        if self.mechanism is not None and (not isinstance(self.mechanism, str) or not self.mechanism):
-            raise ValueError(f"CurrentProbe.mechanism must be a non-empty string or None, got {self.mechanism!r}.")
+    def _validate(self) -> None:
+        require_str(self.ion, "CurrentProbe", "ion", optional=True)
+        require_str(self.mechanism, "CurrentProbe", "mechanism", optional=True)
         if self.ion is None and self.mechanism is None:
             raise ValueError("CurrentProbe requires at least one of 'ion' or 'mechanism'.")
 
 
 @dataclass(frozen=True)
-class ProbeMechanism(Point):
+class ProbeMechanism(_LegacyProbe):
     """Observer that records a named variable at a point location.
 
     Parameters
@@ -320,20 +312,10 @@ class ProbeMechanism(Point):
     variable: str
     target: str | None = None
 
-    def __post_init__(self) -> None:
-        _warn_legacy_probe("ProbeMechanism")
-        if not isinstance(self.variable, str) or not self.variable:
-            raise ValueError(f"ProbeMechanism.variable must be a non-empty str, got {self.variable!r}.")
+    def _validate(self) -> None:
+        require_str(self.variable, "ProbeMechanism", "variable")
         if self.target is not None and not isinstance(self.target, str):
             raise TypeError(f"ProbeMechanism.target must be str or None, got {type(self.target).__name__!r}.")
-
-
-def _warn_legacy_probe(name: str) -> None:
-    warnings.warn(
-        f"{name} is deprecated; use Cell.record(..., braincell.observe.*) for new code.",
-        DeprecationWarning,
-        stacklevel=3,
-    )
 
 
 class SynapseSpec(Point):
@@ -370,8 +352,7 @@ class SynapseSpec(Point):
         name: str | None = None,
         **params: Any,
     ) -> None:
-        if not isinstance(synapse_type, str) or not synapse_type:
-            raise ValueError(f"SynapseSpec.synapse_type must be a non-empty string, got {synapse_type!r}.")
+        require_str(synapse_type, "SynapseSpec", "synapse_type")
         if synapse_type in {"AMPA", "GABAa", "NMDA"}:
             raise NotImplementedError(
                 f"{synapse_type} is temporarily unavailable while its transmitter-pulse and "
@@ -379,8 +360,7 @@ class SynapseSpec(Point):
             )
         if "params" in params:
             raise TypeError("Synapse parameters must be passed as keyword arguments, not as params={...}.")
-        if name is not None and not isinstance(name, str):
-            raise TypeError(f"SynapseSpec.name must be a string or None, got {type(name).__name__!r}.")
+        require_str(name, "SynapseSpec", "name", optional=True)
         object.__setattr__(self, "synapse_type", synapse_type)
         object.__setattr__(self, "params", Params(params) if params else Params())
         object.__setattr__(self, "name", name)
@@ -396,11 +376,6 @@ class SynapseSpec(Point):
         """Display label — ``self.name`` if set, else ``synapse_type``."""
         return self.name if self.name is not None else self.synapse_type
 
-    @property
-    def identity(self) -> tuple[str, str]:
-        """Return ``(instance_name, synapse_type)`` for table views."""
-        return (self.instance_name, self.synapse_type)
-
     def __eq__(self, other: object) -> bool:
         if type(self) is not type(other):
             return NotImplemented
@@ -413,44 +388,31 @@ class SynapseSpec(Point):
         return f"SynapseSpec(synapse_type={self.synapse_type!r}, params={self.params!r}, name={self.name!r})"
 
 
-class Synapse(SynapseSpec):
-    """Deprecated spelling of :class:`SynapseSpec`."""
-
-    def __init__(self, *args, **kwargs) -> None:
-        import warnings
-
-        warnings.warn(
-            "braincell.mech.Synapse is deprecated; use braincell.mech.SynapseSpec.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        super().__init__(*args, **kwargs)
-
-
 # ---------------------------------------------------------------------------
 # helpers
 # ---------------------------------------------------------------------------
 
 
-def _coerce_scalar_quantity(value: Any, *, unit: Any, field_name: str) -> Any:
-    if not hasattr(value, "to_decimal"):
-        raise TypeError(f"{field_name} must be a Quantity, got {value!r}.")
-    return value.in_unit(unit)
+def _coerce_quantity(value: Any, *, unit: Any, field_name: str, allow_sequence: bool = True) -> Any:
+    """Coerce ``value`` to a Quantity in ``unit``.
 
-
-def _coerce_quantity(value: Any, *, unit: Any, field_name: str) -> Any:
+    With ``allow_sequence=False`` this is the former
+    ``_coerce_scalar_quantity``, which was a strict subset of this
+    function -- and which, despite its name, never checked scalar-ness.
+    """
     if value is None:
         raise TypeError(f"{field_name} must not be None.")
     if hasattr(value, "to_decimal"):
         return value.in_unit(unit)
-    if isinstance(value, (list, tuple)):
+    if allow_sequence and isinstance(value, (list, tuple)):
         if len(value) == 0:
             raise ValueError(f"{field_name} must be non-empty.")
         if not all(hasattr(item, "to_decimal") for item in value):
             raise TypeError(f"{field_name} entries must be Quantities.")
         decimals = [item.to_decimal(unit) for item in value]
         return u.Quantity(np.stack(decimals, axis=-1), unit)
-
+    if not allow_sequence:
+        raise TypeError(f"{field_name} must be a Quantity, got {value!r}.")
     raise TypeError(f"{field_name} must be a Quantity or sequence of Quantities, got {type(value).__name__!r}.")
 
 
@@ -460,16 +422,3 @@ def _raise_if_nonpositive_duration(value: Any) -> None:
         raise ValueError("CurrentClamp.durations must be non-empty.")
     if np.any(decimals <= 0.0):
         raise ValueError(f"CurrentClamp.durations entries must be > 0, got {value!r}.")
-
-
-def _normalize_target_index(value: Any) -> Any:
-    if value is None:
-        return None
-    arr = np.asarray(value)
-    if arr.ndim != 1:
-        raise ValueError(f"CurrentClamp.target_index must be one-dimensional, got shape {arr.shape!r}.")
-    if not np.issubdtype(arr.dtype, np.integer):
-        raise TypeError("CurrentClamp.target_index entries must be integers.")
-    if np.any(arr < 0):
-        raise ValueError("CurrentClamp.target_index entries must be non-negative.")
-    return tuple(int(item) for item in arr.tolist())

--- a/braincell/mech/_point_test.py
+++ b/braincell/mech/_point_test.py
@@ -29,7 +29,6 @@ from braincell.mech import (
     ProbeMechanism,
     SineClamp,
     StateProbe,
-    Synapse,
     SynapseSpec,
 )
 
@@ -105,28 +104,6 @@ class CurrentClampTest(unittest.TestCase):
                 delay=0.0 * u.ms,
                 durations=(-1.0 * u.ms,),
                 amplitudes=(0.1 * u.nA,),
-            )
-
-    def test_target_index_is_normalized(self) -> None:
-        cc = CurrentClamp(
-            durations=1.0 * u.ms,
-            amplitudes=0.1 * u.nA,
-            target_index=[2, 0],
-        )
-        self.assertEqual(cc.target_index, (2, 0))
-
-    def test_bad_target_index_raises(self) -> None:
-        with self.assertRaises(ValueError):
-            CurrentClamp(
-                durations=1.0 * u.ms,
-                amplitudes=0.1 * u.nA,
-                target_index=[[0]],
-            )
-        with self.assertRaises(TypeError):
-            CurrentClamp(
-                durations=1.0 * u.ms,
-                amplitudes=0.1 * u.nA,
-                target_index=[0.5],
             )
 
     def test_is_frozen_hashable(self) -> None:
@@ -295,12 +272,10 @@ class SynapseTest(unittest.TestCase):
     def test_default_instance_name(self) -> None:
         syn = SynapseSpec("ExpSyn")
         self.assertEqual(syn.instance_name, "ExpSyn")
-        self.assertEqual(syn.identity, ("ExpSyn", "ExpSyn"))
 
     def test_override_instance_name(self) -> None:
         syn = SynapseSpec("ExpSyn", name="fast")
         self.assertEqual(syn.instance_name, "fast")
-        self.assertEqual(syn.identity, ("fast", "ExpSyn"))
 
     def test_equality_and_hash(self) -> None:
         a = SynapseSpec("ExpSyn", tau=5.0, e=0.0)
@@ -324,11 +299,6 @@ class SynapseTest(unittest.TestCase):
         syn = SynapseSpec("ExpSyn")
         with self.assertRaises(AttributeError):
             syn.synapse_type = "Exp2Syn"
-
-    def test_deprecated_synapse_alias_constructs_spec(self) -> None:
-        with self.assertWarns(DeprecationWarning):
-            syn = Synapse("ExpSyn")
-        self.assertIsInstance(syn, SynapseSpec)
 
     def test_unmigrated_receptors_are_rejected(self) -> None:
         for model in ("AMPA", "GABAa", "NMDA"):

--- a/braincell/mech/_registry.py
+++ b/braincell/mech/_registry.py
@@ -198,37 +198,6 @@ class MechanismRegistry:
         for alias in entry.aliases:
             self._aliases.pop((category, alias), None)
 
-    def add_alias(self, *, category: str, alias: str, name: str) -> None:
-        """Add a new alias to an existing canonical entry.
-
-        Parameters
-        ----------
-        category : str
-            Category the alias lives in.
-        alias : str
-            The new alias name.
-        name : str
-            Existing canonical name that the alias should resolve to.
-
-        Raises
-        ------
-        KeyError
-            If no canonical entry exists for ``(category, name)``.
-        ValueError
-            If ``alias`` collides with an existing canonical name or
-            alias in the same category.
-        """
-        _check_category(category)
-        target_key = (category, name)
-        if target_key not in self._entries:
-            raise KeyError(f"Cannot add alias {alias!r}: no canonical mechanism registered at {category!r}/{name!r}.")
-        alias_key = (category, alias)
-        if alias_key in self._entries:
-            raise ValueError(f"Alias {category!r}/{alias!r} collides with existing canonical name.")
-        if alias_key in self._aliases:
-            raise ValueError(f"Alias {category!r}/{alias!r} is already registered for {self._aliases[alias_key]!r}.")
-        self._aliases[alias_key] = name
-
     def clear(self) -> None:
         """Remove every registered entry and alias.
 
@@ -323,16 +292,12 @@ class MechanismRegistry:
         """
         if category is not None:
             _check_category(category)
-            canonical = sorted(entry.name for (cat, _), entry in self._entries.items() if cat == category)
-            if not include_aliases:
-                return tuple(canonical)
-            aliases = sorted(alias for (cat, alias) in self._aliases if cat == category)
-            return tuple(canonical + aliases)
-
-        canonical = sorted(entry.name for entry in self._entries.values())
+        canonical = sorted(
+            entry.name for (cat, _), entry in self._entries.items() if category is None or cat == category
+        )
         if not include_aliases:
             return tuple(canonical)
-        aliases = sorted(alias for (_, alias) in self._aliases)
+        aliases = sorted(alias for (cat, alias) in self._aliases if category is None or cat == category)
         return tuple(canonical + aliases)
 
     def items(self, category: str | None = None) -> tuple[tuple[str, type], ...]:
@@ -351,9 +316,9 @@ class MechanismRegistry:
         """
         if category is not None:
             _check_category(category)
-            pairs = [(entry.name, entry.cls) for (cat, _), entry in self._entries.items() if cat == category]
-        else:
-            pairs = [(entry.name, entry.cls) for entry in self._entries.values()]
+        pairs = [
+            (entry.name, entry.cls) for (cat, _), entry in self._entries.items() if category is None or cat == category
+        ]
         pairs.sort(key=lambda item: item[0])
         return tuple(pairs)
 

--- a/braincell/mech/_registry_test.py
+++ b/braincell/mech/_registry_test.py
@@ -159,24 +159,6 @@ class MechanismRegistryAliasTest(MechanismRegistryIsolationMixin, unittest.TestC
         self.assertIs(reg.get("channel", "IL"), _DummyChannel)
         self.assertIs(reg.get("channel", "leaky"), _DummyChannel)
 
-    def test_add_alias_to_existing(self) -> None:
-        reg = self.make_registry()
-        reg.register(MechanismEntry(category="channel", name="IL", cls=_DummyChannel))
-        reg.add_alias(category="channel", alias="passive", name="IL")
-        self.assertIs(reg.get("channel", "passive"), _DummyChannel)
-
-    def test_add_alias_to_missing_entry_raises(self) -> None:
-        reg = self.make_registry()
-        with self.assertRaises(KeyError):
-            reg.add_alias(category="channel", alias="a", name="missing")
-
-    def test_add_alias_collision_raises(self) -> None:
-        reg = self.make_registry()
-        reg.register(MechanismEntry(category="channel", name="IL", cls=_DummyChannel))
-        reg.add_alias(category="channel", alias="leaky", name="IL")
-        with self.assertRaises(ValueError):
-            reg.add_alias(category="channel", alias="leaky", name="IL")
-
 
 class MechanismRegistryRemovalTest(MechanismRegistryIsolationMixin, unittest.TestCase):
     def test_unregister_removes_canonical_and_aliases(self) -> None:

--- a/braincell/mech/_synapse_schema.py
+++ b/braincell/mech/_synapse_schema.py
@@ -58,8 +58,7 @@ class DerivedSpec:
 
 def positive(value: object, name: str) -> None:
     """Require every canonical value to be finite and strictly positive."""
-    decimal = _decimal(value)
-    if np.any(decimal <= 0.0):
+    if np.any(np.asarray(u.get_mantissa(value)) <= 0.0):
         raise ValueError(f"Synapse parameter {name!r} must be > 0.")
 
 
@@ -83,9 +82,3 @@ def _validate_like_default(value: object, default: object, *, name: str) -> None
         raise TypeError(f"Synapse field {name!r} must be numeric.") from exc
     if not np.all(finite):
         raise ValueError(f"Synapse field {name!r} must contain only finite values.")
-
-
-def _decimal(value: object) -> np.ndarray:
-    if isinstance(value, u.Quantity):
-        return np.asarray(value.to_decimal(value.unit))
-    return np.asarray(value)

--- a/braincell/mech/_testing.py
+++ b/braincell/mech/_testing.py
@@ -1,0 +1,63 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared fixture builders for ``braincell.mech`` tests.
+
+The leading underscore in the filename keeps pytest from discovering this
+module as a test file. Nothing here is part of the public API.
+
+``make_cable`` lives here rather than in
+``braincell/_discretization/_testing.py`` because :class:`CableProperty`
+is a ``braincell.mech`` type; ``_discretization`` re-exports it so its
+own tests keep a single import site, the same way
+``braincell/filter/_testing.py`` re-exports the ``braincell.morph``
+builders.
+
+This module imports only from ``braincell.mech`` itself, preserving the
+leaf-package invariant documented in :mod:`braincell.mech`.
+"""
+
+import brainunit as u
+
+from braincell.mech._cable import CableProperty
+
+__all__ = ["make_cable"]
+
+
+def make_cable(cm: float = 1.0, ra: float = 100.0, v: float = -65.0) -> CableProperty:
+    """Build a :class:`CableProperty` from bare floats in the usual units.
+
+    The defaults are the values that were retyped as a literal at
+    seventeen call sites across the repository.
+
+    Parameters
+    ----------
+    cm : float
+        Specific membrane capacitance in ``uF / cm ** 2``.
+    ra : float
+        Axial resistivity in ``ohm * cm``.
+    v : float
+        Resting potential in ``mV``.
+
+    Returns
+    -------
+    CableProperty
+        The assembled declaration.
+    """
+    return CableProperty(
+        resting_potential=v * u.mV,
+        membrane_capacitance=cm * (u.uF / u.cm**2),
+        axial_resistivity=ra * (u.ohm * u.cm),
+    )

--- a/braincell/mech/_validate.py
+++ b/braincell/mech/_validate.py
@@ -1,0 +1,109 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared field validation for :mod:`braincell.mech` declarations.
+
+Every declaration class in this package validates the same handful of
+field shapes. Before this module existed the "must be a non-empty
+string" check alone was written eleven times across :mod:`._density`
+and :mod:`._point`, and — because each copy chose its own exception —
+the same condition raised ``TypeError`` in some classes and
+``ValueError`` in others. Callers had no way to write a correct
+``except`` clause.
+
+The rule these helpers apply is the Python convention the package was
+already half-following:
+
+* ``TypeError`` when the value is of the wrong type.
+* ``ValueError`` when the type is right but the value is not.
+
+This module deliberately depends on nothing outside the standard
+library, so it does not disturb the leaf-package invariant documented in
+:mod:`braincell.mech` — ``braincell.mech`` imports nothing from
+``braincell``.
+"""
+
+from typing import Any
+
+__all__ = ["require_str", "require_fraction"]
+
+
+def require_str(value: Any, owner: str, field: str, *, optional: bool = False) -> str | None:
+    """Validate that ``value`` is a non-empty string.
+
+    Parameters
+    ----------
+    value : object
+        The value to check.
+    owner : str
+        Owning class name, used to build the error message.
+    field : str
+        Field name, used to build the error message.
+    optional : bool
+        When ``True``, ``None`` is accepted and returned unchanged.
+
+    Returns
+    -------
+    str or None
+        ``value`` unchanged, once validated.
+
+    Raises
+    ------
+    TypeError
+        If ``value`` is not a :class:`str` (or ``None`` when *optional*).
+    ValueError
+        If ``value`` is an empty string.
+    """
+    if optional and value is None:
+        return None
+    suffix = " or None" if optional else ""
+    if not isinstance(value, str):
+        raise TypeError(f"{owner}.{field} must be a non-empty string{suffix}, got {type(value).__name__!r}.")
+    if not value:
+        raise ValueError(f"{owner}.{field} must be a non-empty string{suffix}, got {value!r}.")
+    return value
+
+
+def require_fraction(value: Any, owner: str, field: str) -> float:
+    """Validate that ``value`` is a real number in ``[0, 1]``.
+
+    Parameters
+    ----------
+    value : object
+        The value to check; converted with :class:`float`.
+    owner : str
+        Owning class name, used to build the error message.
+    field : str
+        Field name, used to build the error message.
+
+    Returns
+    -------
+    float
+        ``value`` as a float, once validated.
+
+    Raises
+    ------
+    TypeError
+        If ``value`` cannot be converted to :class:`float`.
+    ValueError
+        If the converted value lies outside ``[0, 1]``.
+    """
+    try:
+        fraction = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{owner}.{field} must be a real number, got {type(value).__name__!r}.") from exc
+    if not (0.0 <= fraction <= 1.0):
+        raise ValueError(f"{owner}.{field} must lie in [0, 1], got {fraction!r}.")
+    return fraction

--- a/braincell/network/_testing.py
+++ b/braincell/network/_testing.py
@@ -106,7 +106,7 @@ def make_post_cell(size: int = 2) -> Cell:
     cell.place(at("soma", 0.5), braincell.mech.MechanismProbe(name="g", mechanism="exp", field="g"))
     cell.place(
         at("soma", 0.5),
-        braincell.mech.Synapse(
+        braincell.mech.SynapseSpec(
             "ExpSyn",
             tau=2.0 * u.ms,
             e=0.0 * u.mV,
@@ -128,7 +128,7 @@ def make_post_cell_with_synapse_pool(size: int = 2) -> Cell:
     )
     cell.place(
         at("soma", 0.5) | at(1, 0.5),
-        braincell.mech.Synapse(
+        braincell.mech.SynapseSpec(
             "ExpSyn",
             tau=2.0 * u.ms,
             e=0.0 * u.mV,
@@ -160,7 +160,7 @@ def make_recording_post_cell(size: int = 2) -> Cell:
 
     This is the :class:`~braincell.mech.SynapseSpec` + ``observe`` counterpart
     to :func:`make_post_cell`, which predates that API and still declares its
-    synapse with ``mech.Synapse`` plus a ``MechanismProbe``.
+    synapse with ``mech.SynapseSpec`` plus a ``MechanismProbe``.
     """
     cell = Cell(
         make_soma_tree(),

--- a/docs/apis/braincell.mech.rst
+++ b/docs/apis/braincell.mech.rst
@@ -13,7 +13,7 @@ from the :class:`Mechanism` marker base class and splits into two families:
   (:class:`Density` and its concrete subclasses :class:`Channel` for ion
   channels and :class:`Ion` for ion species).
 - **Point mechanisms** are attached to a single location (:class:`Point` and
-  its subclasses, including :class:`Synapse`, :class:`Junction`, and the probe
+  its subclasses, including :class:`SynapseSpec`, :class:`Junction`, and the probe
   declarations).
 
 The passive cable property and the stimulus clamps
@@ -95,7 +95,7 @@ Point Mechanisms
 
     Point
     Junction
-    Synapse
+    SynapseSpec
 
 
 Probes

--- a/docs/design/interface-map.md
+++ b/docs/design/interface-map.md
@@ -265,19 +265,14 @@ metric 属性：
 - `Params.items()`
 - `Params.get(...)`
 - `Params.with_updates(...)`
-- `Params.without(...)`
 - `Params.coerce(...)`
 
 ### Cable / density mechanisms
 
 - `CableProperty`
-- `CableProperty.with_updates(...)`
 - `Density`
 - `Density.instance_name`
-- `Density.identity`
-- `Density.with_params(...)`
 - `Density.with_coverage(...)`
-- `Density.with_name(...)`
 - `mech.Channel(class_name, ..., ion_name=None, ion_names=None, **params)`
 - `mech.Ion(class_name, ..., **params)`
 
@@ -292,9 +287,8 @@ metric 属性：
 - `MechanismProbe`
 - `CurrentProbe`
 - `ProbeMechanism`
-- `Synapse`
-- `Synapse.instance_name`
-- `Synapse.identity`
+- `SynapseSpec`
+- `SynapseSpec.instance_name`
 - `Junction`
 
 ### Registry
@@ -303,7 +297,6 @@ metric 属性：
 - `MechanismRegistry`
 - `MechanismRegistry.register(...)`
 - `MechanismRegistry.unregister(...)`
-- `MechanismRegistry.add_alias(...)`
 - `MechanismRegistry.clear()`
 - `MechanismRegistry.contains(...)`
 - `MechanismRegistry.get(...)`

--- a/docs/specs/2026-09-02-mech-simplification.md
+++ b/docs/specs/2026-09-02-mech-simplification.md
@@ -1,0 +1,343 @@
+# `braincell/mech` simplification
+
+Iteration 4 of the module-by-module simplification sweep. Predecessors:
+`quad` (#138), `morph` (#139), `filter` (#140).
+
+## Scope and method
+
+`braincell/mech` is 4,017 lines across 19 files — 11 source modules and 8
+co-located test modules. Four independent quality reviews were run over the
+package (reuse, simplification, efficiency, altitude), their findings
+deduplicated, and each surviving one re-verified **by execution** rather than
+by reading, before anything was edited.
+
+Two invariants govern this pass, carried forward from iteration 3:
+
+1. Breaking changes are allowed, but every in-repo caller moves in the same
+   commit, and no deprecation shim, alias, or `warnings.warn` bridge is left
+   behind. The old spelling is deleted outright.
+2. Every performance claim carries a measurement taken by this pass, not one
+   inherited from a review report.
+
+### The constraint that shaped this iteration
+
+`braincell.mech` is a **leaf package**: it imports nothing from `braincell`.
+This is stated in `mech/__init__.py` and verified here —
+`grep -rn "^from braincell\|^import braincell" braincell/mech/*.py` returns
+nothing for non-test sources.
+
+That single fact vetoes a whole class of otherwise-attractive reuse:
+
+- The `_typing.py` aliases (`Initializer`, `ArrayLike`, …) that AGENTS.md
+  requires elsewhere **cannot** be used here — importing `braincell._typing`
+  executes `braincell/__init__.py`, which imports `mech`. `mech` therefore
+  annotates with `Any` where the rest of the package would use an alias, and
+  that stays.
+- `_misc.normalize_param`, `_misc.validate_time_quantity`, and
+  `filter.helper._is_quantity` are equally unreachable, even though `mech`
+  contains near-copies of all three.
+
+`brainunit` is *not* `braincell`, so `u.get_mantissa` and friends remain fair
+game — that distinction is what makes one of the reuse fixes below legal.
+
+## Bugs fixed
+
+Both were found while consolidating, both are reproduced by a new test first.
+
+### `Channel(..., params={...})` silently discarded the caller's parameters
+
+`Density.__init__` captures `**params`, so a caller writing the natural-looking
+`Channel("IL", params={"g_max": ...})` did not set `g_max`. They created a
+parameter *literally named* `"params"` whose value was the dict. Verified:
+
+```
+>>> Channel('IL', params={'g_max': 1.0*u.mS/u.cm**2}).params
+{'params': {'g_max': Quantity(1., "mS / cm^2")}}
+```
+
+The failure is silent — no exception, and `g_max` quietly falls back to its
+default at lowering time. `SynapseSpec.__init__` already guarded exactly this
+mistake with a clear `TypeError`; `Channel` and `Ion` did not. The guard moves
+to `Density.__init__` so all three declaration families behave alike.
+
+### `with_coverage` bypassed the validation `__init__` advertises
+
+`Density.__init__` enforces `coverage_area_fraction ∈ [0, 1]`, but
+`with_coverage` routed through `_replace`, which only does `float(...)`. The
+invariant held on one construction path and not the other, so
+`density.with_coverage(7.0)` produced an object `Density(...)` would have
+rejected. `with_integration` is the counter-example that got it right — it
+re-runs its normalizer before `_replace`. Normalization now lives in one place
+that both paths go through.
+
+## Breaking changes
+
+### Zero-caller API deleted
+
+Each was confirmed to have no caller in `braincell/`, `examples/`, or `docs/`
+outside its own test:
+
+| Symbol | Note |
+|---|---|
+| `Density.identity`, `SynapseSpec.identity` | see below |
+| `Density.with_params`, `Density.with_name` | `with_coverage` is live and stays |
+| `Density.with_integration` | |
+| `Params.without` | `Params.with_updates` is live and stays |
+| `CableProperty.with_updates` | |
+| `MechanismRegistry.add_alias` | `unregister` / `contains` are live and stay |
+| `CurrentClamp.target_index` + `_normalize_target_index` | field documented "Reserved"; no reader |
+| `mech.Synapse` | deprecated alias; its 2 callers in `network/_testing.py` move to `SynapseSpec` |
+
+`identity` earns a specific note. Both copies documented themselves as
+returning `(instance_name, class_name)` "for table views", but the actual table
+view — `_compute/table.py:194` — builds `(class_name, instance_name)`, the
+opposite order, inline, and never calls `identity`. The property was not merely
+unused; its docstring pointed at a real consumer that had silently disagreed
+with it. `instance_name` has 30+ production readers and stays.
+
+### One exception type for "not a non-empty string"
+
+The same condition was validated 11 times across `_density.py` and `_point.py`
+with **three different exception types** — `ValueError` in the probes,
+`TypeError` in `Density.name` / `Channel.ion_name` / `SynapseSpec.name`,
+`ValueError` in `SynapseSpec.synapse_type`. A caller writing `except` had no
+way to be right.
+
+One helper now owns the check and picks by cause, following the Python
+convention the package was already half-following: **`TypeError` when the value
+is not a `str`, `ValueError` when it is an empty `str`.** No test in the
+package asserted on these types, so nothing in-repo depended on the old
+inconsistency.
+
+### `CVContext.diam_mid` becomes a derived property
+
+It was a stored field whose sole construction site passed exactly
+`2.0 * radius_mid`, so two fields had to agree and nothing enforced it. Read
+access is unchanged — a user callable writing `ctx.diam_mid` still works — but
+it is no longer a constructor parameter.
+
+## Efficiency — measured, or not landed
+
+Median of 7 runs, same machine, before/after trees differing only by this
+branch (`main` at `48fdd26` checked out into a scratch worktree for the
+"before" column). Each row prints a digest; **all five digests match across
+both columns.** Iteration counts are taken from the real workload: 3,405
+control volumes is a CA1 cell at `CVPerBranch(5)`, and 2,046 is the measured
+number of `Params.__hash__` calls in one `CellRuntimeState.from_cell` build.
+
+| Benchmark | Before | After | Change |
+|---|---:|---:|---|
+| `Params.__hash__` ×2046, 500-element array param | 19.57 ms | 0.11 ms | **178× faster** |
+| `Params.__hash__` ×2046, scalar params | 2.16 ms | 0.12 ms | **18× faster** |
+| `Channel.__hash__` ×2046 | 2.51 ms | 1.25 ms | **2.0× faster** |
+| `ScalarEventInput.validate_payload` ×20000 | 68.86 ms | 36.94 ms | **1.9× faster** |
+| `CableProperty` rebuilt ×3405 CVs | 259.29 ms | 218.75 ms | **40.5 ms saved** |
+
+**Why `Params` hashing was the big one.** `Params` is immutable, but
+`__hash__` re-walked every value through `_to_hashable` on *every call*, and
+`__eq__` built two complete converted dicts each time. `__init__` was already
+computing that exact walk to validate hashability — and throwing it away. It
+now keeps the converted view and the resulting hash. The array row is the
+point: `_to_hashable` turns a Quantity array into a Python tuple via
+`reshape(-1).tolist()`, so the old cost scaled with *array length × number of
+hash calls*. A 500-element `g_max` painted over a cell went quadratic in CV
+count; it is now paid once at construction.
+
+**`validate_payload` was doing arithmetic to answer a metadata question.** It
+called `payload.to_decimal(self.unit)` and discarded the result — a real array
+multiply per call. The check is purely dimensional, so it now compares
+`payload.dim` against the contract's. Honest scoping: the supported run paths
+(`_multi_compartment/run.py`, `network/engine.py`) drive the step under
+`brainstate.transform.for_loop` + `jit`, where XLA's DCE already eliminated the
+dead convert. This 1.9× is real only for eager `Cell.update()` loops — tests,
+notebooks, single-step drivers — and under jit it removes one dead node per
+layout from the jaxpr rather than any runtime cost.
+
+**`CableProperty` is the smallest relative win and the most conditional one.**
+The paint lowering pass rebuilds a `CableProperty` per control volume from
+fields it has *already* canonicalized, so `_coerce_temperature` re-did a decimal
+conversion, an `asarray`, and a fresh `Quantity` allocation for a value that was
+already in exactly the target form. Instrumenting the guard showed **8,178 hits
+and 0 misses** across a full build+init — every single call was redundant. The
+15% saving here is bounded by the fact that the other three cable fields still
+go through the same rebuild; this pass did not touch those.
+
+**Not claimed.** `_resolve_class_name`'s registry scan is ~185× slower than a
+reverse index but ran 3 times in a full build, all short-circuiting before
+touching the registry — microseconds. It is listed under *Deliberately not
+changed* rather than reported as a win.
+
+## What was fixed
+
+### Reuse
+
+- **`_synapse_schema._decimal` re-implemented `brainunit.get_mantissa`.**
+  `value.to_decimal(value.unit)` converts a quantity to its own unit, which is
+  the mantissa. Verified equal across scalar/array/bare/int-dtype cases; the
+  private helper is deleted in favour of the documented API the rest of the
+  repo already uses.
+- **`CableProperty` was hand-built at 17 sites repo-wide** from the identical
+  three-field literal. `braincell/_discretization/_testing.py` already had
+  `make_cable` with byte-matching defaults, but `mech` owns `CableProperty`, so
+  the builder moves to a new `braincell/mech/_testing.py` and `_discretization`
+  re-exports it — the pattern `filter/_testing.py` uses for `morph`.
+- **`_CHANNEL` / `_ION` string literals** in `_density.py` duplicated
+  `_CATEGORY_CHANNEL` / `_CATEGORY_ION` in the sibling `_registry.py`, which
+  `_density.py` already imports from. Two sources of truth for the strings that
+  key the registry.
+
+### Simplification
+
+- **`Params` re-implemented five `collections.abc.Mapping` mixins** it already
+  inherits (`keys`/`values`/`items`/`get`/`__contains__`), and its
+  `__getitem__` wrapped a dict lookup in `try/except KeyError: raise
+  KeyError(key) from None` — verified at runtime that the bare lookup already
+  produces exactly `KeyError('zz')`. Its `__eq__` had two branches differing
+  only in `other._items.items()` vs `other.items()`, which are the same thing
+  for a `Mapping`.
+- **`_to_hashable` had two array branches producing byte-identical output.**
+  For an `np.ndarray`, `np.asarray(value) is value` and cannot raise, so the
+  generic shape/dtype branch reproduces the ndarray branch exactly. Verified
+  for 1-D, 2-D, and 0-D arrays.
+- **`Density` enumerated its six fields five times** — `__init__`, `__eq__`,
+  `__hash__`, `__repr__`, `_replace` — and every subclass had to re-enumerate
+  all five. The sharpest symptom was `Channel.__repr__` doing string surgery on
+  its parent's output (`base = super().__repr__(); base = base[:-1]`) to splice
+  two fields in before the closing paren, and `Channel.__hash__` hashing a hash.
+  The field list is now derived once by walking `__slots__` up the MRO.
+- **The four probe classes repeated the same `__post_init__` preamble**, each
+  passing its own class name to the deprecation warning as a string literal
+  that a rename would silently desync, then repeating the same optional-`name`
+  check. A `_LegacyProbe` base now owns both — deriving the name from
+  `type(self).__name__` — and each subclass implements only `_validate` for its
+  own fields.
+- **`SineClamp.__post_init__` was six near-identical coercions**, two
+  near-identical positivity guards, and five `object.__setattr__` lines; it
+  becomes two table-driven loops.
+- **`_coerce_scalar_quantity` was a strict subset of `_coerce_quantity`** and,
+  despite its name, never checked scalar-ness. One parameterized function.
+- **`MechanismRegistry.names()` and `.items()` each duplicated their whole body**
+  across the `category is None` / `not None` branches.
+- **`CVContext.position` duplicated `local_position`'s body** rather than
+  delegating — two error messages for one condition. Its sibling
+  `SamplingContext.position` in `filter` already delegates; iteration 3 made it
+  do so.
+- **`if cls is Density or not cls.category:`** — `Density.category` is `""`, so
+  the second clause already covers the first.
+
+### Docstrings describing behaviour the code does not have
+
+- `_density.py` cross-referenced `braincell.cv._lower` as the module that sets
+  `coverage_area_fraction`. There is no `braincell/cv/` package; the real site
+  is `_discretization/mechanism.py`. It was the only `braincell.cv` reference
+  in the repository.
+- `_base.py` cross-referenced `braincell.mech.Probe`. No such class exists —
+  the real ones are `StateProbe` / `MechanismProbe` / `CurrentProbe`.
+- `Density` documented `params : Mapping or None` as a constructor parameter,
+  which is the bug fixed above.
+
+## Deliberately not changed
+
+Recorded so the next reader does not re-litigate them, and so later iterations
+inherit the reasoning rather than the rediscovery.
+
+1. **`metric.branch_x` / `metric.radius` keep their two-name fallback lists.**
+   Iteration 3 deferred to this iteration the question of whether `CVContext`
+   should expose `branch_x` / `radius` directly so `filter/metric.py`'s
+   fallbacks collapse to one name each. Answer: no. `CVContext`'s names are
+   coherent triples — `prox`/`midpoint`/`dist` and
+   `radius_prox`/`radius_mid`/`radius_dist`. Renaming `midpoint` to `branch_x`
+   would break both triples to save two list entries, and adding an alias
+   property would *add* a second spelling, which is the opposite of the goal.
+   The fallback list in `metric.py` is exactly the right adapter between two
+   internally-coherent vocabularies, and it is documented public API
+   (`examples/multi_compartment/synapse.ipynb`).
+
+2. **`ProbeMechanism` is dead but not deleted here.** Zero construction sites
+   outside `_point_test.py`, yet four production dispatch branches exist for it
+   in `_compute/layouts.py` and `_compute/table.py`, plus entries in
+   `docs/apis/`, `docs/tutorials/mech.ipynb`, and `interface-map.md`. Deleting
+   it is a `_compute` change wearing a `mech` hat; it belongs to **iteration 8**
+   (`_compute`), which will be reworking that dispatch chain anyway.
+
+3. **`_warn_legacy_probe` stays.** It fires on 222 in-repo construction sites,
+   including the repo's own `network/_testing.py` fixtures, with no
+   `filterwarnings` entry to damp it — genuinely noisy. But the warning names a
+   real replacement (`Cell.record(..., braincell.observe.*)`), and the fix is
+   to *perform* the migration across 222 sites, not to silence the signal.
+   That is a migration, not a simplification.
+
+4. **`Junction` has no construction site outside its own tests**, but
+   `TODO.md:472` tracks "Junction runtime wiring" as planned work. Flagged, not
+   deleted.
+
+5. **The `Density` / `SynapseSpec` duplication is not unified.** They are the
+   same "registry-keyed, named, params-carrying declaration" implemented twice,
+   and `SynapseSpec` lacking a `category` is why three separate consumer chains
+   in `_compute` each need a parallel branch. A shared `RegistryKeyed` mixin is
+   the right end state, but it changes `_compute/layouts.py`, `_compute/table.py`,
+   and `_discretization` together — **iteration 14**.
+
+6. **Probe default-name derivation stays where it is.** `Density` and
+   `SynapseSpec` have `instance_name`; the probe classes do not, so
+   `_discretization/mechanism.py` and `_compute/table.py` each hand-roll the
+   same three suffix formulas. Giving the probes a `default_name` is a genuine
+   altitude fix, but the payoff lands in two other packages — **iteration 14**.
+
+7. **`MechanismRegistry` and `quad`'s `IntegratorRegistry` are not unified.**
+   Structurally similar, semantically divergent: `mech` namespaces by category
+   and has no metadata/override/deprecation; `quad` has all three and no
+   category namespace. That is a redesign, not a reuse fix.
+
+8. **`_registry._resolve_class_name`'s linear scan is left alone.** It sorts an
+   entire registry category to answer one identity question, which is ~185×
+   slower than a reverse-index lookup — but it was called 3 times in a full
+   CA1 build, all of which short-circuited before touching the registry. The
+   absolute saving is microseconds; adding and maintaining a `_by_class` index
+   costs more than it returns.
+
+9. **`Mechanism` (`_base.py`) is left in place, with its docstring corrected.**
+   The marker has zero `isinstance` call sites outside `mech` — verified — and
+   `CableProperty`, which `Cell.paint` accepts alongside `Density`, does not
+   inherit it. So it is currently an abstraction with no clients. Both fixes
+   (give it a real job by including `CableProperty`, or delete it) change
+   `_discretization/mechanism.py`'s `paint` signature, so the decision travels
+   with **iteration 14**.
+
+## Verification
+
+```
+$ pytest braincell/mech -q
+177 passed, 23 warnings, 4 subtests passed in 4.26s
+
+$ pytest braincell/ -q
+2724 passed, 15 skipped, 411 warnings, 401 subtests passed in 173.11s
+
+$ pre-commit run --files <24 changed files>
+... ruff (legacy alias) .... Passed
+... ruff format .......... Passed          (all hooks Passed or Skipped)
+```
+
+Against the baseline `main` at `48fdd26` (2,730 passed / 397 subtests), the
+package total moves to **2,724 passed / 401 subtests** — a net of **−6 tests
+and +4 subtests**, every one of which is accounted for:
+
+| Module | Δ | Detail |
+|---|---:|---|
+| `_density_test.py` | **+3** | −3 tests for the deleted `with_params` / `with_name` / `with_integration`; +1 copy-preserves-subclass-fields; +1 `with_coverage` range regression (2 subtests); +4 in the new `DensityParamsKeywordTest` |
+| `_params_test.py` | −2 | the two `Params.without` tests |
+| `_registry_test.py` | −3 | the three `add_alias` tests |
+| `_cable_test.py` | −1 | −1 `with_updates`; two temperature-rejection tests merged into one with 2 subtests (−1); +1 canonical-passthrough |
+| `_point_test.py` | −3 | the deprecated `Synapse` alias test and the two `target_index` tests |
+| **Total** | **−6** | subtests **+4** = 2 (`with_coverage`) + 2 (temperature) |
+
+`braincell/mech` alone goes 183 → 177, matching the same −6.
+
+**One cross-package failure surfaced during verification and was fixed, not
+worked around.** The first full-suite run returned
+`filter/metric_test.py::test_cv_context_maps_midpoint_and_midpoint_radius` —
+it constructed a `CVContext` with an explicit `diam_mid=2.0 * u.um`, which is
+no longer a constructor parameter. The test now omits it and additionally
+asserts that the derived value equals `2 * radius_mid`, which is the property
+the change introduces. The `mech`-only run was green, so this was visible only
+package-wide — the same lesson iteration 3 recorded.


### PR DESCRIPTION
Iteration 4 of 14 in the module-by-module simplification sweep. The spec ships
with the change at `docs/specs/2026-09-02-mech-simplification.md`, which also
records nine findings deliberately deferred — most to iteration 14 — so the
next reader inherits the reasoning rather than rediscovering it.

## The constraint that shaped this iteration

`braincell.mech` is a **leaf package**: it imports nothing from `braincell`.
Verified, not assumed — `grep -rn "^from braincell\|^import braincell"` over
the non-test sources returns nothing, and `mech/__init__.py` states the rule.

That vetoes a class of otherwise-attractive reuse. The `_typing.py` aliases
AGENTS.md requires elsewhere **cannot** be used here (importing
`braincell._typing` executes `braincell/__init__.py`, which imports `mech`), so
`mech` keeps annotating with `Any`. Same for `_misc.normalize_param` and
`filter.helper._is_quantity`, of which `mech` holds near-copies. `brainunit` is
*not* `braincell`, which is what makes the `get_mantissa` fix below legal.

## Bugs fixed

Both are silent — no exception, wrong result — and both got a failing test
first.

**1. `Channel(..., params={...})` discarded the caller's parameters.**
`Density.__init__` captures `**params`, so this natural-looking call created a
parameter *literally named* `"params"` and left `g_max` unset:

```
>>> Channel('IL', params={'g_max': 1.0*u.mS/u.cm**2}).params
{'params': {'g_max': Quantity(1., "mS / cm^2")}}
```

`g_max` then quietly fell back to its default at lowering time. `SynapseSpec`
already guarded exactly this mistake; `Channel` and `Ion` did not. The guard
moves to `Density.__init__` so all three behave alike.

**2. `with_coverage` bypassed the validation `__init__` advertises.**
`__init__` enforces `coverage_area_fraction ∈ [0, 1]`; `with_coverage` went
straight to `_replace`, which only did `float(...)`. So `d.with_coverage(7.0)`
produced an object `Density(...)` would have rejected. Normalization now lives
in one place that both construction paths go through.

## Efficiency

Median of 7, same machine, before/after trees differing only by this branch
(`main` at `48fdd26` in a scratch worktree for the "before" column). **All five
digests match across both columns.** Iteration counts come from the real
workload: 3,405 CVs is a CA1 cell at `CVPerBranch(5)`; 2,046 is the measured
`Params.__hash__` call count in one `CellRuntimeState.from_cell`.

| Benchmark | Before | After | Change |
|---|---:|---:|---|
| `Params.__hash__` ×2046, 500-element array param | 19.57 ms | 0.11 ms | **178× faster** |
| `Params.__hash__` ×2046, scalar params | 2.16 ms | 0.12 ms | **18× faster** |
| `Channel.__hash__` ×2046 | 2.51 ms | 1.25 ms | **2.0× faster** |
| `validate_payload` ×20000 | 68.86 ms | 36.94 ms | **1.9× faster** |
| `CableProperty` rebuilt ×3405 CVs | 259.29 ms | 218.75 ms | **40.5 ms saved** |

`Params` is immutable, yet `__hash__` re-walked every value through
`_to_hashable` on every call and `__eq__` built two converted dicts each time —
while `__init__` computed that exact walk to validate hashability and *threw it
away*. It now keeps it. The array row is the point: `_to_hashable` turns a
Quantity array into a Python tuple via `reshape(-1).tolist()`, so the old cost
scaled with array length × hash-call count, going quadratic in CV count for an
array-valued `g_max`.

Two honest caveats, both also in the spec:

- **`validate_payload`'s 1.9× is real only for eager `Cell.update()` loops.**
  The supported run paths drive the step under `for_loop` + `jit`, where XLA's
  DCE already eliminated the discarded `to_decimal`. Under jit this removes one
  dead jaxpr node per layout, not runtime cost.
- **`_resolve_class_name` is not claimed as a win.** Its registry scan is ~185×
  slower than a reverse index, but it ran 3 times in a full build, all
  short-circuiting before touching the registry. Microseconds. Listed under
  *deliberately not changed* rather than reported.

## Breaking changes

1. **Zero-caller API deleted** — each confirmed to have no caller in
   `braincell/`, `examples/`, or `docs/` outside its own test:
   `Density.identity`, `SynapseSpec.identity`, `Density.with_params`,
   `Density.with_name`, `Density.with_integration`, `Params.without`,
   `CableProperty.with_updates`, `MechanismRegistry.add_alias`, and
   `CurrentClamp.target_index` (a field its own docstring called "Reserved",
   with no reader). `with_coverage`, `Params.with_updates`,
   `MechanismRegistry.unregister`/`contains` are live and stay.

   `identity` earns a note: both copies documented themselves as returning
   `(instance_name, class_name)` "for table views", but the actual table view
   builds `(class_name, instance_name)` — the opposite order — inline, and
   never called `identity`. Not merely unused; its docstring pointed at a real
   consumer that had silently disagreed with it.

2. **`mech.Synapse` (deprecated alias) is deleted.** Its two callers, both in
   `braincell/network/_testing.py`, move to `SynapseSpec`. Note the docs
   documented only the deprecated spelling and never `SynapseSpec` itself;
   `docs/apis/braincell.mech.rst` and `interface-map.md` are corrected.
   (`braincell._base_channel.Synapse` is an unrelated runtime class and is
   untouched.)

3. **One exception type for "not a non-empty string".** The same condition was
   validated 11 times across `_density.py` and `_point.py` with **three
   different exception types** — `ValueError` in the probes, `TypeError` in
   `Density.name`/`Channel.ion_name`, `ValueError` in
   `SynapseSpec.synapse_type`. A caller writing `except` could not be right.
   One helper now picks by cause: **`TypeError` for a non-`str`, `ValueError`
   for an empty `str`.** No test asserted on these types.

4. **`CVContext.diam_mid` becomes a derived property.** It was a stored field
   whose sole construction site passed exactly `2.0 * radius_mid`, so two
   fields had to agree with nothing enforcing it. Read access is unchanged —
   a user callable writing `ctx.diam_mid` still works — but it is no longer a
   constructor parameter.

## Other cleanups

- `_synapse_schema._decimal` re-implemented `brainunit.get_mantissa`
  (`value.to_decimal(value.unit)` *is* the mantissa); verified equal across
  scalar/array/bare/int-dtype cases and deleted.
- `CableProperty` was hand-built from the identical literal at 17 sites; the
  builder moves to a new `braincell/mech/_testing.py` (the package that owns
  the type) with `_discretization/_testing.py` re-exporting it.
- `_density.py`'s `_CHANNEL`/`_ION` duplicated `_registry.py`'s category
  constants — two sources of truth for the strings that key the registry.
- `_to_hashable` had two array branches producing byte-identical output.
- Dead Sphinx refs: `braincell.cv._lower` (no such package) and
  `braincell.mech.Probe` (no such class).

## Verification

```
$ pytest braincell/mech -q
177 passed, 23 warnings, 4 subtests passed in 4.26s

$ pytest braincell/ -q
2724 passed, 15 skipped, 411 warnings, 401 subtests passed in 173.11s

$ pre-commit run --files <24 changed files>
(all hooks Passed or Skipped)
```

Against baseline `main` (2,730 passed / 397 subtests) this is **−6 tests, +4
subtests**, every one accounted for: `_density_test` **+3** (−3 for deleted
copy constructors, +6 for the new params-keyword and range-regression tests),
`_params_test` −2, `_registry_test` −3, `_cable_test` −1 (two
temperature-rejection tests merged into one with 2 subtests), `_point_test` −3.
Subtests +4 = 2 (`with_coverage` range) + 2 (temperature). `braincell/mech`
alone goes 183 → 177, the same −6.

**A cross-package failure surfaced during verification and is disclosed rather
than buried.** The first full-suite run failed
`filter/metric_test.py::test_cv_context_maps_midpoint_and_midpoint_radius`,
which constructed a `CVContext` with an explicit `diam_mid=` (breaking change
4). It now omits it and additionally asserts the derived value equals
`2 * radius_mid`. The `mech`-only run was green, so this was visible only
package-wide — the same lesson iteration 3 recorded.

## Summary by Sourcery

Simplify the mech package by fixing silent construction and validation bugs, removing unused APIs, and improving declaration performance.

Bug Fixes:
- Reject mapping-style params passed to Channel and Ion instead of silently storing them under a literal `params` key.
- Ensure copied density declarations validate coverage fractions consistently with direct construction.
- Validate event payload dimensions without performing discarded conversions.

Enhancements:
- Cache normalized parameter representations and hashes to substantially reduce repeated Params and mechanism hashing costs.
- Simplify density, probe, clamp, registry, and parameter implementations while consolidating shared validation and normalization logic.
- Derive CVContext.diam_mid from radius_mid to keep geometry fields consistent.
- Avoid redundant CableProperty temperature coercion for already canonical values.

Documentation:
- Update mechanism API and interface documentation for removed APIs, renamed synapse declarations, and corrected references.

Tests:
- Add regression coverage for keyword parameter handling, coverage validation, derived midpoint diameter, canonical cable temperatures, and related refactors.

Chores:
- Remove unused mechanism APIs, the deprecated mech.Synapse alias, and the reserved CurrentClamp.target_index field.
- Move shared CableProperty test construction into the mech package and reuse registry category constants and brainunit mantissa handling.