### PR TITLE
refactor(ion): share the cdp declaration tables, fix a swallowed TypeError, cut traced work

### DIFF
--- a/braincell/ion/__init__.py
+++ b/braincell/ion/__init__.py
@@ -57,15 +57,28 @@ __all__ = _calcium_all + _nonspecific_all + _potassium_all + _sodium_all + ["bui
 
 
 def build_placeholder_ions(size=(1,)) -> dict[str, object]:
-    """Return default Na/K/Ca fixed-ion containers for scaffolding.
+    """Return one fixed-ion container per ion family, keyed by family symbol.
 
-    Used by test doubles and by :class:`HHTypedNeuron` construction
-    before the real runtime ion containers are instantiated.
+    Scaffolding for the compute layer: ``braincell._compute.ions`` calls
+    this to obtain a default container for a family a model refers to but
+    never declares. The containers carry only the class-level defaults,
+    so they stand in for a real ion rather than modelling one.
+
+    Not called during :class:`~braincell.HHTypedNeuron` construction --
+    ``braincell/_multi_compartment/cell_test.py`` asserts the opposite,
+    since building four ion containers per cell at ``__init__`` would be
+    wasted work for the common case where every family is declared.
 
     Parameters
     ----------
     size : tuple of int, optional
         Varshape of the ion containers. Defaults to ``(1,)``.
+
+    Returns
+    -------
+    dict
+        Maps each family symbol -- ``"na"``, ``"k"``, ``"ca"``, ``"no"``
+        -- to a freshly constructed fixed-ion container.
     """
     return {
         "na": SodiumFixed(size=size),

--- a/braincell/ion/_base.py
+++ b/braincell/ion/_base.py
@@ -100,6 +100,75 @@ def _nernst(*, Ci, Co, temp, valence):
     return (u.gas_constant * temp / (valence * u.faraday_constant)) * u.math.log(Co / Ci)
 
 
+def _nernst_of(owner):
+    """Return :func:`_nernst` evaluated on one ion's four live fields.
+
+    The three templates that expose a reversal potential -- the stored
+    one on :class:`InitNernstIon` and the recomputed properties on
+    :class:`DynamicNernstIon` and :class:`KineticIon` -- all read the
+    same ``Ci``/``Co``/``temp``/``valence`` quadruple through
+    :func:`_unwrap`. Naming that once keeps the four keyword arguments
+    from drifting out of alignment in one copy only.
+
+    Parameters
+    ----------
+    owner : Any
+        Ion instance carrying ``Ci``, ``Co``, ``temp``, and ``valence``,
+        each either a plain quantity or a :class:`brainstate.State`.
+
+    Returns
+    -------
+    Any
+        The reversal potential, as a voltage.
+    """
+    return _nernst(
+        Ci=_unwrap(owner.Ci),
+        Co=_unwrap(owner.Co),
+        temp=_unwrap(owner.temp),
+        valence=_unwrap(owner.valence),
+    )
+
+
+def species_initializer_view(name: str) -> property:
+    """Return a property exposing ``species_initializers[name]`` as an attribute.
+
+    A kinetic ion must expose every constructor parameter as an
+    attribute of the same name: ``_compute.ions`` reflects over
+    ``cls.__init__``'s signature and reads each parameter back off a
+    baseline instance with ``getattr`` to build the per-layout runtime
+    values. A ``<species>_initializer`` argument therefore cannot simply
+    be folded into the ``species_initializers`` dict and forgotten.
+
+    Storing it a second time as a plain attribute *does* satisfy that
+    contract, but leaves two copies that no longer move together --
+    writing through ``species_initializers`` leaves the attribute
+    stale, and vice versa. A view satisfies the contract with one
+    source of truth.
+
+    Parameters
+    ----------
+    name : str
+        Species name to expose.
+
+    Returns
+    -------
+    property
+        Readable and writable view onto ``species_initializers[name]``.
+
+    See Also
+    --------
+    KineticIon.Ci_initializer : The reserved species' view.
+    """
+
+    def getter(self):
+        return self.species_initializers[name]
+
+    def setter(self, value):
+        self.species_initializers[name] = value
+
+    return property(getter, setter, doc=f"Initializer for the ``{name}`` species.")
+
+
 @dataclass(frozen=True)
 class Factor:
     """Named constant factor for visible-to-amount conversion.
@@ -198,9 +267,13 @@ class Source:
     target : str
         Target diffeq species.
     flux : callable
-        Callable ``flux(owner, V, species_values)`` returning a contribution to
-        the factor-scaled derivative of ``target``. When ``target`` has no
-        factor this reduces to the ordinary visible derivative.
+        Callable ``flux(owner, V, species_values, total_current=None)``
+        returning a contribution to the factor-scaled derivative of
+        ``target``. When ``target`` has no factor this reduces to the
+        ordinary visible derivative. The ``total_current`` keyword is
+        always passed and is ``None`` unless the owning ion sets
+        ``uses_total_current``; a source that ignores it must still
+        accept it.
 
     See Also
     --------
@@ -387,12 +460,7 @@ class InitNernstIon(brainstate.mixin.Mixin):
 
     def _update_reversal(self):
         """Recompute and store ``E`` from the current ``Ci/Co/temp/valence``."""
-        self.E = _nernst(
-            Ci=_unwrap(self.Ci),
-            Co=_unwrap(self.Co),
-            temp=_unwrap(self.temp),
-            valence=_unwrap(self.valence),
-        )
+        self.E = _nernst_of(self)
 
     def _ion_init_state_hook(self, V, batch_size: int = None):
         """Refresh the stored Nernst reversal during ion initialization."""
@@ -509,12 +577,7 @@ class DynamicNernstIon(brainstate.mixin.Mixin):
     @property
     def E(self):
         """Compute ``E`` from the current dynamic ``Ci`` via Nernst."""
-        return _nernst(
-            Ci=_unwrap(self.Ci),
-            Co=_unwrap(self.Co),
-            temp=_unwrap(self.temp),
-            valence=_unwrap(self.valence),
-        )
+        return _nernst_of(self)
 
     def _ion_init_state_hook(self, V, batch_size: int = None):
         """Create the runtime ``Ci`` state from the stored initializer."""
@@ -695,30 +758,91 @@ class KineticIon(IndependentIntegration):
         self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
         self.species_initializers = dict(species_initializers or {})
 
-    @property
-    def Ci_initializer(self):
-        """Initializer for the reserved ``Ci`` species.
-
-        A view onto ``species_initializers["Ci"]`` rather than a second
-        copy of it: the two were previously written independently by
-        every subclass constructor and could drift apart whenever one
-        of them was rewritten in place.
-        """
-        return self.species_initializers["Ci"]
-
-    @Ci_initializer.setter
-    def Ci_initializer(self, value):
-        self.species_initializers["Ci"] = value
+    #: View onto ``species_initializers["Ci"]`` for the reserved species.
+    Ci_initializer = species_initializer_view("Ci")
 
     @property
     def E(self):
         """Nernst reversal potential from the current ``Ci``."""
-        return _nernst(
-            Ci=_unwrap(self.Ci),
-            Co=_unwrap(self.Co),
-            temp=_unwrap(self.temp),
-            valence=_unwrap(self.valence),
-        )
+        return _nernst_of(self)
+
+    @property
+    def diffeq_species(self) -> tuple[str, ...]:
+        """Names of the species this ion integrates as differential equations.
+
+        Derived from :attr:`species` minus the algebraic species claimed
+        by :attr:`conserves`, and cached per subclass by
+        :meth:`_Specs.for_type`. Subclasses must not restate it: a
+        hand-written copy and the declaration it shadows can disagree,
+        and the only symptom is
+        :meth:`_resolve_species_initializers` rejecting a legitimate
+        override.
+        """
+        return _Specs.for_type(type(self)).diffeq_names
+
+    def _as_initializer(self, value):
+        """Normalize one species initializer, preserving per-point shape.
+
+        A callable is an initializer already. A tuple is a per-point
+        listing that must survive as one array -- with the shared unit
+        factored out when the entries carry one -- rather than being
+        broadcast from its first element. Anything else is a constant.
+        """
+        if callable(value):
+            return value
+        if isinstance(value, tuple):
+            resolved = [item.value if hasattr(item, "value") else item for item in value]
+            first = resolved[0]
+            if hasattr(first, "unit"):
+                unit = first.unit
+                decimals = [u.Quantity(item).to_decimal(unit) for item in resolved]
+                return u.Quantity(u.math.asarray(decimals), unit)
+            return u.math.asarray(resolved)
+        return braintools.init.Constant(value)
+
+    def _resolve_species_initializers(self, *, Ci_initializer, species_initializers) -> dict[str, Any]:
+        """Merge caller overrides onto this ion's declared species defaults.
+
+        Parameters
+        ----------
+        Ci_initializer : Any, optional
+            Override for the reserved ``"Ci"`` species, or ``None`` to
+            take the subclass's own resting default.
+        species_initializers : dict, optional
+            Per-species overrides. Keys must name differential species;
+            an algebraic species is solved from its
+            :class:`Conserve` relation and cannot be seeded.
+
+        Returns
+        -------
+        dict
+            One normalized initializer per declared default, ready to
+            pass to :meth:`_init_kinetic_ion`.
+
+        Raises
+        ------
+        ValueError
+            If ``species_initializers`` names anything outside
+            :attr:`diffeq_species`.
+        """
+        overrides = dict(species_initializers or {})
+        invalid = set(overrides).difference(self.diffeq_species)
+        if invalid:
+            invalid_names = ", ".join(sorted(invalid))
+            raise ValueError(f"{type(self).__name__} only accepts differential-species overrides; got {invalid_names}.")
+
+        defaults = self._default_species_initializers(Ci_initializer)
+        defaults.update(overrides)
+        return {name: self._as_initializer(value) for name, value in defaults.items()}
+
+    def _default_species_initializers(self, Ci_initializer) -> dict[str, Any]:
+        """Return this ion's resting species initializers, before overrides.
+
+        Implemented by subclasses that accept a ``species_initializers``
+        argument; the returned mapping is consumed by
+        :meth:`_resolve_species_initializers`.
+        """
+        raise NotImplementedError
 
     def make_integration(self, V, recursive_child: bool = True):
         """Advance this ion with its own solver and substep schedule."""
@@ -729,7 +853,7 @@ class KineticIon(IndependentIntegration):
             )
 
     def _step_solver(self, V, recursive_child: bool = True):
-        args = (V,) if recursive_child else (V, recursive_child)
+        args = (V, recursive_child)
         try:
             self.solver(self, *args, excluded_paths=(("channels",),))
         except TypeError as exc:
@@ -785,10 +909,11 @@ class _RadialShellGeometry(brainstate.mixin.Mixin):
     compartment into ``Nannuli`` concentric shells and scales its
     reaction rates by the resulting per-length volume and surface
     factors. That geometry, the mass-action equilibrium used to seed a
-    buffer's free/bound split, and the ``diam_arc_mean`` precondition
-    the shells depend on are identical across all of those mechanisms;
-    only the reaction network above them differs. Mix this in ahead of
-    :class:`KineticIon` so the geometry lives in one place.
+    buffer's free/bound split, the current-driven ``Ci`` source term,
+    and the ``diam_arc_mean`` precondition the shells depend on are
+    identical across all of those mechanisms; only the reaction network
+    above them differs. Mix this in ahead of :class:`KineticIon` so the
+    geometry lives in one place.
 
     See Also
     --------
@@ -812,58 +937,67 @@ class _RadialShellGeometry(brainstate.mixin.Mixin):
     hooks check it before any species is materialized.
     """
 
-    def _as_initializer(self, value):
-        """Normalize one species initializer, preserving per-point shape.
-
-        A callable is an initializer already. A tuple is a per-point
-        listing that must survive as one array -- with the shared unit
-        factored out when the entries carry one -- rather than being
-        broadcast from its first element. Anything else is a constant.
-        """
-        if callable(value):
-            return value
-        if isinstance(value, tuple):
-            resolved = []
-            for item in value:
-                if hasattr(item, "value"):
-                    resolved.append(item.value)
-                else:
-                    resolved.append(item)
-            first = resolved[0]
-            if hasattr(first, "unit"):
-                unit = first.unit
-                decimals = [u.Quantity(item).to_decimal(unit) for item in resolved]
-                return u.Quantity(u.math.asarray(decimals), unit)
-            return u.math.asarray(resolved)
-        return braintools.init.Constant(value)
-
     def _require_diam_arc_mean(self):
         """Return ``diam_arc_mean``, or raise if the geometry is not set yet."""
         if not hasattr(self, "diam_arc_mean"):
             raise AttributeError(f"{type(self).__name__} requires 'diam_arc_mean' before kinetic state initialization.")
         return self.diam_arc_mean
 
+    def _seed_geometry(self):
+        """Derive and cache the diameter-dependent shell factors.
+
+        ``dsq``, ``dsqvol``, and ``parea`` are fixed once the
+        compartment layer has written ``diam_arc_mean``, but the
+        reaction networks above them read ``dsqvol`` 39 to 97 times
+        within a single ``compute_derivative`` -- each read previously
+        re-deriving the same eight array operations.
+
+        The cache records the diameter it was built from, so rebinding
+        ``diam_arc_mean`` reseeds on the next read rather than serving a
+        stale factor. Both lifecycle hooks call this eagerly so that a
+        missing geometry still fails before any species is materialized.
+        """
+        diam_arc_mean = self._require_diam_arc_mean()
+        self._dsq = diam_arc_mean * diam_arc_mean
+        self._dsqvol = self._dsq * self.vrat
+        self._parea = u.math.pi * diam_arc_mean
+        self._geometry_source = diam_arc_mean
+
+    def _geometry(self, name: str):
+        """Return one cached shell factor, reseeding if the diameter changed."""
+        if getattr(self, "_geometry_source", None) is not self._require_diam_arc_mean():
+            self._seed_geometry()
+        return getattr(self, name)
+
     @property
     def vrat(self):
-        """Outermost-shell volume ratio implied by ``Nannuli``."""
-        dr2 = 0.25 / (self.Nannuli - 1.0)
-        return u.math.pi * (0.5 - (dr2 / 2.0)) * 2.0 * dr2
+        """Outermost-shell volume ratio implied by ``Nannuli``.
+
+        Depends only on ``Nannuli``, which is fixed at construction, so
+        unlike the other three factors this one is available before the
+        compartment layer attaches ``diam_arc_mean``.
+        """
+        cached = getattr(self, "_vrat", None)
+        if cached is None:
+            dr2 = 0.25 / (self.Nannuli - 1.0)
+            cached = u.math.pi * (0.5 - (dr2 / 2.0)) * 2.0 * dr2
+            self._vrat = cached
+        return cached
 
     @property
     def dsq(self):
         """Squared arc-mean diameter of the compartment."""
-        diam_arc_mean = self._require_diam_arc_mean()
-        return diam_arc_mean * diam_arc_mean
+        return self._geometry("_dsq")
 
     @property
     def dsqvol(self):
         """Combined ``dsq * vrat`` volume factor for the outermost shell."""
-        return self.dsq * self.vrat
+        return self._geometry("_dsqvol")
 
     @property
     def parea(self):
         """Perimeter of the compartment, the pump's surface scale factor."""
-        return u.math.pi * self._require_diam_arc_mean()
+        return self._geometry("_parea")
 
     def _ss_buffer_free(self, total, kon, koff, cai):
         """Return the free fraction of a buffer at mass-action equilibrium."""
@@ -873,15 +1007,27 @@ class _RadialShellGeometry(brainstate.mixin.Mixin):
         """Return the calcium-bound fraction of a buffer at equilibrium."""
         return total / (1.0 + koff / (kon * cai))
 
+    def _ci_source_flux(self, total_current):
+        """Return the ``Ci`` source term driven by the aggregate ion current.
+
+        NEURON's raw ``ica`` is efflux-positive, but BrainCell channel
+        currents are inward-positive, so a positive calcium current
+        *increases* the local pool. Returns a correctly-united zero when
+        no current is supplied, so a source declaration need not branch.
+        """
+        if total_current is None:
+            return self.dsqvol * (0.0 * u.mM / u.ms)
+        return (total_current * self.parea) / (2.0 * u.faraday_constant)
+
     def _ion_init_state_hook(self, V, batch_size: int = None):
-        """Check the geometry, then initialize species as ``KineticIon`` does."""
-        self._require_diam_arc_mean()
-        KineticIon._ion_init_state_hook(self, V, batch_size=batch_size)
+        """Seed the geometry, then initialize species as ``KineticIon`` does."""
+        self._seed_geometry()
+        super()._ion_init_state_hook(V, batch_size=batch_size)
 
     def _ion_reset_state_hook(self, V, batch_size: int = None):
-        """Check the geometry, then reset species as ``KineticIon`` does."""
-        self._require_diam_arc_mean()
-        KineticIon._ion_reset_state_hook(self, V, batch_size=batch_size)
+        """Seed the geometry, then reset species as ``KineticIon`` does."""
+        self._seed_geometry()
+        super()._ion_reset_state_hook(V, batch_size=batch_size)
 
 
 class _Specs:
@@ -895,26 +1041,11 @@ class _Specs:
         cached = cls._cache.get(ion_type)
         if cached is None:
             cached = cls(
-                factors=tuple(
-                    type_factor if isinstance(type_factor, Factor) else Factor(*type_factor)
-                    for type_factor in getattr(ion_type, "factors", ())
-                ),
-                species=tuple(
-                    type_species if isinstance(type_species, Species) else Species(*type_species)
-                    for type_species in getattr(ion_type, "species", ())
-                ),
-                reactions=tuple(
-                    type_reaction if isinstance(type_reaction, Reaction) else Reaction(*type_reaction)
-                    for type_reaction in getattr(ion_type, "reactions", ())
-                ),
-                sources=tuple(
-                    type_source if isinstance(type_source, Source) else Source(*type_source)
-                    for type_source in getattr(ion_type, "sources", ())
-                ),
-                conserves=tuple(
-                    type_conserve if isinstance(type_conserve, Conserve) else Conserve(*type_conserve)
-                    for type_conserve in getattr(ion_type, "conserves", ())
-                ),
+                factors=tuple(getattr(ion_type, "factors", ())),
+                species=tuple(getattr(ion_type, "species", ())),
+                reactions=tuple(getattr(ion_type, "reactions", ())),
+                sources=tuple(getattr(ion_type, "sources", ())),
+                conserves=tuple(getattr(ion_type, "conserves", ())),
             )
             cls._cache[ion_type] = cached
         return cached
@@ -984,6 +1115,7 @@ class _Species:
     def __init__(self, owner, specs: _Specs):
         self.owner = owner
         self.specs = specs
+        self._factors = {}
 
     def _species_value(self, spec, batch_size: int = None):
         """Materialize one species initializer at the owner's full state shape.
@@ -1028,29 +1160,6 @@ class _Species:
                 else:
                     setattr(self.owner, spec.name, hidden_state(value))
 
-    def algebraic_state(self, value):
-        """Allocate an algebraic species state matching its siblings' class.
-
-        :meth:`_Conserve.writeback` runs during simulation, *outside* the
-        :func:`~braincell.state_grouping` scope the host establishes around
-        ``init_state``. Reading the ambient scope there would silently
-        produce a plain :class:`brainstate.HiddenState` on a
-        :class:`braincell.Cell`, whose hidden states must all be grouped.
-        Deriving the class from an already-allocated sibling species makes
-        the decision independent of when the allocation happens.
-
-        Falls back to the scoped factory only when no sibling has been
-        allocated yet, which is the genuine initialization path — and that
-        one does run inside the host's scope.
-        """
-        for name in self.specs.species_by_name:
-            sibling = getattr(self.owner, name, None)
-            if isinstance(sibling, brainstate.HiddenState):
-                if isinstance(sibling, brainstate.HiddenGroupState):
-                    return brainstate.HiddenGroupState(value)
-                return brainstate.HiddenState(value)
-        return hidden_state(value)
-
     def value(self, name: str):
         """Return one species' current visible value."""
         raw = getattr(self.owner, name)
@@ -1061,11 +1170,22 @@ class _Species:
         getattr(self.owner, name).derivative = value
 
     def factor_value(self, name: str):
-        """Return one species' concrete factor value, defaulting to ``1``."""
+        """Return one species' concrete factor value, defaulting to ``1``.
+
+        Memoized per factor name for the lifetime of this adapter, which
+        is one derivative evaluation: :class:`Factor` documents its value
+        as constant during a single integration step, and a reaction
+        network reads the same factor once per species it touches -- up
+        to 52 times in one ``compute_derivative``.
+        """
         spec = self.specs.species_by_name[name]
         if spec.factor is None:
             return 1.0
-        return self.specs.factors_by_name[spec.factor].value(self.owner)
+        cached = self._factors.get(spec.factor)
+        if cached is None:
+            cached = self.specs.factors_by_name[spec.factor].value(self.owner)
+            self._factors[spec.factor] = cached
+        return cached
 
     def to_scaled(self, name: str, value=None):
         """Convert a visible species value to its factor-scaled form."""
@@ -1108,19 +1228,14 @@ class _Conserve:
     def writeback(self, V=None):
         """Update cached algebraic species values on the owner object.
 
-        Runs every simulation step, so the allocation branch below is dead
-        in normal flow — :meth:`_Species.init` has already turned every
-        species into a ``State``. It stays defensive rather than raising,
-        but routes through :meth:`_Species.algebraic_state` so that a late
-        allocation cannot silently pick the wrong hidden-state class.
+        Every algebraic species is already a :class:`brainstate.State`
+        by the time this runs: :meth:`_Species.init` allocates the whole
+        table, and both lifecycle hooks call it before their own
+        writeback.
         """
         values = self.resolve(V)
         for name in self.specs.algebraic_names:
-            raw = getattr(self.owner, name)
-            if isinstance(raw, brainstate.State):
-                raw.value = values[name]
-            else:
-                setattr(self.owner, name, self.species.algebraic_state(values[name]))
+            getattr(self.owner, name).value = values[name]
 
 
 class _Flux:
@@ -1153,15 +1268,7 @@ class _Flux:
                     scaled_derivs[name] = scaled_derivs[name] + contrib
 
         for source in self.specs.sources:
-            try:
-                contrib = source.flux(
-                    self.owner,
-                    V,
-                    species_values,
-                    total_current=total_current,
-                )
-            except TypeError:
-                contrib = source.flux(self.owner, V, species_values)
+            contrib = source.flux(self.owner, V, species_values, total_current=total_current)
             scaled_derivs[source.target] = scaled_derivs[source.target] + contrib
 
         for name in self.specs.diffeq_names:

--- a/braincell/ion/_base_test.py
+++ b/braincell/ion/_base_test.py
@@ -473,14 +473,16 @@ class IonTemplateTest(unittest.TestCase):
 
 
 class ConserveWritebackStateClassTest(unittest.TestCase):
-    """``_Conserve.writeback`` must not allocate a wrongly-classed state.
+    """``_Conserve.writeback`` must reuse the state ``_Species.init`` made.
 
-    ``writeback`` *does* run every simulation step, outside the
+    ``writeback`` runs every simulation step, outside the
     :func:`braincell.state_grouping` scope the host sets around
-    ``init_state``. Its allocation branch is dead in normal flow because
-    ``_Species.init`` ran first — these tests pin both halves of that, so
-    a regression shows up as a failure rather than as a silently
-    non-grouped state inside a ``Cell``.
+    ``init_state``, so allocating there would silently hand back a plain
+    ``HiddenState`` and break a ``Cell``'s grouped-hidden-state
+    invariant. ``writeback`` no longer has an allocation branch at all —
+    this test pins the precondition that makes that safe: every
+    algebraic species is already a grouped state when the step begins,
+    and the same object survives it.
 
     See ``docs/specs/2026-08-13-cell-hidden-group-state.md``.
     """
@@ -500,39 +502,30 @@ class ConserveWritebackStateClassTest(unittest.TestCase):
         cell.init_state()
         return cell
 
-    def test_writeback_runs_mid_step_but_allocates_nothing(self) -> None:
+    def test_writeback_runs_mid_step_and_reuses_the_grouped_states(self) -> None:
         from braincell.ion import _base as ionbase
 
         cell = self._kinetic_cell()
-        calls = {"writeback": 0, "allocated": 0}
+        calls = {"writeback": 0}
         original_writeback = ionbase._Conserve.writeback
-        original_algebraic = ionbase._Species.algebraic_state
 
         def counting_writeback(self, V=None):
             calls["writeback"] += 1
             return original_writeback(self, V)
 
-        def counting_algebraic(self, value):
-            calls["allocated"] += 1
-            return original_algebraic(self, value)
-
         # Identity of every algebraic state before the step, so a
-        # reallocation is visible as a swapped object and not only as an
-        # extra ``algebraic_state`` call.
+        # reallocation is visible as a swapped object.
         before = self._algebraic_states(cell)
         self.assertGreater(len(before), 0, "expected at least one algebraic species")
 
         ionbase._Conserve.writeback = counting_writeback
-        ionbase._Species.algebraic_state = counting_algebraic
         try:
             with brainstate.environ.context(t=0.0 * u.ms, dt=0.01 * u.ms):
                 cell.update()
         finally:
             ionbase._Conserve.writeback = original_writeback
-            ionbase._Species.algebraic_state = original_algebraic
 
         self.assertGreater(calls["writeback"], 0, "writeback should run during a step")
-        self.assertEqual(calls["allocated"], 0, "writeback must not allocate mid-run")
 
         after = self._algebraic_states(cell)
         self.assertEqual(set(before), set(after))
@@ -556,53 +549,17 @@ class ConserveWritebackStateClassTest(unittest.TestCase):
             if path and str(path[-1]) in names
         }
 
-    def test_late_allocation_still_matches_its_siblings(self) -> None:
-        # Force the dead branch: drop the algebraic species back to a bare
-        # value so the next writeback has to re-allocate it. writeback runs
-        # outside any state_grouping scope, so an ambient-scope allocation
-        # would hand back a plain HiddenState and break the Cell invariant.
-        from braincell.ion import _base as ionbase
-
+    def test_init_leaves_every_algebraic_species_already_grouped(self) -> None:
+        # The precondition that makes writeback's unconditional assignment
+        # safe: init_state, which *does* run inside the host's
+        # state_grouping scope, has already allocated every algebraic
+        # species as a grouped state. There is no later allocation path.
         cell = self._kinetic_cell()
-        ion = cell.get_ion("CdpCR_MA2020_GrC")
-        specs = ionbase._Specs.for_type(type(ion))
-        (name,) = specs.algebraic_names
-
-        state = getattr(ion, name)
-        self.assertIsInstance(state, brainstate.HiddenGroupState)
-        setattr(ion, name, state.value)
-        self.assertNotIsInstance(getattr(ion, name), brainstate.State)
-
-        species = ionbase._Species(ion, specs)
-        ionbase._Conserve(ion, specs, species).writeback(cell.V.value)
-
-        restored = getattr(ion, name)
-        self.assertIsInstance(restored, brainstate.HiddenGroupState)
-        self.assertEqual(restored.value.shape, state.value.shape)
-
-    def test_late_allocation_stays_plain_when_its_siblings_are_plain(self) -> None:
-        # The mirror of the test above. A sibling-derived class has to work
-        # in both directions, or "derive it from a sibling" is really just
-        # "always group", which would be wrong outside a Cell.
-        from braincell.ion import _base as ionbase
-
-        ion = _SimpleKineticIon(size=3)
-        ion.init_state(jnp.ones(3) * -65.0 * u.mV)
-        specs = ionbase._Specs.for_type(type(ion))
-        (name,) = specs.algebraic_names
-
-        state = getattr(ion, name)
-        self.assertIsInstance(state, brainstate.HiddenState)
-        self.assertNotIsInstance(state, brainstate.HiddenGroupState)
-        setattr(ion, name, state.value)
-
-        species = ionbase._Species(ion, specs)
-        ionbase._Conserve(ion, specs, species).writeback(jnp.ones(3) * -65.0 * u.mV)
-
-        restored = getattr(ion, name)
-        self.assertIsInstance(restored, brainstate.HiddenState)
-        self.assertNotIsInstance(restored, brainstate.HiddenGroupState)
-        self.assertEqual(restored.value.shape, state.value.shape)
+        states = self._algebraic_states(cell)
+        self.assertGreater(len(states), 0, "expected at least one algebraic species")
+        for path, state in states.items():
+            with self.subTest(state=path):
+                self.assertIsInstance(state, brainstate.HiddenGroupState)
 
 
 class _ShellGeometryIon(Calcium, _RadialShellGeometry, KineticIon):

--- a/braincell/ion/_testing.py
+++ b/braincell/ion/_testing.py
@@ -1,0 +1,225 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared fixtures for the ``braincell.ion`` test modules.
+
+Private by name so pytest does not collect it as a test module, following
+the same convention as ``braincell/mech/_testing.py`` and
+``braincell/filter/_testing.py``.
+
+Two kinds of helper live here:
+
+- constructors (:func:`V`, :func:`make_shell_ion`) that every ion test
+  file otherwise retypes, and
+- contract mixins (:class:`FixedIonContractTests`,
+  :class:`KineticPumpContractTests`) carrying test methods that are
+  identical across sibling ion species and were previously copy-pasted
+  once per species.
+
+A contract mixin is parameterized by class attributes on the concrete
+``TestCase`` that mixes it in, so a new ion species inherits the shared
+suite by declaring those attributes rather than by copying the methods.
+"""
+
+import brainunit as u
+import jax.numpy as jnp
+
+__all__ = [
+    "V",
+    "make_shell_ion",
+    "FixedIonContractTests",
+    "KineticPumpContractTests",
+]
+
+
+def V(values, unit=u.mV):
+    """Return a membrane-potential array for a test.
+
+    Parameters
+    ----------
+    values : array-like
+        Membrane potentials, in ``unit``.
+    unit : brainunit.Unit, optional
+        Unit the values are expressed in. Defaults to ``u.mV``.
+
+    Returns
+    -------
+    brainunit.Quantity
+        The values as a united array.
+    """
+    return jnp.asarray(values) * unit
+
+
+def make_shell_ion(cls, size=1, diameter=20.0 * u.um, **kwargs):
+    """Build a radial-shell ion with its compartment geometry attached.
+
+    ``diam_arc_mean`` and ``diam_mid`` are written onto a ``cdp*`` ion by
+    the compartment layer, not by its constructor, so a bare instance
+    raises from ``_require_diam_arc_mean`` the moment any species is
+    materialized. Every kinetic-calcium test therefore has to stand in
+    for that layer.
+
+    Parameters
+    ----------
+    cls : type
+        The ion class to instantiate.
+    size : brainstate.typing.Size, optional
+        Varshape of the ion. Defaults to ``1``.
+    diameter : brainunit.Quantity, optional
+        Value written to both ``diam_arc_mean`` and ``diam_mid``.
+        Defaults to ``20 um``.
+    **kwargs
+        Forwarded unchanged to ``cls``.
+
+    Returns
+    -------
+    braincell.ion._base.KineticIon
+        The constructed ion, ready for ``init_state``.
+    """
+    ion = cls(size=size, **kwargs)
+    geometry = jnp.broadcast_to(u.get_mantissa(diameter), ion.varshape) * u.get_unit(diameter)
+    ion.diam_mid = geometry
+    ion.diam_arc_mean = geometry
+    return ion
+
+
+class FixedIonContractTests:
+    """Behaviour every ``FixedIon`` species shares, parameterized by class.
+
+    Mix into a :class:`unittest.TestCase` and declare:
+
+    ``ION_CLASS``
+        The concrete ``*Fixed`` class under test.
+    ``FAMILY_CLASS``
+        Its abstract family base (``Potassium``, ``Sodium``, ...).
+    ``DEFAULT_E``, ``DEFAULT_CI``, ``DEFAULT_CO``, ``DEFAULT_VALENCE``
+        The documented resting defaults, as quantities.
+
+    The four ``*Fixed`` species differ only in those values, so the
+    assertions below were previously four near-identical copies.
+    """
+
+    ION_CLASS = None
+    FAMILY_CLASS = None
+    DEFAULT_E = None
+    DEFAULT_CI = None
+    DEFAULT_CO = None
+    DEFAULT_VALENCE = None
+
+    def test_family_module_is_the_public_namespace(self) -> None:
+        self.assertEqual(self.FAMILY_CLASS.__module__, "braincell.ion")
+        self.assertEqual(self.ION_CLASS.__module__, "braincell.ion")
+
+    def test_is_subclass_of_its_family(self) -> None:
+        self.assertTrue(issubclass(self.ION_CLASS, self.FAMILY_CLASS))
+
+    def test_documented_defaults_are_what_the_constructor_produces(self) -> None:
+        ion = self.ION_CLASS(size=1)
+        self.assertTrue(u.math.allclose(ion.E, self.DEFAULT_E, atol=1e-9 * u.mV))
+        self.assertTrue(u.math.allclose(ion.Ci, self.DEFAULT_CI, atol=1e-9 * u.mM))
+        self.assertTrue(u.math.allclose(ion.Co, self.DEFAULT_CO, atol=1e-9 * u.mM))
+        self.assertTrue(u.math.allclose(ion.valence, jnp.full((1,), self.DEFAULT_VALENCE), atol=1e-9))
+
+    def test_varshape_follows_size(self) -> None:
+        self.assertEqual(self.ION_CLASS(size=1).varshape, (1,))
+        self.assertEqual(self.ION_CLASS(size=5).varshape, (5,))
+        self.assertEqual(self.ION_CLASS(size=(2, 3)).varshape, (2, 3))
+
+    def test_explicit_none_reversal_potential_is_rejected(self) -> None:
+        # ``E`` is the one field with no class-level default: an ion whose
+        # reversal potential is unset would silently produce a zero current.
+        with self.assertRaises(ValueError):
+            self.ION_CLASS(size=1, E=None)
+
+    def test_callable_parameters_broadcast_across_size(self) -> None:
+        ion = self.ION_CLASS(
+            size=3,
+            E=lambda shape: jnp.array([-90.0, -95.0, -100.0]) * u.mV,
+            Ci=lambda shape: jnp.array([0.04, 0.05, 0.06]) * u.mM,
+            Co=lambda shape: jnp.array([2.5, 2.6, 2.7]) * u.mM,
+        )
+        self.assertEqual(ion.E.shape, (3,))
+        self.assertEqual(ion.Ci.shape, (3,))
+        self.assertEqual(ion.Co.shape, (3,))
+        self.assertTrue(u.math.allclose(ion.E, jnp.array([-90.0, -95.0, -100.0]) * u.mV, atol=1e-9 * u.mV))
+        self.assertTrue(u.math.allclose(ion.Ci, jnp.array([0.04, 0.05, 0.06]) * u.mM, atol=1e-9 * u.mM))
+
+    def test_pack_info_reports_the_stored_values(self) -> None:
+        from braincell._base_channel import IonInfo
+
+        ion = self.ION_CLASS(size=1, E=-85.0 * u.mV, Ci=0.02 * u.mM, Co=2.8 * u.mM, valence=1)
+        info = ion.pack_info()
+        self.assertIsInstance(info, IonInfo)
+        self.assertTrue(u.math.allclose(info.E, -85.0 * u.mV, atol=1e-9 * u.mV))
+        self.assertTrue(u.math.allclose(info.Ci, 0.02 * u.mM, atol=1e-9 * u.mM))
+        self.assertTrue(u.math.allclose(info.Co, 2.8 * u.mM, atol=1e-9 * u.mM))
+        self.assertTrue(u.math.allclose(info.valence, jnp.ones((1,)), atol=1e-9))
+
+    def test_empty_container_reports_no_channels_and_no_current(self) -> None:
+        ion = self.ION_CLASS(size=1)
+        self.assertEqual(ion.channels, {})
+        self.assertEqual(ion.external_currents, {})
+        self.assertIsNone(ion.current(V([-60.0])))
+
+    def test_external_current_keys_must_be_unique(self) -> None:
+        ion = self.ION_CLASS(size=1)
+
+        def external(V_local, info):
+            return jnp.array([1.0]) * u.uA / u.cm**2
+
+        ion.register_external_current("ext", external)
+        self.assertIn("ext", ion.external_currents)
+        with self.assertRaises(ValueError):
+            ion.register_external_current("ext", external)
+
+
+class KineticPumpContractTests:
+    """Pump behaviour every ``cdp*`` calcium pool shares.
+
+    Mix into a :class:`unittest.TestCase` and declare ``ION_CLASS``. The
+    four pools that carry a surface pump previously held byte-identical
+    copies of both methods below.
+    """
+
+    ION_CLASS = None
+
+    def make_ion(self, **kwargs):
+        """Return the ion under test with its geometry attached."""
+        return make_shell_ion(self.ION_CLASS, **kwargs)
+
+    def test_positive_inward_current_produces_positive_ci_source_flux(self) -> None:
+        ion = self.make_ion()
+        ion.init_state(V([-60.0]))
+        flux = ion.sources[0].flux(
+            ion,
+            V([-60.0]),
+            ion.species_values(),
+            total_current=jnp.array([0.01]) * u.mA / (u.cm**2),
+        )
+        self.assertGreater(float(flux[0].to_decimal(u.mM * u.um**2 / u.ms)), 0.0)
+
+    def test_conserve_keeps_pump_plus_pumpca_equal_total_scaled_pool(self) -> None:
+        ion = self.make_ion()
+        ion.init_state(V([-60.0]))
+        values = ion.species_values()
+        total = ion.TotalPump * ion.parea
+        combined = ion.pump.value * ion.parea + values["pumpca"] * ion.parea
+        self.assertTrue(
+            u.math.allclose(
+                combined.to_decimal(total.unit),
+                total.to_decimal(total.unit),
+                atol=1e-12,
+            )
+        )

--- a/braincell/ion/calcium.py
+++ b/braincell/ion/calcium.py
@@ -13,15 +13,13 @@
 # limitations under the License.
 # ==============================================================================
 
-# -*- coding: utf-8 -*-
-
 from typing import Optional
 
+import brainstate
 import braintools
 import brainunit as u
 
 from braincell._base_ion import Ion
-from braincell._base_neuron import HHTypedNeuron
 from braincell._typing import Initializer, Size
 from braincell.mech import register_ion
 from braincell.ion._base import (
@@ -35,6 +33,7 @@ from braincell.ion._base import (
     Source,
     Species,
     _RadialShellGeometry,
+    species_initializer_view,
 )
 
 __all__ = [
@@ -58,6 +57,52 @@ __all__ = [
     'CdpHVA_SU2015_DCN',
     'CdpLVA_SU2015_DCN',
 ]
+
+
+class _ParvalbuminEquilibrium(brainstate.mixin.Mixin):
+    r"""Resting occupancy of a parvalbumin pool competing for Ca and Mg.
+
+    Parvalbumin binds calcium and magnesium at the same site, so its
+    three states are fixed by two dissociation ratios rather than one:
+    :math:`k_{dc} = c_{null} m_1 / m_2` for calcium and
+    :math:`k_{dm} = mg_{null} p_1 / p_2` for magnesium. The free,
+    calcium-bound, and magnesium-bound fractions then partition
+    ``PVnull`` as :math:`1 : k_{dc} : k_{dm}`.
+
+    The chemistry is identical wherever the pool appears, so the three
+    ``cdp`` mechanisms that carry parvalbumin mix this in rather than
+    restating it. It is calcium chemistry, not shell geometry, which is
+    why it lives here and not on
+    :class:`~braincell.ion._base._RadialShellGeometry`.
+
+    Requires ``cainull``, ``mginull``, ``PVnull``, and the four rate
+    parameters ``m1``, ``m2``, ``p1``, ``p2`` on the concrete ion.
+
+    See Also
+    --------
+    CdpStC_NoCAM_MA2020_GoC : Golgi-cell pool carrying parvalbumin.
+    CdpStC_MA2020_GoC : The same pool with calmodulin added.
+    CdpCAM_MA2024_PC : Purkinje-cell pool with parvalbumin and calbindin.
+    """
+
+    def _pv_dissociation_ratios(self):
+        """Return the ``(calcium, magnesium)`` dissociation ratios."""
+        return (self.cainull * self.m1) / self.m2, (self.mginull * self.p1) / self.p2
+
+    def _ss_pv_free(self):
+        """Return the metal-free parvalbumin fraction at equilibrium."""
+        kdc, kdm = self._pv_dissociation_ratios()
+        return self.PVnull / (1.0 + kdc + kdm)
+
+    def _ss_pv_ca(self):
+        """Return the calcium-bound parvalbumin fraction at equilibrium."""
+        kdc, kdm = self._pv_dissociation_ratios()
+        return (self.PVnull * kdc) / (1.0 + kdc + kdm)
+
+    def _ss_pv_mg(self):
+        """Return the magnesium-bound parvalbumin fraction at equilibrium."""
+        kdc, kdm = self._pv_dissociation_ratios()
+        return (self.PVnull * kdm) / (1.0 + kdc + kdm)
 
 
 class Calcium(Ion):
@@ -102,9 +147,6 @@ class Calcium(Ion):
 
     Attributes
     ----------
-    root_type : type
-        Root container type this ion attaches to. Set to
-        :class:`~braincell.HHTypedNeuron`.
     ion_symbol : str
         Symbol used for runtime family lookup. Set to ``'Ca'``.
     default_Ci : brainunit.Quantity
@@ -117,7 +159,6 @@ class Calcium(Ion):
 
     __module__ = 'braincell.ion'
 
-    root_type = HHTypedNeuron
     ion_symbol = 'Ca'
     default_Ci = 5e-05 * u.mM
     default_Co = 2.0 * u.mM
@@ -406,7 +447,7 @@ class CalciumDetailed(Calcium, DynamicNernstIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`DynamicNernstIon._init_dynamic_nernst_ion`.
     Ci_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the dynamic ``Ci`` state. Defaults to a
+        Initializer for the dynamic ``Ci`` state. Defaults to a
         constant ``2.4e-4 mM`` initializer, matching ``C_rest``.
     name : str or None, optional
         Runtime ion instance name. Defaults to ``None``.
@@ -531,7 +572,7 @@ class CalciumFirstOrder(Calcium, DynamicNernstIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`DynamicNernstIon._init_dynamic_nernst_ion`.
     Ci_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the dynamic ``Ci`` state. Defaults to a
+        Initializer for the dynamic ``Ci`` state. Defaults to a
         constant ``2.4e-4 mM`` initializer.
     name : str or None, optional
         Runtime ion instance name. Defaults to ``None``.
@@ -667,9 +708,9 @@ class ToyCaBindingKinetic_SU2015_DCN(Calcium, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``0.10 mM``.
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
     BC_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``BC`` species. Defaults to ``0.00 mM``.
+        Initializer for the ``BC`` species. Defaults to ``0.00 mM``.
     solver : str, optional
         Integrator name used for the reaction network. Defaults to
         ``"rk4"``.
@@ -711,6 +752,10 @@ class ToyCaBindingKinetic_SU2015_DCN(Calcium, KineticIon):
     """
 
     __module__ = "braincell.ion"
+
+    #: View onto ``species_initializers["BC"]``, kept readable
+    #: because ``_compute.ions`` reflects over ``__init__``.
+    BC_initializer = species_initializer_view("BC")
 
     species = (
         Species("Ci", init=0.10 * u.mM),
@@ -761,7 +806,6 @@ class ToyCaBindingKinetic_SU2015_DCN(Calcium, KineticIon):
             solver=solver,
             substeps=substeps,
         )
-        self.BC_initializer = BC_initializer
         self.kf = braintools.init.param(kf, self.varshape, allow_none=False)
         self.kb = braintools.init.param(kb, self.varshape, allow_none=False)
         self.Btot = braintools.init.param(Btot, self.varshape, allow_none=False)
@@ -813,9 +857,9 @@ class ToyCaBindingSourceKinetic_SU2015_DCN(Calcium, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``0.10 mM``.
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
     BC_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``BC`` species. Defaults to ``0.00 mM``.
+        Initializer for the ``BC`` species. Defaults to ``0.00 mM``.
     solver : str, optional
         Integrator name used for the reaction network. Defaults to
         ``"rk4"``.
@@ -857,12 +901,16 @@ class ToyCaBindingSourceKinetic_SU2015_DCN(Calcium, KineticIon):
 
     __module__ = "braincell.ion"
 
+    #: View onto ``species_initializers["BC"]``, kept readable
+    #: because ``_compute.ions`` reflects over ``__init__``.
+    BC_initializer = species_initializer_view("BC")
+
     species = ToyCaBindingKinetic_SU2015_DCN.species
     reactions = ToyCaBindingKinetic_SU2015_DCN.reactions
     sources = (
         Source(
             target="Ci",
-            flux=lambda self, V, x: self.ci_source,
+            flux=lambda self, V, x, total_current=None: self.ci_source,
         ),
     )
     conserves = ToyCaBindingKinetic_SU2015_DCN.conserves
@@ -895,7 +943,6 @@ class ToyCaBindingSourceKinetic_SU2015_DCN(Calcium, KineticIon):
             solver=solver,
             substeps=substeps,
         )
-        self.BC_initializer = BC_initializer
         self.kf = braintools.init.param(kf, self.varshape, allow_none=False)
         self.kb = braintools.init.param(kb, self.varshape, allow_none=False)
         self.Btot = braintools.init.param(Btot, self.varshape, allow_none=False)
@@ -942,9 +989,9 @@ class ToyCaBindingIcaSourceKinetic_SU2015_DCN(Calcium, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``0.10 mM``.
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
     BC_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``BC`` species. Defaults to ``0.00 mM``.
+        Initializer for the ``BC`` species. Defaults to ``0.00 mM``.
     solver : str, optional
         Integrator name used for the reaction network. Defaults to
         ``"rk4"``.
@@ -991,6 +1038,10 @@ class ToyCaBindingIcaSourceKinetic_SU2015_DCN(Calcium, KineticIon):
     """
 
     __module__ = "braincell.ion"
+
+    #: View onto ``species_initializers["BC"]``, kept readable
+    #: because ``_compute.ions`` reflects over ``__init__``.
+    BC_initializer = species_initializer_view("BC")
     uses_total_current = True
 
     species = ToyCaBindingKinetic_SU2015_DCN.species
@@ -1002,7 +1053,7 @@ class ToyCaBindingIcaSourceKinetic_SU2015_DCN(Calcium, KineticIon):
                 braintools.init.param(0.0 * (u.mM / u.ms), self.varshape)
                 if total_current is None
                 else (
-                    self.kCa.to_decimal(self.kCa.unit)
+                    u.get_mantissa(self.kCa)
                     / self.depth.to_decimal(u.um)
                     * total_current.to_decimal(u.mA / u.cm**2)
                     * 1e4
@@ -1042,7 +1093,6 @@ class ToyCaBindingIcaSourceKinetic_SU2015_DCN(Calcium, KineticIon):
             solver=solver,
             substeps=substeps,
         )
-        self.BC_initializer = BC_initializer
         self.kf = braintools.init.param(kf, self.varshape, allow_none=False)
         self.kb = braintools.init.param(kb, self.varshape, allow_none=False)
         self.Btot = braintools.init.param(Btot, self.varshape, allow_none=False)
@@ -1107,9 +1157,9 @@ class ToyCaPumpFactorKinetic_SU2015_DCN(Calcium, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``0.10 mM``.
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
     PumpBound_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``PumpBound`` species. Defaults to
+        Initializer for the ``PumpBound`` species. Defaults to
         ``0.00 mM * um``.
     solver : str, optional
         Integrator name used for the reaction network. Defaults to
@@ -1165,6 +1215,10 @@ class ToyCaPumpFactorKinetic_SU2015_DCN(Calcium, KineticIon):
     """
 
     __module__ = "braincell.ion"
+
+    #: View onto ``species_initializers["PumpBound"]``, kept readable
+    #: because ``_compute.ions`` reflects over ``__init__``.
+    PumpBound_initializer = species_initializer_view("PumpBound")
     uses_total_current = True
 
     factors = (
@@ -1199,7 +1253,7 @@ class ToyCaPumpFactorKinetic_SU2015_DCN(Calcium, KineticIon):
                 else self.cyt_volume
                 * (
                     (
-                        self.kCa.to_decimal(self.kCa.unit)
+                        u.get_mantissa(self.kCa)
                         / self.depth.to_decimal(u.um)
                         * total_current.to_decimal(u.mA / u.cm**2)
                         * 1e4
@@ -1249,7 +1303,6 @@ class ToyCaPumpFactorKinetic_SU2015_DCN(Calcium, KineticIon):
             solver=solver,
             substeps=substeps,
         )
-        self.PumpBound_initializer = PumpBound_initializer
         self.kf = braintools.init.param(kf, self.varshape, allow_none=False)
         self.kb = braintools.init.param(kb, self.varshape, allow_none=False)
         self.k_rel = braintools.init.param(k_rel, self.varshape, allow_none=False)
@@ -1320,9 +1373,9 @@ class ToyDiamFactorKinetic_SU2015_DCN(Calcium, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``0.10 mM``.
+        Initializer for the ``Ci`` species. Defaults to ``0.10 mM``.
     PumpBound_initializer : array-like or callable, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``PumpBound`` species. Defaults to
+        Initializer for the ``PumpBound`` species. Defaults to
         ``0.00 mM * um``.
     solver : str, optional
         Integrator name used for the reaction network. Defaults to
@@ -1390,6 +1443,10 @@ class ToyDiamFactorKinetic_SU2015_DCN(Calcium, KineticIon):
 
     __module__ = "braincell.ion"
 
+    #: View onto ``species_initializers["PumpBound"]``, kept readable
+    #: because ``_compute.ions`` reflects over ``__init__``.
+    PumpBound_initializer = species_initializer_view("PumpBound")
+
     factors = (
         Factor("cyto", lambda self: u.math.pi * self.diam_mid * self.depth),
         Factor("pump_area", lambda self: u.math.pi * self.diam_mid),
@@ -1444,11 +1501,139 @@ class ToyDiamFactorKinetic_SU2015_DCN(Calcium, KineticIon):
             solver=solver,
             substeps=substeps,
         )
-        self.PumpBound_initializer = PumpBound_initializer
         self.kf = braintools.init.param(kf, self.varshape, allow_none=False)
         self.kb = braintools.init.param(kb, self.varshape, allow_none=False)
         self.PumpTot = braintools.init.param(PumpTot, self.varshape, allow_none=False)
         self.depth = braintools.init.param(depth, self.varshape, allow_none=False)
+
+
+# ---------------------------------------------------------------------------
+# Declaration blocks shared by the ported ``cdp`` calcium pools.
+#
+# The five ``Cdp*`` mechanisms below are different reaction networks over a
+# common substrate: the same cytosolic buffer set, the same parvalbumin
+# triple, the same surface pump pair, and -- where calmodulin is modelled at
+# all -- the same nine CaM states. Each block is declared once here and
+# composed into the class tables, so a correction to the shared chemistry
+# reaches every model that uses it instead of three or four hand-kept copies.
+# ---------------------------------------------------------------------------
+
+_CI_SPECIES = (Species("Ci", init=0.0 * u.mM, factor="cyto"),)
+
+_BUFFER_SPECIES = (
+    Species("mg", init=0.0 * u.mM, factor="cyto"),
+    Species("Buff1", init=0.0 * u.mM, factor="cyto"),
+    Species("Buff1_ca", init=0.0 * u.mM, factor="cyto"),
+    Species("Buff2", init=0.0 * u.mM, factor="cyto"),
+    Species("Buff2_ca", init=0.0 * u.mM, factor="cyto"),
+    Species("BTC", init=0.0 * u.mM, factor="cyto"),
+    Species("BTC_ca", init=0.0 * u.mM, factor="cyto"),
+    Species("DMNPE", init=0.0 * u.mM, factor="cyto"),
+    Species("DMNPE_ca", init=0.0 * u.mM, factor="cyto"),
+)
+
+_PV_SPECIES = (
+    Species("PV", init=0.0 * u.mM, factor="cyto"),
+    Species("PV_ca", init=0.0 * u.mM, factor="cyto"),
+    Species("PV_mg", init=0.0 * u.mM, factor="cyto"),
+)
+
+_PUMP_SPECIES = (
+    Species("pump", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
+    Species("pumpca", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
+)
+
+#: Calmodulin states, in the binding order the ``cdp`` mod files declare them.
+_CAM_STATES = (
+    "CAM0",
+    "CAM1C",
+    "CAM2C",
+    "CAM1N2C",
+    "CAM1N",
+    "CAM2N",
+    "CAM2N1C",
+    "CAM1C1N",
+    "CAM4",
+)
+
+
+_BUFFER_REACTIONS = (
+    Reaction(
+        lhs={"pump": 1, "Ci": 1},
+        rhs={"pumpca": 1},
+        forward=lambda self, V, x: self.kpmp1 * self.parea,
+        backward=lambda self, V, x: self.kpmp2 * self.parea,
+    ),
+    Reaction(
+        lhs={"pumpca": 1},
+        rhs={"pump": 1},
+        forward=lambda self, V, x: self.kpmp3 * self.parea,
+        backward=None,
+    ),
+    Reaction(
+        lhs={"Ci": 1, "Buff1": 1},
+        rhs={"Buff1_ca": 1},
+        forward=lambda self, V, x: self.rf1 * self.dsqvol,
+        backward=lambda self, V, x: self.rf2 * self.dsqvol,
+    ),
+    Reaction(
+        lhs={"Ci": 1, "Buff2": 1},
+        rhs={"Buff2_ca": 1},
+        forward=lambda self, V, x: self.rf3 * self.dsqvol,
+        backward=lambda self, V, x: self.rf4 * self.dsqvol,
+    ),
+    Reaction(
+        lhs={"Ci": 1, "BTC": 1},
+        rhs={"BTC_ca": 1},
+        forward=lambda self, V, x: self.b1 * self.dsqvol,
+        backward=lambda self, V, x: self.b2 * self.dsqvol,
+    ),
+    Reaction(
+        lhs={"Ci": 1, "DMNPE": 1},
+        rhs={"DMNPE_ca": 1},
+        forward=lambda self, V, x: self.c1 * self.dsqvol,
+        backward=lambda self, V, x: self.c2 * self.dsqvol,
+    ),
+)
+
+_PV_REACTIONS = (
+    Reaction(
+        lhs={"Ci": 1, "PV": 1},
+        rhs={"PV_ca": 1},
+        forward=lambda self, V, x: self.m1 * self.dsqvol,
+        backward=lambda self, V, x: self.m2 * self.dsqvol,
+    ),
+    Reaction(
+        lhs={"mg": 1, "PV": 1},
+        rhs={"PV_mg": 1},
+        forward=lambda self, V, x: self.p1 * self.dsqvol,
+        backward=lambda self, V, x: self.p2 * self.dsqvol,
+    ),
+)
+
+
+def _cam_species(factor: str) -> tuple:
+    """Return the nine calmodulin species, scaled by ``factor``.
+
+    The Golgi-cell pools give calmodulin its own unit-carrying
+    ``"cam_unit"`` factor, so its states are not scaled by the shell
+    volume a second time; the Purkinje-cell pool scales them by
+    ``"cyto"`` like every other cytosolic species. The states themselves
+    are the same nine either way, which is why the factor is the only
+    parameter.
+
+    Parameters
+    ----------
+    factor : str
+        Name of the :class:`~braincell.ion._base.Factor` these states
+        are converted through.
+
+    Returns
+    -------
+    tuple of braincell.ion._base.Species
+        The nine calmodulin states, in ``_CAM_STATES`` order.
+    """
+    return tuple(Species(name, init=0.0 * u.mM, factor=factor) for name in _CAM_STATES)
 
 
 @register_ion("CdpStC_CAMOnly_MA2020_GoC")
@@ -1504,7 +1689,7 @@ class CdpStC_CAMOnly_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable or None, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``None``,
+        Initializer for the ``Ci`` species. Defaults to ``None``,
         which falls back to ``cainull``.
     species_initializers : dict or None, optional
         Per-species initializer overrides, keyed by one of this
@@ -1616,21 +1801,10 @@ class CdpStC_CAMOnly_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
         # whose magnitude is 1 instead of ``dsqvol``.
         Factor(
             "cam_unit",
-            lambda self: u.math.ones_like(self.dsqvol.to_decimal(u.um**2)) * (u.um**2),
+            lambda self: 1.0 * u.um**2,
         ),
     )
-    species = (
-        Species("Ci", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM0", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM1C", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM2C", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM1N2C", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM1N", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM2N", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM2N1C", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM1C1N", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM4", init=0.0 * u.mM, factor="cam_unit"),
-    )
+    species = _CI_SPECIES + _cam_species("cam_unit")
     reactions = (
         Reaction(
             lhs={"Ci": 1, "CAM0": 1},
@@ -1708,19 +1882,6 @@ class CdpStC_CAMOnly_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
     sources = ()
     conserves = ()
 
-    _diffeq_species = (
-        "Ci",
-        "CAM0",
-        "CAM1C",
-        "CAM2C",
-        "CAM1N2C",
-        "CAM1N",
-        "CAM2N",
-        "CAM2N1C",
-        "CAM1C1N",
-        "CAM4",
-    )
-
     def __init__(
         self,
         size: Size,
@@ -1770,19 +1931,8 @@ class CdpStC_CAMOnly_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
             substeps=substeps,
         )
 
-    def _resolve_species_initializers(
-        self,
-        *,
-        Ci_initializer,
-        species_initializers,
-    ) -> dict[str, object]:
-        species_initializers = dict(species_initializers or {})
-        invalid = set(species_initializers).difference(self._diffeq_species)
-        if invalid:
-            invalid_names = ", ".join(sorted(invalid))
-            raise ValueError(f"{type(self).__name__} only accepts differential-species overrides; got {invalid_names}.")
-
-        defaults = {
+    def _default_species_initializers(self, Ci_initializer) -> dict[str, object]:
+        return {
             "Ci": self.cainull if Ci_initializer is None else Ci_initializer,
             "CAM0": self.CAM_start,
             "CAM1C": 0.0 * u.mM,
@@ -1794,12 +1944,10 @@ class CdpStC_CAMOnly_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
             "CAM1C1N": 0.0 * u.mM,
             "CAM4": 0.0 * u.mM,
         }
-        defaults.update(species_initializers)
-        return {name: self._as_initializer(value) for name, value in defaults.items()}
 
 
 @register_ion("CdpStC_NoCAM_MA2020_GoC")
-class CdpStC_NoCAM_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
+class CdpStC_NoCAM_MA2020_GoC(Calcium, _ParvalbuminEquilibrium, _RadialShellGeometry, KineticIon):
     r"""BrainCell-factored calcium pool: pump, non-CaM buffers, no CaM.
 
     Keeps the pump and non-calmodulin buffer subnetworks of the
@@ -1890,7 +2038,7 @@ class CdpStC_NoCAM_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable or None, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``None``,
+        Initializer for the ``Ci`` species. Defaults to ``None``,
         which falls back to ``cainull``.
     species_initializers : dict or None, optional
         Per-species initializer overrides, keyed by one of this
@@ -2002,73 +2150,8 @@ class CdpStC_NoCAM_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
         Factor("cyto", lambda self: self.dsqvol),
         Factor("pump_area", lambda self: self.parea),
     )
-    species = (
-        Species("Ci", init=0.0 * u.mM, factor="cyto"),
-        Species("mg", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff1", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff1_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff2", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff2_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("BTC", init=0.0 * u.mM, factor="cyto"),
-        Species("BTC_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("DMNPE", init=0.0 * u.mM, factor="cyto"),
-        Species("DMNPE_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("PV", init=0.0 * u.mM, factor="cyto"),
-        Species("PV_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("PV_mg", init=0.0 * u.mM, factor="cyto"),
-        Species("pump", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
-        Species("pumpca", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
-    )
-    reactions = (
-        Reaction(
-            lhs={"pump": 1, "Ci": 1},
-            rhs={"pumpca": 1},
-            forward=lambda self, V, x: self.kpmp1 * self.parea,
-            backward=lambda self, V, x: self.kpmp2 * self.parea,
-        ),
-        Reaction(
-            lhs={"pumpca": 1},
-            rhs={"pump": 1},
-            forward=lambda self, V, x: self.kpmp3 * self.parea,
-            backward=None,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "Buff1": 1},
-            rhs={"Buff1_ca": 1},
-            forward=lambda self, V, x: self.rf1 * self.dsqvol,
-            backward=lambda self, V, x: self.rf2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "Buff2": 1},
-            rhs={"Buff2_ca": 1},
-            forward=lambda self, V, x: self.rf3 * self.dsqvol,
-            backward=lambda self, V, x: self.rf4 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "BTC": 1},
-            rhs={"BTC_ca": 1},
-            forward=lambda self, V, x: self.b1 * self.dsqvol,
-            backward=lambda self, V, x: self.b2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "DMNPE": 1},
-            rhs={"DMNPE_ca": 1},
-            forward=lambda self, V, x: self.c1 * self.dsqvol,
-            backward=lambda self, V, x: self.c2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "PV": 1},
-            rhs={"PV_ca": 1},
-            forward=lambda self, V, x: self.m1 * self.dsqvol,
-            backward=lambda self, V, x: self.m2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"mg": 1, "PV": 1},
-            rhs={"PV_mg": 1},
-            forward=lambda self, V, x: self.p1 * self.dsqvol,
-            backward=lambda self, V, x: self.p2 * self.dsqvol,
-        ),
-    )
+    species = _CI_SPECIES + _BUFFER_SPECIES + _PV_SPECIES + _PUMP_SPECIES
+    reactions = _BUFFER_REACTIONS + _PV_REACTIONS
     sources = (
         Source(
             target="Ci",
@@ -2081,23 +2164,6 @@ class CdpStC_NoCAM_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
             algebraic="pumpca",
             total=lambda self, V, x: self.TotalPump * self.parea,
         ),
-    )
-
-    _diffeq_species = (
-        "Ci",
-        "mg",
-        "Buff1",
-        "Buff1_ca",
-        "Buff2",
-        "Buff2_ca",
-        "BTC",
-        "BTC_ca",
-        "DMNPE",
-        "DMNPE_ca",
-        "PV",
-        "PV_ca",
-        "PV_mg",
-        "pump",
     )
 
     def __init__(
@@ -2175,19 +2241,8 @@ class CdpStC_NoCAM_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
             substeps=substeps,
         )
 
-    def _resolve_species_initializers(
-        self,
-        *,
-        Ci_initializer,
-        species_initializers,
-    ) -> dict[str, object]:
-        species_initializers = dict(species_initializers or {})
-        invalid = set(species_initializers).difference(self._diffeq_species)
-        if invalid:
-            invalid_names = ", ".join(sorted(invalid))
-            raise ValueError(f"{type(self).__name__} only accepts differential-species overrides; got {invalid_names}.")
-
-        defaults = {
+    def _default_species_initializers(self, Ci_initializer) -> dict[str, object]:
+        return {
             "Ci": self.cainull if Ci_initializer is None else Ci_initializer,
             "mg": self.mginull,
             "Buff1": self._ss_buffer_free(self.Buffnull1, self.rf1, self.rf2, self.cainull),
@@ -2203,37 +2258,6 @@ class CdpStC_NoCAM_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
             "PV_mg": self._ss_pv_mg(),
             "pump": self.TotalPump,
         }
-        defaults.update(species_initializers)
-        return {name: self._as_initializer(value) for name, value in defaults.items()}
-
-    def _kdc(self):
-        return (self.cainull * self.m1) / self.m2
-
-    def _kdm(self):
-        return (self.mginull * self.p1) / self.p2
-
-    def _ss_pv_free(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return self.PVnull / (1.0 + kdc + kdm)
-
-    def _ss_pv_ca(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return (self.PVnull * kdc) / (1.0 + kdc + kdm)
-
-    def _ss_pv_mg(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return (self.PVnull * kdm) / (1.0 + kdc + kdm)
-
-    def _ci_source_flux(self, total_current):
-        if total_current is None:
-            return self.dsqvol * (0.0 * u.mM / u.ms)
-        # NEURON's raw GoC ``ica`` is efflux-positive, but BrainCell channel
-        # currents are inward-positive. A positive calcium current therefore
-        # increases the local calcium pool.
-        return (total_current * u.math.pi * self._require_diam_arc_mean()) / (2.0 * u.faraday_constant)
 
 
 @register_ion("CdpStC_MA2025_BC")
@@ -2388,7 +2412,7 @@ class CdpStC_RI2021_SC(CdpStC_NoCAM_MA2020_GoC):
 
 
 @register_ion("CdpStC_MA2020_GoC")
-class CdpStC_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
+class CdpStC_MA2020_GoC(Calcium, _ParvalbuminEquilibrium, _RadialShellGeometry, KineticIon):
     r"""Golgi-cell calcium pool: pump, generic buffers, PV, and CaM.
 
     Undivided import of the Golgi-cell ``CdpStC`` calcium pool:
@@ -2493,7 +2517,7 @@ class CdpStC_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable or None, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``None``,
+        Initializer for the ``Ci`` species. Defaults to ``None``,
         which falls back to ``cainull``.
     species_initializers : dict or None, optional
         Per-species initializer overrides, keyed by one of this
@@ -2618,157 +2642,11 @@ class CdpStC_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
         Factor("pump_area", lambda self: self.parea),
         Factor(
             "cam_unit",
-            lambda self: u.math.ones_like(self.dsqvol.to_decimal(u.um**2)) * (u.um**2),
+            lambda self: 1.0 * u.um**2,
         ),
     )
-    species = (
-        Species("Ci", init=0.0 * u.mM, factor="cyto"),
-        Species("mg", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff1", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff1_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff2", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff2_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("BTC", init=0.0 * u.mM, factor="cyto"),
-        Species("BTC_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("DMNPE", init=0.0 * u.mM, factor="cyto"),
-        Species("DMNPE_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("PV", init=0.0 * u.mM, factor="cyto"),
-        Species("PV_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("PV_mg", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM0", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM1C", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM2C", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM1N2C", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM1N", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM2N", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM2N1C", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM1C1N", init=0.0 * u.mM, factor="cam_unit"),
-        Species("CAM4", init=0.0 * u.mM, factor="cam_unit"),
-        Species("pump", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
-        Species("pumpca", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
-    )
-    reactions = (
-        Reaction(
-            lhs={"pump": 1, "Ci": 1},
-            rhs={"pumpca": 1},
-            forward=lambda self, V, x: self.kpmp1 * self.parea,
-            backward=lambda self, V, x: self.kpmp2 * self.parea,
-        ),
-        Reaction(
-            lhs={"pumpca": 1},
-            rhs={"pump": 1},
-            forward=lambda self, V, x: self.kpmp3 * self.parea,
-            backward=None,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "Buff1": 1},
-            rhs={"Buff1_ca": 1},
-            forward=lambda self, V, x: self.rf1 * self.dsqvol,
-            backward=lambda self, V, x: self.rf2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "Buff2": 1},
-            rhs={"Buff2_ca": 1},
-            forward=lambda self, V, x: self.rf3 * self.dsqvol,
-            backward=lambda self, V, x: self.rf4 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "BTC": 1},
-            rhs={"BTC_ca": 1},
-            forward=lambda self, V, x: self.b1 * self.dsqvol,
-            backward=lambda self, V, x: self.b2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "DMNPE": 1},
-            rhs={"DMNPE_ca": 1},
-            forward=lambda self, V, x: self.c1 * self.dsqvol,
-            backward=lambda self, V, x: self.c2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "PV": 1},
-            rhs={"PV_ca": 1},
-            forward=lambda self, V, x: self.m1 * self.dsqvol,
-            backward=lambda self, V, x: self.m2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"mg": 1, "PV": 1},
-            rhs={"PV_mg": 1},
-            forward=lambda self, V, x: self.p1 * self.dsqvol,
-            backward=lambda self, V, x: self.p2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM0": 1},
-            rhs={"CAM1C": 1},
-            forward=lambda self, V, x: self.K1Con * self.dsqvol,
-            backward=lambda self, V, x: self.K1Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1C": 1},
-            rhs={"CAM2C": 1},
-            forward=lambda self, V, x: self.K2Con * self.dsqvol,
-            backward=lambda self, V, x: self.K2Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM2C": 1},
-            rhs={"CAM1N2C": 1},
-            forward=lambda self, V, x: self.K1Non * self.dsqvol,
-            backward=lambda self, V, x: self.K1Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1N2C": 1},
-            rhs={"CAM4": 1},
-            forward=lambda self, V, x: self.K2Non * self.dsqvol,
-            backward=lambda self, V, x: self.K2Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM0": 1},
-            rhs={"CAM1N": 1},
-            forward=lambda self, V, x: self.K1Non * self.dsqvol,
-            backward=lambda self, V, x: self.K1Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1N": 1},
-            rhs={"CAM2N": 1},
-            forward=lambda self, V, x: self.K2Non * self.dsqvol,
-            backward=lambda self, V, x: self.K2Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM2N": 1},
-            rhs={"CAM2N1C": 1},
-            forward=lambda self, V, x: self.K1Con * self.dsqvol,
-            backward=lambda self, V, x: self.K1Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM2N1C": 1},
-            rhs={"CAM4": 1},
-            forward=lambda self, V, x: self.K2Con * self.dsqvol,
-            backward=lambda self, V, x: self.K2Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1C": 1},
-            rhs={"CAM1C1N": 1},
-            forward=lambda self, V, x: self.K1Non * self.dsqvol,
-            backward=lambda self, V, x: self.K1Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1N": 1},
-            rhs={"CAM1C1N": 1},
-            forward=lambda self, V, x: self.K1Con * self.dsqvol,
-            backward=lambda self, V, x: self.K1Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1C1N": 1},
-            rhs={"CAM1N2C": 1},
-            forward=lambda self, V, x: self.K2Con * self.dsqvol,
-            backward=lambda self, V, x: self.K2Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1C1N": 1},
-            rhs={"CAM2N1C": 1},
-            forward=lambda self, V, x: self.K2Non * self.dsqvol,
-            backward=lambda self, V, x: self.K2Noff * self.dsqvol,
-        ),
-    )
+    species = _CI_SPECIES + _BUFFER_SPECIES + _PV_SPECIES + _cam_species("cam_unit") + _PUMP_SPECIES
+    reactions = CdpStC_NoCAM_MA2020_GoC.reactions + CdpStC_CAMOnly_MA2020_GoC.reactions
     sources = (
         Source(
             target="Ci",
@@ -2781,32 +2659,6 @@ class CdpStC_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
             algebraic="pumpca",
             total=lambda self, V, x: self.TotalPump * self.parea,
         ),
-    )
-
-    _diffeq_species = (
-        "Ci",
-        "mg",
-        "Buff1",
-        "Buff1_ca",
-        "Buff2",
-        "Buff2_ca",
-        "BTC",
-        "BTC_ca",
-        "DMNPE",
-        "DMNPE_ca",
-        "PV",
-        "PV_ca",
-        "PV_mg",
-        "CAM0",
-        "CAM1C",
-        "CAM2C",
-        "CAM1N2C",
-        "CAM1N",
-        "CAM2N",
-        "CAM2N1C",
-        "CAM1C1N",
-        "CAM4",
-        "pump",
     )
 
     def __init__(
@@ -2902,19 +2754,8 @@ class CdpStC_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
             substeps=substeps,
         )
 
-    def _resolve_species_initializers(
-        self,
-        *,
-        Ci_initializer,
-        species_initializers,
-    ) -> dict[str, object]:
-        species_initializers = dict(species_initializers or {})
-        invalid = set(species_initializers).difference(self._diffeq_species)
-        if invalid:
-            invalid_names = ", ".join(sorted(invalid))
-            raise ValueError(f"{type(self).__name__} only accepts differential-species overrides; got {invalid_names}.")
-
-        defaults = {
+    def _default_species_initializers(self, Ci_initializer) -> dict[str, object]:
+        return {
             "Ci": self.cainull if Ci_initializer is None else Ci_initializer,
             "mg": self.mginull,
             "Buff1": self._ss_buffer_free(self.Buffnull1, self.rf1, self.rf2, self.cainull),
@@ -2939,41 +2780,10 @@ class CdpStC_MA2020_GoC(Calcium, _RadialShellGeometry, KineticIon):
             "CAM4": 0.0 * u.mM,
             "pump": self.TotalPump,
         }
-        defaults.update(species_initializers)
-        return {name: self._as_initializer(value) for name, value in defaults.items()}
-
-    def _kdc(self):
-        return (self.cainull * self.m1) / self.m2
-
-    def _kdm(self):
-        return (self.mginull * self.p1) / self.p2
-
-    def _ss_pv_free(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return self.PVnull / (1.0 + kdc + kdm)
-
-    def _ss_pv_ca(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return (self.PVnull * kdc) / (1.0 + kdc + kdm)
-
-    def _ss_pv_mg(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return (self.PVnull * kdm) / (1.0 + kdc + kdm)
-
-    def _ci_source_flux(self, total_current):
-        if total_current is None:
-            return self.dsqvol * (0.0 * u.mM / u.ms)
-        # NEURON's raw GoC ``ica`` is efflux-positive, but BrainCell channel
-        # currents are inward-positive. A positive calcium current therefore
-        # increases the local calcium pool.
-        return (total_current * u.math.pi * self._require_diam_arc_mean()) / (2.0 * u.faraday_constant)
 
 
 @register_ion("CdpCAM_MA2024_PC")
-class CdpCAM_MA2024_PC(Calcium, _RadialShellGeometry, KineticIon):
+class CdpCAM_MA2024_PC(Calcium, _ParvalbuminEquilibrium, _RadialShellGeometry, KineticIon):
     r"""Purkinje-cell calcium pool: pump, buffers, Calbindin, PV, CaM.
 
     Extends the Golgi-cell pump/generic-buffer/parvalbumin/calmodulin
@@ -3090,7 +2900,7 @@ class CdpCAM_MA2024_PC(Calcium, _RadialShellGeometry, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable or None, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``None``,
+        Initializer for the ``Ci`` species. Defaults to ``None``,
         which falls back to ``cainull``.
     species_initializers : dict or None, optional
         Per-species initializer overrides, keyed by one of this
@@ -3157,11 +2967,12 @@ class CdpCAM_MA2024_PC(Calcium, _RadialShellGeometry, KineticIon):
     True``; ``sources`` and ``conserves`` are the exact tuple objects
     defined on :class:`CdpStC_MA2020_GoC` (same ``Ci``-driving
     :class:`~braincell.ion._base.Source` and same ``pump + pumpca =
-    TotalPump * parea`` :class:`~braincell.ion._base.Conserve`), and
-    several geometry/current helpers (:attr:`vrat`, :attr:`parea`,
-    :attr:`dsq`, :attr:`dsqvol`, ``_require_diam_arc_mean``,
-    ``_ci_source_flux``, ``_as_initializer``) explicitly delegate to
-    :class:`CdpStC_MA2020_GoC` rather than redefining the same logic.
+    TotalPump * parea`` :class:`~braincell.ion._base.Conserve`). The
+    shell geometry and the current-driven ``Ci`` source
+    (:attr:`vrat`, :attr:`parea`, :attr:`dsq`, :attr:`dsqvol`,
+    ``_require_diam_arc_mean``, ``_ci_source_flux``) are inherited from
+    :class:`~braincell.ion._base._RadialShellGeometry`, and the
+    parvalbumin equilibrium from :class:`_ParvalbuminEquilibrium`.
 
     Twenty-four reactions couple the twenty-eight species: the two
     pump steps and four of the six buffer/PV steps from
@@ -3208,213 +3019,51 @@ class CdpCAM_MA2024_PC(Calcium, _RadialShellGeometry, KineticIon):
         Factor("pump_area", lambda self: self.parea),
     )
     species = (
-        Species("Ci", init=0.0 * u.mM, factor="cyto"),
-        Species("mg", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff1", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff1_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff2", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff2_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("BTC", init=0.0 * u.mM, factor="cyto"),
-        Species("BTC_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("DMNPE", init=0.0 * u.mM, factor="cyto"),
-        Species("DMNPE_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("CB", init=0.0 * u.mM, factor="cyto"),
-        Species("CB_f_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("CB_ca_s", init=0.0 * u.mM, factor="cyto"),
-        Species("CB_ca_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("PV", init=0.0 * u.mM, factor="cyto"),
-        Species("PV_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("PV_mg", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM0", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM1C", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM2C", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM1N2C", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM1N", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM2N", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM2N1C", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM1C1N", init=0.0 * u.mM, factor="cyto"),
-        Species("CAM4", init=0.0 * u.mM, factor="cyto"),
-        Species("pump", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
-        Species("pumpca", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
+        _CI_SPECIES
+        + _BUFFER_SPECIES
+        + (
+            Species("CB", init=0.0 * u.mM, factor="cyto"),
+            Species("CB_f_ca", init=0.0 * u.mM, factor="cyto"),
+            Species("CB_ca_s", init=0.0 * u.mM, factor="cyto"),
+            Species("CB_ca_ca", init=0.0 * u.mM, factor="cyto"),
+        )
+        + _PV_SPECIES
+        + _cam_species("cyto")
+        + _PUMP_SPECIES
     )
     reactions = (
-        Reaction(
-            lhs={"pump": 1, "Ci": 1},
-            rhs={"pumpca": 1},
-            forward=lambda self, V, x: self.kpmp1 * self.parea,
-            backward=lambda self, V, x: self.kpmp2 * self.parea,
-        ),
-        Reaction(
-            lhs={"pumpca": 1},
-            rhs={"pump": 1},
-            forward=lambda self, V, x: self.kpmp3 * self.parea,
-            backward=None,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "Buff1": 1},
-            rhs={"Buff1_ca": 1},
-            forward=lambda self, V, x: self.rf1 * self.dsqvol,
-            backward=lambda self, V, x: self.rf2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "Buff2": 1},
-            rhs={"Buff2_ca": 1},
-            forward=lambda self, V, x: self.rf3 * self.dsqvol,
-            backward=lambda self, V, x: self.rf4 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "BTC": 1},
-            rhs={"BTC_ca": 1},
-            forward=lambda self, V, x: self.b1 * self.dsqvol,
-            backward=lambda self, V, x: self.b2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "DMNPE": 1},
-            rhs={"DMNPE_ca": 1},
-            forward=lambda self, V, x: self.c1 * self.dsqvol,
-            backward=lambda self, V, x: self.c2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CB": 1},
-            rhs={"CB_ca_s": 1},
-            forward=lambda self, V, x: self.nf1 * self.dsqvol,
-            backward=lambda self, V, x: self.nf2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CB": 1},
-            rhs={"CB_f_ca": 1},
-            forward=lambda self, V, x: self.ns1 * self.dsqvol,
-            backward=lambda self, V, x: self.ns2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CB_f_ca": 1},
-            rhs={"CB_ca_ca": 1},
-            forward=lambda self, V, x: self.nf1 * self.dsqvol,
-            backward=lambda self, V, x: self.nf2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CB_ca_s": 1},
-            rhs={"CB_ca_ca": 1},
-            forward=lambda self, V, x: self.ns1 * self.dsqvol,
-            backward=lambda self, V, x: self.ns2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "PV": 1},
-            rhs={"PV_ca": 1},
-            forward=lambda self, V, x: self.m1 * self.dsqvol,
-            backward=lambda self, V, x: self.m2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"mg": 1, "PV": 1},
-            rhs={"PV_mg": 1},
-            forward=lambda self, V, x: self.p1 * self.dsqvol,
-            backward=lambda self, V, x: self.p2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM0": 1},
-            rhs={"CAM1C": 1},
-            forward=lambda self, V, x: self.K1Con * self.dsqvol,
-            backward=lambda self, V, x: self.K1Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1C": 1},
-            rhs={"CAM2C": 1},
-            forward=lambda self, V, x: self.K2Con * self.dsqvol,
-            backward=lambda self, V, x: self.K2Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM2C": 1},
-            rhs={"CAM1N2C": 1},
-            forward=lambda self, V, x: self.K1Non * self.dsqvol,
-            backward=lambda self, V, x: self.K1Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1N2C": 1},
-            rhs={"CAM4": 1},
-            forward=lambda self, V, x: self.K2Non * self.dsqvol,
-            backward=lambda self, V, x: self.K2Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM0": 1},
-            rhs={"CAM1N": 1},
-            forward=lambda self, V, x: self.K1Non * self.dsqvol,
-            backward=lambda self, V, x: self.K1Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1N": 1},
-            rhs={"CAM2N": 1},
-            forward=lambda self, V, x: self.K2Non * self.dsqvol,
-            backward=lambda self, V, x: self.K2Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM2N": 1},
-            rhs={"CAM2N1C": 1},
-            forward=lambda self, V, x: self.K1Con * self.dsqvol,
-            backward=lambda self, V, x: self.K1Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM2N1C": 1},
-            rhs={"CAM4": 1},
-            forward=lambda self, V, x: self.K2Con * self.dsqvol,
-            backward=lambda self, V, x: self.K2Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1C": 1},
-            rhs={"CAM1C1N": 1},
-            forward=lambda self, V, x: self.K1Non * self.dsqvol,
-            backward=lambda self, V, x: self.K1Noff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1N": 1},
-            rhs={"CAM1C1N": 1},
-            forward=lambda self, V, x: self.K1Con * self.dsqvol,
-            backward=lambda self, V, x: self.K1Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1C1N": 1},
-            rhs={"CAM1N2C": 1},
-            forward=lambda self, V, x: self.K2Con * self.dsqvol,
-            backward=lambda self, V, x: self.K2Coff * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "CAM1C1N": 1},
-            rhs={"CAM2N1C": 1},
-            forward=lambda self, V, x: self.K2Non * self.dsqvol,
-            backward=lambda self, V, x: self.K2Noff * self.dsqvol,
-        ),
+        _BUFFER_REACTIONS
+        + (
+            Reaction(
+                lhs={"Ci": 1, "CB": 1},
+                rhs={"CB_ca_s": 1},
+                forward=lambda self, V, x: self.nf1 * self.dsqvol,
+                backward=lambda self, V, x: self.nf2 * self.dsqvol,
+            ),
+            Reaction(
+                lhs={"Ci": 1, "CB": 1},
+                rhs={"CB_f_ca": 1},
+                forward=lambda self, V, x: self.ns1 * self.dsqvol,
+                backward=lambda self, V, x: self.ns2 * self.dsqvol,
+            ),
+            Reaction(
+                lhs={"Ci": 1, "CB_f_ca": 1},
+                rhs={"CB_ca_ca": 1},
+                forward=lambda self, V, x: self.nf1 * self.dsqvol,
+                backward=lambda self, V, x: self.nf2 * self.dsqvol,
+            ),
+            Reaction(
+                lhs={"Ci": 1, "CB_ca_s": 1},
+                rhs={"CB_ca_ca": 1},
+                forward=lambda self, V, x: self.ns1 * self.dsqvol,
+                backward=lambda self, V, x: self.ns2 * self.dsqvol,
+            ),
+        )
+        + _PV_REACTIONS
+        + CdpStC_CAMOnly_MA2020_GoC.reactions
     )
     sources = CdpStC_MA2020_GoC.sources
     conserves = CdpStC_MA2020_GoC.conserves
-
-    _diffeq_species = (
-        "Ci",
-        "mg",
-        "Buff1",
-        "Buff1_ca",
-        "Buff2",
-        "Buff2_ca",
-        "BTC",
-        "BTC_ca",
-        "DMNPE",
-        "DMNPE_ca",
-        "CB",
-        "CB_f_ca",
-        "CB_ca_s",
-        "CB_ca_ca",
-        "PV",
-        "PV_ca",
-        "PV_mg",
-        "CAM0",
-        "CAM1C",
-        "CAM2C",
-        "CAM1N2C",
-        "CAM1N",
-        "CAM2N",
-        "CAM2N1C",
-        "CAM1C1N",
-        "CAM4",
-        "pump",
-    )
 
     def __init__(
         self,
@@ -3519,19 +3168,8 @@ class CdpCAM_MA2024_PC(Calcium, _RadialShellGeometry, KineticIon):
             substeps=substeps,
         )
 
-    def _resolve_species_initializers(
-        self,
-        *,
-        Ci_initializer,
-        species_initializers,
-    ) -> dict[str, object]:
-        species_initializers = dict(species_initializers or {})
-        invalid = set(species_initializers).difference(self._diffeq_species)
-        if invalid:
-            invalid_names = ", ".join(sorted(invalid))
-            raise ValueError(f"{type(self).__name__} only accepts differential-species overrides; got {invalid_names}.")
-
-        defaults = {
+    def _default_species_initializers(self, Ci_initializer) -> dict[str, object]:
+        return {
             "Ci": self.cainull if Ci_initializer is None else Ci_initializer,
             "mg": self.mginull,
             "Buff1": self._ss_buffer_free(self.Buffnull1, self.rf1, self.rf2, self.cainull),
@@ -3560,8 +3198,6 @@ class CdpCAM_MA2024_PC(Calcium, _RadialShellGeometry, KineticIon):
             "CAM4": 0.0 * u.mM,
             "pump": self.TotalPump,
         }
-        defaults.update(species_initializers)
-        return {name: self._as_initializer(value) for name, value in defaults.items()}
 
     def _kdf(self):
         return (self.cainull * self.nf1) / self.nf2
@@ -3588,30 +3224,6 @@ class CdpCAM_MA2024_PC(Calcium, _RadialShellGeometry, KineticIon):
         kdf = self._kdf()
         kds = self._kds()
         return (self.CBnull * kdf * kds) / (1.0 + kdf + kds + kdf * kds)
-
-    def _kdc(self):
-        return (self.cainull * self.m1) / self.m2
-
-    def _kdm(self):
-        return (self.mginull * self.p1) / self.p2
-
-    def _ss_pv_free(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return self.PVnull / (1.0 + kdc + kdm)
-
-    def _ss_pv_ca(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return (self.PVnull * kdc) / (1.0 + kdc + kdm)
-
-    def _ss_pv_mg(self):
-        kdc = self._kdc()
-        kdm = self._kdm()
-        return (self.PVnull * kdm) / (1.0 + kdc + kdm)
-
-    def _ci_source_flux(self, total_current):
-        return CdpStC_MA2020_GoC._ci_source_flux(self, total_current)
 
 
 @register_ion("CdpCR_MA2020_GrC")
@@ -3702,7 +3314,7 @@ class CdpCR_MA2020_GrC(Calcium, _RadialShellGeometry, KineticIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`KineticIon._init_kinetic_ion`.
     Ci_initializer : array-like or callable or None, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species. Defaults to ``None``,
+        Initializer for the ``Ci`` species. Defaults to ``None``,
         which falls back to ``cainull``.
     species_initializers : dict or None, optional
         Per-species initializer overrides, keyed by one of this
@@ -3771,11 +3383,11 @@ class CdpCR_MA2020_GrC(Calcium, _RadialShellGeometry, KineticIon):
     objects defined on :class:`CdpStC_MA2020_GoC` (same
     ``Ci``-driving :class:`~braincell.ion._base.Source` and same
     ``pump + pumpca = TotalPump * parea``
-    :class:`~braincell.ion._base.Conserve`), and several
-    geometry/current helpers (:attr:`vrat`, :attr:`parea`,
+    :class:`~braincell.ion._base.Conserve`). The shell geometry and
+    the current-driven ``Ci`` source (:attr:`vrat`, :attr:`parea`,
     :attr:`dsq`, :attr:`dsqvol`, ``_require_diam_arc_mean``,
-    ``_ci_source_flux``, ``_as_initializer``) explicitly delegate to
-    :class:`CdpStC_MA2020_GoC` rather than redefining the same logic.
+    ``_ci_source_flux``) are inherited from
+    :class:`~braincell.ion._base._RadialShellGeometry`.
 
     Nineteen reactions couple the twenty-two species: the two pump
     steps, four generic-buffer steps (``Buff1``, ``Buff2``, ``BTC``,
@@ -3825,66 +3437,23 @@ class CdpCR_MA2020_GrC(Calcium, _RadialShellGeometry, KineticIon):
         Factor("pump_area", lambda self: self.parea),
     )
     species = (
-        Species("Ci", init=0.0 * u.mM, factor="cyto"),
-        Species("mg", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff1", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff1_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff2", init=0.0 * u.mM, factor="cyto"),
-        Species("Buff2_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("BTC", init=0.0 * u.mM, factor="cyto"),
-        Species("BTC_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("DMNPE", init=0.0 * u.mM, factor="cyto"),
-        Species("DMNPE_ca", init=0.0 * u.mM, factor="cyto"),
-        Species("CR", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_1C_0N", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_2C_0N", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_2C_1N", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_1C_1N", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_0C_1N", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_0C_2N", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_1C_2N", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_2C_2N", init=0.0 * u.mM, factor="cyto"),
-        Species("CR_1V", init=0.0 * u.mM, factor="cyto"),
-        Species("pump", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
-        Species("pumpca", init=0.0 * (u.mol / u.cm**2), factor="pump_area"),
+        _CI_SPECIES
+        + _BUFFER_SPECIES
+        + (
+            Species("CR", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_1C_0N", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_2C_0N", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_2C_1N", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_1C_1N", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_0C_1N", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_0C_2N", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_1C_2N", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_2C_2N", init=0.0 * u.mM, factor="cyto"),
+            Species("CR_1V", init=0.0 * u.mM, factor="cyto"),
+        )
+        + _PUMP_SPECIES
     )
-    reactions = (
-        Reaction(
-            lhs={"pump": 1, "Ci": 1},
-            rhs={"pumpca": 1},
-            forward=lambda self, V, x: self.kpmp1 * self.parea,
-            backward=lambda self, V, x: self.kpmp2 * self.parea,
-        ),
-        Reaction(
-            lhs={"pumpca": 1},
-            rhs={"pump": 1},
-            forward=lambda self, V, x: self.kpmp3 * self.parea,
-            backward=None,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "Buff1": 1},
-            rhs={"Buff1_ca": 1},
-            forward=lambda self, V, x: self.rf1 * self.dsqvol,
-            backward=lambda self, V, x: self.rf2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "Buff2": 1},
-            rhs={"Buff2_ca": 1},
-            forward=lambda self, V, x: self.rf3 * self.dsqvol,
-            backward=lambda self, V, x: self.rf4 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "BTC": 1},
-            rhs={"BTC_ca": 1},
-            forward=lambda self, V, x: self.b1 * self.dsqvol,
-            backward=lambda self, V, x: self.b2 * self.dsqvol,
-        ),
-        Reaction(
-            lhs={"Ci": 1, "DMNPE": 1},
-            rhs={"DMNPE_ca": 1},
-            forward=lambda self, V, x: self.c1 * self.dsqvol,
-            backward=lambda self, V, x: self.c2 * self.dsqvol,
-        ),
+    reactions = _BUFFER_REACTIONS + (
         Reaction(
             lhs={"Ci": 1, "CR": 1},
             rhs={"CR_1C_0N": 1},
@@ -3967,30 +3536,6 @@ class CdpCR_MA2020_GrC(Calcium, _RadialShellGeometry, KineticIon):
     sources = CdpStC_MA2020_GoC.sources
     conserves = CdpStC_MA2020_GoC.conserves
 
-    _diffeq_species = (
-        "Ci",
-        "mg",
-        "Buff1",
-        "Buff1_ca",
-        "Buff2",
-        "Buff2_ca",
-        "BTC",
-        "BTC_ca",
-        "DMNPE",
-        "DMNPE_ca",
-        "CR",
-        "CR_1C_0N",
-        "CR_2C_0N",
-        "CR_2C_1N",
-        "CR_1C_1N",
-        "CR_0C_1N",
-        "CR_0C_2N",
-        "CR_1C_2N",
-        "CR_2C_2N",
-        "CR_1V",
-        "pump",
-    )
-
     def __init__(
         self,
         size: Size,
@@ -4070,19 +3615,8 @@ class CdpCR_MA2020_GrC(Calcium, _RadialShellGeometry, KineticIon):
             substeps=substeps,
         )
 
-    def _resolve_species_initializers(
-        self,
-        *,
-        Ci_initializer,
-        species_initializers,
-    ) -> dict[str, object]:
-        species_initializers = dict(species_initializers or {})
-        invalid = set(species_initializers).difference(self._diffeq_species)
-        if invalid:
-            invalid_names = ", ".join(sorted(invalid))
-            raise ValueError(f"{type(self).__name__} only accepts differential-species overrides; got {invalid_names}.")
-
-        defaults = {
+    def _default_species_initializers(self, Ci_initializer) -> dict[str, object]:
+        return {
             "Ci": self.cainull if Ci_initializer is None else Ci_initializer,
             "mg": self.mginull,
             "Buff1": self._ss_buffer_free(self.Buffnull1, self.rf1, self.rf2, self.cainull),
@@ -4105,11 +3639,6 @@ class CdpCR_MA2020_GrC(Calcium, _RadialShellGeometry, KineticIon):
             "CR_1V": 0.0 * u.mM,
             "pump": self.TotalPump,
         }
-        defaults.update(species_initializers)
-        return {name: self._as_initializer(value) for name, value in defaults.items()}
-
-    def _ci_source_flux(self, total_current):
-        return CdpStC_MA2020_GoC._ci_source_flux(self, total_current)
 
 
 @register_ion("CdpHVA_SU2015_DCN")
@@ -4151,7 +3680,7 @@ class CdpHVA_SU2015_DCN(Calcium, DynamicNernstIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`DynamicNernstIon._init_dynamic_nernst_ion`.
     Ci_initializer : array-like or callable or None, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the dynamic ``Ci`` state. Defaults to
+        Initializer for the dynamic ``Ci`` state. Defaults to
         ``None``, which falls back to a constant initializer at
         ``caiBase``.
     name : str or None, optional
@@ -4271,10 +3800,7 @@ class CdpHVA_SU2015_DCN(Calcium, DynamicNernstIon):
         # channels follow the repo-wide inward-positive current convention, so
         # the equivalent imported-ion drive here is positive in ``total_current``.
         drive_value = (
-            self.kCa.to_decimal(self.kCa.unit)
-            / self.depth.to_decimal(u.um)
-            * total_current.to_decimal(u.mA / u.cm**2)
-            * 1e4
+            u.get_mantissa(self.kCa) / self.depth.to_decimal(u.um) * total_current.to_decimal(u.mA / u.cm**2) * 1e4
         )
         drive = drive_value * (u.mM / u.ms)
         return drive - (Ci - self.caiBase) / self.tauCa
@@ -4321,7 +3847,7 @@ class CdpLVA_SU2015_DCN(Calcium, DynamicNernstIon):
         which falls back to :attr:`Calcium.default_Co` inside
         :meth:`DynamicNernstIon._init_dynamic_nernst_ion`.
     Ci_initializer : array-like or callable or None, optional
-        Union[brainstate.typing.ArrayLike, Callable] for the dynamic ``Ci`` state. Defaults to
+        Initializer for the dynamic ``Ci`` state. Defaults to
         ``None``, which falls back to a constant initializer at
         ``caliBase``.
     name : str or None, optional
@@ -4444,10 +3970,7 @@ class CdpLVA_SU2015_DCN(Calcium, DynamicNernstIon):
         # channel currents use the repo-wide inward-positive convention, so
         # the equivalent imported-ion drive here is positive in ``total_current``.
         drive_value = (
-            self.kCal.to_decimal(self.kCal.unit)
-            / self.depth.to_decimal(u.um)
-            * total_current.to_decimal(u.mA / u.cm**2)
-            * 1e4
+            u.get_mantissa(self.kCal) / self.depth.to_decimal(u.um) * total_current.to_decimal(u.mA / u.cm**2) * 1e4
         )
         drive = drive_value * (u.mM / u.ms)
         return drive - (Ci - self.caliBase) / self.tauCal

--- a/braincell/ion/calcium_test.py
+++ b/braincell/ion/calcium_test.py
@@ -49,13 +49,10 @@ from braincell.ion.calcium import (
     ToyCaPumpFactorKinetic_SU2015_DCN,
     ToyCaBindingSourceKinetic_SU2015_DCN,
 )
-from braincell.ion._base import DynamicNernstIon, InitNernstIon, KineticIon
+from braincell.ion._testing import V as _V, KineticPumpContractTests, make_shell_ion
+from braincell.ion._base import DynamicNernstIon, InitNernstIon, KineticIon, _Specs
 from braincell.mech import get_registry
 from braincell.quad.protocol import DiffEqState
-
-
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
 
 
 class CalciumBaseTest(unittest.TestCase):
@@ -848,14 +845,13 @@ class ToyDiamFactorKinetic_SU2015_DCNTest(unittest.TestCase):
         self.assertTrue(u.math.allclose(info.Ci, ion.Ci.value, atol=1e-12 * u.mM))
 
 
-class CdpStC_MA2020_GoCTest(unittest.TestCase):
+class CdpStC_MA2020_GoCTest(KineticPumpContractTests, unittest.TestCase):
     """Imported GoC calcium pool with preserved KINETIC reactions."""
 
+    ION_CLASS = CdpStC_MA2020_GoC
+
     def _make_ion(self, **kwargs):
-        ion = CdpStC_MA2020_GoC(size=1, **kwargs)
-        ion.diam_mid = jnp.asarray([20.0]) * u.um
-        ion.diam_arc_mean = jnp.asarray([20.0]) * u.um
-        return ion
+        return make_shell_ion(CdpStC_MA2020_GoC, **kwargs)
 
     def test_is_subclass_of_calcium(self) -> None:
         self.assertTrue(issubclass(CdpStC_MA2020_GoC, Calcium))
@@ -922,31 +918,6 @@ class CdpStC_MA2020_GoCTest(unittest.TestCase):
         flux = ion.sources[0].flux(ion, _V([-60.0]), ion.species_values(), total_current=None)
         self.assertTrue(
             u.math.allclose(flux, jnp.array([0.0]) * u.mM * u.um**2 / u.ms, atol=1e-12 * u.mM * u.um**2 / u.ms)
-        )
-
-    def test_positive_inward_current_produces_positive_ci_source_flux(self) -> None:
-        ion = self._make_ion()
-        ion.init_state(_V([-60.0]))
-        flux = ion.sources[0].flux(
-            ion,
-            _V([-60.0]),
-            ion.species_values(),
-            total_current=jnp.array([0.01]) * u.mA / (u.cm**2),
-        )
-        self.assertGreater(float(flux[0].to_decimal(u.mM * u.um**2 / u.ms)), 0.0)
-
-    def test_conserve_keeps_pump_plus_pumpca_equal_total_scaled_pool(self) -> None:
-        ion = self._make_ion()
-        ion.init_state(_V([-60.0]))
-        values = ion.species_values()
-        total = ion.TotalPump * ion.parea
-        combined = ion.pump.value * ion.parea + values["pumpca"] * ion.parea
-        self.assertTrue(
-            u.math.allclose(
-                combined.to_decimal(total.unit),
-                total.to_decimal(total.unit),
-                atol=1e-12,
-            )
         )
 
     def test_reaction_r2_pump_release_is_irreversible(self) -> None:
@@ -1040,10 +1011,7 @@ class CdpStC_CAMOnly_MA2020_GoCTest(unittest.TestCase):
     """Imported GoC calcium pool with only the calmodulin subnetwork."""
 
     def _make_ion(self, **kwargs):
-        ion = CdpStC_CAMOnly_MA2020_GoC(size=1, **kwargs)
-        ion.diam_mid = jnp.asarray([20.0]) * u.um
-        ion.diam_arc_mean = jnp.asarray([20.0]) * u.um
-        return ion
+        return make_shell_ion(CdpStC_CAMOnly_MA2020_GoC, **kwargs)
 
     def test_is_subclass_of_calcium(self) -> None:
         self.assertTrue(issubclass(CdpStC_CAMOnly_MA2020_GoC, Calcium))
@@ -1104,14 +1072,13 @@ class CdpStC_CAMOnly_MA2020_GoCTest(unittest.TestCase):
             self.assertTrue(np.isfinite(arr).all())
 
 
-class CdpStC_NoCAM_MA2020_GoCTest(unittest.TestCase):
+class CdpStC_NoCAM_MA2020_GoCTest(KineticPumpContractTests, unittest.TestCase):
     """Imported GoC calcium pool without the calmodulin subnetwork."""
 
+    ION_CLASS = CdpStC_NoCAM_MA2020_GoC
+
     def _make_ion(self, **kwargs):
-        ion = CdpStC_NoCAM_MA2020_GoC(size=1, **kwargs)
-        ion.diam_mid = jnp.asarray([20.0]) * u.um
-        ion.diam_arc_mean = jnp.asarray([20.0]) * u.um
-        return ion
+        return make_shell_ion(CdpStC_NoCAM_MA2020_GoC, **kwargs)
 
     def test_is_subclass_of_calcium(self) -> None:
         self.assertTrue(issubclass(CdpStC_NoCAM_MA2020_GoC, Calcium))
@@ -1175,31 +1142,6 @@ class CdpStC_NoCAM_MA2020_GoCTest(unittest.TestCase):
         flux = ion.sources[0].flux(ion, _V([-60.0]), ion.species_values(), total_current=None)
         self.assertTrue(
             u.math.allclose(flux, jnp.array([0.0]) * u.mM * u.um**2 / u.ms, atol=1e-12 * u.mM * u.um**2 / u.ms)
-        )
-
-    def test_positive_inward_current_produces_positive_ci_source_flux(self) -> None:
-        ion = self._make_ion()
-        ion.init_state(_V([-60.0]))
-        flux = ion.sources[0].flux(
-            ion,
-            _V([-60.0]),
-            ion.species_values(),
-            total_current=jnp.array([0.01]) * u.mA / (u.cm**2),
-        )
-        self.assertGreater(float(flux[0].to_decimal(u.mM * u.um**2 / u.ms)), 0.0)
-
-    def test_conserve_keeps_pump_plus_pumpca_equal_total_scaled_pool(self) -> None:
-        ion = self._make_ion()
-        ion.init_state(_V([-60.0]))
-        values = ion.species_values()
-        total = ion.TotalPump * ion.parea
-        combined = ion.pump.value * ion.parea + values["pumpca"] * ion.parea
-        self.assertTrue(
-            u.math.allclose(
-                combined.to_decimal(total.unit),
-                total.to_decimal(total.unit),
-                atol=1e-12,
-            )
         )
 
     def test_reaction_r2_pump_release_is_irreversible(self) -> None:
@@ -1266,10 +1208,7 @@ class CdpStCInheritedCellVariantTest(unittest.TestCase):
     )
 
     def _make_ion(self, cls):
-        ion = cls(size=1)
-        ion.diam_mid = jnp.asarray([20.0]) * u.um
-        ion.diam_arc_mean = jnp.asarray([20.0]) * u.um
-        return ion
+        return make_shell_ion(cls)
 
     def test_cell_specific_variants_are_registered_subclasses(self) -> None:
         registry = get_registry()
@@ -1286,7 +1225,14 @@ class CdpStCInheritedCellVariantTest(unittest.TestCase):
                 self.assertIs(cls.reactions, CdpStC_NoCAM_MA2020_GoC.reactions)
                 self.assertIs(cls.sources, CdpStC_NoCAM_MA2020_GoC.sources)
                 self.assertIs(cls.conserves, CdpStC_NoCAM_MA2020_GoC.conserves)
-                self.assertEqual(cls._diffeq_species, CdpStC_NoCAM_MA2020_GoC._diffeq_species)
+                # Derived from the shared species/conserves declarations
+                # above rather than restated per class, so this follows
+                # from them -- but pin it, since it is what
+                # ``_default_species_initializers`` is validated against.
+                self.assertEqual(
+                    _Specs.for_type(cls).diffeq_names,
+                    _Specs.for_type(CdpStC_NoCAM_MA2020_GoC).diffeq_names,
+                )
                 self.assertTrue(cls.uses_total_current)
 
     def test_variants_match_nocam_state_derivative_and_source_flux(self) -> None:
@@ -1333,14 +1279,13 @@ class CdpStCInheritedCellVariantTest(unittest.TestCase):
                 self.assertTrue(u.math.allclose(flux_variant, flux_base, atol=1e-12 * flux_base.unit))
 
 
-class CdpCAM_MA2024_PCTest(unittest.TestCase):
+class CdpCAM_MA2024_PCTest(KineticPumpContractTests, unittest.TestCase):
     """Imported PC calcium pool with active CB and CAM subnetworks."""
 
+    ION_CLASS = CdpCAM_MA2024_PC
+
     def _make_ion(self, **kwargs):
-        ion = CdpCAM_MA2024_PC(size=1, **kwargs)
-        ion.diam_mid = jnp.asarray([20.0]) * u.um
-        ion.diam_arc_mean = jnp.asarray([20.0]) * u.um
-        return ion
+        return make_shell_ion(CdpCAM_MA2024_PC, **kwargs)
 
     def test_is_registered_kinetic_calcium_ion(self) -> None:
         self.assertTrue(issubclass(CdpCAM_MA2024_PC, Calcium))
@@ -1407,31 +1352,6 @@ class CdpCAM_MA2024_PCTest(unittest.TestCase):
     def test_species_initializer_rejects_algebraic_override(self) -> None:
         with self.assertRaisesRegex(ValueError, "differential-species overrides"):
             self._make_ion(species_initializers={"pumpca": 0.0 * (u.mol / u.cm**2)})
-
-    def test_positive_inward_current_produces_positive_ci_source_flux(self) -> None:
-        ion = self._make_ion()
-        ion.init_state(_V([-60.0]))
-        flux = ion.sources[0].flux(
-            ion,
-            _V([-60.0]),
-            ion.species_values(),
-            total_current=jnp.array([0.01]) * u.mA / (u.cm**2),
-        )
-        self.assertGreater(float(flux[0].to_decimal(u.mM * u.um**2 / u.ms)), 0.0)
-
-    def test_conserve_keeps_pump_plus_pumpca_equal_total_scaled_pool(self) -> None:
-        ion = self._make_ion()
-        ion.init_state(_V([-60.0]))
-        values = ion.species_values()
-        total = ion.TotalPump * ion.parea
-        combined = ion.pump.value * ion.parea + values["pumpca"] * ion.parea
-        self.assertTrue(
-            u.math.allclose(
-                combined.to_decimal(total.unit),
-                total.to_decimal(total.unit),
-                atol=1e-12,
-            )
-        )
 
     def test_cb_fast_binding_consumes_cb_and_builds_cb_f_ca(self) -> None:
         ion = self._make_ion()
@@ -1501,14 +1421,13 @@ class CdpCAM_MA2024_PCTest(unittest.TestCase):
         self.assertLess(float(ion.Ci.value[0].to_decimal(u.mM)), 1e-3)
 
 
-class CdpCR_MA2020_GrCTest(unittest.TestCase):
+class CdpCR_MA2020_GrCTest(KineticPumpContractTests, unittest.TestCase):
     """Imported GrC calcium pool with Calretinin buffering."""
 
+    ION_CLASS = CdpCR_MA2020_GrC
+
     def _make_ion(self, **kwargs):
-        ion = CdpCR_MA2020_GrC(size=1, **kwargs)
-        ion.diam_mid = jnp.asarray([20.0]) * u.um
-        ion.diam_arc_mean = jnp.asarray([20.0]) * u.um
-        return ion
+        return make_shell_ion(CdpCR_MA2020_GrC, **kwargs)
 
     def test_is_registered_kinetic_calcium_ion(self) -> None:
         self.assertTrue(issubclass(CdpCR_MA2020_GrC, Calcium))
@@ -1582,31 +1501,6 @@ class CdpCR_MA2020_GrCTest(unittest.TestCase):
     def test_species_initializer_rejects_algebraic_override(self) -> None:
         with self.assertRaisesRegex(ValueError, "differential-species overrides"):
             self._make_ion(species_initializers={"pumpca": 0.0 * (u.mol / u.cm**2)})
-
-    def test_positive_inward_current_produces_positive_ci_source_flux(self) -> None:
-        ion = self._make_ion()
-        ion.init_state(_V([-60.0]))
-        flux = ion.sources[0].flux(
-            ion,
-            _V([-60.0]),
-            ion.species_values(),
-            total_current=jnp.array([0.01]) * u.mA / (u.cm**2),
-        )
-        self.assertGreater(float(flux[0].to_decimal(u.mM * u.um**2 / u.ms)), 0.0)
-
-    def test_conserve_keeps_pump_plus_pumpca_equal_total_scaled_pool(self) -> None:
-        ion = self._make_ion()
-        ion.init_state(_V([-60.0]))
-        values = ion.species_values()
-        total = ion.TotalPump * ion.parea
-        combined = ion.pump.value * ion.parea + values["pumpca"] * ion.parea
-        self.assertTrue(
-            u.math.allclose(
-                combined.to_decimal(total.unit),
-                total.to_decimal(total.unit),
-                atol=1e-12,
-            )
-        )
 
     def test_cr_slow_branch_consumes_cr_and_builds_cr_1c_0n(self) -> None:
         ion = self._make_ion()

--- a/braincell/ion/nonspecific_test.py
+++ b/braincell/ion/nonspecific_test.py
@@ -1,0 +1,109 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for the nonspecific current-owner placeholder ion."""
+
+import unittest
+
+import brainunit as u
+import jax.numpy as jnp
+
+from braincell._base_ion import Ion
+from braincell._base_neuron import HHTypedNeuron
+from braincell.ion._base import FixedIon
+from braincell.ion._testing import V, FixedIonContractTests
+from braincell.ion.nonspecific import NonSpecific, NonSpecificFixed
+from braincell.mech import get_registry
+
+
+class NonSpecificBaseTest(unittest.TestCase):
+    """The abstract placeholder family."""
+
+    def test_is_an_ion_but_declares_no_real_species(self) -> None:
+        self.assertTrue(issubclass(NonSpecific, Ion))
+        self.assertEqual(NonSpecific.ion_symbol, "no")
+
+    def test_root_type_is_inherited_from_ion(self) -> None:
+        self.assertIs(NonSpecific.root_type, HHTypedNeuron)
+        self.assertIs(NonSpecific.root_type, Ion.root_type)
+        self.assertNotIn("root_type", NonSpecific.__dict__)
+
+    def test_placeholder_defaults_are_the_documented_ones(self) -> None:
+        # The docstring is explicit that these are arbitrary values chosen
+        # so the ordinary Ion interfaces resolve, not physiological data.
+        # Pinning them keeps that claim and the code in step.
+        self.assertTrue(u.math.allclose(NonSpecific.default_Ci, 1.0 * u.mM, atol=1e-12 * u.mM))
+        self.assertTrue(u.math.allclose(NonSpecific.default_Co, 1.0 * u.mM, atol=1e-12 * u.mM))
+        self.assertEqual(NonSpecific.default_valence, 1)
+
+
+class NonSpecificFixedContractTest(FixedIonContractTests, unittest.TestCase):
+    """The shared ``FixedIon`` contract, for the nonspecific placeholder."""
+
+    ION_CLASS = NonSpecificFixed
+    FAMILY_CLASS = NonSpecific
+    DEFAULT_E = 0.0 * u.mV
+    DEFAULT_CI = 1.0 * u.mM
+    DEFAULT_CO = 1.0 * u.mM
+    DEFAULT_VALENCE = 1
+
+
+class NonSpecificFixedTest(unittest.TestCase):
+    """Behaviour specific to :class:`NonSpecificFixed`."""
+
+    def test_is_registered_under_its_own_name(self) -> None:
+        self.assertIs(get_registry().get("ion", "NonSpecificFixed"), NonSpecificFixed)
+
+    def test_builds_on_the_fixed_ion_template(self) -> None:
+        self.assertTrue(issubclass(NonSpecificFixed, FixedIon))
+
+    def test_reversal_potential_defaults_to_zero_not_to_a_family_default(self) -> None:
+        # Unlike the real species, a nonspecific owner has no Nernst
+        # potential to fall back on, so its constructor supplies 0 mV
+        # rather than leaving E unset.
+        self.assertTrue(u.math.allclose(NonSpecificFixed(size=1).E, 0.0 * u.mV, atol=1e-12 * u.mV))
+
+    def test_explicit_reversal_potential_is_honoured(self) -> None:
+        no = NonSpecificFixed(size=2, E=-40.0 * u.mV)
+        self.assertTrue(u.math.allclose(no.E, -40.0 * u.mV, atol=1e-12 * u.mV))
+
+    def test_placeholder_concentrations_can_be_overridden(self) -> None:
+        no = NonSpecificFixed(size=1, Ci=0.3 * u.mM, Co=4.0 * u.mM, valence=2)
+        self.assertTrue(u.math.allclose(no.Ci, 0.3 * u.mM, atol=1e-12 * u.mM))
+        self.assertTrue(u.math.allclose(no.Co, 4.0 * u.mM, atol=1e-12 * u.mM))
+        self.assertTrue(u.math.allclose(no.valence, jnp.full((1,), 2), atol=1e-12))
+
+    def test_carries_a_channel_and_reports_its_current(self) -> None:
+        from braincell.channel.potassium_sodium import Kv1p5_MA2020_GrC
+
+        # Kv1p5 is the shipped channel that declares a nonspecific current
+        # owner, so it is the one that exercises this container for real.
+        no = NonSpecificFixed(size=1, Ikv=Kv1p5_MA2020_GrC(size=1))
+        self.assertIn("Ikv", no.channels)
+
+    def test_external_current_is_added_to_the_total(self) -> None:
+        no = NonSpecificFixed(size=1)
+        delta = jnp.array([2.5]) * u.uA / u.cm**2
+
+        def external(V_local, info):
+            return delta
+
+        no.register_external_current("ext", external)
+        total = no.current(V([-60.0]), include_external=True)
+        self.assertTrue(u.math.allclose(total.to_decimal(u.uA / u.cm**2), jnp.array([2.5]), atol=1e-9))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/braincell/ion/potassium_test.py
+++ b/braincell/ion/potassium_test.py
@@ -20,16 +20,12 @@ import unittest
 import brainunit as u
 import jax.numpy as jnp
 
-from braincell._base_channel import IonInfo
 from braincell._base_ion import Ion
 from braincell._base_neuron import HHTypedNeuron
 from braincell.channel.potassium import K_TM1991
 from braincell.ion._base import InitNernstIon
+from braincell.ion._testing import V as _V, FixedIonContractTests
 from braincell.ion.potassium import Potassium, PotassiumFixed, PotassiumInitNernst
-
-
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
 
 
 class PotassiumBaseTest(unittest.TestCase):
@@ -41,27 +37,9 @@ class PotassiumBaseTest(unittest.TestCase):
     def test_root_type_is_hh_typed_neuron(self) -> None:
         self.assertIs(Potassium.root_type, HHTypedNeuron)
 
-    def test_module_attribute_is_public_namespace(self) -> None:
-        self.assertEqual(Potassium.__module__, "braincell.ion")
-
 
 class PotassiumFixedDefaultsTest(unittest.TestCase):
     """Defaults and parameter storage for :class:`PotassiumFixed`."""
-
-    def test_default_reversal_potential_is_minus_95_mV(self) -> None:
-        k = PotassiumFixed(size=1)
-        self.assertTrue(u.math.allclose(k.E, -95.0 * u.mV, atol=1e-9 * u.mV))
-
-    def test_default_intracellular_and_extracellular_concentrations(self) -> None:
-        k = PotassiumFixed(size=1)
-        self.assertTrue(u.math.allclose(k.Ci, 54.4 * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(k.Co, 2.5 * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(k.valence, jnp.ones((1,)), atol=1e-9))
-
-    def test_varshape_matches_size(self) -> None:
-        self.assertEqual(PotassiumFixed(size=1).varshape, (1,))
-        self.assertEqual(PotassiumFixed(size=5).varshape, (5,))
-        self.assertEqual(PotassiumFixed(size=(2, 3)).varshape, (2, 3))
 
     def test_custom_scalar_parameters_are_honoured(self) -> None:
         k = PotassiumFixed(size=2, E=-80.0 * u.mV, Ci=0.1 * u.mM, Co=3.0 * u.mM, valence=1)
@@ -69,63 +47,14 @@ class PotassiumFixedDefaultsTest(unittest.TestCase):
         self.assertTrue(u.math.allclose(k.Ci, 0.1 * u.mM, atol=1e-9 * u.mM))
         self.assertTrue(u.math.allclose(k.Co, 3.0 * u.mM, atol=1e-9 * u.mM))
 
-    def test_callable_parameters_broadcast_across_size(self) -> None:
-        k = PotassiumFixed(
-            size=3,
-            E=lambda shape: jnp.array([-90.0, -95.0, -100.0]) * u.mV,
-            Ci=lambda shape: jnp.array([0.04, 0.05, 0.06]) * u.mM,
-            Co=lambda shape: jnp.array([2.5, 2.6, 2.7]) * u.mM,
-        )
-        self.assertEqual(k.E.shape, (3,))
-        self.assertEqual(k.Ci.shape, (3,))
-        self.assertEqual(k.Co.shape, (3,))
-        self.assertTrue(
-            u.math.allclose(
-                k.E,
-                jnp.array([-90.0, -95.0, -100.0]) * u.mV,
-                atol=1e-9 * u.mV,
-            )
-        )
-        self.assertTrue(
-            u.math.allclose(
-                k.Ci,
-                jnp.array([0.04, 0.05, 0.06]) * u.mM,
-                atol=1e-9 * u.mM,
-            )
-        )
-
-
-class PotassiumFixedPackInfoTest(unittest.TestCase):
-    def test_pack_info_returns_ion_info(self) -> None:
-        k = PotassiumFixed(size=1)
-        info = k.pack_info()
-        self.assertIsInstance(info, IonInfo)
-
-    def test_pack_info_fields_match_stored_values(self) -> None:
-        k = PotassiumFixed(size=1, E=-85.0 * u.mV, Ci=0.02 * u.mM, Co=2.8 * u.mM, valence=1)
-        info = k.pack_info()
-        self.assertTrue(u.math.allclose(info.Ci, 0.02 * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(info.Co, 2.8 * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(info.E, -85.0 * u.mV, atol=1e-9 * u.mV))
-        self.assertTrue(u.math.allclose(info.valence, jnp.ones((1,)), atol=1e-9))
-
 
 class PotassiumFixedContainerTest(unittest.TestCase):
     """Ion-as-container behaviour."""
-
-    def test_no_channels_by_default(self) -> None:
-        k = PotassiumFixed(size=1)
-        self.assertEqual(k.channels, {})
-        self.assertEqual(k.external_currents, {})
 
     def test_channels_kwarg_is_attached(self) -> None:
         k = PotassiumFixed(size=1, IK=K_TM1991(size=1))
         self.assertIn("IK", k.channels)
         self.assertIsInstance(k.channels["IK"], K_TM1991)
-
-    def test_current_without_channels_returns_none(self) -> None:
-        k = PotassiumFixed(size=1)
-        self.assertIsNone(k.current(_V([-60.0])))
 
     def test_current_with_channel_delegates_to_channel(self) -> None:
         k = PotassiumFixed(size=1, IK=K_TM1991(size=1))
@@ -134,17 +63,6 @@ class PotassiumFixedContainerTest(unittest.TestCase):
         k.reset_state(V)
         i = k.current(V)
         self.assertEqual(i.shape, (1,))
-
-    def test_register_external_current_rejects_duplicate_keys(self) -> None:
-        k = PotassiumFixed(size=1)
-
-        def fake(V, info):
-            return jnp.array([1.0]) * u.uA / u.cm**2
-
-        k.register_external_current("ext", fake)
-        self.assertIn("ext", k.external_currents)
-        with self.assertRaises(ValueError):
-            k.register_external_current("ext", fake)
 
     def test_current_with_include_external_adds_registered_fn(self) -> None:
         k = PotassiumFixed(size=1, IK=K_TM1991(size=1))
@@ -235,6 +153,17 @@ class PotassiumInitNernstTest(unittest.TestCase):
         k = PotassiumInitNernst(size=1, Ci=60.0 * u.mM, Co=3.0 * u.mM)
         self.assertTrue(u.math.allclose(k.Ci, 60.0 * u.mM, atol=1e-9 * u.mM))
         self.assertTrue(u.math.allclose(k.Co, 3.0 * u.mM, atol=1e-9 * u.mM))
+
+
+class PotassiumFixedContractTest(FixedIonContractTests, unittest.TestCase):
+    """The shared ``FixedIon`` contract, for potassium."""
+
+    ION_CLASS = PotassiumFixed
+    FAMILY_CLASS = Potassium
+    DEFAULT_E = -95.0 * u.mV
+    DEFAULT_CI = 54.4 * u.mM
+    DEFAULT_CO = 2.5 * u.mM
+    DEFAULT_VALENCE = 1
 
 
 if __name__ == "__main__":

--- a/braincell/ion/sodium_test.py
+++ b/braincell/ion/sodium_test.py
@@ -20,16 +20,12 @@ import unittest
 import brainunit as u
 import jax.numpy as jnp
 
-from braincell._base_channel import IonInfo
 from braincell._base_ion import Ion
 from braincell._base_neuron import HHTypedNeuron
 from braincell.channel.sodium import Na_TM1991
 from braincell.ion._base import InitNernstIon
+from braincell.ion._testing import V as _V, FixedIonContractTests
 from braincell.ion.sodium import Sodium, SodiumFixed, SodiumInitNernst
-
-
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
 
 
 class SodiumBaseTest(unittest.TestCase):
@@ -41,29 +37,9 @@ class SodiumBaseTest(unittest.TestCase):
     def test_root_type_is_hh_typed_neuron(self) -> None:
         self.assertIs(Sodium.root_type, HHTypedNeuron)
 
-    def test_module_attribute_is_public_namespace(self) -> None:
-        # Sodium should be exposed under ``braincell.ion`` in the public
-        # namespace even though the class lives in ``braincell.ion.sodium``.
-        self.assertEqual(Sodium.__module__, "braincell.ion")
-
 
 class SodiumFixedDefaultsTest(unittest.TestCase):
     """Defaults and parameter storage for :class:`SodiumFixed`."""
-
-    def test_default_reversal_potential_is_50_mV(self) -> None:
-        na = SodiumFixed(size=1)
-        self.assertTrue(u.math.allclose(na.E, 50.0 * u.mV, atol=1e-9 * u.mV))
-
-    def test_default_intracellular_concentration_is_10_mM(self) -> None:
-        na = SodiumFixed(size=1)
-        self.assertTrue(u.math.allclose(na.Ci, 10.0 * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(na.Co, 140.0 * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(na.valence, jnp.ones((1,)), atol=1e-9))
-
-    def test_varshape_matches_size(self) -> None:
-        self.assertEqual(SodiumFixed(size=1).varshape, (1,))
-        self.assertEqual(SodiumFixed(size=4).varshape, (4,))
-        self.assertEqual(SodiumFixed(size=(2, 3)).varshape, (2, 3))
 
     def test_custom_scalar_parameters_are_honoured(self) -> None:
         na = SodiumFixed(size=3, E=40.0 * u.mV, Ci=0.5 * u.mM, Co=100.0 * u.mM, valence=1)
@@ -71,54 +47,14 @@ class SodiumFixedDefaultsTest(unittest.TestCase):
         self.assertTrue(u.math.allclose(na.Ci, 0.5 * u.mM, atol=1e-9 * u.mM))
         self.assertTrue(u.math.allclose(na.Co, 100.0 * u.mM, atol=1e-9 * u.mM))
 
-    def test_callable_parameters_broadcast_across_size(self) -> None:
-        na = SodiumFixed(
-            size=2,
-            E=lambda shape: jnp.array([50.0, 40.0]) * u.mV,
-            Ci=lambda shape: jnp.array([0.1, 0.2]) * u.mM,
-            Co=lambda shape: jnp.array([140.0, 141.0]) * u.mM,
-        )
-        self.assertEqual(na.E.shape, (2,))
-        self.assertEqual(na.Ci.shape, (2,))
-        self.assertEqual(na.Co.shape, (2,))
-        self.assertTrue(u.math.allclose(na.E, jnp.array([50.0, 40.0]) * u.mV, atol=1e-9 * u.mV))
-        self.assertTrue(u.math.allclose(na.Ci, jnp.array([0.1, 0.2]) * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(na.Co, jnp.array([140.0, 141.0]) * u.mM, atol=1e-9 * u.mM))
-
-
-class SodiumFixedPackInfoTest(unittest.TestCase):
-    """``pack_info`` returns a well-formed :class:`IonInfo`."""
-
-    def test_pack_info_returns_named_tuple(self) -> None:
-        na = SodiumFixed(size=1)
-        info = na.pack_info()
-        self.assertIsInstance(info, IonInfo)
-
-    def test_pack_info_fields_match_stored_values(self) -> None:
-        na = SodiumFixed(size=1, E=30.0 * u.mV, Ci=0.2 * u.mM, Co=120.0 * u.mM, valence=1)
-        info = na.pack_info()
-        self.assertTrue(u.math.allclose(info.Ci, 0.2 * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(info.Co, 120.0 * u.mM, atol=1e-9 * u.mM))
-        self.assertTrue(u.math.allclose(info.E, 30.0 * u.mV, atol=1e-9 * u.mV))
-        self.assertTrue(u.math.allclose(info.valence, jnp.ones((1,)), atol=1e-9))
-
 
 class SodiumFixedContainerTest(unittest.TestCase):
     """Ion-as-container behaviour: child channels are managed correctly."""
-
-    def test_no_channels_by_default(self) -> None:
-        na = SodiumFixed(size=1)
-        self.assertEqual(na.channels, {})
-        self.assertEqual(na.external_currents, {})
 
     def test_channels_kwarg_is_attached(self) -> None:
         na = SodiumFixed(size=1, INa=Na_TM1991(size=1))
         self.assertIn("INa", na.channels)
         self.assertIsInstance(na.channels["INa"], Na_TM1991)
-
-    def test_current_without_channels_returns_none(self) -> None:
-        na = SodiumFixed(size=1)
-        self.assertIsNone(na.current(_V([-60.0])))
 
     def test_current_with_channel_delegates_to_channel(self) -> None:
         na = SodiumFixed(size=1, INa=Na_TM1991(size=1))
@@ -129,17 +65,6 @@ class SodiumFixedContainerTest(unittest.TestCase):
         # Channel.current returns g_max * m^3 * h * (E - V). We just require
         # the call to succeed and return a quantity of the expected shape.
         self.assertEqual(i.shape, (1,))
-
-    def test_register_external_current_rejects_duplicate_keys(self) -> None:
-        na = SodiumFixed(size=1)
-
-        def fake(V, info):
-            return jnp.array([1.0]) * u.uA / u.cm**2
-
-        na.register_external_current("ext", fake)
-        self.assertIn("ext", na.external_currents)
-        with self.assertRaises(ValueError):
-            na.register_external_current("ext", fake)
 
     def test_current_with_include_external_adds_registered_fn(self) -> None:
         na = SodiumFixed(size=1, INa=Na_TM1991(size=1))
@@ -231,6 +156,17 @@ class SodiumInitNernstTest(unittest.TestCase):
         na = SodiumInitNernst(size=1, Ci=15.0 * u.mM, Co=130.0 * u.mM)
         self.assertTrue(u.math.allclose(na.Ci, 15.0 * u.mM, atol=1e-9 * u.mM))
         self.assertTrue(u.math.allclose(na.Co, 130.0 * u.mM, atol=1e-9 * u.mM))
+
+
+class SodiumFixedContractTest(FixedIonContractTests, unittest.TestCase):
+    """The shared ``FixedIon`` contract, for sodium."""
+
+    ION_CLASS = SodiumFixed
+    FAMILY_CLASS = Sodium
+    DEFAULT_E = 50.0 * u.mV
+    DEFAULT_CI = 10.0 * u.mM
+    DEFAULT_CO = 140.0 * u.mM
+    DEFAULT_VALENCE = 1
 
 
 if __name__ == "__main__":

--- a/docs/apis/braincell.ion.rst
+++ b/docs/apis/braincell.ion.rst
@@ -59,6 +59,18 @@ Sodium Ions
    SodiumInitNernst
 
 
+Non-Specific Ions
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+   NonSpecific
+   NonSpecificFixed
+
+
 Helpers
 -------
 

--- a/docs/specs/2026-09-02-ion-simplification.md
+++ b/docs/specs/2026-09-02-ion-simplification.md
@@ -1,0 +1,485 @@
+# `braincell/ion` simplification
+
+Iteration 5 of the module-by-module simplification sweep. Target:
+`braincell/ion` (9,490 lines across 11 files, of which `calcium.py` is
+4,453 and `_base.py` is 1,183).
+
+Breaking changes are allowed. Every in-repo caller is updated in the same
+PR. No deprecation shims, no back-compat aliases, no `warnings.warn`
+bridges — the old spelling is deleted outright.
+
+## Scope and method
+
+Four parallel review passes (reuse, simplification, efficiency, altitude)
+over the package, then independent re-verification of every claim I acted
+on. Re-verification mattered: one high-value reuse claim — that the five
+`Cdp*` **species** tables compose the way their **reaction** tables do —
+is false, and acting on it unchecked would have silently changed
+`CdpCAM_MA2024_PC`'s calmodulin scaling. See "What the reviews got wrong".
+
+Unlike `braincell/mech` (iteration 4), `braincell/ion` is **not** a leaf
+package: `calcium.py` already imports `braincell._base_ion`,
+`braincell._base_neuron`, `braincell._typing`, and `braincell.mech`, and
+`_base.py` imports `braincell.quad.protocol`. The `_typing.py` aliases and
+the rest of the shared infrastructure are therefore available here, and
+`braincell/ion/_base.py` is the natural home for shared ion-side logic.
+
+## Bugs fixed
+
+### `_Flux.compute` swallowed genuine `TypeError`s from source callbacks
+
+`_base.py:1155-1165` called each `Source.flux` with a `total_current=`
+keyword and, on `TypeError`, retried without it:
+
+```python
+try:
+    contrib = source.flux(self.owner, V, species_values, total_current=total_current)
+except TypeError:
+    contrib = source.flux(self.owner, V, species_values)
+```
+
+The probe exists for exactly one declaration. There are five `Source(...)`
+constructions in the repository (`calcium.py:863, 999, 1194, 2073, 2773`);
+four already accept `total_current=None`, and only `calcium.py:865`
+(`flux=lambda self, V, x: self.ci_source`) does not.
+
+The cost is not the wasted call. A real `TypeError` raised *inside* any
+flux body — a unit mismatch, a bad index, a `None` where an array was
+expected — is indistinguishable from a signature mismatch, so it is
+swallowed, the callback is re-invoked with a different signature, and the
+user sees a confusing second failure from a different line. This runs on
+the per-step derivative path.
+
+Fixed by giving `calcium.py:865` the four-argument signature every other
+source already has and deleting the `try`/`except` entirely, leaving one
+unconditional call.
+
+### `CdpCAM_MA2024_PC` docstring claimed six helpers were delegated that are simply inherited
+
+`calcium.py:3161-3164` stated that `vrat`, `parea`, `dsq`, `dsqvol`,
+`_require_diam_arc_mean`, `_ci_source_flux`, and `_as_initializer`
+"explicitly delegate to `CdpStC_MA2020_GoC` rather than redefining the
+same logic". Six of the seven are inherited from `_RadialShellGeometry`
+and involve no delegation at all; only `_ci_source_flux` was a genuine
+cross-class call, and this change removes that too. Docstring corrected.
+
+### 19 corrupted parameter descriptions in `calcium.py`
+
+A mechanical replacement of the `Initializer` type alias with its
+expansion hit prose as well as annotations, leaving 19 NumPy-doc
+descriptions that read:
+
+```
+Ci_initializer : array-like or callable, optional
+    Union[brainstate.typing.ArrayLike, Callable] for the ``Ci`` species.
+```
+
+The sentence should begin `Initializer for the ...`. `calcium.py` is the
+only package module affected. These render as gibberish in Sphinx.
+
+### `# -*- coding: utf-8 -*-` below the licence header is inert
+
+`calcium.py:16` carries the PEP 263 magic comment on line 16. PEP 263
+only honours it on line 1 or 2, so the line does nothing, and AGENTS.md's
+placement rule ("only a shebang and a PEP 263 encoding line may sit above
+the header") forbids it there. Deleted. The other five files in the
+package have it correctly on line 1 and are left alone.
+
+### `build_placeholder_ions` docstring contradicted by a test
+
+`ion/__init__.py:60-69` claims the function is "used by test doubles and
+by `HHTypedNeuron` construction". No test calls it, and
+`braincell/_multi_compartment/cell_test.py:1053` is named
+`test_build_placeholder_ions_not_called_in_init` and patches it with
+`side_effect=AssertionError(...)` — asserting the opposite. The docstring
+also says "Na/K/Ca" while the body returns four containers including
+`"no"`. Rewritten to name the real caller, and given the missing
+`Returns` section.
+
+## Breaking changes
+
+Each of these deletes a spelling outright. Every in-repo caller is updated
+in this PR.
+
+### `_diffeq_species` class variables are deleted
+
+The five `Cdp*` kinetic classes each declared a `_diffeq_species` tuple
+(`calcium.py:1711, 2086, 2786, 3389, 3970` — 105 lines) restating a value
+`_Specs` already derives. Verified at runtime against the worktree tree:
+
+```
+CdpStC_CAMOnly_MA2020_GoC      equal=True  n=10
+CdpStC_NoCAM_MA2020_GoC        equal=True  n=14
+CdpStC_MA2020_GoC              equal=True  n=23
+CdpCAM_MA2024_PC               equal=True  n=27
+CdpCR_MA2020_GrC               equal=True  n=21
+```
+
+Two fields that must agree, with no guard: adding a species and
+forgetting the tuple silently makes the `species_initializers` validation
+reject a legitimate override. Replaced by a derived
+`KineticIon.diffeq_species` property reading
+`_Specs.for_type(type(self)).diffeq_names`.
+
+`calcium_test.py:1289`, which asserted the two thin `CdpStC_*` subclasses
+inherit the parent's tuple, is rewritten against the property.
+
+### `_Species.algebraic_state` is deleted
+
+`_base.py:1031-1052`. Its only call site is the `else` branch of
+`_Conserve.writeback`, whose own docstring says "the allocation branch
+below is dead in normal flow", and `_base_test.py:535` asserts it is
+never reached. `writeback` collapses to the unconditional assignment.
+
+Two `_base_test.py` tests that drove the deleted branch directly
+(`test_late_allocation_still_matches_its_siblings`,
+`test_late_allocation_stays_plain_when_its_siblings_are_plain`) are
+deleted with it; the invariant they protected is now structural.
+
+### `Calcium.root_type` is deleted
+
+`calcium.py:120` restated `Ion.root_type = HHTypedNeuron`, already set for
+every ion at `_base_ion.py:706`. `Sodium`, `Potassium`, and `NonSpecific`
+correctly say nothing. Verified `Calcium.root_type is Ion.root_type` is
+`True` before the change. Removing it also removes `calcium.py`'s only
+import from the private `braincell._base_neuron`.
+
+### `_RadialShellGeometry._as_initializer` moves to `KineticIon`
+
+`_base.py:815`. It normalizes a species initializer and touches no
+geometry field; it was reachable only because the `Cdp*` classes happen to
+mix in both. Moved to `KineticIon`, where every kinetic ion can use it.
+`_base_test.py`'s `_as_initializer` tests move with it.
+
+### Five duplicated `*_initializer` attributes become views (not deletions)
+
+`calcium.py:764, 898, 1045` (`self.BC_initializer = BC_initializer`) and
+`calcium.py:1252, 1447` (`self.PumpBound_initializer = ...`) each store a
+second copy of a value that has already gone into
+`species_initializers={...}`, which is the dict `_Species._species_value`
+actually reads. The two copies do not move together: writing through
+`species_initializers` leaves the attribute stale, and vice versa. This is
+exactly the hazard `KineticIon.Ci_initializer` was introduced to fix — its
+docstring says so — and the fix was applied to `Ci` and not to its
+siblings.
+
+**These attributes are not dead, and an earlier draft of this spec was
+wrong to say so.** A text search finds only the five assignments, because
+the read is through a *computed* attribute name:
+`_compute/ions.py:310` does
+`getattr(baseline_ion, _ion_runtime_attr_name(runtime_cls, param_name))`,
+where `param_name` comes from reflecting over `cls.__init__`'s signature
+(`_supported_ion_runtime_params`, `ions.py:238`). Deleting them made
+`bindings_test.py::test_cell_schedule_applies_to_markov_channels_and_kinetic_ions`
+fail with `'ToyCaBindingKinetic_SU2015_DCN' object has no attribute
+'BC_initializer'`. Neither the reviews nor my own grep could see that
+read; the full-suite run is what caught it.
+
+There is a real cross-module contract here, now written down: **a kinetic
+ion must expose every constructor parameter as a readable attribute of
+the same name.** So the five are converted to views rather than removed.
+`_base.py` gains `species_initializer_view(name)`, a property factory over
+`species_initializers`, and `KineticIon.Ci_initializer` is re-expressed
+through it, so one mechanism now serves all six.
+
+### `_Specs.for_type` no longer coerces bare tuples
+
+`_base.py:898-918` ran five parallel
+`X if isinstance(X, Klass) else Klass(*X)` branches. Across every
+`KineticIon` subclass in the package there are 288 spec declarations and
+zero non-dataclass ones, and no subclass exists outside `braincell/ion`.
+A mis-shaped declaration now fails at the dataclass constructor with a
+named field rather than at an unpacking `TypeError`.
+
+## Altitude: logic moved to where it belongs
+
+### `_resolve_species_initializers` becomes a template method
+
+Five copies (`calcium.py:1773, 2178, 2905, 3522, 4073`) whose 12-line
+preamble and 2-line trailer are byte-identical; only the `defaults` dict
+literal varies. `KineticIon` gains the concrete method — owning the
+validation, the error message, the `.update`, and the `_as_initializer`
+map — delegating to an abstract `_default_species_initializers`. Each leaf
+keeps only its dict.
+
+### The parvalbumin equilibrium quintet gets a mixin
+
+`_kdc`, `_kdm`, `_ss_pv_free`, `_ss_pv_ca`, `_ss_pv_mg` are byte-identical
+across `CdpStC_NoCAM_MA2020_GoC`, `CdpStC_MA2020_GoC`, and
+`CdpCAM_MA2024_PC` (verified by source comparison). Hoisted to a
+`_ParvalbuminEquilibrium` mixin in `calcium.py` — not into `_base.py`,
+because a competitive Ca/Mg buffer is calcium chemistry, not shell
+geometry.
+
+`_ss_pv_free`/`_ss_pv_ca`/`_ss_pv_mg` each recomputed `_kdc()` and
+`_kdm()`; the mixin computes them once and shares them. This is
+setup-path work (once per ion construction), so it is a readability fix,
+not a measurable speedup — see "Efficiency".
+
+### `_ci_source_flux` moves to `_RadialShellGeometry`
+
+Two verbatim copies (`calcium.py:2230, 2966`) plus two classes reaching
+across the class graph for an implementation they do not inherit:
+
+```python
+calcium.py:3614:  return CdpStC_MA2020_GoC._ci_source_flux(self, total_current)
+calcium.py:4112:  return CdpStC_MA2020_GoC._ci_source_flux(self, total_current)
+```
+
+`CdpCAM_MA2024_PC` and `CdpCR_MA2020_GrC` are not subclasses of
+`CdpStC_MA2020_GoC`; editing that sibling silently changed two other
+models. The body uses only `self.dsqvol` and `self._require_diam_arc_mean()`,
+both already members of `_RadialShellGeometry`. All four classes mix that
+in, so both copies and both cross-class stubs disappear.
+
+### The Nernst read block is written once
+
+`_base.py:388-395`, `:509-517`, `:713-721` were three verbatim copies of
+`_nernst(Ci=_unwrap(self.Ci), Co=_unwrap(self.Co), temp=_unwrap(self.temp),
+valence=_unwrap(self.valence))`. `_nernst` gains an owner-taking form so
+the four keyword arguments cannot drift out of alignment in one copy only.
+
+### `_RadialShellGeometry` hooks use `super()`
+
+`_base.py:879, 884` called `KineticIon._ion_init_state_hook(self, ...)` by
+explicit class name. `KineticIon` is the MRO successor of
+`_RadialShellGeometry` for all five users, so `super()` is equivalent and
+drops the hard-coded coupling.
+
+## Shared declaration tables
+
+The five `Cdp*` reaction tables total 508 lines. Runtime-verified
+composition (structural comparison of `lhs`/`rhs` and the source text of
+every `forward`/`backward` lambda, not textual diffing):
+
+```
+stc == nocam + camonly  : True   (20 == 8 + 12)
+cdpcam[-12:] == camonly : True
+first 6 shared across nocam/stc/cdpcam/cdpcr : True
+```
+
+The species tables share four blocks, verified the same way:
+
+```
+buffer head (10: Ci, mg, Buff1, Buff1_ca, Buff2, Buff2_ca,
+             BTC, BTC_ca, DMNPE, DMNPE_ca)  shared by nocam/stc/cdpcam/cdpcr : True
+PV triple   (PV, PV_ca, PV_mg)              shared by nocam/stc/cdpcam       : True
+pump pair   (pump, pumpca)                  shared by all four               : True
+CAM block   (9)  stc[13:22] == camonly[1:]                                   : True
+```
+
+Hoisted to module-level constants in `calcium.py` and composed, using the
+idiom the file already uses at `calcium.py:860-861` and `:3386-3387`.
+
+## What the reviews got wrong
+
+Two claims did not survive re-verification, and are **not** acted on:
+
+1. **"The species tables compose like the reactions do."** They do not.
+   `stc == nocam + camonly[1:]` is `False`, and
+   `cdpcam[-9:] == camonly[1:]` is `False`. `CdpCAM_MA2024_PC`'s
+   calmodulin species carry `factor="cyto"` where
+   `CdpStC_CAMOnly_MA2020_GoC`'s carry `factor="cam_unit"`. The names and
+   initializers match; the factor does not. The CAM block is therefore
+   shared through a `_cam_species(factor)` helper, not a shared constant.
+   Blind composition here would have silently rescaled a published model.
+
+2. **"`CdpLVA_SU2015_DCN` is a rename-only clone of `CdpHVA_SU2015_DCN`,
+   collapse it."** Correct as an observation, wrong as a prescription:
+   `kCal`/`tauCal`/`caliBase` are the NMODL `RANGE` names the port exists
+   to preserve, and `examples/convert_mod` validates against them. Left
+   alone. A second reviewer independently reached the same conclusion.
+
+## Efficiency
+
+The kinetic-ion runtime re-derives run-constant geometry 39-97 times per
+`compute_derivative` call. Measured evaluation counts for one call:
+
+| class | `dsqvol` | `dsq` | `vrat` | `parea` |
+|---|---|---|---|---|
+| `CdpCAM_MA2024_PC` | 97 | 97 | 97 | 8 |
+| `CdpStC_MA2020_GoC` | 81 | 81 | 81 | 8 |
+| `CdpCR_MA2020_GrC` | 75 | 75 | 75 | 8 |
+| `CdpStC_CAMOnly_MA2020_GoC` | 44 | 44 | 44 | 0 |
+| `CdpStC_NoCAM_MA2020_GoC` | 39 | 39 | 39 | 8 |
+
+Three changes address it:
+
+- `_RadialShellGeometry` computes `vrat`/`dsq`/`dsqvol`/`parea` once in
+  its lifecycle hooks and the properties become cache readers. Safe
+  because `diam_arc_mean` is written exactly once per ion, by
+  `_compute/bridge.py:302`, before `init_state`, and both hooks reseed.
+- `_Species` memoizes `factor_value` per name. A `_Species` never
+  outlives one derivative evaluation, and `Factor`'s own docstring
+  already declares the factor "constant during one integration step".
+- `Factor("cam_unit", ...)` built a full `dsqvol` (8 array ops) and threw
+  the value away, keeping only `ones_like`'s shape. Replaced with a
+  scalar `1.0 * u.um**2`, which broadcasts identically.
+
+**This is a tracing win, not a simulation-speed win, and is reported as
+such.** XLA already common-subexpression-eliminates and fuses the
+duplicates away, so the compiled program does the same work either way.
+
+Emitted jaxpr equations for one `compute_derivative`:
+
+| model | before | after | |
+|---|---:|---:|---|
+| `CdpCAM_MA2024_PC` | 699 | 497 | −28.9% |
+| `CdpStC_MA2020_GoC` | 605 | 417 | −31.1% |
+| `CdpCR_MA2020_GrC` | 550 | 392 | −28.7% |
+| `CdpStC_CAMOnly_MA2020_GoC` | 340 | 234 | −31.2% |
+| `CdpStC_NoCAM_MA2020_GoC` / `_MA2025_BC` / `_RI2021_SC` | 278 | 192 | −30.9% |
+| `ToyDiamFactorKinetic_SU2015_DCN` | 39 | 34 | −12.8% |
+
+Python tracing time for that same call, `size=512`, median of 5:
+
+| model | before | after | |
+|---|---:|---:|---|
+| `CdpCAM_MA2024_PC` | 64.6 ms | 46.3 ms | −28% |
+| `CdpStC_MA2020_GoC` | 61.2 ms | 40.4 ms | −34% |
+| `CdpCR_MA2020_GrC` | 48.8 ms | 36.7 ms | −25% |
+| `CdpStC_CAMOnly_MA2020_GoC` | 32.7 ms | 22.6 ms | −31% |
+| `CdpStC_NoCAM_MA2020_GoC` | 27.1 ms | 18.2 ms | −33% |
+
+Two things measured and found **unchanged**, reported because they are
+what a reader would assume improved:
+
+- **First `jit` call (trace + XLA compile)**: 814→879, 713→722, 579→566,
+  374→353, 358→348 ms. Compilation dominates and does not shrink; the
+  differences are within run-to-run variance in both directions.
+- **Steady-state step time**: unchanged. Three alternating before/after
+  rounds, `size=512`, median of 40 steps each — `CdpCAM_MA2024_PC`
+  1.779/1.943/1.889 before vs 1.780/1.799/1.820 after;
+  `CdpStC_CAMOnly_MA2020_GoC` 0.737/0.730/0.733 vs 0.752/0.735/0.773 ms.
+  The spread within each arm is larger than the gap between them.
+
+### Numerical effect
+
+Every model's `compute_derivative` output, resolved species map, geometry
+factors, and `E` are **bit-identical** before and after, across all 12
+kinetic and 4 dynamic calcium models.
+
+The one difference is after a full `backward_euler` step: 35 of the
+species values differ, by at most `3.47e-07` relative — 2.9 float32 ULP.
+This is floating-point reassociation, expected when common
+subexpressions are hoisted, and it enters through the Newton solve rather
+than through the model equations, whose outputs are unchanged.
+
+## Tests
+
+- **New `braincell/ion/_testing.py`** — the sanctioned private-helper
+  location. Holds:
+  - `V()`, an identical 2-line helper copied into `calcium_test.py:57`,
+    `potassium_test.py:31`, and `sodium_test.py:31`;
+  - `make_shell_ion(cls, **kwargs)`, replacing six near-identical
+    `_make_ion` copies at `calcium_test.py:854, 1042, 1110, 1268, 1339,
+    1507`, each standing in for the compartment layer that writes
+    `diam_arc_mean`/`diam_mid`;
+  - `KineticPumpContractTests`, for the two whole test methods that were
+    byte-identical across four test classes (`calcium_test.py:927-951`,
+    `1180-1204`, `1411-1435`, `1586-1610`);
+  - `FixedIonContractTests`, a nine-test suite parameterized by
+    `(ION_CLASS, FAMILY_CLASS, DEFAULT_E, DEFAULT_CI, DEFAULT_CO,
+    DEFAULT_VALENCE)`, replacing the near-duplicate defaults / varshape /
+    callable-broadcast / `pack_info` / container suites in
+    `potassium_test.py` and `sodium_test.py`.
+
+  A contract mixin is the point here: a new ion species now inherits the
+  shared suite by declaring six attributes, rather than by copying
+  methods that then drift. `NonSpecificFixed` picks up nine tests it
+  never had this way, and the mixin is what surfaced that
+  `NonSpecificFixed(size=1, E=None)` raising `ValueError` was untested for
+  every species except through hand-written copies.
+- **New `braincell/ion/nonspecific_test.py`** — AGENTS.md rule 10
+  violation: `nonspecific.py` has no sibling test file. Its only current
+  coverage is a docstring-conformance sweep in `__init___test.py` and two
+  *channel* tests that touch the type object. `NonSpecificFixed.__init__`
+  — including the `ValueError` its own `Raises` section documents — has no
+  direct test anywhere.
+
+## Docs
+
+`docs/apis/braincell.ion.rst` documents every calcium, potassium, and
+sodium class but omits `NonSpecific` and `NonSpecificFixed`, both of which
+are in `braincell.ion.__all__`. A "Non-Specific Ions" section is added.
+
+## Deliberately not changed
+
+Recorded rather than done, with the reason:
+
+1. **`_cached_total_current` is an ad-hoc `setattr`/`hasattr`/`delattr`
+   protocol** spanning `_multi_compartment/cell.py:3150-3169`,
+   `ion/_base.py:541-549`, and `ion/_base.py:765-771` (the last two an
+   identical 8-line block). The fix — `uses_total_current` plus
+   `cache_total_current`/`clear_total_current_cache`/`resolve_total_current`
+   on `Ion` — lands in `braincell/_base_ion.py` and
+   `braincell/_multi_compartment/`, which are iterations 13 and 11.
+2. **Two duplicate four-way `issubclass` species chains**
+   (`_compute/ions.py:214-223`, `_compute/bindings.py:983-994`) while the
+   class attribute encoding exactly that fact — `ion_symbol`, declared on
+   all four family bases — is read nowhere. `ion_symbol.lower()` yields
+   the exact keys both functions return. Deferred to iteration 8
+   (`_compute`) rather than reaching into that package now; `ion_symbol`
+   is kept precisely so iteration 8 can make it load-bearing.
+3. **`_runtime_ion_family`, `_ion_runtime_attr_name`, the hardcoded
+   `excluded = {"solver", "substeps", "species_initializers"}`, the
+   `cainull` fallback in a generic module, and the
+   `hasattr(ion, "_update_reversal")` probe** — all in
+   `_compute/ions.py`. Same reason: iteration 8.
+4. **`KineticIon._step_solver` detects `excluded_paths` support by
+   string-matching a `TypeError` message** (`_base.py:733-738`). The real
+   fix declares the capability on the integrator protocol in
+   `braincell/quad/protocol.py`; cross-package, iteration 14.
+5. **A shared `_CdpBufferedShellIon` base for the four big kinetic
+   classes**, collapsing their 23-parameter constructors and the 169
+   `self.X = braintools.init.param(X, self.varshape, allow_none=False)`
+   lines in this file. Real, and larger than everything above combined —
+   but it changes five published models' MRO at once. The declaration
+   tables are shared in this PR; the constructor is a separate change
+   that deserves its own before/after numerical comparison.
+6. **Hoisting the four identical `*Fixed` constructors and the three
+   byte-identical `*InitNernst` constructors.** `Ion.__init__` precedes
+   both mixins in the MRO (`PotassiumFixed -> Potassium -> Ion -> ... ->
+   FixedIon`), so a bare hoist is shadowed and the bases must be
+   reordered — and `_compute/ions.py:239` introspects `cls.__init__` for
+   runtime parameters. The per-leaf signatures also carry the numpydoc
+   `Parameters` blocks. A real trade, not a free win.
+7. **`build_placeholder_ions` builds a `NonSpecificFixed` that its only
+   consumer discards** (`_compute/ions.py:107` iterates `("na","k","ca")`).
+   Changing the returned dict is a public-API break whose payoff is one
+   avoided construction, and the real fix is in the consumer. Docstring
+   corrected here; behaviour left alone.
+8. **`_unwrap` has three more copies outside this package**
+   (`_base_ion.py:443-451`, `_multi_compartment/probes.py:314,325`). A
+   shared `unwrap_state` in `_misc.py` is a cross-package change:
+   iteration 14.
+
+## Verification
+
+```
+before:  pytest braincell/ion -q -> 232 passed, 1 warning, 7 subtests passed in 57.20s
+after:   pytest braincell/ion -q -> 248 passed, 1 warning, 8 subtests passed in 61.36s
+before:  pytest braincell/     -q -> 2724 passed, 15 skipped
+after:   pytest braincell/     -q -> 2740 passed, 15 skipped, 402 subtests passed in 216.39s
+pre-commit run --files <11 changed files> -> all hooks Passed
+```
+
+The `+16` in `braincell/ion` reconciles exactly:
+
+| change | delta |
+|---|---:|
+| `_base_test.py`: two late-allocation tests deleted, one precondition test added | −1 |
+| `potassium_test.py`: 8 tests + a 2-test class replaced by the 9-test contract mixin | −1 |
+| `sodium_test.py`: same | −1 |
+| `calcium_test.py`: 8 duplicated pump tests removed, 8 inherited from the mixin | 0 |
+| `nonspecific_test.py`: new file | +19 |
+| **total** | **+16** |
+
+The full-suite `+16` is the same 16 — no test outside `braincell/ion`
+changed count.
+
+Beyond the suite, this change edits five published model declarations, so
+it is also checked numerically: a fingerprint harness records every
+kinetic and dynamic calcium model's resolved species map, geometry
+factors, `E`, per-species derivatives, and post-step state, and compares
+the two trees. Results in "Numerical effect" above.


### PR DESCRIPTION
Iteration 5 of the module-by-module simplification sweep. Spec:
`docs/specs/2026-09-02-ion-simplification.md`.

Production modules net **−357 lines** (`+571 / −928`); tests net +50 while
gaining 16 tests and losing all the copy-paste.

## Bugs fixed

- **`_Flux.compute` swallowed genuine `TypeError`s from source callbacks.**
  It probed each `Source.flux` signature with `try/except TypeError` and
  retried without the `total_current` keyword. The probe existed for exactly
  one three-argument lambda (`calcium.py:865`) out of five `Source`
  declarations — but any `TypeError` raised *inside* a flux body was
  indistinguishable from a signature mismatch, so it was swallowed and the
  callback re-invoked, surfacing as a confusing second failure from a
  different line. On the per-step derivative path. Widened the one lambda,
  deleted the `except`.
- **19 corrupted parameter descriptions in `calcium.py`** reading
  `Union[brainstate.typing.ArrayLike, Callable] for the ...` — an alias
  expansion that landed in the prose as well as the annotation. Gibberish in
  Sphinx.
- **`CdpCAM_MA2024_PC` and `CdpCR_MA2020_GrC` docstrings** claimed seven
  helpers "explicitly delegate to `CdpStC_MA2020_GoC`"; six are plain
  inheritance from `_RadialShellGeometry`, and this PR removes the seventh.
- **`build_placeholder_ions`** claimed it is used by `HHTypedNeuron`
  construction; `cell_test.py:1053` is named
  `test_build_placeholder_ions_not_called_in_init` and asserts the opposite.
- **An inert `# -*- coding: utf-8 -*-`** at `calcium.py:16`, below the licence
  header, where PEP 263 does not honour it and AGENTS.md forbids it.

## Breaking changes

- **`_diffeq_species` class variables deleted** (5 copies, 105 lines).
  `_Specs` already derives the value; verified equal for all five classes.
  Replaced by a derived `KineticIon.diffeq_species` property. Two fields that
  had to agree with no guard — adding a species and forgetting the tuple
  silently made `species_initializers` reject a legitimate override.
- **`_Species.algebraic_state` deleted**, along with `_Conserve.writeback`'s
  allocation branch. The branch's own docstring called it dead and a test
  asserted it was never reached.
- **`Calcium.root_type` deleted** — it restated `Ion.root_type`, which
  `Sodium`/`Potassium`/`NonSpecific` correctly leave alone. Removes
  `calcium.py`'s only import from the private `braincell._base_neuron`.
- **`_RadialShellGeometry._as_initializer` moved to `KineticIon`** — it
  normalizes a species initializer and touches no geometry field.
- **`_Specs.for_type` no longer coerces bare tuples.** 288 spec declarations
  across the package, none a bare tuple; no `KineticIon` subclass exists
  outside `braincell/ion`.

## Shared declarations

The five `Cdp*` mechanisms are different reaction networks over one
substrate. Every composition was verified against the *parsed* declarations
(stoichiometry plus the source text of each lambda), not by textual diffing:

```
stc.reactions == nocam.reactions + camonly.reactions : True   (20 == 8 + 12)
cdpcam.reactions[-12:] == camonly.reactions          : True
buffer head (6 reactions) shared by all four          : True
buffer/PV/pump species blocks shared as declared      : True
```

`_resolve_species_initializers` became a template method on `KineticIon` over
an abstract `_default_species_initializers` (five copies of a 14-line
preamble). The parvalbumin equilibrium quintet became a `_ParvalbuminEquilibrium`
mixin. `_ci_source_flux` moved to `_RadialShellGeometry`, deleting two
verbatim copies **and two cross-class unbound calls** — `CdpCAM_MA2024_PC` and
`CdpCR_MA2020_GrC` are not subclasses of `CdpStC_MA2020_GoC`, so editing that
sibling silently changed two other models.

### One review claim rejected

A reviewer reported that the species tables compose like the reactions do.
They do not: `CdpCAM_MA2024_PC`'s calmodulin species carry `factor="cyto"`
where `CdpStC_CAMOnly_MA2020_GoC`'s carry `factor="cam_unit"`. Names and
initializers match; the factor does not. Blind composition would have
silently rescaled a published model. The CAM block is shared through a
`_cam_species(factor)` helper instead.

## Efficiency — a tracing win, not a simulation-speed win

The kinetic runtime re-derived run-constant geometry 39–97 times per
`compute_derivative`. `_RadialShellGeometry` now caches its diameter-derived
factors (keyed on the diameter, so a rebind reseeds) and `_Species` memoizes
`factor_value`.

| model | jaxpr eqns | | trace time | |
|---|---:|---|---:|---|
| `CdpCAM_MA2024_PC` | 699 → 497 | −28.9% | 64.6 → 46.3 ms | −28% |
| `CdpStC_MA2020_GoC` | 605 → 417 | −31.1% | 61.2 → 40.4 ms | −34% |
| `CdpCR_MA2020_GrC` | 550 → 392 | −28.7% | 48.8 → 36.7 ms | −25% |
| `CdpStC_CAMOnly_MA2020_GoC` | 340 → 234 | −31.2% | 32.7 → 22.6 ms | −31% |
| `CdpStC_NoCAM_MA2020_GoC` | 278 → 192 | −30.9% | 27.1 → 18.2 ms | −33% |

**Steady-state step time is unchanged** — XLA already CSEs and fuses the
duplicates away. Three alternating before/after rounds, `size=512`, median of
40 steps: `CdpCAM_MA2024_PC` 1.779/1.943/1.889 before vs 1.780/1.799/1.820
after. The spread within each arm exceeds the gap between them. First-`jit`
time is likewise unchanged; XLA compilation dominates and does not shrink.

### Numerical effect

Derivatives, resolved species, geometry factors and `E` are **bit-identical**
across all 12 kinetic and 4 dynamic calcium models. The only difference is
after a full `backward_euler` step: 35 species values differ by at most
`3.47e-07` relative — 2.9 float32 ULP — from floating-point reassociation
entering through the Newton solve, not through the model equations.

## Correction to an earlier conclusion

An earlier pass concluded that five `<species>_initializer` attributes were
write-only and deleted them. **They are not dead.** `_compute/ions.py:310`
reads them through a *computed* name —
`getattr(baseline_ion, _ion_runtime_attr_name(runtime_cls, param_name))`,
where `param_name` comes from reflecting over `cls.__init__` — which no text
search can see. The full-suite run caught it
(`test_cell_schedule_applies_to_markov_channels_and_kinetic_ions`).

The real contract, now written down: **a kinetic ion must expose every
constructor parameter as a readable attribute of the same name.** The five
are converted to views over `species_initializers` via a new shared
`species_initializer_view` property factory, which also now backs
`KineticIon.Ci_initializer`. One source of truth, contract intact.

## Tests

New `braincell/ion/_testing.py` (`V`, `make_shell_ion`,
`FixedIonContractTests`, `KineticPumpContractTests`) and new
`braincell/ion/nonspecific_test.py` — `nonspecific.py` had no sibling test
file (AGENTS.md rule 10) and `NonSpecificFixed.__init__` had no direct test
anywhere. `NonSpecific`/`NonSpecificFixed` also added to
`docs/apis/braincell.ion.rst`, which omitted them despite both being in
`__all__`.

## Verification

```
before:  pytest braincell/ion -q -> 232 passed, 1 warning, 7 subtests passed in 57.20s
after:   pytest braincell/ion -q -> 248 passed, 1 warning, 8 subtests passed in 61.36s

before:  pytest braincell/ -q -> 2724 passed, 15 skipped
after:   pytest braincell/ -q -> 2740 passed, 15 skipped, 411 warnings, 402 subtests passed in 216.39s

pre-commit run --files <11 changed files>
  check python ast ... Passed | ruff (legacy alias) ... Passed
  ruff format ... Passed      | all other hooks Passed
```

The `+16` reconciles exactly: `_base_test` −1 (two late-allocation tests
deleted, one precondition test added), `potassium_test` −1 and `sodium_test`
−1 (8 tests + a 2-test class each, replaced by the 9-test contract mixin),
`calcium_test` 0 (8 duplicated pump tests removed, 8 inherited), and
`nonspecific_test` +19.

## Deferred, with reasons (recorded in the spec)

`_cached_total_current`'s ad-hoc `setattr`/`hasattr`/`delattr` protocol
(iterations 11/13); two duplicate four-way `issubclass` species chains in
`_compute` while the `ion_symbol` attribute that encodes exactly that fact is
read nowhere — kept deliberately so iteration 8 can make it load-bearing;
`_step_solver`'s `excluded_paths` detection by `TypeError` string-matching
(needs a `braincell/quad` protocol change); a shared `_CdpBufferedShellIon`
base collapsing the 23-parameter constructors (changes five published models'
MRO at once — deserves its own PR); and `CdpLVA`/`CdpHVA` unification, which
two reviewers split on and I left alone because `kCal`/`tauCal`/`caliBase`
are the NMODL `RANGE` names the port exists to preserve.
