### PR TITLE
refactor(channel): add GhkHH/OhmicMarkov templates, collapse copy-pasted channels, share test fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ cell.paint(AllRegion(), mech.CableProperty(
 
 # Paint ion channels onto specific regions
 cell.paint(AllRegion(), mech.Channel("IL", g_max=0.0003 * u.S / u.cm**2, E=-70 * u.mV))
-cell.paint(branch_in("type", "soma"), mech.Channel("INa_Ba2002", g_max=0.12 * u.S / u.cm**2))
+cell.paint(branch_in("type", "soma"), mech.Channel("Na_Ba2002", g_max=0.12 * u.S / u.cm**2))
 cell.paint(
     branch_in("type", ("dendrite", "basal_dendrite", "apical_dendrite")),
-    mech.Channel("ICaL_IS2008", g_max=0.002 * u.S / u.cm**2),
+    mech.Channel("CaL_IS2008", g_max=0.002 * u.S / u.cm**2),
 )
 
 # Inject current at the soma

--- a/braincell/channel/__init__.py
+++ b/braincell/channel/__init__.py
@@ -15,15 +15,17 @@
 # ==============================================================================
 
 
-import warnings
-
 from ._base import (
     Gate,
     Transition,
     HH,
     OhmicHH,
+    GhkHH,
     Markov,
+    OhmicMarkov,
+    freeze_gradient,
     ghk_flux,
+    q10_factor,
 )
 from ._base import __all__ as _base_all
 from .calcium import (
@@ -171,43 +173,3 @@ __all__ = (
     + _potassium_sodium_all
     + _sodium_all
 )
-
-
-# Backward-compatibility aliases for channel classes renamed in the
-# v0.x normalization (PRs #80/#93). Only the unambiguous 1:1 renames
-# (old name == new name with the leading ``I`` dropped) are aliased.
-# Ambiguous renames (one old name now split into region variants) and
-# removed classes are intentionally absent and raise ``AttributeError``.
-_DEPRECATED_ALIASES = {
-    "INa_HH1952": "Na_HH1952",
-    "INa_Ba2002": "Na_Ba2002",
-    "INa_TM1991": "Na_TM1991",
-    "IK_HH1952": "K_HH1952",
-    "IK_TM1991": "K_TM1991",
-    "IK_Leak": "K_Leak",
-    "IKDR_Ba2002": "KDR_Ba2002",
-    "IKNI_Ya1989": "KNI_Ya1989",
-    "IKA1_HM1992": "KA1_HM1992",
-    "IKA2_HM1992": "KA2_HM1992",
-    "IKK2A_HM1992": "KK2A_HM1992",
-    "IKK2B_HM1992": "KK2B_HM1992",
-    "ICaN_IS2008": "CaN_IS2008",
-    "ICaL_IS2008": "CaL_IS2008",
-    "ICaT_HM1992": "CaT_HM1992",
-    "ICaT_HP1992": "CaT_HP1992",
-    "ICaHT_HM1992": "CaHT_HM1992",
-    "ICaHT_Re1993": "CaHT_Re1993",
-    "IAHP_De1994": "AHP_De1994",
-}
-
-
-def __getattr__(name):
-    if name in _DEPRECATED_ALIASES:
-        new_name = _DEPRECATED_ALIASES[name]
-        warnings.warn(
-            f"braincell.channel.{name} is deprecated and will be removed; use braincell.channel.{new_name} instead.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return globals()[new_name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/braincell/channel/__init___test.py
+++ b/braincell/channel/__init___test.py
@@ -18,8 +18,8 @@
 Three concerns live here because all are properties of the package as a whole
 rather than of any single module: the docstring conformance sweep over every
 covered module, the re-export completeness of the explicit import block, and
-the ``__getattr__`` deprecation shim declared in
-``braincell/channel/__init__.py``.
+the agreement between each channel's class name and the key it is registered
+under.
 """
 
 import unittest
@@ -27,9 +27,9 @@ import unittest
 import pytest
 
 import braincell.channel as channel
+from braincell._base_channel import Channel
 from braincell._testing import DocstringConformanceTests
 from braincell.channel import (
-    _DEPRECATED_ALIASES,
     _base,
     calcium,
     hyperpolarization_activated,
@@ -39,6 +39,7 @@ from braincell.channel import (
     potassium_sodium,
     sodium,
 )
+from braincell.mech import get_registry
 
 # Extended by one module per docstring task. A module is listed only once
 # every one of its public symbols satisfies the shared assertions.
@@ -64,7 +65,11 @@ _NO_PRIMARY_SOURCE = frozenset(
         "Transition",
         "HH",
         "OhmicHH",
+        "GhkHH",
         "Markov",
+        "OhmicMarkov",
+        "freeze_gradient",
+        "q10_factor",
         "CaN_IS2008",
         "CaL_IS2008",
         "K_Leak",
@@ -82,7 +87,8 @@ class ChannelReExportTest(unittest.TestCase):
     """Guard the explicit re-export block against drift.
 
     ``braincell/channel/__init__.py`` builds ``__all__`` by concatenating
-    the submodules' own ``__all__`` but imports the names one by one.
+    the submodules' own ``__all__`` but imports the names one by one. The
+    two lists are the reason this guard exists.
     Adding a channel to a submodule's ``__all__`` without adding it to the
     matching import block would leave ``braincell.channel.__all__`` naming
     an attribute the package does not have -- which only fails at
@@ -104,21 +110,17 @@ class ChannelReExportTest(unittest.TestCase):
         self.assertEqual(sorted(expected - set(channel.__all__)), [])
 
 
-@pytest.mark.parametrize("old_name, new_name", sorted(_DEPRECATED_ALIASES.items()))
-def test_deprecated_alias_resolves_with_warning(old_name, new_name):
-    with pytest.warns(DeprecationWarning, match=new_name):
-        resolved = getattr(channel, old_name)
-    assert resolved is getattr(channel, new_name)
-
-
-def test_deprecated_names_absent_from_all():
-    for old_name in _DEPRECATED_ALIASES:
-        assert old_name not in channel.__all__
+def _registered_channel_classes():
+    """Return every channel class this package contributes to the registry."""
+    return [(name, cls) for name, cls in get_registry().items("channel") if getattr(channel, cls.__name__, None) is cls]
 
 
 @pytest.mark.parametrize(
     "name",
     [
+        "INa_HH1952",  # renamed: the leading ``I`` was dropped
+        "IKDR_Ba2002",
+        "ICaN_IS2008",
         "ICav12_Ma2020",  # ambiguous: split into region variants
         "Ih_HM1992",  # ambiguous: renamed to HCN_HM1992 family
         "INa_Rsg",  # removed, no successor
@@ -127,9 +129,45 @@ def test_deprecated_names_absent_from_all():
         "DoesNotExist",
     ],
 )
-def test_non_aliased_names_raise_attribute_error(name):
+def test_pre_normalization_names_raise_attribute_error(name):
+    """The old ``I``-prefixed spellings resolve to nothing.
+
+    They were carried by a ``__getattr__`` shim until this package's
+    simplification pass; the shim covered module attribute access only and
+    never the mechanism registry, which is the path the documented
+    ``mech.Channel("...")`` API uses.
+    """
     with pytest.raises(AttributeError):
         getattr(channel, name)
+
+
+class ChannelRegistryKeyTest(unittest.TestCase):
+    """Guard the ``@register_channel("Name")`` argument against drift.
+
+    Every channel in the catalogue is registered under its own class name, so
+    the string is pure duplication -- and a rename that updates the class but
+    not the decorator would leave ``mech.Channel("...")`` resolving to the
+    wrong mechanism, or to nothing, with no other signal.
+    """
+
+    def test_every_registry_key_matches_its_class_name(self):
+        mismatched = [(key, cls.__name__) for key, cls in _registered_channel_classes() if key != cls.__name__]
+        self.assertEqual(mismatched, [], f"registry keys that do not match their class: {mismatched}")
+
+    def test_every_public_channel_class_is_registered(self):
+        registered = {cls for _, cls in _registered_channel_classes()}
+        # The templates in ``_base`` and the abstract leak base are extension
+        # points, not mechanisms, so they are deliberately unregistered.
+        templates = set(_base.__all__) | {"LeakageChannel"}
+        missing = sorted(
+            name
+            for name in channel.__all__
+            if name not in templates
+            and isinstance(getattr(channel, name), type)
+            and issubclass(getattr(channel, name), Channel)
+            and getattr(channel, name) not in registered
+        )
+        self.assertEqual(missing, [], f"unregistered public channels: {missing}")
 
 
 if __name__ == "__main__":

--- a/braincell/channel/_base.py
+++ b/braincell/channel/_base.py
@@ -16,7 +16,6 @@
 
 from dataclasses import dataclass
 import inspect
-import warnings
 import numpy as np
 from typing import Any, Optional
 from typing import ClassVar
@@ -39,9 +38,18 @@ __all__ = [
     "Transition",
     "HH",
     "OhmicHH",
+    "GhkHH",
     "Markov",
+    "OhmicMarkov",
+    "freeze_gradient",
     "ghk_flux",
+    "q10_factor",
 ]
+
+#: ``u.get_dim(1 / u.ms)``, hoisted out of the per-evaluation validators.
+#: Rebuilding it costs ~15 us per call and it is consulted once per gate and
+#: once per Markov state on every trace.
+_INVERSE_TIME_DIM = u.get_dim(1 / u.ms)
 
 
 def ghk_flux(V, ci, co, z, temp):
@@ -173,6 +181,212 @@ def q10_factor(q10, temp, temp_ref):
     return q10 ** (((temp - temp_ref) / u.kelvin) / 10.0)
 
 
+def cached_q10_factor(owner, slot: str, q10, temp, temp_ref):
+    """Return :func:`q10_factor`, memoised on ``owner`` under ``slot``.
+
+    ``q10_factor`` runs eagerly on concrete parameters and produces a
+    constant, but it is called once per gate per trace on the HH side and
+    once per *rate method* on the Markov side -- 26 times per
+    ``compute_derivative`` for ``Kca1p1_MA2020_GoC``. At ~0.3 ms a call that
+    dominates the trace time of the affected channels.
+
+    The memo is keyed on the *identity* of the three inputs rather than on
+    their values. ``braincell._compute.bindings`` writes runtime parameters by
+    rebinding the attribute (``setattr``) before calling
+    ``_on_param_updated``, so a runtime temperature change replaces
+    ``owner.temp`` with a new object and invalidates the memo automatically.
+
+    Parameters
+    ----------
+    owner : object
+        Instance the memo is stored on.
+    slot : str
+        Attribute name to store the memo under. Must not collide with a
+        parameter or state name.
+    q10, temp, temp_ref : ArrayLike
+        Passed straight through to :func:`q10_factor`.
+
+    Returns
+    -------
+    ArrayLike
+        The dimensionless Q10 factor.
+    """
+    key = (q10, temp, temp_ref)
+    cached = getattr(owner, slot, None)
+    if cached is not None and all(a is b for a, b in zip(cached[0], key)):
+        return cached[1]
+    value = q10_factor(q10, temp, temp_ref)
+    setattr(owner, slot, (key, value))
+    return value
+
+
+def freeze_gradient(value):
+    """Return ``value`` with gradients through it stopped, keeping its unit.
+
+    ``jax.lax.stop_gradient`` operates on arrays, so a
+    :class:`brainunit.Quantity` has to be taken apart and put back together
+    around it. Channels whose published variant freezes the driving force use
+    this; see :attr:`GhkHH.freeze_drive_gradient`.
+
+    Parameters
+    ----------
+    value : ArrayLike
+        A quantity or bare array.
+
+    Returns
+    -------
+    ArrayLike
+        The same value, with the backward pass cut.
+    """
+    return u.Quantity(jax.lax.stop_gradient(u.get_mantissa(value)), u.get_unit(value))
+
+
+def is_disabled(flag) -> bool:
+    """Return True when ``flag`` is concrete and uniformly zero.
+
+    Several imported NMODL mechanisms carry an on/off switch as a *parameter*
+    rather than as a class-level flag, so that it can vary per compartment and
+    stay traceable. The usual encoding is
+    ``value - u.math.where(flag != 0, extra, 0.0 * extra)``, which traces the
+    whole ``extra`` expression even when the switch is off everywhere -- 20 of
+    the 25 equations in ``Kv1p1_MA2025_BC.current``.
+
+    This predicate lets a caller take a Python-level fast path in the common
+    case without giving up either behaviour: it answers ``False`` for a traced
+    flag and for any concrete flag with a non-zero entry, so the array-valued
+    and traced cases still go through ``u.math.where``.
+
+    Parameters
+    ----------
+    flag : ArrayLike
+        The switch parameter.
+
+    Returns
+    -------
+    bool
+        True only if the switch is off everywhere and known at trace time.
+
+    Notes
+    -----
+    The test runs in **numpy**, not ``u.math``/``jnp``. A concrete flag is
+    still inspected from inside an open trace -- ``current`` is called under
+    ``jit``/``for_loop``, which is this package's mandated execution model --
+    and under an open trace every jax operation returns a tracer even when its
+    inputs are concrete, so ``bool()`` on the result would raise
+    ``TracerBoolConversionError``. numpy stages nothing.
+    """
+    if is_traced_value(flag):
+        return False
+    return not bool(np.any(np.asarray(jax.device_get(u.get_mantissa(flag))) != 0))
+
+
+def _steady_state_inputs(owner, V, ions, xp, asarray, template_shape, flat_size):
+    """Flatten ``conserve`` and every transition rate to ``(flat_size,)``.
+
+    The backend-independent half of the steady-state solve. Both
+    :meth:`Markov._solve_steady_state_jax` and
+    :meth:`Markov._solve_steady_state_host` need exactly this, differing only
+    in which array namespace they build it with.
+
+    Parameters
+    ----------
+    owner : Markov
+        The channel whose rates are being resolved.
+    V : ArrayLike
+        Membrane potential the rates are evaluated at.
+    ions : tuple
+        Ion states forwarded to each rate method.
+    xp : module
+        ``numpy`` or ``jax.numpy``; used for ``full`` and ``broadcast_to``.
+    asarray : callable
+        Converts one value to an ``xp`` array. The host backend pulls the
+        value off the device here, which is also what makes it raise on a
+        tracer -- see :meth:`Markov._solve_steady_state`.
+    template_shape : tuple of int
+        Shape every flattened value must broadcast to.
+    flat_size : int
+        ``prod(template_shape)``.
+
+    Returns
+    -------
+    tuple
+        ``(conserve, pair_rates, rates)``, where ``pair_rates`` pairs each
+        :class:`Transition` with its resolved ``(forward, backward)`` arrays
+        and ``rates`` is the flat list used for dtype promotion.
+    """
+
+    def flatten(value, label: str):
+        array = asarray(u.get_magnitude(value))
+        if array.shape != template_shape:
+            if array.size == 1:
+                array = xp.full(template_shape, array.reshape(()), dtype=array.dtype)
+            else:
+                try:
+                    array = xp.broadcast_to(array, template_shape)
+                except ValueError as err:
+                    raise ValueError(
+                        f"{type(owner).__name__}.{label} could not be broadcast to steady-state shape {template_shape}."
+                    ) from err
+        return array.reshape(flat_size)
+
+    conserve = flatten(owner._conserve_value(), "conserve")
+    pair_rates = []
+    rates = []
+    # Resolve each rate once; steady-state assembly reuses the arrays below.
+    for pair in owner._iter_pairs():
+        forward = flatten(owner._transition_rate(pair.forward, V, *ions), pair.forward)
+        backward = None
+        if pair.backward is not None:
+            backward = flatten(owner._transition_rate(pair.backward, V, *ions), pair.backward)
+        pair_rates.append((pair, forward, backward))
+        rates.append(forward)
+        if backward is not None:
+            rates.append(backward)
+    return conserve, pair_rates, rates
+
+
+def _finish_steady_state(owner, xp, solution, conserve, state_names, template_shape, *, check: bool):
+    """Validate, renormalise and unpack a solved steady-state distribution.
+
+    Parameters
+    ----------
+    owner : Markov
+        The channel, named in every error message.
+    xp : module
+        ``numpy`` or ``jax.numpy``.
+    solution : array
+        ``(flat_size, n_states)`` raw solve output.
+    conserve : array
+        ``(flat_size,)`` total probability mass each column must sum to.
+    state_names : tuple of str
+        Column order of ``solution``.
+    template_shape : tuple of int
+        Shape each returned state is reshaped back to.
+    check : bool
+        Run the finiteness / range / non-degeneracy guards. Skipped when the
+        solution is a tracer, where the required Python ``bool`` is unavailable.
+
+    Returns
+    -------
+    dict
+        One entry per state name.
+    """
+    if check:
+        if not bool(xp.all(xp.isfinite(solution))):
+            raise ValueError(f"{type(owner).__name__} steady-state solve returned non-finite values.")
+        tol = 1e-7
+        if bool(xp.any(solution < -tol)) or bool(xp.any(solution > conserve[:, None] + tol)):
+            raise ValueError(f"{type(owner).__name__} steady-state solve returned out-of-range probabilities.")
+
+    solution = xp.clip(solution, 0.0, None)
+    totals = solution.sum(axis=1, keepdims=True)
+    if check and not bool(xp.all(totals > 0.0)):
+        raise ValueError(f"{type(owner).__name__} steady-state solve collapsed to zero probability mass.")
+    solution = solution * (conserve[:, None] / totals)
+
+    return {name: jnp.asarray(solution[:, index].reshape(template_shape)) for index, name in enumerate(state_names)}
+
+
 def _resolve_value(owner, value):
     """Resolve a piece of gate metadata against the owning channel instance.
 
@@ -261,6 +475,22 @@ def _check_identifier(cls: type, name: str, kind: str) -> None:
     """
     if not name.isidentifier():
         raise ValueError(f"{cls.__name__}: {kind} name {name!r} is not a valid Python identifier.")
+
+
+def _check_no_class_attribute(cls: type, name: str, kind: str) -> None:
+    """Reject a declared name that already means something on the class.
+
+    :func:`_bind_state` catches the same collision, but only once
+    ``init_state`` runs on an instance -- and only for attributes the
+    constructor set. A gate called ``current``, ``size`` or ``gates`` shadows a
+    method or a class attribute instead, which ``_bind_state`` cannot see and
+    which produces a failure far from its cause. This runs at class creation.
+    """
+    if hasattr(cls, name):
+        raise ValueError(
+            f"{cls.__name__}: {kind} name {name!r} collides with an existing class attribute "
+            f"of type {type(getattr(cls, name)).__name__}. Rename the {kind}."
+        )
 
 
 def _bind_state(owner, name: str, value, kind: str) -> None:
@@ -353,9 +583,11 @@ def _as_gate_quantity(value, gate: Gate, label: str, *, inverse: bool):
     ``value / time_unit``. A value that already carries a unit is checked
     against the expected dimension and passed through untouched.
     """
-    expected = 1 / gate.time_unit if inverse else gate.time_unit
     if u.get_dim(value) == u.DIMENSIONLESS:
         return value / gate.time_unit if inverse else value * gate.time_unit
+    # Built only on the rare united-value path: constructing ``1 / u.ms`` costs
+    # more than the whole dimensionless branch it used to precede.
+    expected = 1 / gate.time_unit if inverse else gate.time_unit
     if u.get_dim(value) != u.get_dim(expected):
         raise ValueError(
             f"Gate {gate.name!r}: {label} must be dimensionless (read as "
@@ -390,7 +622,7 @@ def _as_markov_rate(value, owner_type: type, rate_name: str):
     dim = u.get_dim(value)
     if dim == u.DIMENSIONLESS:
         return value
-    if dim != u.get_dim(1 / u.ms):
+    if dim != _INVERSE_TIME_DIM:
         raise ValueError(
             f"{owner_type.__name__}.{rate_name} must be dimensionless (read as 1/ms) or carry "
             f"an inverse-time dimension, got dimension {dim}. Check that phi/q10 are dimensionless."
@@ -411,7 +643,7 @@ def _check_derivative(value, label: str):
     Catch it here, where the gate or state is still known, rather than letting
     it surface as a bare unit mismatch far downstream.
     """
-    if u.get_dim(value) != u.get_dim(1 / u.ms):
+    if u.get_dim(value) != _INVERSE_TIME_DIM:
         raise ValueError(
             f"{label}: derivative must have an inverse-time dimension, got "
             f"dimension {u.get_dim(value)}. Check that phi/q10 are dimensionless."
@@ -534,6 +766,7 @@ class HH(Channel):
             if gate.name in seen:
                 raise ValueError(f"{cls.__name__}: gate {gate.name!r} is declared more than once.")
             seen.add(gate.name)
+            _check_no_class_attribute(cls, gate.name, "gate")
 
             has_inf_tau = hasattr(cls, f"f_{gate.name}_inf") and hasattr(cls, f"f_{gate.name}_tau")
             has_alpha_beta = hasattr(cls, f"f_{gate.name}_alpha") and hasattr(cls, f"f_{gate.name}_beta")
@@ -569,14 +802,44 @@ class HH(Channel):
         1. explicit ``phi``
         2. ``q10`` + ``temp_ref`` using ``self.temp``
         3. default ``1.0``
+
+        The ``q10`` branch is memoised per gate through
+        :func:`cached_q10_factor`; 99 of the catalogue's 148 gates take it, and
+        recomputing it once per gate per trace costs ~0.3 ms each.
         """
         if gate.phi is not None:
             return _resolve_value(self, gate.phi)
         if gate.q10 is not None:
-            q10 = _resolve_value(self, gate.q10)
-            temp_ref = _resolve_value(self, gate.temp_ref)
-            return q10_factor(q10, self.temp, temp_ref)
+            return cached_q10_factor(
+                self,
+                f"_gate_phi_memo_{gate.name}",
+                _resolve_value(self, gate.q10),
+                self.temp,
+                _resolve_value(self, gate.temp_ref),
+            )
         return 1.0
+
+    def _shifted_voltage(self, V):
+        """Return the voltage a subclass's rate functions should be read at.
+
+        Defaults to ``V`` unchanged. Mechanisms transcribed from a ``.mod``
+        file that declares a ``vshift``-style offset override this with
+        ``return V - self.V_sh`` (or, where the source's sign convention
+        demands it, ``V + self.V_sh``). Declaring it here gives
+        :class:`GhkHH` one place to apply the shift and gives the four
+        existing overrides a documented contract to override.
+
+        Parameters
+        ----------
+        V : ArrayLike
+            Membrane potential.
+
+        Returns
+        -------
+        ArrayLike
+            The shifted potential, as a voltage.
+        """
+        return V
 
     def _gate_form(self, gate: Gate) -> str:
         return type(self)._gate_forms[gate.name]
@@ -596,12 +859,15 @@ class HH(Channel):
 
     def conductance_factor(self, V, *ions):
         _ = (V, ions)
+        # Seeded from the first gate rather than from a literal ``1.0``: the
+        # leading multiply is exact but still one traced equation per channel.
         product = 1.0
-        for gate in self._iter_gates():
+        for index, gate in enumerate(self._iter_gates()):
             value = self._gate_value(gate)
             if gate.clip:
                 value = u.math.clip(value, 0.0, 1.0)
-            product = product * (value if gate.power == 1 else value**gate.power)
+            factor = value if gate.power == 1 else value**gate.power
+            product = factor if index == 0 else product * factor
         return product
 
     def reset_state(self, V, *ions, batch_size: int = None):
@@ -635,14 +901,68 @@ class HH(Channel):
             self._gate_state(gate).derivative = _check_derivative(derivative, f"Gate {gate.name!r}")
 
 
-class OhmicHH(HH):
+class _OhmicCurrent:
+    r"""Mixin supplying :math:`g \cdot \text{conductance factor} \cdot (E - V)`.
+
+    Kept separate from :class:`OhmicHH` so that :class:`OhmicMarkov` can reach
+    the identical current expression: the two differ only in what
+    ``conductance_factor`` means (a product of gates versus a sum of open
+    probability states), which is the gating template's business rather than
+    the driving force's.
+    """
+
+    def reversal_potential(self, V, *ions):
+        """Return the reversal potential driving the current.
+
+        Parameters
+        ----------
+        V : ArrayLike
+            Membrane potential. Unused by the default implementation; present
+            so overrides can depend on it.
+        *ions : IonInfo
+            Ion states, in the declaration order of ``root_type``.
+
+        Returns
+        -------
+        ArrayLike
+            Reversal potential, as a voltage. Defaults to that of the first
+            ion, which for a joint root type is the first entry of
+            ``root_type.__args__``. A channel whose ``root_type`` is
+            :class:`~braincell.HHTypedNeuron` is called with no ions at all,
+            and falls back to a fixed ``self.E`` set by the constructor.
+            Override to read a non-leading ion, or to ignore an ion that *is*
+            passed.
+        """
+        _ = V
+        return ions[0].E if ions else self.E
+
+    def current(self, V, *ions):
+        """Return the ohmic current through the channel.
+
+        Parameters
+        ----------
+        V : ArrayLike
+            Membrane potential.
+        *ions : IonInfo
+            Ion states, in the declaration order of ``root_type``.
+
+        Returns
+        -------
+        ArrayLike
+            ``g_max * conductance_factor(V, *ions) * (E - V)``, where ``E``
+            comes from :meth:`reversal_potential`.
+        """
+        return self.g_max * self.conductance_factor(V, *ions) * (self.reversal_potential(V, *ions) - V)
+
+
+class OhmicHH(_OhmicCurrent, HH):
     r"""HH gating driven by an ohmic current, :math:`g \cdot \prod g_i^{p_i} \cdot (E - V)`.
 
     Most voltage-gated channels in the catalogue share exactly this current
     expression, so :class:`HH` covers only the gating and this subclass adds
-    the driving force. Channels whose current is not ohmic -- GHK flux and
-    permeability-scaled calcium channels -- inherit :class:`HH` directly and
-    implement :meth:`current` themselves.
+    the driving force. Channels whose current is a constant-field flux use
+    :class:`GhkHH` instead; anything else inherits :class:`HH` directly and
+    implements :meth:`current` itself.
 
     The maximal conductance is read from ``self.g_max``. A channel that names
     it differently, or that scales the driving force some other way, overrides
@@ -651,6 +971,8 @@ class OhmicHH(HH):
     See Also
     --------
     HH : Gating-only template, for channels with a non-ohmic current.
+    GhkHH : Sibling template for constant-field (GHK) calcium currents.
+    OhmicMarkov : The same driving force over Markov probability states.
 
     Examples
     --------
@@ -680,45 +1002,110 @@ class OhmicHH(HH):
 
     __module__ = "braincell.channel"
 
-    def reversal_potential(self, V, *ions):
-        """Return the reversal potential driving the current.
 
-        Parameters
-        ----------
-        V : ArrayLike
-            Membrane potential. Unused by the default implementation; present
-            so overrides can depend on it.
-        *ions : IonInfo
-            Ion states, in the declaration order of ``root_type``.
+class GhkHH(HH):
+    r"""HH gating driven by a constant-field (GHK) flux.
+
+    The catalogue's voltage-gated calcium channels do not carry an ohmic
+    driving force: their current is a permeability times the Goldman-Hodgkin-
+    Katz constant-field flux, sign-flipped into BrainCell's inward-positive
+    convention.
+
+    .. math::
+
+        I = -P \cdot \prod_i g_i^{p_i} \cdot
+            \Phi\!\left(V', [Ca]_i, [Ca]_o, z, T\right)
+
+    The twelve concrete channels that use this form vary along exactly four
+    axes, each of which is a declaration here rather than a re-written
+    :meth:`current`:
+
+    ``ghk``
+        Which flux function to call. Defaults to :func:`ghk_flux`. Mechanisms
+        transcribed from a ``.mod`` file that hardcodes its own Faraday and gas
+        constants point this at the matching helper instead; those constants
+        are load-bearing and differ from the shared ones by up to 2e-3
+        relative, so the choice must stay explicit per class.
+    ``_shifted_voltage``
+        The voltage :math:`V'` the flux is evaluated at. Inherited from
+        :class:`HH`, where it defaults to ``V``.
+    ``freeze_drive_gradient``
+        Whether to cut the backward pass through the driving force. Applied to
+        ``V`` *before* the shift: ``stop_gradient(V) - V_sh`` leaves a live
+        gradient path to ``V_sh`` that ``stop_gradient(V - V_sh)`` would kill,
+        and the published frozen variants were written the first way.
+    ``permeability``
+        The scale factor. Defaults to ``self.g_max``, which occupies the
+        permeability slot a textbook GHK equation writes as :math:`P_s`.
+
+    Note that the gating product is always evaluated at the *unfrozen*,
+    *unshifted* ``V``; only the flux term sees ``V'``.
+
+    Attributes
+    ----------
+    ghk : callable
+        Flux function, called as ``ghk(V=..., ci=..., co=..., z=..., temp=...)``.
+    freeze_drive_gradient : bool
+        Freeze the driving-force gradient. Default ``False``.
+
+    See Also
+    --------
+    OhmicHH : Sibling template for the ohmic driving force.
+    ghk_flux : The default constant-field flux.
+    freeze_gradient : The helper ``freeze_drive_gradient`` switches on.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> from braincell.channel import GhkHH
+        >>> class MyCav(GhkHH):
+        ...     ...
+        >>> class MyCavFrozen(MyCav):
+        ...     freeze_drive_gradient = True
+    """
+
+    __module__ = "braincell.channel"
+
+    ghk = staticmethod(ghk_flux)
+    freeze_drive_gradient: ClassVar[bool] = False
+
+    def permeability(self):
+        """Return the scale multiplying the constant-field flux.
 
         Returns
         -------
         ArrayLike
-            Reversal potential, as a voltage. Defaults to that of the first
-            ion, which for a joint root type is the first entry of
-            ``root_type.__args__``. Override to read a fixed ``self.E`` or a
-            non-leading ion.
+            ``self.g_max`` by default. Channels whose ``.mod`` source scales a
+            separate permeability parameter override this.
         """
-        _ = V
-        return ions[0].E
+        return self.g_max
 
     def current(self, V, *ions):
-        """Return the ohmic current through the channel.
+        """Return the constant-field current through the channel.
 
         Parameters
         ----------
         V : ArrayLike
             Membrane potential.
         *ions : IonInfo
-            Ion states, in the declaration order of ``root_type``.
+            Ion states; the flux reads the first one.
 
         Returns
         -------
         ArrayLike
-            ``g_max * conductance_factor(V, *ions) * (E - V)``, where ``E``
-            comes from :meth:`reversal_potential`.
+            ``-permeability() * conductance_factor(V, *ions) * flux``.
         """
-        return self.g_max * self.conductance_factor(V, *ions) * (self.reversal_potential(V, *ions) - V)
+        ion = ions[0]
+        drive_V = freeze_gradient(V) if type(self).freeze_drive_gradient else V
+        drive = type(self).ghk(
+            V=self._shifted_voltage(drive_V),
+            ci=ion.Ci,
+            co=ion.Co,
+            z=self.z,
+            temp=self.temp,
+        )
+        return -self.permeability() * self.conductance_factor(V, *ions) * drive
 
 
 class Markov(Channel, IndependentIntegration):
@@ -726,10 +1113,11 @@ class Markov(Channel, IndependentIntegration):
 
     ``pairs`` define one conserved probability pool. One state is eliminated
     and reconstructed algebraically from the others; ``dependent_state``
-    names it. Declaring it is required in practice -- the fallback to "the
-    last state discovered while scanning ``pairs``" is order-dependent, so
-    reordering ``pairs`` would silently eliminate a different state, and it
-    now emits a ``DeprecationWarning``.
+    names it, and declaring it is mandatory. Which state is eliminated changes
+    the conditioning of the steady-state solve, so inferring it from the
+    ordering of ``pairs`` -- as this template once did -- meant that
+    reordering an otherwise-equivalent transition table silently changed the
+    model.
 
     ``state_values()`` returns the raw stored states plus the reconstructed
     dependent state. ``compute_derivative()`` uses ``_kinetic_state_values()``,
@@ -756,12 +1144,11 @@ class Markov(Channel, IndependentIntegration):
         per instance the same way as :class:`Gate` metadata -- a ``str``
         names an instance attribute, a callable is applied to the
         instance, anything else is a literal.
-    dependent_state : str or None, default None
+    dependent_state : str
         Name of the state eliminated from the independent set and
-        reconstructed as ``conserve`` minus the others. Declaring it
-        explicitly is effectively required: the ``None`` fallback resolves
-        to "the last state discovered while scanning ``pairs``", which is
-        order-dependent, and doing so emits a ``DeprecationWarning``.
+        reconstructed as ``conserve`` minus the others. Every subclass that
+        declares ``pairs`` must declare this too; omitting it raises
+        ``ValueError`` when the subclass is created.
     default_solver : str, default "backward_euler"
         Solver name used by :class:`IndependentIntegration` when the
         constructor's ``solver`` argument is not supplied.
@@ -823,6 +1210,7 @@ class Markov(Channel, IndependentIntegration):
             for name in (pair.src, pair.dst):
                 if name not in seen:
                     _check_identifier(cls, name, "state")
+                    _check_no_class_attribute(cls, name, "Markov state")
                     names.append(name)
                     seen.add(name)
         if len(names) < 2:
@@ -830,7 +1218,13 @@ class Markov(Channel, IndependentIntegration):
         cls._resolved_state_names = tuple(names)
 
         declared = cls.dependent_state
-        if declared is not None and declared not in seen:
+        if declared is None:
+            raise ValueError(
+                f"{cls.__name__}: Markov subclasses must declare `dependent_state`, naming the state "
+                f"eliminated from the independent set. Choose one of {sorted(seen)}; the choice fixes "
+                f"the conditioning of the steady-state solve, so it cannot be inferred from `pairs`."
+            )
+        if declared not in seen:
             raise ValueError(
                 f"{cls.__name__}: dependent_state {declared!r} is not one of the declared states {sorted(seen)}."
             )
@@ -862,6 +1256,13 @@ class Markov(Channel, IndependentIntegration):
             raise ValueError("substeps must be at least 1.")
 
     def make_integration(self, *args, **kwargs):
+        # Every channel in the catalogue runs one substep, where the loop is
+        # pure overhead: it stages a length-1 scan whose stacked output is
+        # discarded. Skipping it cuts ~19% off the trace time of every Markov
+        # channel and leaves the optimized HLO otherwise unchanged.
+        if self.substeps == 1:
+            self.solver(self, *args, **kwargs)
+            return
         with brainstate.environ.context(dt=brainstate.environ.get_dt() / self.substeps):
             brainstate.transform.for_loop(
                 lambda i: self.solver(self, *args, **kwargs),
@@ -875,22 +1276,10 @@ class Markov(Channel, IndependentIntegration):
         return type(self)._resolved_state_names
 
     def _dependent_state_name(self) -> str:
-        state_names = self._state_names()
-        if len(state_names) < 2:
-            raise ValueError("Markov requires at least two states.")
         declared = type(self).dependent_state
-        if declared is not None:
-            return declared
-        warnings.warn(
-            f"{type(self).__name__} does not declare `dependent_state`, so it falls back to "
-            f"{state_names[-1]!r} -- the last state discovered while scanning `pairs`. Reordering "
-            f"`pairs` would silently eliminate a different state and change the conditioning of "
-            f"the steady-state solve. Set `dependent_state` explicitly; the implicit fallback "
-            f"will be removed.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return state_names[-1]
+        if declared is None:
+            raise ValueError(f"{type(self).__name__} does not declare `dependent_state`.")
+        return declared
 
     def _independent_state_names(self) -> tuple[str, ...]:
         dependent = self._dependent_state_name()
@@ -916,15 +1305,14 @@ class Markov(Channel, IndependentIntegration):
             total = 0.0
         return self._conserve_value() - total
 
-    def _project_independent_state(self, name: str, value):
-        _ = name
-        if not type(self).clip_states:
-            return value
-        return u.math.clip(value, 0.0, 1.0)
-
     def _kinetic_state_values(self):
         raw_states = self._independent_state_values()
-        states = {name: self._project_independent_state(name, value) for name, value in raw_states.items()}
+        if type(self).clip_states:
+            states = {name: u.math.clip(value, 0.0, 1.0) for name, value in raw_states.items()}
+        else:
+            states = dict(raw_states)
+        # Reconstructed from the *raw* sum, not the clipped one, so the pool
+        # still sums to ``conserve``.
         states[self._dependent_state_name()] = self._dependent_state_value(raw_states)
         return states
 
@@ -996,34 +1384,7 @@ class Markov(Channel, IndependentIntegration):
         template_shape = template.shape
         flat_size = int(template.size)
 
-        def _flatten_like(value, label: str):
-            array = jnp.asarray(u.get_magnitude(value))
-            if array.shape != template_shape:
-                if array.size == 1:
-                    array = jnp.full(template_shape, array.reshape(()), dtype=array.dtype)
-                else:
-                    try:
-                        array = jnp.broadcast_to(array, template_shape)
-                    except ValueError as err:
-                        raise ValueError(
-                            f"{type(self).__name__}.{label} could not be broadcast "
-                            f"to steady-state shape {template_shape}."
-                        ) from err
-            return array.reshape(flat_size)
-
-        conserve = _flatten_like(self._conserve_value(), "conserve")
-        pair_rates = []
-        rates = []
-        # Resolve each rate once; steady-state assembly reuses the arrays below.
-        for pair in self._iter_pairs():
-            forward = _flatten_like(self._transition_rate(pair.forward, V, *ions), pair.forward)
-            backward = None
-            if pair.backward is not None:
-                backward = _flatten_like(self._transition_rate(pair.backward, V, *ions), pair.backward)
-            pair_rates.append((pair, forward, backward))
-            rates.append(forward)
-            if backward is not None:
-                rates.append(backward)
+        conserve, pair_rates, rates = _steady_state_inputs(self, V, ions, jnp, jnp.asarray, template_shape, flat_size)
 
         dtype = jnp.result_type(template, conserve, *rates) if rates else jnp.result_type(template, conserve)
         conserve = conserve.astype(dtype)
@@ -1047,22 +1408,16 @@ class Markov(Channel, IndependentIntegration):
         except Exception as err:
             raise ValueError(f"{type(self).__name__} steady-state linear system could not be solved.") from err
 
-        traced = is_traced_value(solution)
-        if not traced:
-            if not bool(jnp.all(jnp.isfinite(solution))):
-                raise ValueError(f"{type(self).__name__} steady-state solve returned non-finite values.")
-
-            tol = 1e-7
-            if bool(jnp.any(solution < -tol)) or bool(jnp.any(solution > conserve[:, None] + tol)):
-                raise ValueError(f"{type(self).__name__} steady-state solve returned out-of-range probabilities.")
-
-        solution = jnp.clip(solution, 0.0, None)
-        totals = solution.sum(axis=1, keepdims=True)
-        if not traced and not bool(jnp.all(totals > 0.0)):
-            raise ValueError(f"{type(self).__name__} steady-state solve collapsed to zero probability mass.")
-        solution = solution * (conserve[:, None] / totals)
-
-        return {name: solution[:, index].reshape(template_shape) for index, name in enumerate(state_names)}
+        return _finish_steady_state(
+            self,
+            jnp,
+            solution,
+            conserve,
+            state_names,
+            template_shape,
+            # A tracer cannot answer the guards' Python ``bool``.
+            check=not is_traced_value(solution),
+        )
 
     def _solve_steady_state_host(self, V, *ions):
         """Return Markov steady-state probabilities using a host NumPy solve."""
@@ -1071,36 +1426,21 @@ class Markov(Channel, IndependentIntegration):
         template = jnp.asarray(u.get_magnitude(self._state_zero()))
         template_shape = template.shape
         flat_size = int(template.size)
+        # Pulled off the device before any rate is resolved: this is the line
+        # that raises under a tracer and sends `_solve_steady_state` to the JAX
+        # path, and it must stay ahead of `_steady_state_inputs` so that no
+        # rate method is evaluated on a doomed attempt.
         template_host = np.asarray(jax.device_get(template))
 
-        def _flatten_like(value, label: str):
-            array = np.asarray(jax.device_get(u.get_magnitude(value)))
-            if array.shape != template_shape:
-                if array.size == 1:
-                    array = np.full(template_shape, array.reshape(()), dtype=array.dtype)
-                else:
-                    try:
-                        array = np.broadcast_to(array, template_shape)
-                    except ValueError as err:
-                        raise ValueError(
-                            f"{type(self).__name__}.{label} could not be broadcast "
-                            f"to steady-state shape {template_shape}."
-                        ) from err
-            return array.reshape(flat_size)
-
-        conserve = _flatten_like(self._conserve_value(), "conserve")
-        pair_rates = []
-        rates = []
-        # Resolve each rate once; steady-state assembly reuses the arrays below.
-        for pair in self._iter_pairs():
-            forward = _flatten_like(self._transition_rate(pair.forward, V, *ions), pair.forward)
-            backward = None
-            if pair.backward is not None:
-                backward = _flatten_like(self._transition_rate(pair.backward, V, *ions), pair.backward)
-            pair_rates.append((pair, forward, backward))
-            rates.append(forward)
-            if backward is not None:
-                rates.append(backward)
+        conserve, pair_rates, rates = _steady_state_inputs(
+            self,
+            V,
+            ions,
+            np,
+            lambda value: np.asarray(jax.device_get(value)),
+            template_shape,
+            flat_size,
+        )
 
         if rates:
             dtype = np.dtype(jnp.result_type(template_host, conserve, *rates))
@@ -1129,20 +1469,7 @@ class Markov(Channel, IndependentIntegration):
         except Exception as err:
             raise ValueError(f"{type(self).__name__} steady-state linear system could not be solved.") from err
 
-        if not np.all(np.isfinite(solution)):
-            raise ValueError(f"{type(self).__name__} steady-state solve returned non-finite values.")
-
-        tol = 1e-7
-        if np.any(solution < -tol) or np.any(solution > conserve[:, None] + tol):
-            raise ValueError(f"{type(self).__name__} steady-state solve returned out-of-range probabilities.")
-
-        solution = np.clip(solution, 0.0, None)
-        totals = solution.sum(axis=1, keepdims=True)
-        if not np.all(totals > 0.0):
-            raise ValueError(f"{type(self).__name__} steady-state solve collapsed to zero probability mass.")
-        solution = solution * (conserve[:, None] / totals)
-
-        return {name: jnp.asarray(solution[:, index].reshape(template_shape)) for index, name in enumerate(state_names)}
+        return _finish_steady_state(self, np, solution, conserve, state_names, template_shape, check=True)
 
     def reset_steady_state(self, V, *ions, batch_size: int = None):
         states = self._solve_steady_state(V, *ions)
@@ -1159,21 +1486,92 @@ class Markov(Channel, IndependentIntegration):
 
     def compute_derivative(self, V, *ions):
         states = self._kinetic_state_values()
-        derivatives = {name: self._state_zero() for name in states}
+        # Only independent states are written back, so an accumulator for the
+        # dependent state would be built across every pair and then dropped --
+        # ~26 traced operations per step for a thirteen-pair scheme. Seeding
+        # with the scalar ``0.0`` rather than a zeros array is exact
+        # (``0.0 - x`` and ``zeros_like(x) - x`` agree bit for bit) and skips
+        # one eager ``zeros_like`` dispatch per state.
+        derivatives = {name: 0.0 for name in self._independent_state_names()}
 
         for pair in self._iter_pairs():
             forward = self._transition_rate(pair.forward, V, *ions)
-            derivatives[pair.src] = derivatives[pair.src] - states[pair.src] * forward
-            derivatives[pair.dst] = derivatives[pair.dst] + states[pair.src] * forward
+            flux = states[pair.src] * forward
+            if pair.src in derivatives:
+                derivatives[pair.src] = derivatives[pair.src] - flux
+            if pair.dst in derivatives:
+                derivatives[pair.dst] = derivatives[pair.dst] + flux
 
             if pair.backward is not None:
                 backward = self._transition_rate(pair.backward, V, *ions)
-                derivatives[pair.src] = derivatives[pair.src] + states[pair.dst] * backward
-                derivatives[pair.dst] = derivatives[pair.dst] - states[pair.dst] * backward
+                reverse = states[pair.dst] * backward
+                if pair.src in derivatives:
+                    derivatives[pair.src] = derivatives[pair.src] + reverse
+                if pair.dst in derivatives:
+                    derivatives[pair.dst] = derivatives[pair.dst] - reverse
 
-        for name in self._independent_state_names():
+        for name, derivative in derivatives.items():
             # The rates are normalised to bare per-ms values, so the single
             # division below is what gives the derivative its unit. `conserve`
             # still reaches the states unchecked, hence the assertion.
-            derivative = derivatives[name] / u.ms
+            derivative = derivative / u.ms
             getattr(self, name).derivative = _check_derivative(derivative, f"{type(self).__name__} state {name!r}")
+
+
+class OhmicMarkov(_OhmicCurrent, Markov):
+    r"""Markov kinetics driven by an ohmic current.
+
+    :class:`Markov` is the sibling of :class:`HH`, but only ``HH`` had a
+    driving-force subclass, so every ohmic Markov channel in the catalogue
+    wrote out ``g_max * (sum of open states) * (E - V)`` by hand and none had a
+    :meth:`~_OhmicCurrent.reversal_potential` hook.
+
+    Declaring :attr:`open_states` supplies the conductance factor and the rest
+    is inherited from the same mixin :class:`OhmicHH` uses.
+
+    Attributes
+    ----------
+    open_states : tuple of str
+        Names of the conducting states, summed left to right in the order
+        given. Every name must be one of the states declared by ``pairs``.
+
+    See Also
+    --------
+    OhmicHH : The same driving force over HH gates.
+    Markov : The gating template this builds on.
+    """
+
+    __module__ = "braincell.channel"
+
+    open_states: ClassVar[tuple[str, ...]] = ()
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        declared = cls._resolved_state_names
+        if not declared:
+            return
+        unknown = tuple(name for name in cls.open_states if name not in declared)
+        if unknown:
+            raise ValueError(
+                f"{cls.__name__}: open_states names {list(unknown)} that are not declared states {sorted(declared)}."
+            )
+
+    def conductance_factor(self, V, *ions):
+        """Return the summed occupancy of the conducting states.
+
+        Reads each independent open state directly rather than going through
+        :meth:`~Markov.state_values`, which would additionally reconstruct the
+        dependent state only to discard it. The reconstruction is done only if
+        an open state *is* the dependent one, which no shipped scheme does.
+        """
+        _ = (V, ions)
+        names = type(self).open_states
+        if not names:
+            raise NotImplementedError(f"{type(self).__name__} must declare `open_states`.")
+        dependent = self._dependent_state_name()
+        reconstructed = self.state_values() if dependent in names else None
+        total = None
+        for name in names:
+            value = reconstructed[name] if name == dependent else getattr(self, name).value
+            total = value if total is None else total + value
+        return total

--- a/braincell/channel/_base_test.py
+++ b/braincell/channel/_base_test.py
@@ -15,7 +15,6 @@
 # ==============================================================================
 
 import unittest
-import warnings
 
 import braintools
 import brainunit as u
@@ -24,34 +23,31 @@ import jax.numpy as jnp
 
 from braincell._base_channel import IonInfo
 from braincell.channel._base import Gate
+from braincell.channel._base import GhkHH
 from braincell.channel._base import HH
 from braincell.channel._base import Markov
 from braincell.channel._base import OhmicHH
+from braincell.channel._base import OhmicMarkov
 from braincell.channel._base import Transition
+from braincell.channel._base import cached_q10_factor
+from braincell.channel._base import freeze_gradient
 from braincell.channel._base import ghk_flux
+from braincell.channel._base import is_disabled
 from braincell.channel._base import q10_factor
 from braincell.ion import Calcium
 from braincell.ion import Potassium
 from braincell.quad import get_integrator
 from braincell.quad.protocol import DiffEqState
-
-
-def _k_info(size: int = 1) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), 0.04) * u.mM,
-        Co=jnp.full((size,), 2.5) * u.mM,
-        E=jnp.full((size,), -90.0) * u.mV,
-        valence=1,
-    )
+from braincell.channel.potassium import Kv1p1_MA2025_BC
+from braincell.channel._testing import (
+    ca_info,
+    k_info,
+)
 
 
 def _ca_info(size: int = 1) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), 2.0e-4) * u.mM,
-        Co=jnp.full((size,), 2.0) * u.mM,
-        E=jnp.full((size,), 120.0) * u.mV,
-        valence=2,
-    )
+    """Calcium at the 2e-4 mM the template fixtures were tuned against."""
+    return ca_info(size, Ci=2.0e-4)
 
 
 class _ExampleHHInfTau(HH):
@@ -172,6 +168,39 @@ class _ExampleGHK(HH):
         )
 
 
+class _ExampleGhkHH(GhkHH):
+    """``_ExampleGHK`` rewritten on the template, with a voltage shift."""
+
+    root_type = Calcium
+    gates = (Gate("p", power=2, phi=1.5), Gate("q", power=1))
+
+    def __init__(self, size=1, V_sh=5.0 * u.mV):
+        super().__init__(size=size, name=None)
+        self.g_max = braintools.init.param(0.01 * (u.cm / u.second), self.varshape, allow_none=False)
+        self.V_sh = V_sh
+        self.z = 2
+        self.temp = u.celsius2kelvin(36.0)
+
+    def _shifted_voltage(self, V):
+        return V - self.V_sh
+
+    def f_p_inf(self, V, Ca: IonInfo):
+        _ = (V, Ca)
+        return 0.25
+
+    def f_p_tau(self, V, Ca: IonInfo):
+        _ = (V, Ca)
+        return 2.0
+
+    def f_q_inf(self, V, Ca: IonInfo):
+        _ = (V, Ca)
+        return 0.5
+
+    def f_q_tau(self, V, Ca: IonInfo):
+        _ = (V, Ca)
+        return 4.0
+
+
 class _ExampleMarkov(Markov):
     root_type = Potassium
     pairs = (
@@ -207,41 +236,21 @@ class _ExampleMarkovSteadyReset(_ExampleMarkov):
     reset_to_steady_state = True
 
 
-class _ExampleMarkovImplicitDependent(Markov):
-    root_type = Potassium
-    pairs = (
-        Transition("C", "O", "open_rate", "close_rate"),
-        ("O", "I", "inactivate_rate", None),
-    )
+class _ExampleMarkovTwoOpenStates(OhmicMarkov):
+    """Two conducting states, the trailing one eliminated.
 
-    def __init__(self, size=1):
-        super().__init__(size=size, name=None)
-        self.g_max = braintools.init.param(0.3 * (u.mS / u.cm**2), self.varshape, allow_none=False)
+    ``dependent_state`` is the *last* declared state, so this fixture also
+    covers the reconstruction branch of :meth:`OhmicMarkov.conductance_factor`
+    -- an open state that is itself the eliminated one.
+    """
 
-    def open_rate(self, V, K: IonInfo):
-        _ = (V, K)
-        return 0.2
-
-    def close_rate(self, V, K: IonInfo):
-        _ = (V, K)
-        return 0.1
-
-    def inactivate_rate(self, V, K: IonInfo):
-        _ = (V, K)
-        return 0.05
-
-    def current(self, V, K: IonInfo):
-        states = self.state_values()
-        return self.g_max * states["O"] * (K.E - V)
-
-
-class _ExampleMarkovTwoOpenStates(Markov):
     root_type = Potassium
     pairs = (
         Transition("C", "O1", "open1_rate", "close1_rate"),
         ("O1", "O2", "open2_rate", "close2_rate"),
     )
-    dependent_state = "O2"  # what the implicit scan resolved to; pinned so reordering cannot move it
+    dependent_state = "O2"
+    open_states = ("O1", "O2")
 
     def __init__(self, size=1):
         super().__init__(size=size, name=None)
@@ -262,10 +271,6 @@ class _ExampleMarkovTwoOpenStates(Markov):
     def close2_rate(self, V, K: IonInfo):
         _ = (V, K)
         return 0.02
-
-    def current(self, V, K: IonInfo):
-        states = self.state_values()
-        return self.g_max * (states["O1"] + states["O2"]) * (K.E - V)
 
 
 class _ExampleMarkovVoltageOnlyRates(Markov):
@@ -378,10 +383,77 @@ class ChannelTemplateTest(unittest.TestCase):
         expected = q10_factor(3.0, ch.temp, u.celsius2kelvin(22.0))
         self.assertTrue(u.math.allclose(ch.gate_phi(type(ch).gates[0]), expected, atol=1e-12))
 
+    def test_cached_q10_factor_reuses_the_value_for_unchanged_inputs(self) -> None:
+        ch = _ExampleHHInfTau(size=1)
+        ref = u.celsius2kelvin(22.0)
+        first = cached_q10_factor(ch, "_memo", 3.0, ch.temp, ref)
+        again = cached_q10_factor(ch, "_memo", 3.0, ch.temp, ref)
+
+        self.assertIs(again, first)
+        self.assertTrue(u.math.allclose(first, q10_factor(3.0, ch.temp, ref), atol=1e-12))
+
+    def test_cached_q10_factor_recomputes_when_a_parameter_is_rebound(self) -> None:
+        # The memo is identity-keyed, so rebinding `self.temp` -- which is what
+        # a per-cell temperature sweep does -- has to invalidate it.
+        ch = _ExampleHHInfTau(size=1)
+        ref = u.celsius2kelvin(22.0)
+        first = cached_q10_factor(ch, "_memo", 3.0, ch.temp, ref)
+        ch.temp = u.celsius2kelvin(6.0)
+        second = cached_q10_factor(ch, "_memo", 3.0, ch.temp, ref)
+
+        self.assertIsNot(second, first)
+        self.assertTrue(u.math.allclose(second, q10_factor(3.0, ch.temp, ref), atol=1e-12))
+
+    def test_freeze_gradient_keeps_the_value_and_drops_the_derivative(self) -> None:
+        frozen = freeze_gradient(jnp.array([-60.0, -40.0]) * u.mV)
+        self.assertEqual(u.get_unit(frozen), u.mV)
+        self.assertTrue(u.math.allclose(frozen, jnp.array([-60.0, -40.0]) * u.mV, atol=1e-12 * u.mV))
+
+        # Freeze-then-shift: a `V_sh` downstream of the freeze must keep its
+        # own gradient path, which `stop_gradient(V - V_sh)` would sever.
+        def shifted(V_sh):
+            return u.get_mantissa(freeze_gradient(jnp.array(-60.0) * u.mV) - V_sh * u.mV) ** 2
+
+        self.assertAlmostEqual(float(jax.grad(lambda mV: u.get_mantissa(freeze_gradient(mV * u.mV)))(-60.0)), 0.0)
+        self.assertAlmostEqual(float(jax.grad(shifted)(5.0)), -2.0 * (-65.0), places=4)
+
+    def test_is_disabled_reads_a_concrete_all_zero_flag(self) -> None:
+        self.assertTrue(is_disabled(0.0))
+        self.assertTrue(is_disabled(jnp.zeros((3,)) * (u.mS / u.cm**2)))
+        self.assertFalse(is_disabled(jnp.array([0.0, 1e-9, 0.0]) * (u.mS / u.cm**2)))
+
+    def test_is_disabled_is_false_under_tracing(self) -> None:
+        # A traced flag has no concrete value, so the fast path must not fire
+        # and silently drop the term from the compiled graph.
+        seen = []
+        jax.jit(lambda g: seen.append(is_disabled(g)) or g)(jnp.zeros((3,)))
+        self.assertEqual(seen, [False])
+
+    def test_is_disabled_reads_a_concrete_flag_from_inside_a_trace(self) -> None:
+        # The flag is a stored parameter, so it stays concrete even when the
+        # channel is traced. The predicate must not stage a jax op to inspect
+        # it: under an open trace every jax op returns a tracer, and
+        # ``bool(tracer)`` raises -- which would make every gating-current
+        # channel unusable under ``jit``/``for_loop``, the execution model
+        # this package mandates.
+        flag = jnp.zeros((3,))
+        seen = []
+        jax.make_jaxpr(lambda: seen.append(is_disabled(flag)) or jnp.zeros(()))()
+        self.assertEqual(seen, [True])
+
+    def test_gating_current_channel_traces_under_jit(self) -> None:
+        # Regression for the same defect, at the level a user would hit it.
+        ch = Kv1p1_MA2025_BC(size=3)
+        V = jnp.full((3,), -65.0) * u.mV
+        K = k_info(size=3)
+        ch.init_state(V, K)
+        jaxpr = jax.make_jaxpr(lambda v: ch.current(v, K))(V.mantissa * u.mV)
+        self.assertGreater(len(jaxpr.eqns), 0)
+
     def test_hh_inf_tau_channel(self) -> None:
         ch = _ExampleHHInfTau(size=1)
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         ch.reset_state(V, K)
@@ -397,7 +469,7 @@ class ChannelTemplateTest(unittest.TestCase):
     def test_hh_alpha_beta_channel(self) -> None:
         ch = _ExampleHHAlphaBeta(size=1)
         V = jnp.array([-55.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         ch.reset_state(V, K)
@@ -411,7 +483,7 @@ class ChannelTemplateTest(unittest.TestCase):
     def test_hh_mixed_channel_supports_both_forms(self) -> None:
         ch = _ExampleHHMixed(size=1)
         V = jnp.array([-55.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         ch.reset_state(V, K)
@@ -470,6 +542,31 @@ class ChannelTemplateTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "not a valid Python identifier"):
             _make_hh("_BadName", {"gates": (Gate("m gate"),)})
 
+    def test_hh_rejects_gate_shadowing_a_class_attribute(self) -> None:
+        # `_bind_state` only sees attributes the constructor set, so a gate
+        # named after a *method* would shadow it with no signal at all.
+        with self.assertRaisesRegex(ValueError, r"gate name 'current' collides"):
+            _make_hh(
+                "_ShadowsMethod",
+                {
+                    "gates": (Gate("current"),),
+                    "f_current_inf": lambda self, V, K: 0.5,
+                    "f_current_tau": lambda self, V, K: 1.0,
+                },
+            )
+
+    def test_markov_rejects_state_shadowing_a_class_attribute(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"Markov state name 'conserve' collides"):
+            _make_markov(
+                "_ShadowsConserve",
+                {
+                    "pairs": (Transition("conserve", "B", "fwd", "bwd"),),
+                    "dependent_state": "B",
+                    "fwd": lambda self, V: 0.1,
+                    "bwd": lambda self, V: 0.2,
+                },
+            )
+
     def test_hh_allows_gateless_abstract_subclass(self) -> None:
         # Abstract intermediates declare no gates and must stay definable.
         cls = _make_hh("_Abstract", {})
@@ -506,12 +603,12 @@ class ChannelTemplateTest(unittest.TestCase):
         ch = cls(1)
         ch.g_max = braintools.init.param(1.0 * (u.mS / u.cm**2), ch.varshape, allow_none=False)
         with self.assertRaisesRegex(ValueError, r"gate 'g_max' collides"):
-            ch.init_state(jnp.array([-60.0]) * u.mV, _k_info())
+            ch.init_state(jnp.array([-60.0]) * u.mV, k_info())
 
     def test_init_state_is_idempotent(self) -> None:
         ch = _ExampleHHInfTau(size=1)
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
         ch.init_state(V, K)
         ch.init_state(V, K)  # re-initialisation replaces the existing DiffEqState
         self.assertIsInstance(ch.m, DiffEqState)
@@ -534,6 +631,7 @@ class ChannelTemplateTest(unittest.TestCase):
                 "_MissingRate",
                 {
                     "pairs": (Transition("A", "B", "fwd", "bwd"),),
+                    "dependent_state": "A",
                     "fwd": lambda self, V: 0.1,
                 },
             )
@@ -559,7 +657,7 @@ class ChannelTemplateTest(unittest.TestCase):
         for key, value in attrs.items():
             setattr(ch, key, value)
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
         ch.init_state(V, K)
         ch.reset_state(V, K)
         ch.compute_derivative(V, K)
@@ -651,8 +749,8 @@ class ChannelTemplateTest(unittest.TestCase):
         cls = _make_hh("_Arity", {"gates": (Gate("m"),), "f_m_inf": f_m_inf, "f_m_tau": f_m_tau})
         ch = cls(1)
         V = jnp.array([-60.0]) * u.mV
-        ch.init_state(V, _k_info(), _ca_info())
-        ch.compute_derivative(V, _k_info(), _ca_info())
+        ch.init_state(V, k_info(), _ca_info())
+        ch.compute_derivative(V, k_info(), _ca_info())
         self.assertEqual(seen, {"inf": 1, "tau": 2})
 
     def test_gate_method_with_varargs_receives_every_ion(self) -> None:
@@ -668,8 +766,8 @@ class ChannelTemplateTest(unittest.TestCase):
         )
         ch = cls(1)
         V = jnp.array([-60.0]) * u.mV
-        ch.init_state(V, _k_info(), _ca_info())
-        ch.compute_derivative(V, _k_info(), _ca_info())
+        ch.init_state(V, k_info(), _ca_info())
+        ch.compute_derivative(V, k_info(), _ca_info())
         self.assertEqual(seen["n"], 2)
 
     def test_gate_method_demanding_more_ions_than_supplied_raises(self) -> None:
@@ -683,9 +781,9 @@ class ChannelTemplateTest(unittest.TestCase):
         )
         ch = cls(1)
         V = jnp.array([-60.0]) * u.mV
-        ch.init_state(V, _k_info())
+        ch.init_state(V, k_info())
         with self.assertRaisesRegex(TypeError, "expects 2 ion argument"):
-            ch.compute_derivative(V, _k_info())
+            ch.compute_derivative(V, k_info())
 
     # ------------------------------------------------------------------
     # Gate / state clipping
@@ -704,9 +802,9 @@ class ChannelTemplateTest(unittest.TestCase):
     def _factor_at(self, cls, gate_value):
         ch = cls(1)
         V = jnp.array([-60.0]) * u.mV
-        ch.init_state(V, _k_info())
+        ch.init_state(V, k_info())
         ch.m.value = jnp.array([gate_value])
-        return ch.conductance_factor(V, _k_info())
+        return ch.conductance_factor(V, k_info())
 
     def test_gates_are_not_clipped_by_default(self) -> None:
         cls = self._one_gate("_NoClip", power=3)
@@ -729,16 +827,16 @@ class ChannelTemplateTest(unittest.TestCase):
         cls = self._one_gate("_ClipStore", power=1, clip=True)
         ch = cls(1)
         V = jnp.array([-60.0]) * u.mV
-        ch.init_state(V, _k_info())
+        ch.init_state(V, k_info())
         ch.m.value = jnp.array([1.5])
-        ch.conductance_factor(V, _k_info())
+        ch.conductance_factor(V, k_info())
         self.assertTrue(u.math.allclose(ch.m.value, jnp.array([1.5])))
 
     def test_markov_clip_states_defaults_on_and_can_be_disabled(self) -> None:
         self.assertTrue(Markov.clip_states)
         ch = _ExampleMarkov(size=1)
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
         ch.init_state(V, K)
         ch.O.value = jnp.array([1.4])
         self.assertTrue(u.math.allclose(ch._kinetic_state_values()["O"], jnp.array([1.0])))
@@ -810,7 +908,7 @@ class ChannelTemplateTest(unittest.TestCase):
         for key, value in attrs.items():
             setattr(ch, key, value)
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
         ch.init_state(V, K)
         ch.reset_state(V, K)
         ch.compute_derivative(V, K)
@@ -844,7 +942,7 @@ class ChannelTemplateTest(unittest.TestCase):
         ch = cls(1)
         ch.phi = 2.0 * u.mV
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
         ch.init_state(V, K)
         with self.assertRaisesRegex(ValueError, r"_MkBadSS\.fwd must be dimensionless"):
             ch.reset_steady_state(V, K)
@@ -872,33 +970,19 @@ class ChannelTemplateTest(unittest.TestCase):
         b = self._three_state_markov("_OrderB", reordered, dependent_state="A")
         self.assertEqual(a(1)._dependent_state_name(), "A")
         self.assertEqual(b(1)._dependent_state_name(), "A")
-        # ... whereas the implicit fallback would have moved with the order
+        # The discovery order *does* move, which is exactly why the choice has
+        # to be declared rather than read off the end of `pairs`.
         self.assertEqual(a._resolved_state_names[-1], "C")
         self.assertEqual(b._resolved_state_names[-1], "A")
 
-    def test_implicit_dependent_state_warns(self) -> None:
-        cls = self._three_state_markov(
-            "_Implicit",
-            (Transition("A", "B", "r1", "r2"), Transition("B", "C", "r3", "r4")),
-        )
-        with self.assertWarnsRegex(DeprecationWarning, "does not declare `dependent_state`"):
-            self.assertEqual(cls(1)._dependent_state_name(), "C")
-
-    def test_shipped_markov_channels_declare_dependent_state(self) -> None:
-        # Regression lock: reordering `pairs` in any shipped channel must not
-        # be able to silently change which state is eliminated.
-        import braincell.channel as channel_pkg
-
-        implicit = [
-            name
-            for name in dir(channel_pkg)
-            if isinstance(cls := getattr(channel_pkg, name, None), type)
-            and issubclass(cls, Markov)
-            and cls is not Markov
-            and cls.pairs
-            and cls.dependent_state is None
-        ]
-        self.assertEqual(implicit, [])
+    def test_markov_subclass_must_declare_dependent_state(self) -> None:
+        # Reordering `pairs` would otherwise silently change which state is
+        # eliminated, and with it the conditioning of the steady-state solve.
+        with self.assertRaisesRegex(ValueError, r"must declare `dependent_state`"):
+            self._three_state_markov(
+                "_NoDependent",
+                (Transition("A", "B", "r1", "r2"), Transition("B", "C", "r3", "r4")),
+            )
 
     # ------------------------------------------------------------------
     # OhmicHH
@@ -919,7 +1003,7 @@ class ChannelTemplateTest(unittest.TestCase):
     def test_ohmic_current_uses_first_ion_reversal(self) -> None:
         ch = self._ohmic("_Ohmic")
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
         ch.init_state(V, K)
         ch.reset_state(V, K)
         expected = ch.g_max * ch.conductance_factor(V, K) * (K.E - V)
@@ -929,7 +1013,7 @@ class ChannelTemplateTest(unittest.TestCase):
         ch = self._ohmic("_OhmicFixed", reversal_potential=lambda self, V, *ions: self.E)
         ch.E = jnp.array([-30.0]) * u.mV
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
         ch.init_state(V, K)
         ch.reset_state(V, K)
         expected = ch.g_max * ch.conductance_factor(V, K) * (ch.E - V)
@@ -944,7 +1028,7 @@ class ChannelTemplateTest(unittest.TestCase):
         )
         ch.perm = braintools.init.param(0.25 * (u.mS / u.cm**2), ch.varshape, allow_none=False)
         V = jnp.array([-60.0]) * u.mV
-        K = _k_info()
+        K = k_info()
         ch.init_state(V, K)
         ch.reset_state(V, K)
         expected = ch.perm * ch.conductance_factor(V, K) * (K.E - V)
@@ -955,7 +1039,7 @@ class ChannelTemplateTest(unittest.TestCase):
         # and must draw E from potassium, the first declared ion.
         ch = self._ohmic("_OhmicJoint")
         V = jnp.array([-60.0]) * u.mV
-        K, Ca = _k_info(), _ca_info()
+        K, Ca = k_info(), _ca_info()
         ch.init_state(V, K, Ca)
         ch.reset_state(V, K, Ca)
         self.assertTrue(u.math.allclose(ch.reversal_potential(V, K, Ca), K.E))
@@ -965,6 +1049,7 @@ class ChannelTemplateTest(unittest.TestCase):
             "_TuplePairs",
             {
                 "pairs": (("A", "B", "fwd", "bwd"),),
+                "dependent_state": "A",
                 "fwd": lambda self, V: 0.1,
                 "bwd": lambda self, V: 0.2,
             },
@@ -996,10 +1081,161 @@ class ChannelTemplateTest(unittest.TestCase):
         unit = expected.unit
         self.assertTrue(u.math.allclose(current.to_decimal(unit), expected.to_decimal(unit), atol=1e-6))
 
+    # ------------------------------------------------------------------
+    # GhkHH
+    # ------------------------------------------------------------------
+
+    def _ghk_ready(self, cls=_ExampleGhkHH, **kwargs):
+        ch = cls(size=1, **kwargs)
+        V = jnp.array([-50.0]) * u.mV
+        Ca = _ca_info()
+        ch.init_state(V, Ca)
+        ch.reset_state(V, Ca)
+        return ch, V, Ca
+
+    def test_ghk_hh_current_is_the_sign_flipped_constant_field_flux(self) -> None:
+        ch, V, Ca = self._ghk_ready()
+        expected = (
+            -ch.g_max * ch.p.value**2 * ch.q.value * ghk_flux(V=V - ch.V_sh, ci=Ca.Ci, co=Ca.Co, z=ch.z, temp=ch.temp)
+        )
+        unit = expected.unit
+        self.assertTrue(u.math.allclose(ch.current(V, Ca).to_decimal(unit), expected.to_decimal(unit), atol=1e-12))
+
+    def test_ghk_hh_reads_the_flux_at_the_shifted_voltage(self) -> None:
+        # `_shifted_voltage` must reach the drive, not just the rate methods:
+        # a channel whose `.mod` source offsets `v` offsets the flux too.
+        shifted, V, Ca = self._ghk_ready()
+        unshifted, _, _ = self._ghk_ready(V_sh=0.0 * u.mV)
+        unit = u.mA / u.cm**2
+
+        # Nothing else in `current` depends on V, so shifting the input by
+        # `V_sh` on an unshifted channel has to reproduce the shifted one.
+        self.assertTrue(
+            u.math.allclose(
+                shifted.current(V, Ca).to_decimal(unit),
+                unshifted.current(V - shifted.V_sh, Ca).to_decimal(unit),
+                atol=1e-12,
+            )
+        )
+        self.assertFalse(
+            bool(
+                u.math.allclose(
+                    shifted.current(V, Ca).to_decimal(unit),
+                    unshifted.current(V, Ca).to_decimal(unit),
+                    atol=1e-12,
+                )
+            )
+        )
+
+    def test_ghk_hh_permeability_hook_replaces_g_max(self) -> None:
+        class _RenamedPermeability(_ExampleGhkHH):
+            def __init__(self, size=1, **kwargs):
+                super().__init__(size=size, **kwargs)
+                self.p_max = self.g_max * 3.0
+
+            def permeability(self):
+                return self.p_max
+
+        ch, V, Ca = self._ghk_ready(_RenamedPermeability)
+        baseline, _, _ = self._ghk_ready()
+        unit = u.mA / u.cm**2
+        self.assertTrue(
+            u.math.allclose(
+                ch.current(V, Ca).to_decimal(unit),
+                (baseline.current(V, Ca) * 3.0).to_decimal(unit),
+                atol=1e-12,
+            )
+        )
+
+    def test_ghk_hh_flux_helper_is_a_class_level_declaration(self) -> None:
+        # The catalogue ships three transcriptions of the GHK equation whose
+        # constants differ in the third decimal place, so which one a channel
+        # uses has to be selectable without overriding `current`.
+        calls = []
+
+        def _recording_flux(V, ci, co, z, temp):
+            calls.append(z)
+            return ghk_flux(V=V, ci=ci, co=co, z=z, temp=temp) * 2.0
+
+        class _CustomFlux(_ExampleGhkHH):
+            ghk = staticmethod(_recording_flux)
+
+        ch, V, Ca = self._ghk_ready(_CustomFlux)
+        baseline, _, _ = self._ghk_ready()
+        unit = u.mA / u.cm**2
+        self.assertTrue(
+            u.math.allclose(
+                ch.current(V, Ca).to_decimal(unit),
+                (baseline.current(V, Ca) * 2.0).to_decimal(unit),
+                atol=1e-12,
+            )
+        )
+        self.assertEqual(calls, [2])
+
+    def test_ghk_hh_freeze_drive_gradient_cuts_the_drive_path_only(self) -> None:
+        # Opting in must leave the value untouched and kill only the gradient
+        # that flows through the driving force, matching the `.mod` sources
+        # that treat the flux as a constant within a step.
+        class _FrozenDrive(_ExampleGhkHH):
+            freeze_drive_gradient = True
+
+        live, V, Ca = self._ghk_ready()
+        frozen, _, _ = self._ghk_ready(_FrozenDrive)
+        unit = u.mA / u.cm**2
+
+        self.assertTrue(
+            u.math.allclose(
+                live.current(V, Ca).to_decimal(unit),
+                frozen.current(V, Ca).to_decimal(unit),
+                atol=1e-12,
+            )
+        )
+
+        def sensitivity(ch):
+            return jax.grad(lambda mV: (ch.current(mV * u.mV, Ca) / unit).sum())(u.get_mantissa(V)[0])
+
+        self.assertNotAlmostEqual(float(sensitivity(live)), 0.0)
+        self.assertAlmostEqual(float(sensitivity(frozen)), 0.0)
+
+    # ------------------------------------------------------------------
+    # OhmicMarkov
+    # ------------------------------------------------------------------
+
+    def test_ohmic_markov_rejects_an_undeclared_open_state(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"open_states names \['Z'\]"):
+            type(
+                "_BadOpenStates",
+                (OhmicMarkov,),
+                {
+                    "root_type": Potassium,
+                    "pairs": (Transition("A", "B", "fwd", "bwd"),),
+                    "dependent_state": "A",
+                    "open_states": ("B", "Z"),
+                    "fwd": lambda self, V: 0.1,
+                    "bwd": lambda self, V: 0.2,
+                },
+            )
+
+    def test_ohmic_markov_without_open_states_reports_the_missing_declaration(self) -> None:
+        cls = type(
+            "_NoOpenStates",
+            (OhmicMarkov,),
+            {
+                "root_type": Potassium,
+                "pairs": (Transition("A", "B", "fwd", "bwd"),),
+                "dependent_state": "A",
+                "fwd": lambda self, V: 0.1,
+                "bwd": lambda self, V: 0.2,
+            },
+        )
+        ch = cls(size=1)
+        with self.assertRaisesRegex(NotImplementedError, r"must declare `open_states`"):
+            ch.conductance_factor(jnp.array([-65.0]) * u.mV, k_info())
+
     def test_markov_collects_states_and_builds_dependent_state(self) -> None:
         ch = _ExampleMarkov(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         self.assertEqual(ch.state_names, ("O", "I"))
@@ -1052,30 +1288,28 @@ class ChannelTemplateTest(unittest.TestCase):
         self.assertIs(override.solver, get_integrator("euler"))
         self.assertEqual(override.substeps, 2)
 
-    def test_markov_defaults_dependent_state_to_last_discovered_name(self) -> None:
-        ch = _ExampleMarkovImplicitDependent(size=1)
+    def test_markov_eliminates_the_declared_dependent_state(self) -> None:
+        # `_ExampleMarkovTwoOpenStates` declares the trailing state, so this
+        # also covers a dependent state that is not the first one discovered.
+        ch = _ExampleMarkovTwoOpenStates(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
-        with self.assertWarnsRegex(DeprecationWarning, "does not declare `dependent_state`"):
-            ch.init_state(V, K)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            self.assertEqual(ch.redundant_state, "I")
-            self.assertEqual(ch.state_names, ("C", "O"))
-            self.assertTrue(hasattr(ch, "C"))
-            self.assertTrue(hasattr(ch, "O"))
-            self.assertFalse(hasattr(ch, "I"))
+        ch.init_state(V, K)
+        self.assertEqual(ch.redundant_state, "O2")
+        self.assertEqual(ch.state_names, ("C", "O1"))
+        self.assertTrue(hasattr(ch, "C"))
+        self.assertTrue(hasattr(ch, "O1"))
+        self.assertFalse(hasattr(ch, "O2"))
 
-            ch.C.value = jnp.array([0.3])
-            ch.O.value = jnp.array([0.2])
-            states = ch.state_values()
-        self.assertTrue(u.math.allclose(states["I"], jnp.array([0.5]), atol=1e-6))
+        ch.C.value = jnp.array([0.3])
+        ch.O1.value = jnp.array([0.2])
+        self.assertTrue(u.math.allclose(ch.state_values()["O2"], jnp.array([0.5]), atol=1e-6))
 
     def test_markov_pre_and_post_integral_are_no_ops(self) -> None:
         ch = _ExampleMarkov(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         self.assertIsNone(ch.pre_integral(V, K))
         self.assertIsNone(ch.post_integral(V, K))
@@ -1083,7 +1317,7 @@ class ChannelTemplateTest(unittest.TestCase):
     def test_markov_reset_steady_state_solves_stationary_distribution(self) -> None:
         ch = _ExampleMarkov(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         ch.reset_steady_state(V, K)
@@ -1100,7 +1334,7 @@ class ChannelTemplateTest(unittest.TestCase):
     def test_markov_reset_state_zeroes_states_by_default(self) -> None:
         ch = _ExampleMarkov(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         ch.reset_steady_state(V, K)
@@ -1114,7 +1348,7 @@ class ChannelTemplateTest(unittest.TestCase):
         opted_in = _ExampleMarkovSteadyReset(size=1)
         baseline = _ExampleMarkov(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         for ch in (opted_in, baseline):
             ch.init_state(V, K)
@@ -1126,29 +1360,33 @@ class ChannelTemplateTest(unittest.TestCase):
         for name in opted_in.state_names:
             self.assertTrue(u.math.allclose(getattr(opted_in, name).value, getattr(baseline, name).value, atol=1e-12))
 
-    def test_markov_reset_steady_state_supports_implicit_dependent_state(self) -> None:
-        ch = _ExampleMarkovImplicitDependent(size=1)
+    def test_markov_reset_steady_state_with_a_trailing_dependent_state(self) -> None:
+        # The eliminated state is the last one declared here, so the solve has
+        # to drop a trailing row rather than the leading one it drops above.
+        ch = _ExampleMarkovTwoOpenStates(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            ch.init_state(V, K)
-            ch.reset_steady_state(V, K)
-            states = ch.state_values()
+        ch.init_state(V, K)
+        ch.reset_steady_state(V, K)
+        states = ch.state_values()
 
-            total = states["C"] + states["O"] + states["I"]
-            self.assertTrue(u.math.allclose(total, jnp.array([1.0]), atol=1e-6))
-            self.assertTrue(u.math.allclose(states["I"], jnp.array([1.0]), atol=1e-6))
+        total = states["C"] + states["O1"] + states["O2"]
+        self.assertTrue(u.math.allclose(total, jnp.array([1.0]), atol=1e-6))
+        # Detailed balance along the chain: C:O1 = close1/open1, O1:O2 = close2/open2.
+        expected = jnp.array([1.0, 2.0, 5.0])
+        expected = expected / expected.sum()
+        for name, value in zip(("C", "O1", "O2"), expected):
+            self.assertTrue(u.math.allclose(states[name], jnp.array([value]), atol=1e-6))
 
-            ch.compute_derivative(V, K)
+        ch.compute_derivative(V, K)
         self.assertTrue(u.math.allclose(ch.C.derivative, jnp.array([0.0]) / u.ms, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(ch.O.derivative, jnp.array([0.0]) / u.ms, atol=1e-6 * u.Hz))
+        self.assertTrue(u.math.allclose(ch.O1.derivative, jnp.array([0.0]) / u.ms, atol=1e-6 * u.Hz))
 
     def test_markov_host_steady_state_matches_jax_solver(self) -> None:
         ch = _ExampleMarkovTwoOpenStates(size=3)
         V = jnp.full((3,), -65.0) * u.mV
-        K = _k_info(size=3)
+        K = k_info(size=3)
 
         ch.init_state(V, K)
         host_states = ch._solve_steady_state_host(V, K)
@@ -1161,7 +1399,7 @@ class ChannelTemplateTest(unittest.TestCase):
     def test_markov_steady_state_uses_jax_fallback_when_traced(self) -> None:
         ch = _ExampleMarkovTwoOpenStates(size=3)
         V = jnp.full((3,), -65.0) * u.mV
-        K = _k_info(size=3)
+        K = k_info(size=3)
         ch.init_state(V, K)
 
         solve_open = jax.jit(lambda voltage: ch._solve_steady_state(voltage, K)["O1"])
@@ -1169,28 +1407,10 @@ class ChannelTemplateTest(unittest.TestCase):
         expected = ch._solve_steady_state_jax(V, K)["O1"]
         self.assertTrue(u.math.allclose(actual, expected, atol=1e-6))
 
-    def test_markov_kinetic_states_clip_independent_states_for_dynamics(self) -> None:
+    def test_markov_kinetic_states_clip_independent_states_only(self) -> None:
         ch = _ExampleMarkov(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
-
-        ch.init_state(V, K)
-        ch.O.value = jnp.array([1.2])
-        ch.I.value = jnp.array([-0.1])
-
-        raw_states = ch.state_values()
-        kinetic_states = ch._kinetic_state_values()
-        self.assertTrue(u.math.allclose(raw_states["O"], jnp.array([1.2]), atol=1e-6))
-        self.assertTrue(u.math.allclose(raw_states["I"], jnp.array([-0.1]), atol=1e-6))
-        self.assertTrue(u.math.allclose(raw_states["C"], jnp.array([-0.1]), atol=1e-6))
-        self.assertTrue(u.math.allclose(kinetic_states["O"], jnp.array([1.0]), atol=1e-6))
-        self.assertTrue(u.math.allclose(kinetic_states["I"], jnp.array([0.0]), atol=1e-6))
-        self.assertTrue(u.math.allclose(kinetic_states["C"], jnp.array([-0.1]), atol=1e-6))
-
-    def test_markov_kinetic_states_can_project_independent_states_only_for_dynamics(self) -> None:
-        ch = _ExampleMarkov(size=1)
-        V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         ch.O.value = jnp.array([1.2])
@@ -1211,16 +1431,19 @@ class ChannelTemplateTest(unittest.TestCase):
         self.assertTrue(u.math.allclose(ch.O.derivative, expected_dO, atol=1e-6 * u.Hz))
         self.assertTrue(u.math.allclose(ch.I.derivative, expected_dI, atol=1e-6 * u.Hz))
 
-    def test_markov_current_can_sum_multiple_open_states_manually(self) -> None:
+    def test_ohmic_markov_current_sums_the_declared_open_states(self) -> None:
+        # ``O2`` is also the dependent state, so this exercises the branch of
+        # ``conductance_factor`` that has to reconstruct an open state.
         ch = _ExampleMarkovTwoOpenStates(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         ch.C.value = jnp.array([0.3])
         ch.O1.value = jnp.array([0.2])
         states = ch.state_values()
         self.assertTrue(u.math.allclose(states["O2"], jnp.array([0.5]), atol=1e-6))
+        self.assertTrue(u.math.allclose(ch.conductance_factor(V, K), jnp.array([0.7]), atol=1e-6))
 
         current = ch.current(V, K)
         expected_current = ch.g_max * (states["O1"] + states["O2"]) * (K.E - V)
@@ -1236,7 +1459,7 @@ class ChannelTemplateTest(unittest.TestCase):
     def test_markov_rate_dispatch_respects_declared_signature(self) -> None:
         ch = _ExampleMarkovVoltageOnlyRates(size=1)
         V = jnp.array([-65.0]) * u.mV
-        K = _k_info()
+        K = k_info()
 
         ch.init_state(V, K)
         ch.O.value = jnp.array([0.25])

--- a/braincell/channel/_testing.py
+++ b/braincell/channel/_testing.py
@@ -1,0 +1,162 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared fixtures for the ``braincell.channel`` test modules.
+
+The catalogue's tests all need the same three things: a voltage array, an
+:class:`~braincell.IonInfo` to drive a channel with, and a unit to compare
+current densities in. Each ``*_test.py`` used to carry its own copy, which
+is how the potassium tests ended up asserting against ``K.Ci = 0.04 mM``
+while the potassium-calcium tests used the physiological ``140 mM`` -- a
+divergence that was invisible while the two definitions sat in different
+files. The builders below take the concentrations as keyword arguments so a
+module that needs a different value states it at the call site.
+
+This module is deliberately named with a leading underscore so pytest does
+not collect it.
+"""
+
+from typing import Sequence
+
+import brainunit as u
+import jax.numpy as jnp
+
+from braincell._base_channel import IonInfo
+
+#: Re-exported from ``braincell.ion._testing`` rather than redefined, following
+#: the ``vis/_testing.py`` -> ``io/_testing.py`` precedent. Spelled out because
+#: every test body binds a local ``V`` for the potential it is testing at.
+from braincell.ion._testing import V as voltage
+
+__all__ = [
+    "DENSITY_UNIT",
+    "assert_channels_agree",
+    "ca_info",
+    "k_info",
+    "na_info",
+    "nonspecific_info",
+    "voltage",
+]
+
+#: Current densities are reported in several equivalent unit spellings
+#: depending on how many factors a channel's ``current`` multiplies, so
+#: every comparison goes through ``to_decimal`` with this one unit.
+DENSITY_UNIT = u.mS / u.cm**2 * u.mV
+
+
+def k_info(size: int = 1, *, Ci: float = 0.04, Co: float = 2.5, E: float = -90.0) -> IonInfo:
+    """Return a potassium :class:`~braincell.IonInfo` of shape ``(size,)``."""
+    return IonInfo(
+        Ci=jnp.full((size,), Ci) * u.mM,
+        Co=jnp.full((size,), Co) * u.mM,
+        E=jnp.full((size,), E) * u.mV,
+        valence=1,
+    )
+
+
+def na_info(size: int = 1, *, Ci: float = 0.04, Co: float = 140.0, E: float = 50.0) -> IonInfo:
+    """Return a sodium :class:`~braincell.IonInfo` of shape ``(size,)``."""
+    return IonInfo(
+        Ci=jnp.full((size,), Ci) * u.mM,
+        Co=jnp.full((size,), Co) * u.mM,
+        E=jnp.full((size,), E) * u.mV,
+        valence=1,
+    )
+
+
+def ca_info(size: int = 1, *, Ci: float = 1e-4, Co: float = 2.0, E: float = 120.0) -> IonInfo:
+    """Return a calcium :class:`~braincell.IonInfo` of shape ``(size,)``."""
+    return IonInfo(
+        Ci=jnp.full((size,), Ci) * u.mM,
+        Co=jnp.full((size,), Co) * u.mM,
+        E=jnp.full((size,), E) * u.mV,
+        valence=2,
+    )
+
+
+def nonspecific_info(size: int = 1, *, Ci: float = 1.0, Co: float = 1.0, E: float = 0.0) -> IonInfo:
+    """Return a non-specific-cation :class:`~braincell.IonInfo` of shape ``(size,)``."""
+    return IonInfo(
+        Ci=jnp.full((size,), Ci) * u.mM,
+        Co=jnp.full((size,), Co) * u.mM,
+        E=jnp.full((size,), E) * u.mV,
+        valence=1,
+    )
+
+
+def assert_channels_agree(
+    case,
+    expected,
+    actual,
+    V,
+    *ions: IonInfo,
+    states: Sequence[str] = (),
+    atol: float = 1e-6,
+) -> None:
+    """Assert two channels evolve identically from the same reset state.
+
+    Most of the catalogue is cell-type variants: the same mechanism imported
+    for a different model, differing only in citation, registration key and
+    default parameters. Constructed at matched parameters they must agree
+    exactly, and this is the assertion that says so -- reset both, compare
+    every state in ``states``, compare its derivative, compare the current.
+
+    Parameters
+    ----------
+    case : unittest.TestCase
+        The test case, used for its assertion methods and failure messages.
+    expected, actual : Channel
+        The two channels, already constructed at matched parameters.
+    V : ArrayLike
+        Membrane potential to evaluate both at.
+    *ions : IonInfo
+        Ion states, in the declaration order of ``root_type``.
+    states : sequence of str, optional
+        Names of the states to compare. Empty compares the current alone,
+        which is what a channel with an all-or-nothing correction term (a
+        gating current, say) needs.
+    atol : float, optional
+        Absolute tolerance, default ``1e-6``. Derivatives are compared with
+        the same number in ``u.Hz`` and currents in :data:`DENSITY_UNIT`.
+    """
+    for channel in (expected, actual):
+        channel.init_state(V, *ions)
+        channel.reset_state(V, *ions)
+    for name in states:
+        case.assertTrue(
+            u.math.allclose(getattr(actual, name).value, getattr(expected, name).value, atol=atol),
+            f"state {name!r} diverged",
+        )
+
+    for channel in (expected, actual):
+        channel.compute_derivative(V, *ions)
+    for name in states:
+        case.assertTrue(
+            u.math.allclose(
+                getattr(actual, name).derivative,
+                getattr(expected, name).derivative,
+                atol=atol * u.Hz,
+            ),
+            f"derivative of state {name!r} diverged",
+        )
+
+    case.assertTrue(
+        u.math.allclose(
+            actual.current(V, *ions).to_decimal(DENSITY_UNIT),
+            expected.current(V, *ions).to_decimal(DENSITY_UNIT),
+            atol=atol,
+        ),
+        "current diverged",
+    )

--- a/braincell/channel/calcium.py
+++ b/braincell/channel/calcium.py
@@ -26,7 +26,7 @@ import jax
 from braincell._base_channel import IonInfo
 from braincell._base_neuron import HHTypedNeuron
 from braincell._typing import ArrayLike, Initializer, Size
-from braincell.channel._base import Gate, HH, OhmicHH, ghk_flux, q10_factor
+from braincell.channel._base import Gate, GhkHH, HH, OhmicHH, cached_q10_factor
 from braincell.ion import Calcium
 from braincell.mech import register_channel
 
@@ -36,6 +36,8 @@ _CAV3P1_NMODL_TEMP_OFFSET = 0.04 * u.kelvin
 _CAV3P3_NMODL_FARADAY = 96520.0 * (u.coulomb / u.mol)
 _CAV3P3_NMODL_GAS_CONSTANT = 8.3134 * (u.joule / (u.kelvin * u.mol))
 _CAV3P3_NMODL_TEMP_OFFSET = -0.01 * u.kelvin
+_SU2015_DCN_ZETA_PER_MV_KELVIN = -23.20764929
+_SU2015_DCN_FLUX_SCALE = 4.47814e6
 
 __all__ = [
     "CaN_IS2008",
@@ -98,11 +100,43 @@ def _cav3p3_nmodl_ghk_flux(V, ci, co, z, temp):
     return u.math.where(u.math.abs(exp_term - 1) < 1e-6, small_branch, regular_branch)
 
 
-def _freeze_quantity_gradient(value):
-    return u.Quantity(
-        jax.lax.stop_gradient(u.get_mantissa(value)),
-        u.get_unit(value),
+def _su2015_dcn_ghk_drive(V, ci, co, temp):
+    """Constant-field drive shared by the two SU2015 DCN calcium mechanisms.
+
+    Unlike the Cav3.1 and Cav3.3 helpers this one is not a :attr:`GhkHH.ghk`
+    implementation, and the two callers stay on :class:`HH` with a hand-written
+    ``current``. The DCN ``.mod`` sources do not spell out ``F`` and ``R``: they
+    ship two magic numbers that already fold in Faraday's constant, the gas
+    constant, the valence and the mM-to-M conversion. Recovering the separate
+    factors would change the arithmetic, so the drive is computed on stripped
+    magnitudes and the caller attaches ``mA/cm^2`` to the finished product --
+    which is also what keeps the reported unit spelled the same way as every
+    other channel's.
+    """
+    v_mV = V.to_decimal(u.mV)
+    temp_K = temp.to_decimal(u.kelvin)
+    A = u.math.exp(_SU2015_DCN_ZETA_PER_MV_KELVIN * v_mV / temp_K)
+    return (
+        (_SU2015_DCN_FLUX_SCALE * v_mV / temp_K)
+        * ((ci.to_decimal(u.mM) / 1000.0) - (co.to_decimal(u.mM) / 1000.0) * A)
+        / (1.0 - A)
     )
+
+
+class _FrozenCav3p1Ghk:
+    """Mixin for the three Cav2.1 variants that freeze the drive *and* swap helpers.
+
+    Their ``.mod`` deposits transcribe the Cav3.1 constants rather than the
+    ones :func:`~braincell.channel._base.ghk_flux` uses, so each frozen class
+    differs from its unfrozen sibling in the forward current as well as in the
+    gradient -- by around 5e-4 relative. That was previously implicit in three
+    copies of a ``current`` body; declaring both facts here states the anomaly
+    once and lets each frozen class inherit its parameters from the unfrozen
+    sibling it is meant to mirror.
+    """
+
+    ghk = staticmethod(_cav3p1_nmodl_ghk_flux)
+    freeze_drive_gradient = True
 
 
 @register_channel("CaN_IS2008")
@@ -509,7 +543,7 @@ class CaT_HP1992(OhmicHH):
 
 
 @register_channel("CaHT_HM1992")
-class CaHT_HM1992(OhmicHH):
+class CaHT_HM1992(CaT_HM1992):
     r"""Depolarized-shift variant of the Huguenard & McCormick 1992 T current.
 
     :math:`p^2 q` HH gating with an ohmic driving force, using the
@@ -616,11 +650,6 @@ class CaHT_HM1992(OhmicHH):
     """
 
     __module__ = "braincell.channel"
-    root_type = Calcium
-    gates = (
-        Gate("p", power=2, q10="q10_p", temp_ref="temp_ref_p"),
-        Gate("q", q10="q10_q", temp_ref="temp_ref_q"),
-    )
 
     def __init__(
         self,
@@ -634,33 +663,18 @@ class CaHT_HM1992(OhmicHH):
         V_sh: Initializer = 25.0 * u.mV,
         name: Optional[str] = None,
     ):
-        super().__init__(size=size, name=name)
-        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
-        self.q10_p = braintools.init.param(q10_p, self.varshape, allow_none=False)
-        self.temp_ref_p = braintools.init.param(temp_ref_p, self.varshape, allow_none=False)
-        self.q10_q = braintools.init.param(q10_q, self.varshape, allow_none=False)
-        self.temp_ref_q = braintools.init.param(temp_ref_q, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
-
-    def f_p_inf(self, V, Ca: IonInfo):
-        V = (V - self.V_sh).to_decimal(u.mV)
-        return 1.0 / (1.0 + u.math.exp(-(V + 59.0) / 6.2))
-
-    def f_p_tau(self, V, Ca: IonInfo):
-        V = (V - self.V_sh).to_decimal(u.mV)
-        return 1.0 / (u.math.exp(-(V + 132.0) / 16.7) + u.math.exp((V + 16.8) / 18.2)) + 0.612
-
-    def f_q_inf(self, V, Ca: IonInfo):
-        V = (V - self.V_sh).to_decimal(u.mV)
-        return 1.0 / (1.0 + u.math.exp((V + 83.0) / 4.0))
-
-    def f_q_tau(self, V, Ca: IonInfo):
-        V = (V - self.V_sh).to_decimal(u.mV)
-        return u.math.where(
-            V >= -80.0,
-            u.math.exp(-(V + 22.0) / 10.5) + 28.0,
-            u.math.exp((V + 467.0) / 66.6),
+        # Every gate, constant and rate function is ``CaT_HM1992``'s; the
+        # signature is re-declared only to move ``V_sh``'s default.
+        super().__init__(
+            size=size,
+            g_max=g_max,
+            temp=temp,
+            q10_p=q10_p,
+            temp_ref_p=temp_ref_p,
+            q10_q=q10_q,
+            temp_ref_q=temp_ref_q,
+            V_sh=V_sh,
+            name=name,
         )
 
 
@@ -1038,19 +1052,13 @@ class CaHVA_SU2015_DCN(HH):
         self.qdeltat = braintools.init.param(qdeltat, self.varshape, allow_none=False)
 
     def current(self, V, Ca: IonInfo):
-        v_mV = V.to_decimal(u.mV)
-        temp = self.temp.to_decimal(u.kelvin)
-        ci = Ca.Ci.to_decimal(u.mM)
-        co = Ca.Co.to_decimal(u.mM)
+        drive = _su2015_dcn_ghk_drive(V, Ca.Ci, Ca.Co, self.temp)
         perm = self.perm.to_decimal(u.cm / u.second)
-        A = u.math.exp(-23.20764929 * v_mV / temp)
-        drive = (4.47814e6 * v_mV / temp) * ((ci / 1000.0) - (co / 1000.0) * A) / (1.0 - A)
-        current_value = perm * self.m.value**3 * drive
         # NEURON's raw ``ica`` is outward-positive, so inward calcium entry
         # appears as a negative current. BrainCell channel currents use the
         # repo-wide inward-positive convention, so imported mechanisms flip
         # the sign here and comparisons should use ``-neuron_ica``.
-        return -current_value * (u.mA / (u.cm**2))
+        return -(perm * self.conductance_factor(V, Ca) * drive) * (u.mA / (u.cm**2))
 
     def f_m_inf(self, V, Ca: IonInfo):
         V = V.to_decimal(u.mV)
@@ -1367,19 +1375,13 @@ class CaLVA_SU2015_DCN(HH):
         self.qdeltat = braintools.init.param(qdeltat, self.varshape, allow_none=False)
 
     def current(self, V, Ca: IonInfo):
-        v_mV = V.to_decimal(u.mV)
-        temp = self.temp.to_decimal(u.kelvin)
-        ci = Ca.Ci.to_decimal(u.mM)
-        co = Ca.Co.to_decimal(u.mM)
+        drive = _su2015_dcn_ghk_drive(V, Ca.Ci, Ca.Co, self.temp)
         perm = self.perm.to_decimal(u.cm / u.second)
-        A = u.math.exp(-23.20764929 * v_mV / temp)
-        drive = (4.47814e6 * v_mV / temp) * ((ci / 1000.0) - (co / 1000.0) * A) / (1.0 - A)
-        current_value = perm * self.m.value**2 * self.h.value * drive
         # NEURON's raw ``ical`` is outward-positive, so inward calcium entry
         # appears as a negative current. BrainCell channel currents use the
         # repo-wide inward-positive convention, so imported mechanisms flip
         # the sign here and comparisons should use ``-neuron_ical``.
-        return -current_value * (u.mA / (u.cm**2))
+        return -(perm * self.conductance_factor(V, Ca) * drive) * (u.mA / (u.cm**2))
 
     def f_m_inf(self, V, Ca: IonInfo):
         V = V.to_decimal(u.mV)
@@ -1493,10 +1495,10 @@ class Cav1p2_MA2020_GoC(OhmicHH):
     cited above and does not resolve that third credit, so no
     reference entry is written for it.
 
-    ``V_sh`` is accepted, stored and never read: no rate method of
-    this class uses it. That reproduces the mod file, whose
-    ``PARAMETER`` block likewise declares ``vshift = 0 (mV)`` and
-    never uses it. In the same spirit, the three gates are wired for
+    The mod file's ``PARAMETER`` block declares ``vshift = 0 (mV)``
+    and never uses it; BrainCell does not expose a ``V_sh`` for it,
+    since a shift that silently does nothing is worse than none. In
+    the same spirit, the three gates are wired for
     Q10 scaling through ``Gate(q10="q10", temp_ref="temp_ref")``, but
     the shipped defaults (``q10 = 1.0`` and
     ``temp = temp_ref = 22 degC``) make ``phi`` exactly 1, matching
@@ -1559,7 +1561,6 @@ class Cav1p2_MA2020_GoC(OhmicHH):
         self,
         size: Size,
         g_max: Initializer = 0.0002 * (u.siemens / u.cm**2),
-        V_sh: Initializer = 0.0 * u.mV,
         temp: ArrayLike = u.celsius2kelvin(22.0),
         q10: Initializer = 1.0,
         temp_ref: ArrayLike = u.celsius2kelvin(22.0),
@@ -1567,7 +1568,6 @@ class Cav1p2_MA2020_GoC(OhmicHH):
     ):
         super().__init__(size=size, name=name)
         self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
         self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
         self.q10 = braintools.init.param(q10, self.varshape, allow_none=False)
         self.temp_ref = braintools.init.param(temp_ref, self.varshape, allow_none=False)
@@ -1777,10 +1777,10 @@ class Cav1p3_MA2020_GoC(OhmicHH):
     cited above and does not resolve that third credit, so no
     reference entry is written for it.
 
-    ``V_sh`` is accepted, stored and never read: no rate method of
-    this class uses it. That reproduces the mod file, whose
-    ``PARAMETER`` block likewise declares ``vshift = 0 (mV)`` and
-    never uses it. In the same spirit, the three gates are wired for
+    The mod file's ``PARAMETER`` block declares ``vshift = 0 (mV)``
+    and never uses it; BrainCell does not expose a ``V_sh`` for it,
+    since a shift that silently does nothing is worse than none. In
+    the same spirit, the three gates are wired for
     Q10 scaling through ``Gate(q10="q10", temp_ref="temp_ref")``, but
     the shipped defaults (``q10 = 1.0`` and
     ``temp = temp_ref = 22 degC``) make ``phi`` exactly 1, matching
@@ -1846,7 +1846,6 @@ class Cav1p3_MA2020_GoC(OhmicHH):
         self,
         size: Size,
         g_max: Initializer = 0.000005 * (u.siemens / u.cm**2),
-        V_sh: Initializer = 0.0 * u.mV,
         temp: ArrayLike = u.celsius2kelvin(22.0),
         q10: Initializer = 1.0,
         temp_ref: ArrayLike = u.celsius2kelvin(22.0),
@@ -1854,7 +1853,6 @@ class Cav1p3_MA2020_GoC(OhmicHH):
     ):
         super().__init__(size=size, name=name)
         self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
         self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
         self.q10 = braintools.init.param(q10, self.varshape, allow_none=False)
         self.temp_ref = braintools.init.param(temp_ref, self.varshape, allow_none=False)
@@ -1970,7 +1968,7 @@ class Cav1p3_MA2025_BC(Cav1p3_MA2020_GoC):
 
 
 @register_channel("Cav3p1_MA2020_GoC")
-class Cav3p1_MA2020_GoC(HH):
+class Cav3p1_MA2020_GoC(GhkHH):
     r"""Golgi cell Cav3.1 low-threshold calcium current with GHK drive.
 
     The Cav3.1 (T-type) low-threshold calcium current of the
@@ -2021,9 +2019,6 @@ class Cav3p1_MA2020_GoC(HH):
         mod file's ``pcabar`` -- despite the ``g_max`` name and
         conductance-like spelling. Defaults to ``2.5e-4 cm/s`` (see
         Notes).
-    V_sh : array-like or callable, optional
-        Threshold shift. Accepted and stored, but read by no method
-        of this class (see Notes). Defaults to ``0.0 mV``.
     temp : array-like, optional
         Absolute temperature. Enters both :math:`q_t` and the GHK
         flux. Defaults to 22 degrees Celsius.
@@ -2103,9 +2098,9 @@ class Cav3p1_MA2020_GoC(HH):
     ``g_max`` is a permeability in ``cm/s``, not a conductance
     density: the name is BrainCell's uniform parameter name for the
     scale factor in front of the gating product, and this mechanism's
-    current law is a permeability-scaled GHK flux. ``V_sh`` is
-    accepted, stored and never read; the mod file declares no
-    corresponding parameter at all.
+    current law is a permeability-scaled GHK flux. The mod file
+    declares no threshold-shift parameter, and neither does this
+    class.
 
     ``g_max``'s default is the ``pcabar`` of the cell-model deposit
     this mechanism was imported from -- a value tuned for that model,
@@ -2135,12 +2130,12 @@ class Cav3p1_MA2020_GoC(HH):
         Gate("p", power=2),
         Gate("q"),
     )
+    ghk = staticmethod(_cav3p1_nmodl_ghk_flux)
 
     def __init__(
         self,
         size: Size,
         g_max: Initializer = 2.5e-4 * (u.cm / u.second),
-        V_sh: Initializer = 0.0 * u.mV,
         temp: ArrayLike = u.celsius2kelvin(22.0),
         q10: Initializer = 3.0,
         temp_ref: ArrayLike = u.celsius2kelvin(37.0),
@@ -2148,7 +2143,6 @@ class Cav3p1_MA2020_GoC(HH):
     ):
         super().__init__(size=size, name=name)
         self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
         self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
         self.q10 = braintools.init.param(q10, self.varshape, allow_none=False)
         self.temp_ref = braintools.init.param(temp_ref, self.varshape, allow_none=False)
@@ -2168,18 +2162,18 @@ class Cav3p1_MA2020_GoC(HH):
         self.k_tau_h1 = 7.0 * u.mV
         self.z = 2
 
-    def current(self, V, Ca: IonInfo):
-        drive = _cav3p1_nmodl_ghk_flux(V=V, ci=Ca.Ci, co=Ca.Co, z=self.z, temp=self.temp)
-        return -self.g_max * self.conductance_factor(V, Ca) * drive
-
     def f_p_inf(self, V, Ca: IonInfo):
         return 1.0 / (1.0 + u.math.exp((V - self.v0_m_inf) / self.k_m_inf))
 
     def f_q_inf(self, V, Ca: IonInfo):
         return 1.0 / (1.0 + u.math.exp((V - self.v0_h_inf) / self.k_h_inf))
 
+    def _qt(self):
+        """Memoised ``qt``; both tau branches need it and neither depends on V."""
+        return cached_q10_factor(self, "_qt_memo", self.q10, self.temp, self.temp_ref)
+
     def f_p_tau(self, V, Ca: IonInfo):
-        qt = q10_factor(self.q10, self.temp, self.temp_ref)
+        qt = self._qt()
         return u.math.where(
             V <= -90.0 * u.mV,
             1.0,
@@ -2197,7 +2191,7 @@ class Cav3p1_MA2020_GoC(HH):
         )
 
     def f_q_tau(self, V, Ca: IonInfo):
-        qt = q10_factor(self.q10, self.temp, self.temp_ref)
+        qt = self._qt()
         return (self.C_tau_h + self.A_tau_h / u.math.exp((V - self.v0_tau_h1) / self.k_tau_h1)) / qt
 
 
@@ -2219,10 +2213,6 @@ class Cav3p1_MA2024_PC(Cav3p1_MA2020_GoC):
         Calcium permeability entering the GHK flux (the mod file's
         ``pcabar``), default ``2.5e-4 cm/s``. Inherited from
         :class:`Cav3p1_MA2020_GoC`.
-    V_sh : array-like or callable, optional
-        Accepted but read by no method of this class (see
-        :class:`Cav3p1_MA2020_GoC` Notes). Default ``0.0 mV``.
-        Inherited from :class:`Cav3p1_MA2020_GoC`.
     temp : array-like, optional
         Absolute temperature entering both the ``qt`` factor and the
         GHK flux, default 22 degrees Celsius. Inherited from
@@ -2311,10 +2301,6 @@ class Cav3p1_MA2020_GoC_Frozen(Cav3p1_MA2020_GoC):
         Calcium permeability entering the GHK flux (the mod file's
         ``pcabar``), default ``2.5e-4 cm/s``. Inherited from
         :class:`Cav3p1_MA2020_GoC`.
-    V_sh : array-like or callable, optional
-        Accepted but read by no method of this class (see
-        :class:`Cav3p1_MA2020_GoC` Notes). Default ``0.0 mV``.
-        Inherited from :class:`Cav3p1_MA2020_GoC`.
     temp : array-like, optional
         Absolute temperature entering both the ``qt`` factor and the
         GHK flux, default 22 degrees Celsius. Inherited from
@@ -2333,23 +2319,19 @@ class Cav3p1_MA2020_GoC_Frozen(Cav3p1_MA2020_GoC):
     Cav3p1_MA2020_GoC : The base class; every equation, the GHK
         helper's constants and the header corrections are documented
         there.
-    Cav3p1_MA2024_PC_Frozen : Purkinje-cell counterpart with
-        numerically identical behaviour but a different class graph:
-        it subclasses :class:`~braincell.channel._base.HH` directly
-        and re-declares everything rather than inheriting.
+    Cav3p1_MA2024_PC_Frozen : Purkinje-cell counterpart, built the
+        same way on top of :class:`Cav3p1_MA2024_PC`.
 
     Notes
     -----
     "Frozen" describes the gradient path, not the forward numerics and
     not the channel states. Both gates keep integrating exactly as in
-    the base class -- nothing stops evolving. What
-    :meth:`current` changes is that the membrane potential handed to
-    the GHK helper is first passed through the module-level
-    ``_freeze_quantity_gradient``, which rebuilds the quantity from
-    :func:`jax.lax.stop_gradient` applied to its mantissa. The
-    explicit voltage dependence of the GHK driving force therefore
-    contributes nothing to reverse-mode gradients, while the value it
-    computes is unchanged.
+    the base class -- nothing stops evolving. The whole class body is
+    ``freeze_drive_gradient = True``: :attr:`~braincell.channel.GhkHH.freeze_drive_gradient`
+    routes the membrane potential through
+    :func:`~braincell.channel.freeze_gradient` before it reaches the GHK
+    helper, so the drive's explicit voltage dependence contributes nothing to
+    reverse-mode gradients while the value it computes is unchanged.
 
     The unfrozen ``V`` is still passed to
     :meth:`~braincell.channel._base.HH.conductance_factor`, but that
@@ -2382,15 +2364,11 @@ class Cav3p1_MA2020_GoC_Frozen(Cav3p1_MA2020_GoC):
     """
 
     __module__ = "braincell.channel"
-
-    def current(self, V, Ca: IonInfo):
-        frozen_V = _freeze_quantity_gradient(V)
-        drive = _cav3p1_nmodl_ghk_flux(V=frozen_V, ci=Ca.Ci, co=Ca.Co, z=self.z, temp=self.temp)
-        return -self.g_max * self.conductance_factor(V, Ca) * drive
+    freeze_drive_gradient = True
 
 
 @register_channel("Cav3p1_MA2024_PC_Frozen")
-class Cav3p1_MA2024_PC_Frozen(HH):
+class Cav3p1_MA2024_PC_Frozen(Cav3p1_MA2024_PC):
     r"""Purkinje cell Cav3.1 with the GHK drive frozen for autodiff.
 
     A standalone Purkinje-cell Cav3.1 mechanism that stops the
@@ -2412,9 +2390,6 @@ class Cav3p1_MA2024_PC_Frozen(HH):
         Calcium permeability entering the GHK flux (the mod file's
         ``pcabar``), despite the ``g_max`` name. Defaults to
         ``2.5e-4 cm/s``.
-    V_sh : array-like or callable, optional
-        Threshold shift. Accepted and stored, but read by no method
-        of this class (see Notes). Defaults to ``0.0 mV``.
     temp : array-like, optional
         Absolute temperature. Enters both the ``qt`` factor and the
         GHK flux. Defaults to 22 degrees Celsius.
@@ -2429,34 +2404,27 @@ class Cav3p1_MA2024_PC_Frozen(HH):
     See Also
     --------
     Cav3p1_MA2024_PC : The unfrozen Purkinje-cell import of the same
-        mechanism. This class is **not** derived from it.
+        mechanism, and this class's base.
     Cav3p1_MA2020_GoC : Where the equation set, the GHK helper's
         constants, the tau-embedded temperature handling and the mod
         header corrections are documented in full.
     Cav3p1_MA2020_GoC_Frozen : Golgi-cell counterpart with the same
-        freezing behaviour, reached by inheritance instead.
+        freezing behaviour, built the same way.
 
     Notes
     -----
-    **This class is not a subclass of the unfrozen Purkinje-cell
-    import, and the two frozen Cav3.1 classes in this module are not
-    built the same way.** :class:`Cav3p1_MA2020_GoC_Frozen` derives
-    from :class:`Cav3p1_MA2020_GoC` and overrides :meth:`current`
-    alone.
-    This class derives from :class:`~braincell.channel._base.HH`
-    directly and re-declares everything: ``root_type``, both gates,
-    the whole constructor and parameter block, ``f_p_inf``,
-    ``f_q_inf``, ``f_p_tau``, ``f_q_tau`` and ``current``. The two
-    frozen variants therefore compute the same numbers while sharing
-    no code, and a change to :class:`Cav3p1_MA2020_GoC` propagates to
-    one of them and not to the other.
+    Both frozen Cav3.1 classes in this module are built the same way:
+    each subclasses its own unfrozen sibling and declares
+    ``freeze_drive_gradient = True``, so a change to
+    :class:`Cav3p1_MA2020_GoC` reaches both.
 
     "Frozen" describes the gradient path, not the forward numerics and
     not the channel states. Both gates keep integrating normally --
-    nothing stops evolving. :meth:`current` passes the membrane
-    potential through the module-level ``_freeze_quantity_gradient``,
-    which rebuilds the quantity from :func:`jax.lax.stop_gradient`
-    applied to its mantissa, before handing it to the GHK helper. The
+    nothing stops evolving. :attr:`~braincell.channel.GhkHH.freeze_drive_gradient`
+    routes the membrane potential through
+    :func:`~braincell.channel.freeze_gradient` before it reaches the GHK
+    helper, so the drive's explicit voltage dependence contributes nothing to
+    reverse-mode gradients while the value it computes is unchanged. The
     unfrozen ``V`` still reaches
     :meth:`~braincell.channel._base.HH.conductance_factor`, but that
     method ignores its voltage argument and reads only the gate
@@ -2471,8 +2439,7 @@ class Cav3p1_MA2024_PC_Frozen(HH):
     observe.
 
     As in :class:`Cav3p1_MA2020_GoC`, ``g_max`` is a permeability in
-    ``cm/s`` rather than a conductance density, ``V_sh`` is accepted
-    and never read with no corresponding parameter in the mod file,
+    ``cm/s`` rather than a conductance density,
     the temperature factor ``qt`` is embedded in the tau expressions
     instead of in ``Gate``, the ``tau_p`` constant branch at
     ``V <= -90 mV`` is not divided by ``qt``, and ``current()`` uses
@@ -2502,76 +2469,7 @@ class Cav3p1_MA2024_PC_Frozen(HH):
     """
 
     __module__ = "braincell.channel"
-    root_type = Calcium
-    gates = (
-        Gate("p", power=2),
-        Gate("q"),
-    )
-
-    def __init__(
-        self,
-        size: Size,
-        g_max: Initializer = 2.5e-4 * (u.cm / u.second),
-        V_sh: Initializer = 0.0 * u.mV,
-        temp: ArrayLike = u.celsius2kelvin(22.0),
-        q10: Initializer = 3.0,
-        temp_ref: ArrayLike = u.celsius2kelvin(37.0),
-        name: Optional[str] = None,
-    ):
-        super().__init__(size=size, name=name)
-        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
-        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
-        self.q10 = braintools.init.param(q10, self.varshape, allow_none=False)
-        self.temp_ref = braintools.init.param(temp_ref, self.varshape, allow_none=False)
-        self.v0_m_inf = -52.0 * u.mV
-        self.v0_h_inf = -72.0 * u.mV
-        self.k_m_inf = -5.0 * u.mV
-        self.k_h_inf = 7.0 * u.mV
-        self.C_tau_m = 1.0
-        self.A_tau_m = 1.0
-        self.v0_tau_m1 = -40.0 * u.mV
-        self.v0_tau_m2 = -102.0 * u.mV
-        self.k_tau_m1 = 9.0 * u.mV
-        self.k_tau_m2 = -18.0 * u.mV
-        self.C_tau_h = 15.0
-        self.A_tau_h = 1.0
-        self.v0_tau_h1 = -32.0 * u.mV
-        self.k_tau_h1 = 7.0 * u.mV
-        self.z = 2
-
-    def current(self, V, Ca: IonInfo):
-        frozen_V = _freeze_quantity_gradient(V)
-        drive = _cav3p1_nmodl_ghk_flux(V=frozen_V, ci=Ca.Ci, co=Ca.Co, z=self.z, temp=self.temp)
-        return -self.g_max * self.conductance_factor(V, Ca) * drive
-
-    def f_p_inf(self, V, Ca: IonInfo):
-        return 1.0 / (1.0 + u.math.exp((V - self.v0_m_inf) / self.k_m_inf))
-
-    def f_q_inf(self, V, Ca: IonInfo):
-        return 1.0 / (1.0 + u.math.exp((V - self.v0_h_inf) / self.k_h_inf))
-
-    def f_p_tau(self, V, Ca: IonInfo):
-        qt = q10_factor(self.q10, self.temp, self.temp_ref)
-        return u.math.where(
-            V <= -90.0 * u.mV,
-            1.0,
-            (
-                self.C_tau_m
-                + (
-                    self.A_tau_m
-                    / (
-                        u.math.exp((V - self.v0_tau_m1) / self.k_tau_m1)
-                        + u.math.exp((V - self.v0_tau_m2) / self.k_tau_m2)
-                    )
-                )
-            )
-            / qt,
-        )
-
-    def f_q_tau(self, V, Ca: IonInfo):
-        qt = q10_factor(self.q10, self.temp, self.temp_ref)
-        return (self.C_tau_h + self.A_tau_h / u.math.exp((V - self.v0_tau_h1) / self.k_tau_h1)) / qt
+    freeze_drive_gradient = True
 
 
 @register_channel("Cav3p1Test_PC24")
@@ -2739,9 +2637,13 @@ class Cav3p1Test_PC24(HH):
         _ = Ca
         return 1.0 / (1.0 + u.math.exp((V - self.v0_h_inf) / self.k_h_inf))
 
+    def _qt(self):
+        """Memoised ``qt``; both tau branches need it and neither depends on V."""
+        return cached_q10_factor(self, "_qt_memo", self.q10, self.temp, self.temp_ref)
+
     def f_p_tau(self, V, Ca: IonInfo):
         _ = Ca
-        qt = q10_factor(self.q10, self.temp, self.temp_ref)
+        qt = self._qt()
         return u.math.where(
             V <= -90.0 * u.mV,
             1.0,
@@ -2760,12 +2662,12 @@ class Cav3p1Test_PC24(HH):
 
     def f_q_tau(self, V, Ca: IonInfo):
         _ = Ca
-        qt = q10_factor(self.q10, self.temp, self.temp_ref)
+        qt = self._qt()
         return (self.C_tau_h + self.A_tau_h / u.math.exp((V - self.v0_tau_h1) / self.k_tau_h1)) / qt
 
 
 @register_channel("Cav2p1_RI2021_SC")
-class Cav2p1_RI2021_SC(HH):
+class Cav2p1_RI2021_SC(GhkHH):
     r"""Stellate cell Cav2.1 P-type calcium current with GHK drive.
 
     The Cav2.1 (P-type) calcium current of the cerebellar stellate
@@ -2928,16 +2830,6 @@ class Cav2p1_RI2021_SC(HH):
 
     def _shifted_voltage(self, V):
         return V - self.V_sh
-
-    def current(self, V, Ca: IonInfo):
-        drive = ghk_flux(
-            V=self._shifted_voltage(V),
-            ci=Ca.Ci,
-            co=Ca.Co,
-            z=self.z,
-            temp=self.temp,
-        )
-        return -self.g_max * self.conductance_factor(V, Ca) * drive
 
     def f_m_inf(self, V, Ca: IonInfo):
         V = self._shifted_voltage(V)
@@ -3114,7 +3006,7 @@ class Cav2p1_MA2024_PC(Cav2p1_RI2021_SC):
 
 
 @register_channel("Cav2p1_MA2024_PC_Frozen")
-class Cav2p1_MA2024_PC_Frozen(HH):
+class Cav2p1_MA2024_PC_Frozen(_FrozenCav3p1Ghk, Cav2p1_MA2024_PC):
     r"""Purkinje cell Cav2.1 with the GHK drive frozen for autodiff.
 
     A standalone Purkinje-cell Cav2.1 mechanism that stops the
@@ -3150,42 +3042,40 @@ class Cav2p1_MA2024_PC_Frozen(HH):
     See Also
     --------
     Cav2p1_MA2024_PC : The unfrozen Purkinje-cell import of the same
-        mechanism. This class is **not** derived from it.
+        mechanism, and this class's base.
     Cav2p1_RI2021_SC : Where the equation set, the permeability
         discrepancy and the mod header corrections are documented in
         full.
-    Cav2p1_RI2021_SC_Frozen : Stellate-cell frozen variant, which
-        *is* a subclass of this class and overrides nothing.
-    Cav2p1_MA2025_BC_Frozen : Basket-cell frozen variant, likewise a
-        subclass of this class overriding nothing.
+    Cav2p1_RI2021_SC_Frozen : Stellate-cell frozen variant, built the
+        same way on top of :class:`Cav2p1_RI2021_SC`.
+    Cav2p1_MA2025_BC_Frozen : Basket-cell frozen variant, likewise
+        built on top of :class:`Cav2p1_MA2025_BC`.
 
     Notes
     -----
-    **This class is not a subclass of the unfrozen Purkinje-cell
-    import.** It derives from
-    :class:`~braincell.channel._base.HH` directly and re-declares
-    everything: ``root_type``, the gate, the whole constructor and
-    parameter block, ``f_m_inf``, ``f_m_tau`` and ``current``. A
-    change to :class:`Cav2p1_RI2021_SC` therefore does not propagate
-    here. The two Cav2.1 frozen siblings,
-    :class:`Cav2p1_RI2021_SC_Frozen` and
-    :class:`Cav2p1_MA2025_BC_Frozen`, are subclasses of *this* class
-    and add nothing but a registry key.
+    The class body is the two declarations ``_FrozenCav3p1Ghk``
+    supplies. Every gate, constant and rate function comes from
+    :class:`Cav2p1_MA2024_PC`, so a change to
+    :class:`Cav2p1_RI2021_SC` propagates here. The two Cav2.1 frozen
+    siblings, :class:`Cav2p1_RI2021_SC_Frozen` and
+    :class:`Cav2p1_MA2025_BC_Frozen`, are built the same way over
+    their own unfrozen classes rather than over this one.
 
     "Frozen" describes the gradient path, not the channel states.
     The ``m`` gate keeps integrating exactly as in the unfrozen
-    class -- nothing stops evolving. :meth:`current` passes the
-    membrane potential through the module-level
-    ``_freeze_quantity_gradient``, which rebuilds the quantity from
-    :func:`jax.lax.stop_gradient` applied to its mantissa, before
-    handing it to the GHK helper. The unfrozen ``V`` still reaches
+    class -- nothing stops evolving. :attr:`~braincell.channel.GhkHH.freeze_drive_gradient`
+    routes the membrane potential through
+    :func:`~braincell.channel.freeze_gradient` before it reaches the GHK
+    helper, so the drive's explicit voltage dependence contributes nothing to
+    reverse-mode gradients while the value it computes is unchanged. The unfrozen ``V`` still reaches
     :meth:`~braincell.channel._base.HH.conductance_factor`, but that
     method ignores its voltage argument and reads only the gate
     states, so the distinction affects neither value nor gradient
     there.
 
     **The freezing is not the only difference from the unfrozen
-    class.** :meth:`current` here calls the module-level
+    class.** ``_FrozenCav3p1Ghk`` also declares
+    :attr:`~braincell.channel.GhkHH.ghk` as the module-level
     ``_cav3p1_nmodl_ghk_flux`` helper, whereas
     :class:`Cav2p1_RI2021_SC` calls the shared
     :func:`~braincell.channel._base.ghk_flux`. The two helpers use
@@ -3235,54 +3125,10 @@ class Cav2p1_MA2024_PC_Frozen(HH):
     """
 
     __module__ = "braincell.channel"
-    root_type = Calcium
-    gates = (Gate("m", power=3, q10=3.0, temp_ref=u.celsius2kelvin(23.0)),)
-
-    def __init__(
-        self,
-        size: Size,
-        g_max: Initializer = 2.2e-4 * (u.cm / u.second),
-        V_sh: Initializer = 0.0 * u.mV,
-        temp: ArrayLike = u.celsius2kelvin(23.0),
-        name: Optional[str] = None,
-    ):
-        super().__init__(size=size, name=name)
-        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
-        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
-        self.vhalfm = -29.458 * u.mV
-        self.cvm = 8.429 * u.mV
-        self.z = 2
-
-    def _shifted_voltage(self, V):
-        return V - self.V_sh
-
-    def current(self, V, Ca: IonInfo):
-        frozen_V = _freeze_quantity_gradient(V)
-        drive = _cav3p1_nmodl_ghk_flux(
-            V=self._shifted_voltage(frozen_V),
-            ci=Ca.Ci,
-            co=Ca.Co,
-            z=self.z,
-            temp=self.temp,
-        )
-        return -self.g_max * self.conductance_factor(V, Ca) * drive
-
-    def f_m_inf(self, V, Ca: IonInfo):
-        V = self._shifted_voltage(V)
-        return 1.0 / (1.0 + u.math.exp(-(V - self.vhalfm) / self.cvm))
-
-    def f_m_tau(self, V, Ca: IonInfo):
-        V = self._shifted_voltage(V).to_decimal(u.mV)
-        return u.math.where(
-            V >= -40.0,
-            0.2702 + 1.1622 * u.math.exp(-((V + 26.798) ** 2) / 164.19),
-            0.6923 * u.math.exp(V / 1089.372),
-        )
 
 
 @register_channel("Cav2p1_RI2021_SC_Frozen")
-class Cav2p1_RI2021_SC_Frozen(Cav2p1_MA2024_PC_Frozen):
+class Cav2p1_RI2021_SC_Frozen(_FrozenCav3p1Ghk, Cav2p1_RI2021_SC):
     r"""Stellate cell Cav2.1 with the GHK drive frozen for autodiff.
 
     The stellate-cell registration of the frozen-GHK Cav2.1
@@ -3313,28 +3159,21 @@ class Cav2p1_RI2021_SC_Frozen(Cav2p1_MA2024_PC_Frozen):
 
     See Also
     --------
-    Cav2p1_MA2024_PC_Frozen : The base class; the freezing
-        mechanism, the GHK helper's constants and the difference
-        from the unfrozen classes are documented there.
+    Cav2p1_MA2024_PC_Frozen : The Purkinje-cell frozen variant,
+        where the freezing mechanism, the GHK helper's constants and
+        the difference from the unfrozen classes are documented.
     Cav2p1_RI2021_SC : The unfrozen stellate-cell import of the same
-        mechanism. This class is **not** derived from it, and is not
-        numerically identical to it.
+        mechanism, and this class's base. The two are **not**
+        numerically identical: see the Notes.
 
     Notes
     -----
-    **The cell-type suffix in this class's name describes its model
-    citation, not its implementation.** The class body is empty
-    apart from ``__module__``: every gate, constant, rate function
-    and the ``current`` method come from
-    :class:`Cav2p1_MA2024_PC_Frozen`, the Purkinje-cell frozen
-    variant. That is sound because ``SC/channel/Cav2p1_RI21_SC.mod``
-    and ``PC/channel/Cav2p1_MA24_PC.mod`` are identical apart from
-    their ``SUFFIX`` lines and a ``g_equiv`` diagnostic, but it does
-    mean the stellate-cell class inherits from a Purkinje-cell one
-    rather than from :class:`Cav2p1_RI2021_SC`. Per the
-    bibliography's attribution scan this subclass contributes no
-    rate-function code of its own; its zero literal overlap in that
-    scan is an artefact of the constants living in the base class.
+    The class body is the two declarations ``_FrozenCav3p1Ghk``
+    supplies; every gate, constant and rate function comes from
+    :class:`Cav2p1_RI2021_SC`. Per the bibliography's attribution
+    scan this subclass contributes no rate-function code of its own;
+    its zero literal overlap in that scan is an artefact of the
+    constants living in the base class.
 
     Everything in :class:`Cav2p1_MA2024_PC_Frozen`'s Notes applies
     unchanged and is not repeated here: no channel state stops
@@ -3371,7 +3210,7 @@ class Cav2p1_RI2021_SC_Frozen(Cav2p1_MA2024_PC_Frozen):
 
 
 @register_channel("Cav2p1_MA2025_BC_Frozen")
-class Cav2p1_MA2025_BC_Frozen(Cav2p1_MA2024_PC_Frozen):
+class Cav2p1_MA2025_BC_Frozen(_FrozenCav3p1Ghk, Cav2p1_MA2025_BC):
     r"""Basket cell Cav2.1 with the GHK drive frozen for autodiff.
 
     The basket-cell registration of the frozen-GHK Cav2.1 mechanism
@@ -3402,24 +3241,17 @@ class Cav2p1_MA2025_BC_Frozen(Cav2p1_MA2024_PC_Frozen):
 
     See Also
     --------
-    Cav2p1_MA2024_PC_Frozen : The base class; the freezing
-        mechanism, the GHK helper's constants and the difference
-        from the unfrozen classes are documented there.
+    Cav2p1_MA2024_PC_Frozen : The Purkinje-cell frozen variant,
+        where the freezing mechanism, the GHK helper's constants and
+        the difference from the unfrozen classes are documented.
     Cav2p1_MA2025_BC : The unfrozen basket-cell import of the same
-        mechanism. This class is **not** derived from it, and is not
-        numerically identical to it.
+        mechanism, and this class's base. The two are **not**
+        numerically identical: see the Notes.
 
     Notes
     -----
-    **The cell-type suffix in this class's name describes its model
-    citation, not its implementation.** The class body is empty
-    apart from ``__module__``: every gate, constant, rate function
-    and the ``current`` method come from
-    :class:`Cav2p1_MA2024_PC_Frozen`, the Purkinje-cell frozen
-    variant. That is sound because ``BC/channel/Cav2p1_MA25_BC.mod``
-    and ``PC/channel/Cav2p1_MA24_PC.mod`` are identical apart from
-    their ``SUFFIX`` lines, but it does mean the basket-cell class
-    inherits from a Purkinje-cell one rather than from
+    The class body is the two declarations ``_FrozenCav3p1Ghk``
+    supplies; every gate, constant and rate function comes from
     :class:`Cav2p1_MA2025_BC`. Per the bibliography's attribution
     scan this subclass contributes no rate-function code of its own;
     its zero literal overlap in that scan is an artefact of the
@@ -3457,180 +3289,6 @@ class Cav2p1_MA2025_BC_Frozen(Cav2p1_MA2024_PC_Frozen):
     """
 
     __module__ = "braincell.channel"
-
-
-@register_channel("Cav3p3_MA2024_PC_Frozen")
-class Cav3p3_MA2024_PC_Frozen(HH):
-    r"""Purkinje cell Cav3.3 with the GHK drive frozen for autodiff.
-
-    A standalone Purkinje-cell Cav3.3 mechanism that stops the
-    gradient through the membrane potential where it enters the
-    constant-field (GHK) flux term. Its kinetics, its named
-    parameter block and its forward current are numerically
-    identical to :class:`Cav3p3_MA2024_PC`'s, and its attribution is
-    the same: the Cav3.3 kinetics of the CA3 hippocampal pyramidal
-    neuron model of (Xu & Clancy, 2008) [1]_, imported for the human
-    Purkinje cell model of (Masoli et al., 2024) [2]_. It inherits
-    none of that code -- see Notes.
-
-    Parameters
-    ----------
-    size : brainstate.typing.Size
-        Channel state shape.
-    perm : array-like or callable, optional
-        Calcium permeability entering the GHK flux, the mod file's
-        ``pcabar``. Defaults to ``1.0e-4 cm/s``.
-    g_scale : array-like or callable, optional
-        Dimensionless empirical scale factor multiplying the flux,
-        carrying the numeric value of the mod file's
-        ``gCav3_3bar``. Defaults to ``1.0e-5``.
-    temp : array-like, optional
-        Absolute temperature. Enters both the gates' Q10 factor and
-        the GHK flux. Defaults to 36 degrees Celsius.
-    V_sh : array-like or callable, optional
-        Voltage shift subtracted from :math:`V` before every rate
-        and before the GHK term. Defaults to ``0.0 mV``. The mod
-        file declares no corresponding parameter.
-    name : str, optional
-        Optional channel name.
-
-    See Also
-    --------
-    Cav3p3_MA2024_PC : The unfrozen Purkinje-cell import of the same
-        mechanism. This class is **not** derived from it.
-    Cav3p3_RI2021_SC : Where the equation set, the GHK helper's
-        constants and the current-law scaling caveat are documented
-        in full.
-    Cav2p1_MA2024_PC_Frozen : The module's other standalone frozen
-        variant, which additionally swaps GHK helpers and so is
-        *not* numerically identical to its unfrozen counterpart.
-
-    Notes
-    -----
-    **This class is not a subclass of the unfrozen Purkinje-cell
-    import, and the module's frozen variants are not all built the
-    same way.** :class:`Cav3p3_MA2024_PC` derives from
-    :class:`Cav3p3_RI2021_SC`; this class derives from
-    :class:`~braincell.channel._base.HH` directly and re-declares
-    everything: ``root_type``, both gates, the whole constructor and
-    parameter block, ``f_n_inf``, ``f_l_inf``, ``f_n_tau``,
-    ``f_l_tau`` and ``current``. The two therefore compute the same
-    forward numbers while sharing no code, and a change to
-    :class:`Cav3p3_RI2021_SC` propagates to one and not the other.
-
-    "Frozen" describes the gradient path, not the forward numerics
-    and not the channel states. Both gates keep integrating normally
-    -- nothing stops evolving. :meth:`current` passes the membrane
-    potential through the module-level
-    ``_freeze_quantity_gradient``, which rebuilds the quantity from
-    :func:`jax.lax.stop_gradient` applied to its mantissa, before
-    handing it to the GHK helper. The unfrozen ``V`` still reaches
-    :meth:`~braincell.channel._base.HH.conductance_factor`, but that
-    method ignores its voltage argument and reads only the gate
-    states, so the distinction affects neither value nor gradient
-    there. **Unlike** :class:`Cav2p1_MA2024_PC_Frozen`, this class
-    calls the same ``_cav3p3_nmodl_ghk_flux`` helper its unfrozen
-    counterpart calls, so freezing is the only difference between
-    the two and the forward current is unchanged.
-
-    The kinetics are those of ``PC/channel/Cav3p3_MA24_PC.mod``,
-    which is identical to ``SC/channel/Cav3p3_RI21_SC.mod`` apart
-    from its ``SUFFIX`` line and a ``g_equiv`` diagnostic. No mod
-    file ships a frozen-gradient variant: freezing is a BrainCell
-    autodiff facility with no counterpart in NMODL, so it is not an
-    import deviation and changes nothing a NEURON comparison would
-    observe.
-
-    As in :class:`Cav3p3_RI2021_SC`, the mod file's current-law
-    scaling is not dimensionally self-consistent and ``g_scale`` is
-    therefore dimensionless, the GHK helper carries the mod file's
-    own ``F``/``R`` constants and its ``celsius + 273.14`` Kelvin
-    conversion plus a small-argument series branch the mod file
-    lacks, ``V_sh`` has no counterpart in the mod file, the Q10 is
-    declared on the ``Gate`` objects, and ``current()`` negates
-    NEURON's outward-positive ``ica``. The ``perm`` and ``g_scale``
-    defaults are the deposit's tuned values, not values reported by
-    the origin paper.
-
-    References
-    ----------
-    .. [1] Xu, J., & Clancy, C. E. (2008). Ionic mechanisms of
-           endogenous bursting in CA3 hippocampal pyramidal neurons:
-           A model study. PLoS ONE, 3(4), e2056.
-           doi:10.1371/journal.pone.0002056
-    .. [2] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
-           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
-           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
-           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
-           mouse Purkinje cells in dendritic complexity and
-           computational capacity. Communications Biology, 7(1), 5.
-           doi:10.1038/s42003-023-05689-y
-    """
-
-    __module__ = "braincell.channel"
-    root_type = Calcium
-    gates = (
-        Gate("n", power=2, q10=2.3, temp_ref=u.celsius2kelvin(28.0)),
-        Gate("l", q10=2.3, temp_ref=u.celsius2kelvin(28.0)),
-    )
-
-    def __init__(
-        self,
-        size: Size,
-        perm: Initializer = 1.0e-4 * (u.cm / u.second),
-        g_scale: Initializer = 1.0e-5,
-        temp: ArrayLike = u.celsius2kelvin(36.0),
-        V_sh: Initializer = 0.0 * u.mV,
-        name: Optional[str] = None,
-    ):
-        super().__init__(size=size, name=name)
-        self.perm = braintools.init.param(perm, self.varshape, allow_none=False)
-        self.g_scale = braintools.init.param(g_scale, self.varshape, allow_none=False)
-        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
-        self.vhalfn = -41.5 * u.mV
-        self.vhalfl = -69.8 * u.mV
-        self.kn = 6.2 * u.mV
-        self.kl = -6.1 * u.mV
-        self.z = 2
-
-    def _shifted_voltage(self, V):
-        return V - self.V_sh
-
-    def current(self, V, Ca: IonInfo):
-        frozen_V = _freeze_quantity_gradient(V)
-        drive = _cav3p3_nmodl_ghk_flux(
-            V=self._shifted_voltage(frozen_V),
-            ci=Ca.Ci,
-            co=Ca.Co,
-            z=self.z,
-            temp=self.temp,
-        )
-        return -self.g_scale * self.perm * self.conductance_factor(V, Ca) * drive
-
-    def f_n_inf(self, V, Ca: IonInfo):
-        V = self._shifted_voltage(V)
-        return 1.0 / (1.0 + u.math.exp(-(V - self.vhalfn) / self.kn))
-
-    def f_l_inf(self, V, Ca: IonInfo):
-        V = self._shifted_voltage(V)
-        return 1.0 / (1.0 + u.math.exp(-(V - self.vhalfl) / self.kl))
-
-    def f_n_tau(self, V, Ca: IonInfo):
-        V = self._shifted_voltage(V).to_decimal(u.mV)
-        return u.math.where(
-            V > -60.0,
-            7.2 + 0.02 * u.math.exp(-V / 14.7),
-            0.875 * u.math.exp((V + 120.0) / 41.0),
-        )
-
-    def f_l_tau(self, V, Ca: IonInfo):
-        V = self._shifted_voltage(V).to_decimal(u.mV)
-        return u.math.where(
-            V > -60.0,
-            79.5 + 2.0 * u.math.exp(-V / 9.3),
-            260.0,
-        )
 
 
 @register_channel("Cav3p2_RI2021_SC")
@@ -4031,7 +3689,7 @@ class Cav3p2_MA2024_PC(Cav3p2_RI2021_SC):
 
 
 @register_channel("Cav3p3_RI2021_SC")
-class Cav3p3_RI2021_SC(HH):
+class Cav3p3_RI2021_SC(GhkHH):
     r"""Stellate cell Cav3.3 low-threshold calcium current, GHK drive.
 
     The Cav3.3 (T-type, alpha1I) low-threshold calcium current of
@@ -4195,6 +3853,7 @@ class Cav3p3_RI2021_SC(HH):
         Gate("n", power=2, q10=2.3, temp_ref=u.celsius2kelvin(28.0)),
         Gate("l", q10=2.3, temp_ref=u.celsius2kelvin(28.0)),
     )
+    ghk = staticmethod(_cav3p3_nmodl_ghk_flux)
 
     def __init__(
         self,
@@ -4219,15 +3878,8 @@ class Cav3p3_RI2021_SC(HH):
     def _shifted_voltage(self, V):
         return V - self.V_sh
 
-    def current(self, V, Ca: IonInfo):
-        drive = _cav3p3_nmodl_ghk_flux(
-            V=self._shifted_voltage(V),
-            ci=Ca.Ci,
-            co=Ca.Co,
-            z=self.z,
-            temp=self.temp,
-        )
-        return -self.g_scale * self.perm * self.conductance_factor(V, Ca) * drive
+    def permeability(self):
+        return self.g_scale * self.perm
 
     def f_n_inf(self, V, Ca: IonInfo):
         V = self._shifted_voltage(V)
@@ -4328,6 +3980,111 @@ class Cav3p3_MA2024_PC(Cav3p3_RI2021_SC):
     """
 
     __module__ = "braincell.channel"
+
+
+@register_channel("Cav3p3_MA2024_PC_Frozen")
+class Cav3p3_MA2024_PC_Frozen(Cav3p3_MA2024_PC):
+    r"""Purkinje cell Cav3.3 with the GHK drive frozen for autodiff.
+
+    A standalone Purkinje-cell Cav3.3 mechanism that stops the
+    gradient through the membrane potential where it enters the
+    constant-field (GHK) flux term. Its kinetics, its named
+    parameter block and its forward current are numerically
+    identical to :class:`Cav3p3_MA2024_PC`'s, and its attribution is
+    the same: the Cav3.3 kinetics of the CA3 hippocampal pyramidal
+    neuron model of (Xu & Clancy, 2008) [1]_, imported for the human
+    Purkinje cell model of (Masoli et al., 2024) [2]_. It inherits
+    none of that code -- see Notes.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    perm : array-like or callable, optional
+        Calcium permeability entering the GHK flux, the mod file's
+        ``pcabar``. Defaults to ``1.0e-4 cm/s``.
+    g_scale : array-like or callable, optional
+        Dimensionless empirical scale factor multiplying the flux,
+        carrying the numeric value of the mod file's
+        ``gCav3_3bar``. Defaults to ``1.0e-5``.
+    temp : array-like, optional
+        Absolute temperature. Enters both the gates' Q10 factor and
+        the GHK flux. Defaults to 36 degrees Celsius.
+    V_sh : array-like or callable, optional
+        Voltage shift subtracted from :math:`V` before every rate
+        and before the GHK term. Defaults to ``0.0 mV``. The mod
+        file declares no corresponding parameter.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    Cav3p3_MA2024_PC : The unfrozen Purkinje-cell import of the same
+        mechanism, and this class's base.
+    Cav3p3_RI2021_SC : Where the equation set, the GHK helper's
+        constants and the current-law scaling caveat are documented
+        in full.
+    Cav2p1_MA2024_PC_Frozen : The module's other family of frozen
+        variants, which additionally swap GHK helpers and so are
+        *not* numerically identical to their unfrozen counterparts.
+
+    Notes
+    -----
+    The class body is ``freeze_drive_gradient = True``. Every gate,
+    constant and rate function comes from :class:`Cav3p3_MA2024_PC`,
+    so a change to :class:`Cav3p3_RI2021_SC` reaches this class too.
+
+    "Frozen" describes the gradient path, not the forward numerics
+    and not the channel states. Both gates keep integrating normally
+    -- nothing stops evolving. :attr:`~braincell.channel.GhkHH.freeze_drive_gradient`
+    routes the membrane potential through
+    :func:`~braincell.channel.freeze_gradient` before it reaches the GHK
+    helper, so the drive's explicit voltage dependence contributes nothing to
+    reverse-mode gradients while the value it computes is unchanged. The unfrozen ``V`` still reaches
+    :meth:`~braincell.channel._base.HH.conductance_factor`, but that
+    method ignores its voltage argument and reads only the gate
+    states, so the distinction affects neither value nor gradient
+    there. **Unlike** :class:`Cav2p1_MA2024_PC_Frozen`, this class
+    inherits the same ``_cav3p3_nmodl_ghk_flux`` helper its unfrozen
+    counterpart uses, so freezing is the only difference between
+    the two and the forward current is unchanged.
+
+    The kinetics are those of ``PC/channel/Cav3p3_MA24_PC.mod``,
+    which is identical to ``SC/channel/Cav3p3_RI21_SC.mod`` apart
+    from its ``SUFFIX`` line and a ``g_equiv`` diagnostic. No mod
+    file ships a frozen-gradient variant: freezing is a BrainCell
+    autodiff facility with no counterpart in NMODL, so it is not an
+    import deviation and changes nothing a NEURON comparison would
+    observe.
+
+    As in :class:`Cav3p3_RI2021_SC`, the mod file's current-law
+    scaling is not dimensionally self-consistent and ``g_scale`` is
+    therefore dimensionless, the GHK helper carries the mod file's
+    own ``F``/``R`` constants and its ``celsius + 273.14`` Kelvin
+    conversion plus a small-argument series branch the mod file
+    lacks, ``V_sh`` has no counterpart in the mod file, the Q10 is
+    declared on the ``Gate`` objects, and ``current()`` negates
+    NEURON's outward-positive ``ica``. The ``perm`` and ``g_scale``
+    defaults are the deposit's tuned values, not values reported by
+    the origin paper.
+
+    References
+    ----------
+    .. [1] Xu, J., & Clancy, C. E. (2008). Ionic mechanisms of
+           endogenous bursting in CA3 hippocampal pyramidal neurons:
+           A model study. PLoS ONE, 3(4), e2056.
+           doi:10.1371/journal.pone.0002056
+    .. [2] Masoli, S., Sanchez-Ponce, D., Vrieler, N., Abu-Haya, K.,
+           Lerner, V., Shahar, T., Nedelescu, H., Rizza, M. F.,
+           Benavides-Piccione, R., DeFelipe, J., Yarom, Y., Munoz,
+           A., & D'Angelo, E. (2024). Human Purkinje cells outperform
+           mouse Purkinje cells in dendritic complexity and
+           computational capacity. Communications Biology, 7(1), 5.
+           doi:10.1038/s42003-023-05689-y
+    """
+
+    __module__ = "braincell.channel"
+    freeze_drive_gradient = True
 
 
 @register_channel("CaHVA_MA2020_GoC")

--- a/braincell/channel/calcium_test.py
+++ b/braincell/channel/calcium_test.py
@@ -21,7 +21,6 @@ import brainunit as u
 import jax
 import jax.numpy as jnp
 
-from braincell._base_channel import IonInfo
 from braincell._base_neuron import HHTypedNeuron
 from braincell.channel._base import HH, ghk_flux
 from braincell.channel.calcium import (
@@ -63,6 +62,12 @@ from braincell.channel.calcium import (
 )
 from braincell.ion import Calcium
 from braincell.mech import get_registry
+from braincell.channel._testing import (
+    DENSITY_UNIT,
+    assert_channels_agree,
+    ca_info,
+    voltage,
+)
 
 
 def _cav3p1_nmodl_ghk_flux(V, ci, co, z, temp):
@@ -74,29 +79,6 @@ def _cav3p1_nmodl_ghk_flux(V, ci, co, z, temp):
     small_branch = (z * faraday) * numerator * (1 + zeta / 2)
     regular_branch = (z * zeta * faraday) * numerator / (1 - exp_term)
     return u.math.where(u.math.abs(1 - exp_term) < 1e-6, small_branch, regular_branch)
-
-
-def _ca_info(
-    size: int = 1,
-    C: float = 1e-4,
-    E_mV: float = 120.0,
-    e_mV: float | None = None,
-) -> IonInfo:
-    if e_mV is not None:
-        E_mV = e_mV
-    return IonInfo(
-        Ci=jnp.full((size,), C) * u.mM,
-        Co=jnp.full((size,), 2.0) * u.mM,
-        E=jnp.full((size,), E_mV) * u.mV,
-        valence=2,
-    )
-
-
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
-
-
-_DENSITY_UNIT = u.mS / u.cm**2 * u.mV
 
 
 class _P2QHHMixin:
@@ -143,16 +125,16 @@ class _P2QHHMixin:
 
     def test_init_state_creates_p_and_q(self) -> None:
         ch = self._make(size=2)
-        V = _V([-60.0, -70.0])
-        ca = _ca_info(2)
+        V = voltage([-60.0, -70.0])
+        ca = ca_info(2)
         ch.init_state(V, ca)
         self.assertEqual(ch.p.value.shape, (2,))
         self.assertEqual(ch.q.value.shape, (2,))
 
     def test_reset_state_matches_gate_form(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         gates = {gate.name: gate for gate in ch._iter_gates()}
@@ -176,8 +158,8 @@ class _P2QHHMixin:
 
     def test_compute_derivative_matches_hh_gate_dynamics(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.p.value = jnp.array([0.2])
         ch.q.value = jnp.array([0.6])
@@ -203,29 +185,29 @@ class _P2QHHMixin:
 
     def test_current_matches_p2_q_formula(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         current = ch.current(V, ca)
         expected = ch.g_max * ch.p.value**2 * ch.q.value * (ca.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_current_is_zero_when_gates_closed(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.p.value = jnp.zeros(1)
         ch.q.value = jnp.zeros(1)
         current = ch.current(V, ca)
-        self.assertTrue(u.math.allclose(current.to_decimal(_DENSITY_UNIT), jnp.zeros(1), atol=1e-9))
+        self.assertTrue(u.math.allclose(current.to_decimal(DENSITY_UNIT), jnp.zeros(1), atol=1e-9))
 
 
 class CaT_HM1992Test(_P2QHHMixin, unittest.TestCase):
@@ -269,16 +251,16 @@ class CaHVA_SU2015_DCNTest(unittest.TestCase):
 
     def test_reset_state_sets_m_to_minf(self) -> None:
         ch = CaHVA_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, ca), atol=1e-6))
 
     def test_compute_derivative_matches_inf_tau_form(self) -> None:
         ch = CaHVA_SU2015_DCN(size=1, qdeltat=2.0)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.2])
         ch.compute_derivative(V, ca)
@@ -288,8 +270,8 @@ class CaHVA_SU2015_DCNTest(unittest.TestCase):
 
     def test_current_matches_mod_formula(self) -> None:
         ch = CaHVA_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        ca = _ca_info(C=1e-4)
+        V = voltage([-60.0])
+        ca = ca_info(Ci=1e-4)
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.5])
         current = ch.current(V, ca)
@@ -331,7 +313,7 @@ class CaL_SU2015_DCNTest(unittest.TestCase):
 
     def test_reset_state_sets_m_and_h_to_inf_values(self) -> None:
         ch = CaL_SU2015_DCN(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         ch.init_state(V)
         ch.reset_state(V)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V), atol=1e-6))
@@ -339,7 +321,7 @@ class CaL_SU2015_DCNTest(unittest.TestCase):
 
     def test_rates_use_direct_formulas(self) -> None:
         ch = CaL_SU2015_DCN(size=3, qdeltat=2.0)
-        V = _V([-79.7, -60.2, -49.6])
+        V = voltage([-79.7, -60.2, -49.6])
         v_mV = V.to_decimal(u.mV)
 
         self.assertTrue(u.math.allclose(ch.f_m_inf(V), ch._m_inf_formula(v_mV), atol=1e-12))
@@ -350,13 +332,13 @@ class CaL_SU2015_DCNTest(unittest.TestCase):
     def test_qdeltat_scales_taus(self) -> None:
         base = CaL_SU2015_DCN(size=1, qdeltat=1.0)
         fast = CaL_SU2015_DCN(size=1, qdeltat=2.0)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         self.assertTrue(u.math.allclose(fast.f_m_tau(V), base.f_m_tau(V) / 2.0, atol=1e-6))
         self.assertTrue(u.math.allclose(fast.f_h_tau(V), base.f_h_tau(V) / 2.0, atol=1e-6))
 
     def test_compute_derivative_matches_inf_tau_form(self) -> None:
         ch = CaL_SU2015_DCN(size=1, qdeltat=2.0)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         ch.init_state(V)
         ch.m.value = jnp.array([0.2])
         ch.h.value = jnp.array([0.6])
@@ -369,7 +351,7 @@ class CaL_SU2015_DCNTest(unittest.TestCase):
 
     def test_current_matches_fixed_carev_mod_formula_with_braincell_sign(self) -> None:
         ch = CaL_SU2015_DCN(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         ch.init_state(V)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -377,8 +359,8 @@ class CaL_SU2015_DCNTest(unittest.TestCase):
         expected = ch.g_max * ch.m.value**2 * ch.h.value * (ch.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -405,8 +387,8 @@ class CaLVA_SU2015_DCNTest(unittest.TestCase):
 
     def test_reset_state_sets_m_and_h_to_inf_values(self) -> None:
         ch = CaLVA_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, ca), atol=1e-6))
@@ -414,8 +396,8 @@ class CaLVA_SU2015_DCNTest(unittest.TestCase):
 
     def test_compute_derivative_matches_inf_tau_form(self) -> None:
         ch = CaLVA_SU2015_DCN(size=1, qdeltat=2.0)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.2])
         ch.h.value = jnp.array([0.6])
@@ -428,22 +410,22 @@ class CaLVA_SU2015_DCNTest(unittest.TestCase):
 
     def test_h_tau_uses_low_voltage_branch_below_threshold(self) -> None:
         ch = CaLVA_SU2015_DCN(size=1)
-        low_v = _V([-90.0])
-        tau = ch.f_h_tau(low_v, _ca_info())
+        low_v = voltage([-90.0])
+        tau = ch.f_h_tau(low_v, ca_info())
         expected = 0.333 * u.math.exp((-90.0 + 466.0) / 66.0)
         self.assertTrue(u.math.allclose(tau, jnp.array([expected]), atol=1e-6))
 
     def test_h_tau_uses_high_voltage_branch_at_threshold_and_above(self) -> None:
         ch = CaLVA_SU2015_DCN(size=1)
-        high_v = _V([-81.0])
-        tau = ch.f_h_tau(high_v, _ca_info())
+        high_v = voltage([-81.0])
+        tau = ch.f_h_tau(high_v, ca_info())
         expected = 0.333 * u.math.exp((-81.0 + 21.0) / -10.5) + 9.32
         self.assertTrue(u.math.allclose(tau, jnp.array([expected]), atol=1e-6))
 
     def test_current_matches_mod_formula(self) -> None:
         ch = CaLVA_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        ca = _ca_info(C=1e-4)
+        V = voltage([-60.0])
+        ca = ca_info(Ci=1e-4)
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -489,8 +471,8 @@ class CaN_IS2008Test(unittest.TestCase):
 
     def test_reset_state_sets_p_to_logistic(self) -> None:
         ch = CaN_IS2008(size=1)
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.p.value, ch.f_p_inf(V, ca), atol=1e-6))
@@ -502,8 +484,8 @@ class CaN_IS2008Test(unittest.TestCase):
             q10=3.0,
             temp_ref=u.celsius2kelvin(36.0),
         )
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.p.value = jnp.array([0.25])
         ch.compute_derivative(V, ca)
@@ -513,21 +495,21 @@ class CaN_IS2008Test(unittest.TestCase):
 
     def test_current_depends_on_calcium_concentration(self) -> None:
         ch = CaN_IS2008(size=1)
-        V = _V([-60.0])
-        low = _ca_info(C=1e-4)
-        high = _ca_info(C=10.0)
+        V = voltage([-60.0])
+        low = ca_info(Ci=1e-4)
+        high = ca_info(Ci=10.0)
         ch.init_state(V, low)
         ch.reset_state(V, low)
         i_low = ch.current(V, low)
         i_high = ch.current(V, high)
-        high_mag = float(u.math.abs(i_high).to_decimal(_DENSITY_UNIT)[0])
-        low_mag = float(u.math.abs(i_low).to_decimal(_DENSITY_UNIT)[0])
+        high_mag = float(u.math.abs(i_high).to_decimal(DENSITY_UNIT)[0])
+        low_mag = float(u.math.abs(i_low).to_decimal(DENSITY_UNIT)[0])
         self.assertGreater(high_mag, low_mag)
 
     def test_current_matches_formula(self) -> None:
         ch = CaN_IS2008(size=1, E=10.0 * u.mV, g_max=1.0 * (u.mS / u.cm**2))
-        V = _V([-60.0])
-        ca = _ca_info(C=0.001)
+        V = voltage([-60.0])
+        ca = ca_info(Ci=0.001)
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         current = ch.current(V, ca)
@@ -535,8 +517,8 @@ class CaN_IS2008Test(unittest.TestCase):
         expected = ch.g_max * modulation * ch.p.value * (ch.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-9,
             )
         )
@@ -570,8 +552,8 @@ class _MHNHHMixin:
 
     def test_init_state_creates_m_h_n_gates(self) -> None:
         ch = self._make(size=2)
-        V = _V([-40.0, -60.0])
-        ca = _ca_info(2)
+        V = voltage([-40.0, -60.0])
+        ca = ca_info(2)
         ch.init_state(V, ca)
         self.assertEqual(ch.m.value.shape, (2,))
         self.assertEqual(ch.h.value.shape, (2,))
@@ -579,8 +561,8 @@ class _MHNHHMixin:
 
     def test_reset_state_matches_inf_functions(self) -> None:
         ch = self._make(size=1)
-        V = _V([-50.0])
-        ca = _ca_info()
+        V = voltage([-50.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, ca), atol=1e-6))
@@ -594,8 +576,8 @@ class _MHNHHMixin:
             q10=3.0,
             temp_ref=u.celsius2kelvin(22.0),
         )
-        V = _V([-50.0])
-        ca = _ca_info()
+        V = voltage([-50.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.1])
         ch.h.value = jnp.array([0.2])
@@ -611,8 +593,8 @@ class _MHNHHMixin:
 
     def test_current_matches_formula(self) -> None:
         ch = self._make(size=1)
-        V = _V([-50.0])
-        ca = _ca_info(E_mV=140.0)
+        V = voltage([-50.0])
+        ca = ca_info(E=140.0)
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -621,8 +603,8 @@ class _MHNHHMixin:
         expected = ch.g_max * ch.m.value * ch.h.value * ch.n.value * (ca.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -667,8 +649,8 @@ class Cav3p1_MA2020_GoCTest(unittest.TestCase):
 
     def test_reset_state_matches_infinities(self) -> None:
         ch = Cav3p1_MA2020_GoC(size=1)
-        V = _V([-50.0])
-        ca = _ca_info()
+        V = voltage([-50.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.p.value, ch.f_p_inf(V, ca), atol=1e-6))
@@ -676,8 +658,8 @@ class Cav3p1_MA2020_GoCTest(unittest.TestCase):
 
     def test_compute_derivative_matches_hh_inf_tau_form(self) -> None:
         ch = Cav3p1_MA2020_GoC(size=1)
-        V = _V([-50.0])
-        ca = _ca_info()
+        V = voltage([-50.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.p.value = jnp.array([0.2])
         ch.q.value = jnp.array([0.3])
@@ -690,8 +672,8 @@ class Cav3p1_MA2020_GoCTest(unittest.TestCase):
 
     def test_current_matches_ghk_formula(self) -> None:
         ch = Cav3p1_MA2020_GoC(size=1)
-        V = _V([-40.0])
-        ca = _ca_info(C=0.001, E_mV=140.0)
+        V = voltage([-40.0])
+        ca = ca_info(Ci=0.001, E=140.0)
         ch.init_state(V, ca)
         ch.p.value = jnp.array([0.5])
         ch.q.value = jnp.array([0.25])
@@ -718,8 +700,8 @@ class Cav3p1_MA2020_GoCTest(unittest.TestCase):
 
     def test_current_uses_nmodl_constants_not_generic_ghk(self) -> None:
         ch = Cav3p1_MA2020_GoC(size=1, temp=u.celsius2kelvin(36.0))
-        V = _V([-65.0])
-        ca = _ca_info(C=0.00024, E_mV=120.0)
+        V = voltage([-65.0])
+        ca = ca_info(Ci=0.00024, E=120.0)
         ch.init_state(V, ca)
         ch.p.value = jnp.array([0.06913853271498836])
         ch.q.value = jnp.array([0.26894140923409454])
@@ -747,8 +729,8 @@ class Cav3p1TestPC24Test(unittest.TestCase):
 
     def test_reset_state_matches_infinities(self) -> None:
         ch = Cav3p1Test_PC24(size=1)
-        V = _V([-50.0])
-        ca = _ca_info()
+        V = voltage([-50.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.p.value, ch.f_p_inf(V, ca), atol=1e-6))
@@ -756,8 +738,8 @@ class Cav3p1TestPC24Test(unittest.TestCase):
 
     def test_current_matches_direct_conductance_law(self) -> None:
         ch = Cav3p1Test_PC24(size=1)
-        V = _V([-40.0])
-        ca = _ca_info(C=0.001, E_mV=140.0)
+        V = voltage([-40.0])
+        ca = ca_info(Ci=0.001, E=140.0)
         ch.init_state(V, ca)
         ch.p.value = jnp.array([0.5])
         ch.q.value = jnp.array([0.25])
@@ -766,35 +748,74 @@ class Cav3p1TestPC24Test(unittest.TestCase):
         self.assertTrue(u.math.allclose(current, expected, atol=1e-12 * expected.unit))
 
 
-class Cav3p1FrozenMA20GoCTest(unittest.TestCase):
-    def test_is_registered(self) -> None:
-        self.assertIs(get_registry().get("channel", "Cav3p1_MA2020_GoC_Frozen"), Cav3p1_MA2020_GoC_Frozen)
+class _FrozenVariantTests:
+    """Shared assertions for a ``freeze_drive_gradient`` variant.
 
-    def test_current_matches_unfrozen_value(self) -> None:
-        V = _V([-48.0])
-        ca = _ca_info(size=1, C=2.4e-4, E_mV=137.0)
-        base = Cav3p1_MA2020_GoC(size=1, temp=u.celsius2kelvin(34.0))
-        frozen = Cav3p1_MA2020_GoC_Frozen(size=1, temp=u.celsius2kelvin(34.0))
-        base.init_state(V, ca)
-        frozen.init_state(V, ca)
-        base.reset_state(V, ca)
-        frozen.reset_state(V, ca)
-        self.assertTrue(
+    Every frozen class in this module is now its unfrozen sibling plus one or
+    two class-level declarations, so the interesting questions are the same
+    for all six: does it still inherit the sibling's parameters, does the
+    forward value agree, and is the gradient through the GHK drive actually
+    gone? ``SAME_VALUE`` is ``False`` for the three Cav2.1 variants, whose
+    deposits also transcribe a different GHK helper -- freezing is not their
+    only difference from the unfrozen class.
+    """
+
+    FROZEN: type
+    UNFROZEN: type
+    NAME: str
+    SAME_VALUE = True
+
+    def _pair(self):
+        V = voltage([-48.0])
+        ca = ca_info(size=1, Ci=2.4e-4, E=137.0)
+        frozen, base = self.FROZEN(size=1), self.UNFROZEN(size=1)
+        for ch in (frozen, base):
+            ch.init_state(V, ca)
+            ch.reset_state(V, ca)
+        return frozen, base, V, ca
+
+    def test_is_registered(self) -> None:
+        self.assertIs(get_registry().get("channel", self.NAME), self.FROZEN)
+
+    def test_inherits_its_unfrozen_sibling(self) -> None:
+        self.assertTrue(issubclass(self.FROZEN, self.UNFROZEN))
+
+    def test_forward_value_agrees_with_the_unfrozen_sibling(self) -> None:
+        frozen, base, V, ca = self._pair()
+        unit = u.mA / (u.cm**2)
+        agrees = bool(
             u.math.allclose(
-                frozen.current(V, ca).to_decimal(u.mA / (u.cm**2)),
-                base.current(V, ca).to_decimal(u.mA / (u.cm**2)),
-                atol=1e-6,
+                frozen.current(V, ca).to_decimal(unit),
+                base.current(V, ca).to_decimal(unit),
+                atol=1e-12,
             )
         )
+        self.assertEqual(agrees, self.SAME_VALUE)
+
+    def test_freezing_removes_the_gradient_through_the_drive(self) -> None:
+        # The gates ignore their voltage argument, so the GHK drive is the
+        # only path from V to the current: freezing it must zero the whole
+        # derivative, and not freezing it must leave it non-zero.
+        frozen, base, V, ca = self._pair()
+        unit = u.mA / (u.cm**2)
+
+        def sensitivity(ch):
+            return float(jax.grad(lambda mV: (ch.current(mV * u.mV, ca) / unit).sum())(u.get_mantissa(V)[0]))
+
+        self.assertNotEqual(sensitivity(base), 0.0)
+        self.assertEqual(sensitivity(frozen), 0.0)
 
 
-class Cav3p1FrozenPC24Test(unittest.TestCase):
-    def test_is_registered(self) -> None:
-        self.assertIs(get_registry().get("channel", "Cav3p1_MA2024_PC_Frozen"), Cav3p1_MA2024_PC_Frozen)
+class Cav3p1FrozenMA20GoCTest(_FrozenVariantTests, unittest.TestCase):
+    FROZEN = Cav3p1_MA2020_GoC_Frozen
+    UNFROZEN = Cav3p1_MA2020_GoC
+    NAME = "Cav3p1_MA2020_GoC_Frozen"
 
-    def test_current_uses_frozen_voltage(self) -> None:
-        ch = Cav3p1_MA2024_PC_Frozen(size=1)
-        self.assertTrue(callable(ch.current))
+
+class Cav3p1FrozenPC24Test(_FrozenVariantTests, unittest.TestCase):
+    FROZEN = Cav3p1_MA2024_PC_Frozen
+    UNFROZEN = Cav3p1_MA2024_PC
+    NAME = "Cav3p1_MA2024_PC_Frozen"
 
 
 class Cav2p1RI21SCTest(unittest.TestCase):
@@ -812,8 +833,8 @@ class Cav2p1RI21SCTest(unittest.TestCase):
 
     def test_reset_state_matches_template_minf(self) -> None:
         ch = Cav2p1_RI2021_SC(size=1)
-        V = _V([-30.0])
-        ca = _ca_info()
+        V = voltage([-30.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, ca), atol=1e-6))
@@ -825,8 +846,8 @@ class Cav2p1RI21SCTest(unittest.TestCase):
 
     def test_compute_derivative_matches_hh_inf_tau_form(self) -> None:
         ch = Cav2p1_RI2021_SC(size=1, temp=u.celsius2kelvin(33.0))
-        V = _V([-30.0])
-        ca = _ca_info()
+        V = voltage([-30.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.2])
         ch.compute_derivative(V, ca)
@@ -836,8 +857,8 @@ class Cav2p1RI21SCTest(unittest.TestCase):
 
     def test_tau_matches_template_branches(self) -> None:
         ch = Cav2p1_RI2021_SC(size=2)
-        ca = _ca_info(size=2)
-        V = _V([-39.0, -41.0])
+        ca = ca_info(size=2)
+        V = voltage([-39.0, -41.0])
         tau = ch.f_m_tau(V, ca)
         expected = jnp.asarray(
             [
@@ -849,8 +870,8 @@ class Cav2p1RI21SCTest(unittest.TestCase):
 
     def test_current_matches_ghk_template_formula(self) -> None:
         ch = Cav2p1_RI2021_SC(size=1)
-        V = _V([-40.0])
-        ca = _ca_info(C=0.001)
+        V = voltage([-40.0])
+        ca = ca_info(Ci=0.001)
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.5])
         current = ch.current(V, ca)
@@ -875,8 +896,8 @@ class Cav2p1RI21SCTest(unittest.TestCase):
 
     def test_vshift_applies_to_rates_and_ghk_drive(self) -> None:
         ch = Cav2p1_RI2021_SC(size=1, V_sh=5.0 * u.mV)
-        V = _V([-35.0])
-        ca = _ca_info(C=0.001)
+        V = voltage([-35.0])
+        ca = ca_info(Ci=0.001)
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.5])
 
@@ -915,8 +936,8 @@ class Cav3p1MA24PCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         pc = Cav3p1_MA2024_PC(size=1, temp=temp)
         base = Cav3p1_MA2020_GoC(size=1, temp=temp)
-        V = _V([-65.0])
-        ca = _ca_info()
+        V = voltage([-65.0])
+        ca = ca_info()
 
         pc.init_state(V, ca)
         base.init_state(V, ca)
@@ -938,8 +959,8 @@ class Cav2p1MA25BCTest(unittest.TestCase):
         temp = u.celsius2kelvin(23.0)
         bc = Cav2p1_MA2025_BC(size=1, temp=temp)
         sc = Cav2p1_RI2021_SC(size=1, temp=temp)
-        V = _V([-30.0])
-        ca = _ca_info()
+        V = voltage([-30.0])
+        ca = ca_info()
         bc.init_state(V, ca)
         sc.init_state(V, ca)
         bc.reset_state(V, ca)
@@ -947,38 +968,31 @@ class Cav2p1MA25BCTest(unittest.TestCase):
         self.assertTrue(u.math.allclose(bc.m.value, sc.m.value, atol=1e-6))
 
 
-class Cav2p1FrozenPC24Test(unittest.TestCase):
-    def test_is_registered(self) -> None:
-        self.assertIs(get_registry().get("channel", "Cav2p1_MA2024_PC_Frozen"), Cav2p1_MA2024_PC_Frozen)
-
-    def test_current_uses_frozen_voltage(self) -> None:
-        ch = Cav2p1_MA2024_PC_Frozen(size=1)
-        self.assertTrue(callable(ch.current))
+class Cav2p1FrozenPC24Test(_FrozenVariantTests, unittest.TestCase):
+    FROZEN = Cav2p1_MA2024_PC_Frozen
+    UNFROZEN = Cav2p1_MA2024_PC
+    NAME = "Cav2p1_MA2024_PC_Frozen"
+    SAME_VALUE = False
 
 
-class Cav2p1FrozenRI21SCTest(unittest.TestCase):
-    def test_is_registered(self) -> None:
-        self.assertIs(get_registry().get("channel", "Cav2p1_RI2021_SC_Frozen"), Cav2p1_RI2021_SC_Frozen)
-
-    def test_inherits_pc_frozen_variant(self) -> None:
-        self.assertTrue(issubclass(Cav2p1_RI2021_SC_Frozen, Cav2p1_MA2024_PC_Frozen))
-
-
-class Cav2p1FrozenMA25BCTest(unittest.TestCase):
-    def test_is_registered(self) -> None:
-        self.assertIs(get_registry().get("channel", "Cav2p1_MA2025_BC_Frozen"), Cav2p1_MA2025_BC_Frozen)
-
-    def test_inherits_pc_frozen_variant(self) -> None:
-        self.assertTrue(issubclass(Cav2p1_MA2025_BC_Frozen, Cav2p1_MA2024_PC_Frozen))
+class Cav2p1FrozenRI21SCTest(_FrozenVariantTests, unittest.TestCase):
+    FROZEN = Cav2p1_RI2021_SC_Frozen
+    UNFROZEN = Cav2p1_RI2021_SC
+    NAME = "Cav2p1_RI2021_SC_Frozen"
+    SAME_VALUE = False
 
 
-class Cav3p3FrozenPC24Test(unittest.TestCase):
-    def test_is_registered(self) -> None:
-        self.assertIs(get_registry().get("channel", "Cav3p3_MA2024_PC_Frozen"), Cav3p3_MA2024_PC_Frozen)
+class Cav2p1FrozenMA25BCTest(_FrozenVariantTests, unittest.TestCase):
+    FROZEN = Cav2p1_MA2025_BC_Frozen
+    UNFROZEN = Cav2p1_MA2025_BC
+    NAME = "Cav2p1_MA2025_BC_Frozen"
+    SAME_VALUE = False
 
-    def test_current_uses_frozen_voltage(self) -> None:
-        ch = Cav3p3_MA2024_PC_Frozen(size=1)
-        self.assertTrue(callable(ch.current))
+
+class Cav3p3FrozenPC24Test(_FrozenVariantTests, unittest.TestCase):
+    FROZEN = Cav3p3_MA2024_PC_Frozen
+    UNFROZEN = Cav3p3_MA2024_PC
+    NAME = "Cav3p3_MA2024_PC_Frozen"
 
 
 class Cav2p1MA24PCTest(unittest.TestCase):
@@ -992,8 +1006,8 @@ class Cav2p1MA24PCTest(unittest.TestCase):
         temp = u.celsius2kelvin(23.0)
         pc = Cav2p1_MA2024_PC(size=1, temp=temp)
         sc = Cav2p1_RI2021_SC(size=1, temp=temp)
-        V = _V([-30.0])
-        ca = _ca_info()
+        V = voltage([-30.0])
+        ca = ca_info()
         pc.init_state(V, ca)
         sc.init_state(V, ca)
         pc.reset_state(V, ca)
@@ -1016,8 +1030,8 @@ class Cav3p2RI21SCTest(unittest.TestCase):
 
     def test_reset_state_matches_template_inf_functions(self) -> None:
         ch = Cav3p2_RI2021_SC(size=1)
-        V = _V([-65.0])
-        ca = _ca_info()
+        V = voltage([-65.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, ca), atol=1e-6))
@@ -1039,8 +1053,8 @@ class Cav3p2RI21SCTest(unittest.TestCase):
 
     def test_compute_derivative_matches_hh_inf_tau_form(self) -> None:
         ch = Cav3p2_RI2021_SC(size=1, temp=u.celsius2kelvin(34.0))
-        V = _V([-60.0])
-        ca = _ca_info()
+        V = voltage([-60.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.2])
         ch.h.value = jnp.array([0.3])
@@ -1053,8 +1067,8 @@ class Cav3p2RI21SCTest(unittest.TestCase):
 
     def test_current_matches_linear_template_formula(self) -> None:
         ch = Cav3p2_RI2021_SC(size=1)
-        V = _V([-40.0])
-        ca = _ca_info(E_mV=125.0)
+        V = voltage([-40.0])
+        ca = ca_info(E=125.0)
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -1062,16 +1076,16 @@ class Cav3p2RI21SCTest(unittest.TestCase):
         expected = ch.g_max * ch.m.value**2 * ch.h.value * (ca.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_vshift_applies_only_to_rates_with_template_sign(self) -> None:
         ch = Cav3p2_RI2021_SC(size=1, V_sh=5.0 * u.mV)
-        V = _V([-60.0])
-        ca = _ca_info(E_mV=120.0)
+        V = voltage([-60.0])
+        ca = ca_info(E=120.0)
         shifted = V + 5.0 * u.mV
         expected_m_inf = 1.0 / (1.0 + u.math.exp(-(shifted.to_decimal(u.mV) + 54.8) / 7.4))
         expected_current = ch.g_max * 0.5**2 * 0.25 * (ca.E - V)
@@ -1083,8 +1097,8 @@ class Cav3p2RI21SCTest(unittest.TestCase):
         self.assertTrue(u.math.allclose(ch.f_m_inf(V, ca), expected_m_inf, atol=1e-6))
         self.assertTrue(
             u.math.allclose(
-                ch.current(V, ca).to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                ch.current(V, ca).to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -1101,8 +1115,8 @@ class Cav3p2MA25BCTest(unittest.TestCase):
         temp = u.celsius2kelvin(36.0)
         bc = Cav3p2_MA2025_BC(size=1, temp=temp)
         sc = Cav3p2_RI2021_SC(size=1, temp=temp)
-        V = _V([-65.0])
-        ca = _ca_info()
+        V = voltage([-65.0])
+        ca = ca_info()
         bc.init_state(V, ca)
         sc.init_state(V, ca)
         bc.reset_state(V, ca)
@@ -1122,8 +1136,8 @@ class Cav3p2MA24PCTest(unittest.TestCase):
         temp = u.celsius2kelvin(36.0)
         pc = Cav3p2_MA2024_PC(size=1, temp=temp)
         sc = Cav3p2_RI2021_SC(size=1, temp=temp)
-        V = _V([-65.0])
-        ca = _ca_info()
+        V = voltage([-65.0])
+        ca = ca_info()
         pc.init_state(V, ca)
         sc.init_state(V, ca)
         pc.reset_state(V, ca)
@@ -1147,8 +1161,8 @@ class Cav3p3RI21SCTest(unittest.TestCase):
 
     def test_reset_state_matches_template_inf_functions(self) -> None:
         ch = Cav3p3_RI2021_SC(size=1)
-        V = _V([-65.0])
-        ca = _ca_info()
+        V = voltage([-65.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.n.value, ch.f_n_inf(V, ca), atol=1e-6))
@@ -1163,8 +1177,8 @@ class Cav3p3RI21SCTest(unittest.TestCase):
 
     def test_compute_derivative_matches_hh_inf_tau_form(self) -> None:
         ch = Cav3p3_RI2021_SC(size=1, temp=u.celsius2kelvin(36.0))
-        V = _V([-65.0])
-        ca = _ca_info()
+        V = voltage([-65.0])
+        ca = ca_info()
         ch.init_state(V, ca)
         ch.n.value = jnp.array([0.2])
         ch.l.value = jnp.array([0.3])
@@ -1177,8 +1191,8 @@ class Cav3p3RI21SCTest(unittest.TestCase):
 
     def test_tau_matches_template_branches(self) -> None:
         ch = Cav3p3_RI2021_SC(size=2)
-        ca = _ca_info(size=2)
-        V = _V([-59.0, -61.0])
+        ca = ca_info(size=2)
+        V = voltage([-59.0, -61.0])
         tau_n = ch.f_n_tau(V, ca)
         tau_l = ch.f_l_tau(V, ca)
         expected_n = jnp.asarray(
@@ -1198,8 +1212,8 @@ class Cav3p3RI21SCTest(unittest.TestCase):
 
     def test_current_matches_ghk_template_formula(self) -> None:
         ch = Cav3p3_RI2021_SC(size=1)
-        V = _V([-40.0])
-        ca = _ca_info(C=0.001)
+        V = voltage([-40.0])
+        ca = ca_info(Ci=0.001)
         ch.init_state(V, ca)
         ch.n.value = jnp.array([0.5])
         ch.l.value = jnp.array([0.25])
@@ -1237,8 +1251,8 @@ class Cav3p3MA24PCTest(unittest.TestCase):
         temp = u.celsius2kelvin(36.0)
         pc = Cav3p3_MA2024_PC(size=1, temp=temp)
         sc = Cav3p3_RI2021_SC(size=1, temp=temp)
-        V = _V([-65.0])
-        ca = _ca_info()
+        V = voltage([-65.0])
+        ca = ca_info()
         pc.init_state(V, ca)
         sc.init_state(V, ca)
         pc.reset_state(V, ca)
@@ -1253,8 +1267,8 @@ class CaHVAMA20GoCTest(unittest.TestCase):
 
     def test_current_uses_ca_reversal(self) -> None:
         ch = CaHVA_MA2020_GoC(size=1)
-        V = _V([-20.0])
-        ca = _ca_info(e_mV=100.0)
+        V = voltage([-20.0])
+        ca = ca_info(E=100.0)
         ch.init_state(V, ca)
         ch.s.value = jnp.array([0.5])
         ch.u.value = jnp.array([0.25])
@@ -1262,8 +1276,8 @@ class CaHVAMA20GoCTest(unittest.TestCase):
         expected = ch.g_max * (ch.s.value**2) * ch.u.value * (ca.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -1271,8 +1285,8 @@ class CaHVAMA20GoCTest(unittest.TestCase):
     def test_matches_template_formulas_at_same_reversal(self) -> None:
         temp = u.celsius2kelvin(30.0)
         proto = CaHVA_MA2020_GoC(size=1, temp=temp)
-        V = _V([-30.0])
-        ca = _ca_info()
+        V = voltage([-30.0])
+        ca = ca_info()
 
         proto.init_state(V, ca)
         proto.reset_state(V, ca)
@@ -1296,16 +1310,16 @@ class CaHVAMA20GoCTest(unittest.TestCase):
         expected_current = proto.g_max * (proto.s.value**2) * proto.u.value * (ca.E - V)
         self.assertTrue(
             u.math.allclose(
-                i_proto.to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                i_proto.to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_rates_use_continuous_voltage_formula(self) -> None:
         proto = CaHVA_MA2020_GoC(size=3)
-        ca = _ca_info(size=3)
-        V = _V([-120.0, -50.0, 60.0])
+        ca = ca_info(size=3)
+        V = voltage([-120.0, -50.0, 60.0])
         v = jnp.array([-120.0, -50.0, 60.0])
 
         expected_alpha_s = proto.Aalpha_s * jnp.exp((v - proto.V0alpha_s) / proto.Kalpha_s)
@@ -1325,8 +1339,8 @@ class Cav2p3MA20GoCTest(unittest.TestCase):
 
     def test_reset_state_matches_inf_functions(self) -> None:
         ch = Cav2p3_MA2020_GoC(size=1)
-        V = _V([-60.0])
-        ca = _ca_info(e_mV=140.0)
+        V = voltage([-60.0])
+        ca = ca_info(E=140.0)
         ch.init_state(V, ca)
         ch.reset_state(V, ca)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, ca), atol=1e-6))
@@ -1334,8 +1348,8 @@ class Cav2p3MA20GoCTest(unittest.TestCase):
 
     def test_current_matches_linear_formula(self) -> None:
         ch = Cav2p3_MA2020_GoC(size=1, g_max=0.1 * (u.mS / u.cm**2))
-        V = _V([-40.0])
-        ca = _ca_info(e_mV=140.0)
+        V = voltage([-40.0])
+        ca = ca_info(E=140.0)
         ch.init_state(V, ca)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -1343,8 +1357,8 @@ class Cav2p3MA20GoCTest(unittest.TestCase):
         expected = ch.g_max * (ch.m.value**3) * ch.h.value * (ca.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -1352,8 +1366,8 @@ class Cav2p3MA20GoCTest(unittest.TestCase):
     def test_matches_template_formulas_at_same_reversal(self) -> None:
         temp = u.celsius2kelvin(34.0)
         proto = Cav2p3_MA2020_GoC(size=1, temp=temp)
-        V = _V([-40.0])
-        ca = _ca_info(e_mV=140.0)
+        V = voltage([-40.0])
+        ca = ca_info(E=140.0)
 
         proto.init_state(V, ca)
         proto.reset_state(V, ca)
@@ -1373,8 +1387,8 @@ class Cav2p3MA20GoCTest(unittest.TestCase):
         expected_current = proto.g_max * (proto.m.value**3) * proto.h.value * (ca.E - V)
         self.assertTrue(
             u.math.allclose(
-                i_proto.to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                i_proto.to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -1388,29 +1402,13 @@ class CaHVAMA20GrCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         goc = CaHVA_MA2020_GoC(size=1, temp=temp)
         grc = CaHVA_MA2020_GrC(size=1, temp=temp)
-        V = _V([-30.0])
-        ca = _ca_info()
-
-        goc.init_state(V, ca)
-        grc.init_state(V, ca)
-        goc.reset_state(V, ca)
-        grc.reset_state(V, ca)
-        self.assertTrue(u.math.allclose(grc.s.value, goc.s.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(grc.u.value, goc.u.value, atol=1e-6))
-
-        goc.compute_derivative(V, ca)
-        grc.compute_derivative(V, ca)
-        self.assertTrue(u.math.allclose(grc.s.derivative, goc.s.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(grc.u.derivative, goc.u.derivative, atol=1e-6 * u.Hz))
-
-        i_goc = goc.current(V, ca)
-        i_grc = grc.current(V, ca)
-        self.assertTrue(
-            u.math.allclose(
-                i_grc.to_decimal(_DENSITY_UNIT),
-                i_goc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            goc,
+            grc,
+            voltage([-30.0]),
+            ca_info(),
+            states=("s", "u"),
         )
 
 
@@ -1420,22 +1418,22 @@ class CaZH19IOTest(unittest.TestCase):
 
     def test_reset_state_matches_f_h_inf(self) -> None:
         ch = Ca_ZH2019_IO(size=1)
-        V = _V([-70.0])
+        V = voltage([-70.0])
         ch.init_state(V)
         ch.reset_state(V)
         self.assertTrue(u.math.allclose(ch.h.value, ch.f_h_inf(V), atol=1e-6))
 
     def test_current_uses_instantaneous_m_and_stateful_h(self) -> None:
         ch = Ca_ZH2019_IO(size=1, E=120.0 * u.mV, mMidV=-61.0 * u.mV)
-        V = _V([-50.0])
+        V = voltage([-50.0])
         ch.init_state(V)
         ch.h.value = jnp.array([0.25])
         i = ch.current(V)
         expected = ch.g_max * ch.f_m_inf(V) * ch.h.value * (ch.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -1443,12 +1441,12 @@ class CaZH19IOTest(unittest.TestCase):
     def test_default_freezes_instantaneous_activation_gradient(self) -> None:
         ch = Ca_ZH2019_IO(size=1, E=120.0 * u.mV, mMidV=-61.0 * u.mV)
         V0 = -50.0
-        V = _V([V0])
+        V = voltage([V0])
         ch.init_state(V)
         ch.h.value = jnp.array([0.25])
 
         def current_decimal(v_mV):
-            return ch.current(jnp.asarray([v_mV]) * u.mV).to_decimal(_DENSITY_UNIT)[0]
+            return ch.current(jnp.asarray([v_mV]) * u.mV).to_decimal(DENSITY_UNIT)[0]
 
         actual = jax.grad(current_decimal)(V0)
         expected = -(ch.g_max * ch.f_m_inf(V) * ch.h.value).to_decimal(u.mS / u.cm**2)[0]
@@ -1462,16 +1460,16 @@ class CaZH19IOTest(unittest.TestCase):
             freeze_m_inf=False,
         )
         V0 = -50.0
-        V = _V([V0])
+        V = voltage([V0])
         ch.init_state(V)
         ch.h.value = jnp.array([0.25])
 
         def current_decimal(v_mV):
-            return ch.current(jnp.asarray([v_mV]) * u.mV).to_decimal(_DENSITY_UNIT)[0]
+            return ch.current(jnp.asarray([v_mV]) * u.mV).to_decimal(DENSITY_UNIT)[0]
 
         def unfrozen_expected_current(v_mV):
             v = jnp.asarray([v_mV]) * u.mV
-            return (ch.g_max * ch.f_m_inf(v) * ch.h.value * (ch.E - v)).to_decimal(_DENSITY_UNIT)[0]
+            return (ch.g_max * ch.f_m_inf(v) * ch.h.value * (ch.E - v)).to_decimal(DENSITY_UNIT)[0]
 
         actual = jax.grad(current_decimal)(V0)
         expected = jax.grad(unfrozen_expected_current)(V0)
@@ -1483,7 +1481,7 @@ class CaZH19IOTest(unittest.TestCase):
         self.assertIs(get_registry().get("channel", "Ca_ZH2019_IO_Frozen"), Ca_ZH2019_IO_Frozen)
 
     def test_frozen_current_matches_unfrozen_value(self) -> None:
-        V = _V([-50.0])
+        V = voltage([-50.0])
         base = Ca_ZH2019_IO(size=1, E=120.0 * u.mV, mMidV=-61.0 * u.mV, freeze_m_inf=False)
         frozen = Ca_ZH2019_IO_Frozen(size=1, E=120.0 * u.mV, mMidV=-61.0 * u.mV)
         base.init_state(V)
@@ -1492,8 +1490,8 @@ class CaZH19IOTest(unittest.TestCase):
         frozen.h.value = jnp.array([0.25])
         self.assertTrue(
             u.math.allclose(
-                frozen.current(V).to_decimal(_DENSITY_UNIT),
-                base.current(V).to_decimal(_DENSITY_UNIT),
+                frozen.current(V).to_decimal(DENSITY_UNIT),
+                base.current(V).to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -1501,12 +1499,12 @@ class CaZH19IOTest(unittest.TestCase):
     def test_frozen_variant_keeps_only_driving_force_slope(self) -> None:
         ch = Ca_ZH2019_IO_Frozen(size=1, E=120.0 * u.mV, mMidV=-61.0 * u.mV)
         V0 = -50.0
-        V = _V([V0])
+        V = voltage([V0])
         ch.init_state(V)
         ch.h.value = jnp.array([0.25])
 
         def current_decimal(v_mV):
-            return ch.current(jnp.asarray([v_mV]) * u.mV).to_decimal(_DENSITY_UNIT)[0]
+            return ch.current(jnp.asarray([v_mV]) * u.mV).to_decimal(DENSITY_UNIT)[0]
 
         actual = jax.grad(current_decimal)(V0)
         expected = -(ch.g_max * ch.f_m_inf(V) * ch.h.value).to_decimal(u.mS / u.cm**2)[0]

--- a/braincell/channel/hyperpolarization_activated.py
+++ b/braincell/channel/hyperpolarization_activated.py
@@ -19,15 +19,19 @@
 This module implements hyperpolarization-activated cation channel.
 """
 
-from typing import Optional
+from typing import ClassVar, Optional
 
 import braintools
 import brainunit as u
 
 from braincell._base_neuron import HHTypedNeuron
 from braincell._typing import ArrayLike, Initializer, Size
-from braincell.channel._base import Gate, HH, OhmicHH, q10_factor
+from braincell.channel._base import Gate, HH, OhmicHH, cached_q10_factor
 from braincell.mech import register_channel
+
+#: Hoisted so the identity-keyed memo in ``cached_q10_factor`` can hit:
+#: a freshly built ``celsius2kelvin`` result would miss on every call.
+_TEMP_REF_23C = u.celsius2kelvin(23.0)
 
 __all__ = [
     'HCN_HM1992',
@@ -84,11 +88,10 @@ class HCN_HM1992(OhmicHH):
 
     Notes
     -----
-    This class overrides :meth:`reversal_potential` to return
-    ``self.E`` instead of an ion's reversal potential, so the current
-    is driven against the fixed ``E`` parameter, not an ion state --
-    the correct closed form is ``g_max * p * (E - V)``, not
-    ``g_max * p`` alone.
+    ``root_type`` is :class:`~braincell.HHTypedNeuron`, so no ion
+    state is passed and :meth:`OhmicHH.reversal_potential` falls back
+    to the fixed ``E`` parameter: the current is
+    ``g_max * p * (E - V)``.
 
     References
     ----------
@@ -119,9 +122,6 @@ class HCN_HM1992(OhmicHH):
         self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
         self.q10 = braintools.init.param(q10, self.varshape, allow_none=False)
         self.temp_ref = braintools.init.param(temp_ref, self.varshape, allow_none=False)
-
-    def reversal_potential(self, V, *ions):
-        return self.E
 
     def f_p_inf(self, V):
         V = V.to_decimal(u.mV)
@@ -328,9 +328,10 @@ class HCN1_MA2025_BC(OhmicHH):
 
     Notes
     -----
-    Ported from ``HCN1_MA25_BC.mod``. This class overrides
-    :meth:`reversal_potential` to return ``self.E`` instead of an
-    ion's reversal potential.
+    Ported from ``HCN1_MA25_BC.mod``. ``root_type`` is
+    :class:`~braincell.HHTypedNeuron`, so no ion state is passed and
+    :meth:`OhmicHH.reversal_potential` falls back to the fixed ``E``
+    parameter.
 
     ``HCN1_MA25_BC.mod`` inherits its comment verbatim from the
     ``HCN1_MA24_PC.mod`` Purkinje-cell port, including the note
@@ -388,9 +389,6 @@ class HCN1_MA2025_BC(OhmicHH):
         self.v_tau_half2_noljp = -68.0 * u.mV
         self.v_tau_k1 = -22.0 * u.mV
         self.v_tau_k2 = 7.14 * u.mV
-
-    def reversal_potential(self, V, *ions):
-        return self.E
 
     def f_h_inf(self, V):
         V = V.to_decimal(u.mV)
@@ -460,9 +458,10 @@ class HCN1_MA2024_PC(HCN1_MA2025_BC):
 
     Notes
     -----
-    Ported from ``HCN1_MA24_PC.mod``. This class overrides
-    :meth:`reversal_potential` to return ``self.E`` instead of an
-    ion's reversal potential.
+    Ported from ``HCN1_MA24_PC.mod``. ``root_type`` is
+    :class:`~braincell.HHTypedNeuron`, so no ion state is passed and
+    :meth:`OhmicHH.reversal_potential` falls back to the fixed ``E``
+    parameter.
 
     ``HCN1_MA24_PC.mod`` carries the comment "We call it HCN1 as PC
     express only HCN1 Santoro et al. 2000" -- correctly describing
@@ -551,9 +550,10 @@ class HCN1_RI2021_SC(HCN1_MA2025_BC):
 
     Notes
     -----
-    Ported from ``HCN1_RI21_SC.mod``. This class overrides
-    :meth:`reversal_potential` to return ``self.E`` instead of an
-    ion's reversal potential.
+    Ported from ``HCN1_RI21_SC.mod``. ``root_type`` is
+    :class:`~braincell.HHTypedNeuron`, so no ion state is passed and
+    :meth:`OhmicHH.reversal_potential` falls back to the fixed ``E``
+    parameter.
 
     ``HCN1_RI21_SC.mod`` carries the same inherited comment as the
     basket-cell port, "We call it HCN1 as PC express only HCN1
@@ -589,8 +589,127 @@ class HCN1_RI2021_SC(HCN1_MA2025_BC):
     __module__ = "braincell.channel"
 
 
+class _FastSlowHCN(HH):
+    r"""Two-gate fast/slow h-current template shared by the Golgi-cell isoforms.
+
+    ``HCN1_MA20_GoC.mod`` and ``HCN2_MA20_GoC.mod`` are the same mechanism
+    with a different constant table: two independent open-state gates,
+    ``o_fast`` and ``o_slow``, splitting one Boltzmann steady state by a
+    mixing fraction :math:`r(V)`,
+
+    .. math::
+
+        \begin{aligned}
+        I_h &= \phi_Q \, g_{\mathrm{max}} \,
+               (o_{\mathrm{fast}} + o_{\mathrm{slow}}) \, (E - V) \\
+        o_\infty(V) &= \frac{1}{1 + \exp((V - E_{1/2}) \, c)} \\
+        o_{\mathrm{fast},\infty} &= r(V) \, o_\infty(V) \\
+        o_{\mathrm{slow},\infty} &= (1 - r(V)) \, o_\infty(V) \\
+        \tau_{\mathrm{fast}} &= \exp((t_{Cf} V - t_{Df}) \, t_{Ef}) \\
+        \tau_{\mathrm{slow}} &= \exp((t_{Cs} V - t_{Ds}) \, t_{Es})
+        \end{aligned}
+
+    with :math:`\phi_Q = Q_{10}^{(T - 23^{\circ}\mathrm{C}) / 10}`. Only
+    :math:`r(V)` and the constant table below vary between isoforms, so
+    subclasses override those and nothing else.
+
+    This template subclasses :class:`HH` directly, not :class:`OhmicHH`,
+    because :meth:`current` sums two gate values and applies :math:`\phi_Q`
+    to ``g_max`` rather than taking a single ``power``-weighted product.
+
+    Parameters
+    ----------
+    size : brainstate.typing.Size
+        Channel state shape.
+    g_max : array-like or callable
+        Maximal conductance density. No default: each isoform supplies its
+        own.
+    E : array-like or callable, optional
+        Reversal potential, default ``-20.0 mV``.
+    temp : array-like, optional
+        Absolute temperature driving both the gate Q10 factors and
+        :math:`\phi_Q`, default 22 degrees Celsius.
+    name : str, optional
+        Optional channel name.
+
+    See Also
+    --------
+    HCN1_MA2020_GoC : Isoform with an unclamped :math:`r(V)`.
+    HCN2_MA2020_GoC : Isoform with :math:`r(V)` clamped to ``{0, 1}``.
+
+    Notes
+    -----
+    The eleven kinetic constants are class attributes rather than
+    constructor parameters because neither ``.mod`` file exposes them as
+    ``RANGE`` variables. ``Q10_diff`` is the one value both isoforms share.
+    """
+
+    root_type = HHTypedNeuron
+    gates = (
+        Gate("o_fast", q10=3.0, temp_ref=_TEMP_REF_23C),
+        Gate("o_slow", q10=3.0, temp_ref=_TEMP_REF_23C),
+    )
+
+    Q10_diff: ClassVar[float] = 1.5
+    #: Boltzmann half-activation in mV and its slope in 1/mV.
+    Ehalf: ClassVar[float]
+    c: ClassVar[float]
+    #: Slope (1/mV) and intercept of the linear part of ``r(V)``.
+    rA: ClassVar[float]
+    rB: ClassVar[float]
+    #: Fast and slow time-constant exponent triples.
+    tCf: ClassVar[float]
+    tDf: ClassVar[float]
+    tEf: ClassVar[float]
+    tCs: ClassVar[float]
+    tDs: ClassVar[float]
+    tEs: ClassVar[float]
+
+    def __init__(
+        self,
+        size: Size,
+        g_max: Initializer,
+        E: Initializer = -20.0 * u.mV,
+        temp: ArrayLike = u.celsius2kelvin(22.0),
+        name: Optional[str] = None,
+    ):
+        super().__init__(size=size, name=name)
+        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
+        self.E = braintools.init.param(E, self.varshape, allow_none=False)
+        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
+
+    def current(self, V):
+        o = self.o_fast.value + self.o_slow.value
+        return self._gbar_phi() * self.g_max * o * (self.E - V)
+
+    def _gbar_phi(self):
+        return cached_q10_factor(self, "_gbar_phi_memo", self.Q10_diff, self.temp, _TEMP_REF_23C)
+
+    def o_inf(self, V):
+        V = V.to_decimal(u.mV)
+        return 1.0 / (1.0 + u.math.exp((V - self.Ehalf) * self.c))
+
+    def r(self, V):
+        """Return the fast/slow mixing fraction. Overridden by every isoform."""
+        raise NotImplementedError
+
+    def f_o_fast_inf(self, V):
+        return self.r(V) * self.o_inf(V)
+
+    def f_o_slow_inf(self, V):
+        return (1.0 - self.r(V)) * self.o_inf(V)
+
+    def f_o_fast_tau(self, V):
+        V = V.to_decimal(u.mV)
+        return u.math.exp(((self.tCf * V) - self.tDf) * self.tEf)
+
+    def f_o_slow_tau(self, V):
+        V = V.to_decimal(u.mV)
+        return u.math.exp(((self.tCs * V) - self.tDs) * self.tEs)
+
+
 @register_channel("HCN1_MA2020_GoC")
-class HCN1_MA2020_GoC(HH):
+class HCN1_MA2020_GoC(_FastSlowHCN):
     r"""HCN1 fast/slow h-current imported for the Golgi cell model.
 
     Ports the two-gate NEURON mechanism ``HCN1_MA20_GoC.mod`` used
@@ -624,13 +743,12 @@ class HCN1_MA2020_GoC(HH):
     gates additionally carry ``q10=3.0``, ``temp_ref=23`` degrees
     Celsius on their own state relaxation, independent of the
     :math:`\phi_Q` conductance prefactor above. All eleven constants
-    are fixed internal values set in ``__init__``; they are not
+    are class attributes on :class:`_FastSlowHCN`; they are not
     exposed as parameters.
 
-    This class subclasses :class:`HH` directly, not
-    :class:`OhmicHH`, because :meth:`current` sums two gate values
-    before applying the driving force rather than taking a single
-    ``power``-weighted product.
+    Only the eleven constants and the unclamped :meth:`r` differ from
+    the shared :class:`_FastSlowHCN` template, which carries the
+    gates, the constructor and every other formula.
 
     Parameters
     ----------
@@ -691,11 +809,17 @@ class HCN1_MA2020_GoC(HH):
     """
 
     __module__ = "braincell.channel"
-    root_type = HHTypedNeuron
-    gates = (
-        Gate("o_fast", q10=3.0, temp_ref=u.celsius2kelvin(23.0)),
-        Gate("o_slow", q10=3.0, temp_ref=u.celsius2kelvin(23.0)),
-    )
+
+    Ehalf = -72.49
+    c = 0.11305
+    rA = 0.002096
+    rB = 0.97596
+    tCf = 0.01371
+    tDf = -3.368
+    tEf = 2.30259
+    tCs = 0.01451
+    tDs = -4.056
+    tEs = 2.30259
 
     def __init__(
         self,
@@ -705,55 +829,15 @@ class HCN1_MA2020_GoC(HH):
         temp: ArrayLike = u.celsius2kelvin(22.0),
         name: Optional[str] = None,
     ):
-        super().__init__(size=size, name=name)
-        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.E = braintools.init.param(E, self.varshape, allow_none=False)
-        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
-        self.Q10_diff = 1.5
-        self.Ehalf = -72.49
-        self.c = 0.11305
-        self.rA = 0.002096
-        self.rB = 0.97596
-        self.tCf = 0.01371
-        self.tDf = -3.368
-        self.tEf = 2.30259
-        self.tCs = 0.01451
-        self.tDs = -4.056
-        self.tEs = 2.30259
-
-    def current(self, V):
-        o = self.o_fast.value + self.o_slow.value
-        return self._gbar_phi() * self.g_max * o * (self.E - V)
-
-    def _gbar_phi(self):
-        temp_ref = u.celsius2kelvin(23.0)
-        return q10_factor(self.Q10_diff, self.temp, temp_ref)
-
-    def o_inf(self, V):
-        V = V.to_decimal(u.mV)
-        return 1.0 / (1.0 + u.math.exp((V - self.Ehalf) * self.c))
+        super().__init__(size=size, g_max=g_max, E=E, temp=temp, name=name)
 
     def r(self, V):
         V = V.to_decimal(u.mV)
         return self.rA * V + self.rB
 
-    def f_o_fast_inf(self, V):
-        return self.r(V) * self.o_inf(V)
-
-    def f_o_slow_inf(self, V):
-        return (1.0 - self.r(V)) * self.o_inf(V)
-
-    def f_o_fast_tau(self, V):
-        V = V.to_decimal(u.mV)
-        return u.math.exp(((self.tCf * V) - self.tDf) * self.tEf)
-
-    def f_o_slow_tau(self, V):
-        V = V.to_decimal(u.mV)
-        return u.math.exp(((self.tCs * V) - self.tDs) * self.tEs)
-
 
 @register_channel("HCN2_MA2020_GoC")
-class HCN2_MA2020_GoC(HH):
+class HCN2_MA2020_GoC(_FastSlowHCN):
     r"""HCN2 fast/slow h-current imported for the Golgi cell model.
 
     Ports the two-gate NEURON mechanism ``HCN2_MA20_GoC.mod`` used
@@ -790,13 +874,12 @@ class HCN2_MA2020_GoC(HH):
     additionally carry ``q10=3.0``, ``temp_ref=23`` degrees Celsius
     on their own state relaxation, independent of the
     :math:`\phi_Q` conductance prefactor above. All eleven constants
-    are fixed internal values set in ``__init__``; they are not
+    are class attributes on :class:`_FastSlowHCN`; they are not
     exposed as parameters.
 
-    This class subclasses :class:`HH` directly, not
-    :class:`OhmicHH`, because :meth:`current` sums two gate values
-    before applying the driving force rather than taking a single
-    ``power``-weighted product.
+    Only the eleven constants and the clamped :meth:`r` differ from
+    the shared :class:`_FastSlowHCN` template, which carries the
+    gates, the constructor and every other formula.
 
     Parameters
     ----------
@@ -855,11 +938,17 @@ class HCN2_MA2020_GoC(HH):
     """
 
     __module__ = "braincell.channel"
-    root_type = HHTypedNeuron
-    gates = (
-        Gate("o_fast", q10=3.0, temp_ref=u.celsius2kelvin(23.0)),
-        Gate("o_slow", q10=3.0, temp_ref=u.celsius2kelvin(23.0)),
-    )
+
+    Ehalf = -81.95
+    c = 0.1661
+    rA = -0.0227
+    rB = -1.4694
+    tCf = 0.0269
+    tDf = -5.6111
+    tEf = 2.3026
+    tCs = 0.0152
+    tDs = -5.2944
+    tEs = 2.3026
 
     def __init__(
         self,
@@ -869,33 +958,7 @@ class HCN2_MA2020_GoC(HH):
         temp: ArrayLike = u.celsius2kelvin(22.0),
         name: Optional[str] = None,
     ):
-        super().__init__(size=size, name=name)
-        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.E = braintools.init.param(E, self.varshape, allow_none=False)
-        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
-        self.Q10_diff = 1.5
-        self.Ehalf = -81.95
-        self.c = 0.1661
-        self.rA = -0.0227
-        self.rB = -1.4694
-        self.tCf = 0.0269
-        self.tDf = -5.6111
-        self.tEf = 2.3026
-        self.tCs = 0.0152
-        self.tDs = -5.2944
-        self.tEs = 2.3026
-
-    def current(self, V):
-        o = self.o_fast.value + self.o_slow.value
-        return self._gbar_phi() * self.g_max * o * (self.E - V)
-
-    def _gbar_phi(self):
-        temp_ref = u.celsius2kelvin(23.0)
-        return q10_factor(self.Q10_diff, self.temp, temp_ref)
-
-    def o_inf(self, V):
-        V = V.to_decimal(u.mV)
-        return 1.0 / (1.0 + u.math.exp((V - self.Ehalf) * self.c))
+        super().__init__(size=size, g_max=g_max, E=E, temp=temp, name=name)
 
     def r(self, V):
         V = V.to_decimal(u.mV)
@@ -908,20 +971,6 @@ class HCN2_MA2020_GoC(HH):
                 self.rA * V + self.rB,
             ),
         )
-
-    def f_o_fast_inf(self, V):
-        return self.r(V) * self.o_inf(V)
-
-    def f_o_slow_inf(self, V):
-        return (1.0 - self.r(V)) * self.o_inf(V)
-
-    def f_o_fast_tau(self, V):
-        V = V.to_decimal(u.mV)
-        return u.math.exp(((self.tCf * V) - self.tDf) * self.tEf)
-
-    def f_o_slow_tau(self, V):
-        V = V.to_decimal(u.mV)
-        return u.math.exp(((self.tCs * V) - self.tDs) * self.tEs)
 
 
 @register_channel("HCN_SU2015_DCN")
@@ -957,10 +1006,11 @@ class HCN_SU2015_DCN(OhmicHH):
 
     Notes
     -----
-    This class overrides :meth:`reversal_potential` to return
-    ``self.E`` instead of an ion's reversal potential. The ``m``
-    gate carries no ``q10``/``phi``, so :meth:`HH.gate_phi` resolves
-    to the default ``1.0``.
+    ``root_type`` is :class:`~braincell.HHTypedNeuron`, so no ion
+    state is passed and :meth:`OhmicHH.reversal_potential` falls back
+    to the fixed ``E`` parameter. The ``m`` gate carries no
+    ``q10``/``phi``, so :meth:`HH.gate_phi` resolves to the default
+    ``1.0``.
 
     Ported from ``HCN_SU15_DCN.mod``. Its kinetics belong to the
     deep cerebellar nucleus model of Steuber et al. (2011) [1]_,
@@ -1011,9 +1061,6 @@ class HCN_SU2015_DCN(OhmicHH):
         self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
         self.E = braintools.init.param(E, self.varshape, allow_none=False)
         self.qdeltat = 1.0
-
-    def reversal_potential(self, V, *ions):
-        return self.E
 
     def f_m_inf(self, V):
         V = V.to_decimal(u.mV)
@@ -1121,9 +1168,6 @@ class HCN_ZH2019_IO(OhmicHH):
         super().__init__(size=size, name=name)
         self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
         self.E = braintools.init.param(E, self.varshape, allow_none=False)
-
-    def reversal_potential(self, V, *ions):
-        return self.E
 
     def f_q_inf(self, V):
         V = V.to_decimal(u.mV)

--- a/braincell/channel/hyperpolarization_activated_test.py
+++ b/braincell/channel/hyperpolarization_activated_test.py
@@ -32,13 +32,11 @@ from braincell.channel.hyperpolarization_activated import (
     HCN_SU2015_DCN,
     HCN_ZH2019_IO,
 )
-
-
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
-
-
-_DENSITY_UNIT = u.mS / u.cm**2 * u.mV
+from braincell.channel._testing import (
+    DENSITY_UNIT,
+    assert_channels_agree,
+    voltage,
+)
 
 
 class IhHM1992Test(unittest.TestCase):
@@ -91,7 +89,7 @@ class IhHM1992Test(unittest.TestCase):
 
     def test_reset_state_sets_p_to_steady_state(self) -> None:
         ch = HCN_HM1992(size=1)
-        V = _V([-65.0])
+        V = voltage([-65.0])
         ch.init_state(V)
         ch.reset_state(V)
         self.assertTrue(u.math.allclose(ch.p.value, ch.f_p_inf(V), atol=1e-6))
@@ -103,7 +101,7 @@ class IhHM1992Test(unittest.TestCase):
             q10=3.0,
             temp_ref=u.celsius2kelvin(36.0),
         )
-        V = _V([-60.0])
+        V = voltage([-60.0])
         ch.init_state(V)
         ch.reset_state(V)
         ch.p.value = jnp.array([0.25])
@@ -117,7 +115,7 @@ class IhHM1992Test(unittest.TestCase):
 
     def test_current_matches_formula(self) -> None:
         ch = HCN_HM1992(size=1, g_max=5.0 * (u.mS / u.cm**2), E=-30.0 * u.mV)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         ch.init_state(V)
         ch.p.value = jnp.array([0.3])
         current = ch.current(V)
@@ -133,7 +131,7 @@ class IhHM1992Test(unittest.TestCase):
 
     def test_current_is_zero_when_p_zero(self) -> None:
         ch = HCN_HM1992(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         ch.init_state(V)
         ch.p.value = jnp.zeros(1)
         current = ch.current(V)
@@ -147,136 +145,77 @@ class IhHM1992Test(unittest.TestCase):
 
     def test_p_inf_monotone_in_hyperpolarized_regime(self) -> None:
         ch = HCN_HM1992(size=1)
-        pinf_hyper = ch.f_p_inf(_V([-90.0]))
-        pinf_mid = ch.f_p_inf(_V([-75.0]))
-        pinf_dep = ch.f_p_inf(_V([-60.0]))
+        pinf_hyper = ch.f_p_inf(voltage([-90.0]))
+        pinf_mid = ch.f_p_inf(voltage([-75.0]))
+        pinf_dep = ch.f_p_inf(voltage([-60.0]))
         self.assertGreater(float(pinf_hyper[0]), float(pinf_mid[0]))
         self.assertGreater(float(pinf_mid[0]), float(pinf_dep[0]))
 
 
-class HCN1MA25BCTest(unittest.TestCase):
+class _HCN1VariantTests:
+    """Shared assertions for the three single-``h``-gate HCN1 imports.
+
+    ``HCN1_MA2024_PC`` and ``HCN1_RI2021_SC`` subclass ``HCN1_MA2025_BC``
+    and override nothing but their docstring and registration key, so the
+    same three questions apply to each: the root type, that ``reset_state``
+    lands on ``f_h_inf``, and that ``current`` is the plain ohmic law.
+    """
+
+    CHANNEL: type
+
     def test_root_type_is_hh_typed_neuron(self) -> None:
-        self.assertIs(HCN1_MA2025_BC.root_type, HHTypedNeuron)
+        self.assertIs(self.CHANNEL.root_type, HHTypedNeuron)
 
     def test_reset_state_matches_f_h_inf(self) -> None:
-        ch = HCN1_MA2025_BC(size=1)
-        V = _V([-70.0])
+        ch = self.CHANNEL(size=1)
+        V = voltage([-70.0])
         ch.init_state(V)
         ch.reset_state(V)
         self.assertTrue(u.math.allclose(ch.h.value, ch.f_h_inf(V), atol=1e-6))
 
     def test_current_matches_linear_formula(self) -> None:
-        ch = HCN1_MA2025_BC(size=1, E=-34.4 * u.mV)
-        V = _V([-65.0])
+        ch = self.CHANNEL(size=1, E=-34.4 * u.mV)
+        V = voltage([-65.0])
         ch.init_state(V)
         ch.h.value = jnp.array([0.25])
-        i = ch.current(V)
         expected = ch.g_max * ch.h.value * (ch.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                ch.current(V).to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
 
-class HCN1MA24PCTest(unittest.TestCase):
-    def test_root_type_is_hh_typed_neuron(self) -> None:
-        self.assertIs(HCN1_MA2024_PC.root_type, HHTypedNeuron)
+class _HCN1DerivedVariantTests(_HCN1VariantTests):
+    """Adds the agreement check for the two variants that derive from ``BASE``."""
 
-    def test_reset_state_matches_f_h_inf(self) -> None:
-        ch = HCN1_MA2024_PC(size=1)
-        V = _V([-70.0])
-        ch.init_state(V)
-        ch.reset_state(V)
-        self.assertTrue(u.math.allclose(ch.h.value, ch.f_h_inf(V), atol=1e-6))
-
-    def test_current_matches_linear_formula(self) -> None:
-        ch = HCN1_MA2024_PC(size=1, E=-34.4 * u.mV)
-        V = _V([-65.0])
-        ch.init_state(V)
-        ch.h.value = jnp.array([0.25])
-        i = ch.current(V)
-        expected = ch.g_max * ch.h.value * (ch.E - V)
-        self.assertTrue(
-            u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
-        )
+    BASE: type
 
     def test_matches_bc_variant(self) -> None:
         temp = u.celsius2kelvin(23.0)
-        bc = HCN1_MA2025_BC(size=1, temp=temp)
-        pc = HCN1_MA2024_PC(size=1, temp=temp)
-        V = _V([-70.0])
-
-        bc.init_state(V)
-        pc.init_state(V)
-        bc.reset_state(V)
-        pc.reset_state(V)
-        self.assertTrue(u.math.allclose(pc.h.value, bc.h.value, atol=1e-6))
-
-        i_bc = bc.current(V)
-        i_pc = pc.current(V)
-        self.assertTrue(
-            u.math.allclose(
-                i_pc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            self.BASE(size=1, temp=temp),
+            self.CHANNEL(size=1, temp=temp),
+            voltage([-70.0]),
+            states=("h",),
         )
 
 
-class HCN1RI21SCTest(unittest.TestCase):
-    def test_root_type_is_hh_typed_neuron(self) -> None:
-        self.assertIs(HCN1_RI2021_SC.root_type, HHTypedNeuron)
+class HCN1MA25BCTest(_HCN1VariantTests, unittest.TestCase):
+    CHANNEL = HCN1_MA2025_BC
 
-    def test_reset_state_matches_f_h_inf(self) -> None:
-        ch = HCN1_RI2021_SC(size=1)
-        V = _V([-70.0])
-        ch.init_state(V)
-        ch.reset_state(V)
-        self.assertTrue(u.math.allclose(ch.h.value, ch.f_h_inf(V), atol=1e-6))
 
-    def test_current_matches_linear_formula(self) -> None:
-        ch = HCN1_RI2021_SC(size=1, E=-34.4 * u.mV)
-        V = _V([-65.0])
-        ch.init_state(V)
-        ch.h.value = jnp.array([0.25])
-        i = ch.current(V)
-        expected = ch.g_max * ch.h.value * (ch.E - V)
-        self.assertTrue(
-            u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
-        )
+class HCN1MA24PCTest(_HCN1DerivedVariantTests, unittest.TestCase):
+    CHANNEL = HCN1_MA2024_PC
+    BASE = HCN1_MA2025_BC
 
-    def test_matches_bc_variant(self) -> None:
-        temp = u.celsius2kelvin(23.0)
-        bc = HCN1_MA2025_BC(size=1, temp=temp)
-        sc = HCN1_RI2021_SC(size=1, temp=temp)
-        V = _V([-70.0])
 
-        bc.init_state(V)
-        sc.init_state(V)
-        bc.reset_state(V)
-        sc.reset_state(V)
-        self.assertTrue(u.math.allclose(sc.h.value, bc.h.value, atol=1e-6))
-
-        i_bc = bc.current(V)
-        i_sc = sc.current(V)
-        self.assertTrue(
-            u.math.allclose(
-                i_sc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
-        )
+class HCN1RI21SCTest(_HCN1DerivedVariantTests, unittest.TestCase):
+    CHANNEL = HCN1_RI2021_SC
+    BASE = HCN1_MA2025_BC
 
 
 class HCNSU15DCNTest(unittest.TestCase):
@@ -285,28 +224,28 @@ class HCNSU15DCNTest(unittest.TestCase):
 
     def test_reset_state_matches_f_m_inf(self) -> None:
         ch = HCN_SU2015_DCN(size=1)
-        V = _V([-70.0])
+        V = voltage([-70.0])
         ch.init_state(V)
         ch.reset_state(V)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V), atol=1e-6))
 
     def test_current_matches_linear_formula(self) -> None:
         ch = HCN_SU2015_DCN(size=1, E=-45.0 * u.mV)
-        V = _V([-65.0])
+        V = voltage([-65.0])
         ch.init_state(V)
         ch.m.value = jnp.array([0.25])
         i = ch.current(V)
         expected = ch.g_max * (ch.m.value**2) * (ch.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_tau_is_constant_400_ms(self) -> None:
-        V = _V([-80.0])
+        V = voltage([-80.0])
         self.assertTrue(
             u.math.allclose(
                 HCN_SU2015_DCN(size=1).f_m_tau(V),
@@ -323,7 +262,7 @@ class HCN1MA20GoCTest(unittest.TestCase):
     def test_fast_and_slow_components_follow_template_formulas(self) -> None:
         temp = u.celsius2kelvin(22.0)
         ch = HCN1_MA2020_GoC(size=1, temp=temp)
-        V = _V([-80.0])
+        V = voltage([-80.0])
 
         ch.init_state(V)
         ch.reset_state(V)
@@ -350,8 +289,8 @@ class HCN1MA20GoCTest(unittest.TestCase):
         expected_current = ch._gbar_phi() * ch.g_max * (ch.o_fast.value + ch.o_slow.value) * (ch.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -364,7 +303,7 @@ class HCN2MA20GoCTest(unittest.TestCase):
     def test_fast_and_slow_components_follow_template_formulas(self) -> None:
         temp = u.celsius2kelvin(22.0)
         ch = HCN2_MA2020_GoC(size=1, temp=temp)
-        V = _V([-80.0])
+        V = voltage([-80.0])
 
         ch.init_state(V)
         ch.reset_state(V)
@@ -384,17 +323,17 @@ class HCN2MA20GoCTest(unittest.TestCase):
         expected_current = ch._gbar_phi() * ch.g_max * (ch.o_fast.value + ch.o_slow.value) * (ch.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_r_is_clamped_to_corridor(self) -> None:
         ch = HCN2_MA2020_GoC(size=1)
-        self.assertTrue(u.math.allclose(ch.r(_V([-50.0])), jnp.array([0.0]), atol=1e-6))
-        self.assertTrue(u.math.allclose(ch.r(_V([-120.0])), jnp.array([1.0]), atol=1e-6))
-        inside = ch.r(_V([-80.0]))
+        self.assertTrue(u.math.allclose(ch.r(voltage([-50.0])), jnp.array([0.0]), atol=1e-6))
+        self.assertTrue(u.math.allclose(ch.r(voltage([-120.0])), jnp.array([1.0]), atol=1e-6))
+        inside = ch.r(voltage([-80.0]))
         expected = jnp.array([ch.rA * -80.0 + ch.rB])
         self.assertTrue(u.math.allclose(inside, expected, atol=1e-6))
 
@@ -405,22 +344,22 @@ class HCNZH19IOTest(unittest.TestCase):
 
     def test_reset_state_matches_f_q_inf(self) -> None:
         ch = HCN_ZH2019_IO(size=1)
-        V = _V([-70.0])
+        V = voltage([-70.0])
         ch.init_state(V)
         ch.reset_state(V)
         self.assertTrue(u.math.allclose(ch.q.value, ch.f_q_inf(V), atol=1e-6))
 
     def test_current_matches_linear_formula(self) -> None:
         ch = HCN_ZH2019_IO(size=1, E=-43.0 * u.mV)
-        V = _V([-65.0])
+        V = voltage([-65.0])
         ch.init_state(V)
         ch.q.value = jnp.array([0.25])
         i = ch.current(V)
         expected = ch.g_max * ch.q.value * (ch.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )

--- a/braincell/channel/leaky.py
+++ b/braincell/channel/leaky.py
@@ -20,14 +20,14 @@ This module implements leakage channel.
 
 """
 
-from typing import Union, Sequence, Optional
+from typing import Optional
 
 import braintools
 import brainunit as u
 
 from braincell._base_channel import Channel
 from braincell._base_neuron import HHTypedNeuron
-from braincell._typing import Initializer
+from braincell._typing import Initializer, Size
 from braincell.mech import register_channel
 
 __all__ = [
@@ -65,78 +65,19 @@ class LeakageChannel(Channel):
 
     root_type = HHTypedNeuron
 
-    def pre_integral(self, V):
-        """
-        Perform any necessary operations before the integration step.
-
-        Parameters
-        -----------
-        V : array-like
-            The membrane potential.
-        """
-        pass
-
-    def post_integral(self, V):
-        """
-        Perform any necessary operations after the integration step.
-
-        Parameters
-        -----------
-        V : array-like
-            The membrane potential.
-        """
-        pass
-
     def compute_derivative(self, V):
-        """
-        Compute the derivative of the channel state variables.
+        """Do nothing: a leak has no state to integrate.
+
+        This is the one lifecycle method that differs from
+        :class:`~braincell._base_channel.IonChannel`'s default, which raises
+        ``NotImplementedError``. ``pre_integral``, ``post_integral``,
+        ``init_state``, ``reset_state`` and the ``NotImplementedError`` from
+        ``current`` are all inherited unchanged.
 
         Parameters
-        -----------
+        ----------
         V : array-like
             The membrane potential.
-        """
-        pass
-
-    def current(self, V):
-        """
-        Calculate the current through the leakage channel.
-
-        Parameters
-        -----------
-        V : array-like
-            The membrane potential.
-
-        Raises:
-        -------
-        NotImplementedError
-            This method should be implemented by subclasses.
-        """
-        raise NotImplementedError
-
-    def init_state(self, V, batch_size: int = None):
-        """
-        Initialize the state of the leakage channel.
-
-        Parameters
-        -----------
-        V : array-like
-            The membrane potential.
-        batch_size : int, optional
-            The batch size for initialization.
-        """
-        pass
-
-    def reset_state(self, V, batch_size: int = None):
-        """
-        Reset the state of the leakage channel.
-
-        Parameters
-        -----------
-        V : array-like
-            The membrane potential.
-        batch_size : int, optional
-            The batch size for resetting.
         """
         pass
 
@@ -184,7 +125,7 @@ class IL(LeakageChannel):
 
     def __init__(
         self,
-        size: Union[int, Sequence[int]],
+        size: Size,
         g_max: Initializer = 0.1 * (u.mS / u.cm**2),
         E: Initializer = -70.0 * u.mV,
         name: Optional[str] = None,

--- a/braincell/channel/potassium.py
+++ b/braincell/channel/potassium.py
@@ -22,11 +22,15 @@ from typing import Optional
 import braintools
 import brainunit as u
 
-from braincell._base_channel import Channel, IonInfo
+from braincell._base_channel import IonInfo
 from braincell._typing import ArrayLike, Initializer, Size
-from braincell.channel._base import Gate, HH, OhmicHH, q10_factor
+from braincell.channel._base import Gate, HH, OhmicHH, cached_q10_factor, is_disabled
 from braincell.ion import Potassium
 from braincell.mech import register_channel
+
+#: Hoisted so the identity-keyed memo in ``cached_q10_factor`` can hit:
+#: a freshly built ``celsius2kelvin`` result would miss on every call.
+_TEMP_REF_37C = u.celsius2kelvin(37.0)
 
 __all__ = [
     "KDR_Ba2002",
@@ -72,6 +76,47 @@ __all__ = [
 
 def _sigm(x, y):
     return 1.0 / (u.math.exp(x / y) + 1.0)
+
+
+class _ExpRateGateCurrent:
+    r"""Exponential alpha/beta gating with NMODL's optional gating-current term.
+
+    ``Kv1p1_MA25_BC.mod`` and ``Kv3p3_MA24_PC.mod`` transcribe the same RIKEN
+    construction and differ only in the six rate constants and :math:`z_n`,
+    which each class sets in its own constructor -- so the code is shared
+    through this mixin rather than by making one protein a subclass of the
+    other.
+
+    Users of the mixin must define ``ca``, ``cva``, ``cka``, ``cb``, ``cvb``,
+    ``ckb``, ``zn``, ``gunit``, ``e0`` and ``gateCurrent``, and declare a
+    single ``n`` gate in alpha/beta form.
+    """
+
+    def f_n_alpha(self, V, K: IonInfo):
+        V = V.to_decimal(u.mV)
+        return self.ca * u.math.exp(-(V + self.cva.to_decimal(u.mV)) / self.cka.to_decimal(u.mV))
+
+    def f_n_beta(self, V, K: IonInfo):
+        V = V.to_decimal(u.mV)
+        return self.cb * u.math.exp(-(V + self.cvb.to_decimal(u.mV)) / self.ckb.to_decimal(u.mV))
+
+    def current(self, V, K: IonInfo):
+        conductive = self.g_max * self.conductance_factor(V, K) * (K.E - V)
+        if is_disabled(self.gateCurrent):
+            # The shipped default. NEURON emits the gating current as a
+            # separate NONSPECIFIC_CURRENT that this term folds in; when it is
+            # off, building it costs ~12 traced equations that the
+            # ``u.math.where`` below would then discard. A traced flag takes
+            # the slow path, so the choice never depends on an unknown value.
+            return conductive
+        phi = self.gate_phi(self._iter_gates()[0])
+        n = self.n.value
+        alpha = self.f_n_alpha(V, K)
+        beta = self.f_n_beta(V, K)
+        ngate_flip = phi * (alpha * (1.0 - n) - beta * n) / u.ms
+        nc = 1e12 * self.g_max / self.gunit
+        igate = nc * 1e6 * self.e0 * 4.0 * self.zn * ngate_flip
+        return conductive - u.math.where(self.gateCurrent != 0, igate, 0.0 * igate)
 
 
 @register_channel("KDR_Ba2002")
@@ -594,7 +639,7 @@ class KA1_HM1992(OhmicHH):
 
 
 @register_channel("KA2_HM1992")
-class KA2_HM1992(OhmicHH):
+class KA2_HM1992(KA1_HM1992):
     r"""Huguenard & McCormick 1992 A-type potassium current (IA2).
 
     The second of the two components into which (Huguenard &
@@ -696,11 +741,6 @@ class KA2_HM1992(OhmicHH):
     """
 
     __module__ = "braincell.channel"
-    root_type = Potassium
-    gates = (
-        Gate("p", power=4, q10="q10_p", temp_ref="temp_ref_p"),
-        Gate("q", q10="q10_q", temp_ref="temp_ref_q"),
-    )
 
     def __init__(
         self,
@@ -714,34 +754,23 @@ class KA2_HM1992(OhmicHH):
         V_sh: Initializer = 0.0 * u.mV,
         name: Optional[str] = None,
     ):
-        super().__init__(size=size, name=name)
-        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
-        self.q10_p = braintools.init.param(q10_p, self.varshape, allow_none=False)
-        self.temp_ref_p = braintools.init.param(temp_ref_p, self.varshape, allow_none=False)
-        self.q10_q = braintools.init.param(q10_q, self.varshape, allow_none=False)
-        self.temp_ref_q = braintools.init.param(temp_ref_q, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
+        # Everything but ``f_p_inf`` and ``g_max``'s default is
+        # ``KA1_HM1992``'s; the signature is re-declared to move the default.
+        super().__init__(
+            size=size,
+            g_max=g_max,
+            temp=temp,
+            q10_p=q10_p,
+            temp_ref_p=temp_ref_p,
+            q10_q=q10_q,
+            temp_ref_q=temp_ref_q,
+            V_sh=V_sh,
+            name=name,
+        )
 
     def f_p_inf(self, V, K: IonInfo):
         temp = (V - self.V_sh).to_decimal(u.mV)
         return 1.0 / (1.0 + u.math.exp(-(temp + 36.0) / 20.0))
-
-    def f_p_tau(self, V, K: IonInfo):
-        temp = (V - self.V_sh).to_decimal(u.mV)
-        return 1.0 / (u.math.exp((temp + 35.8) / 19.7) + u.math.exp(-(temp + 79.7) / 12.7)) + 0.37
-
-    def f_q_inf(self, V, K: IonInfo):
-        temp = (V - self.V_sh).to_decimal(u.mV)
-        return 1.0 / (1.0 + u.math.exp((temp + 78.0) / 6.0))
-
-    def f_q_tau(self, V, K: IonInfo):
-        temp = (V - self.V_sh).to_decimal(u.mV)
-        return u.math.where(
-            temp < -63.0,
-            1.0 / (u.math.exp((temp + 46.0) / 5.0) + u.math.exp(-(temp + 238.0) / 37.5)),
-            19.0,
-        )
 
 
 @register_channel("KK2A_HM1992")
@@ -879,7 +908,7 @@ class KK2A_HM1992(OhmicHH):
 
 
 @register_channel("KK2B_HM1992")
-class KK2B_HM1992(OhmicHH):
+class KK2B_HM1992(KK2A_HM1992):
     r"""Huguenard & McCormick 1992 slow potassium current (IK2b).
 
     The second of the two components into which (Huguenard &
@@ -976,44 +1005,6 @@ class KK2B_HM1992(OhmicHH):
     """
 
     __module__ = "braincell.channel"
-    root_type = Potassium
-    gates = (
-        Gate("p", q10="q10_p", temp_ref="temp_ref_p"),
-        Gate("q", q10="q10_q", temp_ref="temp_ref_q"),
-    )
-
-    def __init__(
-        self,
-        size: Size,
-        g_max: Initializer = 10.0 * (u.mS / u.cm**2),
-        temp: ArrayLike = u.celsius2kelvin(36.0),
-        q10_p: Initializer = 1.0,
-        temp_ref_p: ArrayLike = u.celsius2kelvin(36.0),
-        q10_q: Initializer = 1.0,
-        temp_ref_q: ArrayLike = u.celsius2kelvin(36.0),
-        V_sh: Initializer = 0.0 * u.mV,
-        name: Optional[str] = None,
-    ):
-        super().__init__(size=size, name=name)
-        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.temp = braintools.init.param(temp, self.varshape, allow_none=False)
-        self.q10_p = braintools.init.param(q10_p, self.varshape, allow_none=False)
-        self.temp_ref_p = braintools.init.param(temp_ref_p, self.varshape, allow_none=False)
-        self.q10_q = braintools.init.param(q10_q, self.varshape, allow_none=False)
-        self.temp_ref_q = braintools.init.param(temp_ref_q, self.varshape, allow_none=False)
-        self.V_sh = braintools.init.param(V_sh, self.varshape, allow_none=False)
-
-    def f_p_inf(self, V, K: IonInfo):
-        temp = (V - self.V_sh).to_decimal(u.mV)
-        return 1.0 / (1.0 + u.math.exp(-(temp + 43.0) / 17.0))
-
-    def f_p_tau(self, V, K: IonInfo):
-        temp = (V - self.V_sh).to_decimal(u.mV)
-        return 1.0 / (u.math.exp((temp - 81.0) / 25.6) + u.math.exp(-(temp + 132.0) / 18.0)) + 9.9
-
-    def f_q_inf(self, V, K: IonInfo):
-        temp = (V - self.V_sh).to_decimal(u.mV)
-        return 1.0 / (1.0 + u.math.exp((temp + 58.0) / 10.6))
 
     def f_q_tau(self, V, K: IonInfo):
         temp = (V - self.V_sh).to_decimal(u.mV)
@@ -1147,7 +1138,7 @@ class KNI_Ya1989(OhmicHH):
 
 
 @register_channel("K_Leak")
-class K_Leak(Channel):
+class K_Leak(OhmicHH):
     r"""Potassium leak current.
 
     A voltage-independent, always-open potassium conductance:
@@ -1195,6 +1186,9 @@ class K_Leak(Channel):
 
     __module__ = "braincell.channel"
     root_type = Potassium
+    #: No gating variables: the empty tuple makes ``conductance_factor``
+    #: return 1 and turns the whole lifecycle into the template's no-ops.
+    gates = ()
 
     def __init__(
         self,
@@ -1204,18 +1198,6 @@ class K_Leak(Channel):
     ):
         super().__init__(size=size, name=name)
         self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-
-    def init_state(self, V, K: IonInfo, batch_size: int = None):
-        _ = (V, K, batch_size)
-
-    def reset_state(self, V, K: IonInfo, batch_size: int = None):
-        _ = (V, K, batch_size)
-
-    def compute_derivative(self, V, K: IonInfo):
-        pass
-
-    def current(self, V, K: IonInfo):
-        return self.g_max * (K.E - V)
 
 
 @register_channel("K_Kv_test")
@@ -1465,7 +1447,7 @@ class fKdr_SU2015_DCN(OhmicHH):
 
 
 @register_channel("sKdr_SU2015_DCN")
-class sKdr_SU2015_DCN(OhmicHH):
+class sKdr_SU2015_DCN(fKdr_SU2015_DCN):
     r"""Slow delayed rectifier of the DCN model (Sudhakar 2015).
 
     The slow delayed-rectifier potassium current of the deep
@@ -1554,18 +1536,6 @@ class sKdr_SU2015_DCN(OhmicHH):
     """
 
     __module__ = "braincell.channel"
-    root_type = Potassium
-    gates = (Gate("m", power=4),)
-
-    def __init__(
-        self,
-        size: Size,
-        g_max: Initializer = 0.01 * (u.mS / u.cm**2),
-        name: Optional[str] = None,
-    ):
-        super().__init__(size=size, name=name)
-        self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.qdeltat = 1.0
 
     def f_m_inf(self, V, K: IonInfo):
         V = V.to_decimal(u.mV)
@@ -2120,7 +2090,7 @@ class Kir2p3_RI2021_SC(Kir2p3_MA2025_BC):
 
 
 @register_channel("Kv1p1_MA2025_BC")
-class Kv1p1_MA2025_BC(HH):
+class Kv1p1_MA2025_BC(_ExpRateGateCurrent, HH):
     r"""Kv1.1 low-threshold potassium current of the basket cell model.
 
     Non-inactivating, low-threshold potassium current carried by Kv1.1
@@ -2278,25 +2248,6 @@ class Kv1p1_MA2025_BC(HH):
         self.ckb = 12.42101 * u.mV
         self.zn = 2.7978
         self.e0 = 1.60217646e-19 * u.coulomb
-
-    def f_n_alpha(self, V, K: IonInfo):
-        V = V.to_decimal(u.mV)
-        return self.ca * u.math.exp(-(V + self.cva.to_decimal(u.mV)) / self.cka.to_decimal(u.mV))
-
-    def f_n_beta(self, V, K: IonInfo):
-        V = V.to_decimal(u.mV)
-        return self.cb * u.math.exp(-(V + self.cvb.to_decimal(u.mV)) / self.ckb.to_decimal(u.mV))
-
-    def current(self, V, K: IonInfo):
-        conductive = self.g_max * self.conductance_factor(V, K) * (K.E - V)
-        phi = self.gate_phi(self._iter_gates()[0])
-        n = self.n.value
-        alpha = self.f_n_alpha(V, K)
-        beta = self.f_n_beta(V, K)
-        ngate_flip = phi * (alpha * (1.0 - n) - beta * n) / u.ms
-        nc = 1e12 * self.g_max / self.gunit
-        igate = nc * 1e6 * self.e0 * 4.0 * self.zn * ngate_flip
-        return conductive - u.math.where(self.gateCurrent != 0, igate, 0.0 * igate)
 
 
 @register_channel("Kv1p1_MA2024_PC")
@@ -2742,7 +2693,7 @@ class Kv1p5_MA2024_PC(HH):
         return self.g_max * self._voltage_factor(V) * self.conductance_factor(V, K) * (K.E - V)
 
     def _q10(self):
-        return q10_factor(2.2, self.temp, u.celsius2kelvin(37.0))
+        return cached_q10_factor(self, "_q10_memo", 2.2, self.temp, _TEMP_REF_37C)
 
     def _voltage_factor(self, V):
         V = V.to_decimal(u.mV)
@@ -2777,7 +2728,7 @@ class Kv1p5_MA2024_PC(HH):
 
 
 @register_channel("Kv3p3_MA2024_PC")
-class Kv3p3_MA2024_PC(HH):
+class Kv3p3_MA2024_PC(_ExpRateGateCurrent, HH):
     r"""Kv3.3 high-threshold potassium current of the Purkinje model.
 
     Fast-activating, non-inactivating high-threshold potassium
@@ -2944,25 +2895,6 @@ class Kv3p3_MA2024_PC(HH):
         self.ckb = 26.5 * u.mV
         self.zn = 1.9196
         self.e0 = 1.60217646e-19 * u.coulomb
-
-    def f_n_alpha(self, V, K: IonInfo):
-        V = V.to_decimal(u.mV)
-        return self.ca * u.math.exp(-(V + self.cva.to_decimal(u.mV)) / self.cka.to_decimal(u.mV))
-
-    def f_n_beta(self, V, K: IonInfo):
-        V = V.to_decimal(u.mV)
-        return self.cb * u.math.exp(-(V + self.cvb.to_decimal(u.mV)) / self.ckb.to_decimal(u.mV))
-
-    def current(self, V, K: IonInfo):
-        conductive = self.g_max * self.conductance_factor(V, K) * (K.E - V)
-        phi = self.gate_phi(self._iter_gates()[0])
-        n = self.n.value
-        alpha = self.f_n_alpha(V, K)
-        beta = self.f_n_beta(V, K)
-        ngate_flip = phi * (alpha * (1.0 - n) - beta * n) / u.ms
-        nc = 1e12 * self.g_max / self.gunit
-        igate = nc * 1e6 * self.e0 * 4.0 * self.zn * ngate_flip
-        return conductive - u.math.where(self.gateCurrent != 0, igate, 0.0 * igate)
 
 
 @register_channel("Kv3p4_MA2025_BC")
@@ -4956,10 +4888,6 @@ class Kv2p2_0010_MA2020_GrC(OhmicHH):
         Maximal conductance density. Defaults to ``0.01 mS/cm2``,
         which is exactly the source mechanism's
         ``gKv2_2bar = 0.00001 S/cm2``.
-    BBiD : array-like or callable, optional
-        Channelpedia ion-channel identifier, default ``10.0``
-        (dimensionless). This is inert metadata, not a kinetic
-        parameter; see the note below.
     name : str, optional
         Optional channel name.
 
@@ -4980,9 +4908,10 @@ class Kv2p2_0010_MA2020_GrC(OhmicHH):
 
     **``BBiD`` is metadata, not a parameter of the model.** In the
     ``.mod`` file ``BBiD = 10`` is declared ``RANGE`` but never
-    appears in any equation, and BrainCell likewise stores it and
-    never reads it. It is the Channelpedia identifier for Kv2.2 (gene
-    *KCNB2*), and it is also the ``0010`` embedded in the class name.
+    appears in any equation, so BrainCell does not expose it: a
+    constructor argument that is stored and never read is a trap. It
+    is the Channelpedia identifier for Kv2.2 (gene *KCNB2*), and it is
+    also the ``0010`` embedded in the class name.
 
     **How this mechanism was produced.** The ``.mod`` file is machine
     generated, not hand written: its version-control keywords name the
@@ -5040,12 +4969,10 @@ class Kv2p2_0010_MA2020_GrC(OhmicHH):
         self,
         size: Size,
         g_max: Initializer = 0.01 * (u.mS / u.cm**2),
-        BBiD: Initializer = 10.0,
         name: Optional[str] = None,
     ):
         super().__init__(size=size, name=name)
         self.g_max = braintools.init.param(g_max, self.varshape, allow_none=False)
-        self.BBiD = braintools.init.param(BBiD, self.varshape, allow_none=False)
 
     def f_m_inf(self, V, K: IonInfo):
         V = V.to_decimal(u.mV)

--- a/braincell/channel/potassium_calcium.py
+++ b/braincell/channel/potassium_calcium.py
@@ -44,9 +44,13 @@ import jax
 
 from braincell._base_channel import IonInfo
 from braincell._typing import ArrayLike, Initializer, Size
-from braincell.channel._base import Gate, Markov, OhmicHH, Transition, q10_factor
+from braincell.channel._base import Gate, OhmicHH, OhmicMarkov, Transition, cached_q10_factor
 from braincell.ion import Calcium, Potassium
 from braincell.mech import register_channel
+
+#: Hoisted so the identity-keyed memo in ``cached_q10_factor`` can hit:
+#: a freshly built ``celsius2kelvin`` result would miss on every call.
+_TEMP_REF_23C = u.celsius2kelvin(23.0)
 
 __all__ = [
     "AHP_De1994",
@@ -606,7 +610,7 @@ class Kca3p1_MA2024_PC(Kca3p1_MA2020_GoC):
 
 
 @register_channel("Kca2p2_MA2020_GoC")
-class Kca2p2_MA2020_GoC(Markov):
+class Kca2p2_MA2020_GoC(OhmicMarkov):
     r"""Kca2.2 (SK2) calcium-activated K current, Golgi cell.
 
     Template-based import of ``Kca2p2_MA20_GoC.mod``, part of the
@@ -719,6 +723,7 @@ class Kca2p2_MA2020_GoC(Markov):
         Transition("C4", "O2", "diro2_t", "invo2_t"),
     )
     dependent_state = "C1"
+    open_states = ("O1", "O2")
 
     def __init__(
         self,
@@ -751,11 +756,7 @@ class Kca2p2_MA2020_GoC(Markov):
         self.dirc4 = 80.0
 
     def _phi(self):
-        return q10_factor(self.q10_base, self.temp, u.celsius2kelvin(23.0))
-
-    def current(self, V, K: IonInfo, Ca: IonInfo):
-        states = self.state_values()
-        return self.g_max * (states["O1"] + states["O2"]) * (K.E - V)
+        return cached_q10_factor(self, "_phi_memo", self.q10_base, self.temp, _TEMP_REF_23C)
 
     def dirc2_t_ca(self, V, K: IonInfo, Ca: IonInfo):
         return self.dirc2 * self._phi() * (Ca.Ci / u.mM) / self.diff
@@ -1098,7 +1099,7 @@ class Kca2p2_RI2021_SC(Kca2p2_MA2020_GoC):
 
 
 @register_channel("Kca1p1_MA2020_GoC")
-class Kca1p1_MA2020_GoC(Markov):
+class Kca1p1_MA2020_GoC(OhmicMarkov):
     r"""Kca1.1 (BK/mslo) Ca- and voltage-activated K current, Golgi cell.
 
     Template-based import of ``Kca1p1_MA20_GoC.mod``, part of the
@@ -1221,6 +1222,7 @@ class Kca1p1_MA2020_GoC(Markov):
         Transition("C4", "O4", "f4", "b4"),
     )
     dependent_state = "C0"
+    open_states = ("O0", "O1", "O2", "O3", "O4")
 
     def __init__(
         self,
@@ -1258,17 +1260,13 @@ class Kca1p1_MA2020_GoC(Markov):
         self.pb4 = 92e-3
 
     def _phi(self):
-        return q10_factor(self.q10_base, self.temp, u.celsius2kelvin(23.0))
+        return cached_q10_factor(self, "_phi_memo", self.q10_base, self.temp, _TEMP_REF_23C)
 
     def _alpha_factor(self, V):
         return u.math.exp((self.Qo * u.faraday_constant * V) / (u.gas_constant * self.temp))
 
     def _beta_factor(self, V):
         return u.math.exp((self.Qc * u.faraday_constant * V) / (u.gas_constant * self.temp))
-
-    def current(self, V, K: IonInfo, Ca: IonInfo):
-        states = self.state_values()
-        return self.g_max * (states["O0"] + states["O1"] + states["O2"] + states["O3"] + states["O4"]) * (K.E - V)
 
     def c01(self, V, K: IonInfo, Ca: IonInfo):
         return 4 * (Ca.Ci / u.mM) * self.k1 * self.onoffrate * self._phi()

--- a/braincell/channel/potassium_calcium_test.py
+++ b/braincell/channel/potassium_calcium_test.py
@@ -41,31 +41,17 @@ from braincell.channel.potassium_calcium import (
 )
 from braincell.ion import Calcium, Potassium
 from braincell.mech import get_registry
+from braincell.channel._testing import (
+    DENSITY_UNIT,
+    ca_info,
+    k_info,
+    voltage,
+)
 
 
 def _k_info(size: int = 1) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), 140.0) * u.mM,
-        Co=jnp.full((size,), 2.5) * u.mM,
-        E=jnp.full((size,), -90.0) * u.mV,
-        valence=1,
-    )
-
-
-def _ca_info(size: int = 1, C: float = 1e-4) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), C) * u.mM,
-        Co=jnp.full((size,), 2.0) * u.mM,
-        E=jnp.full((size,), 120.0) * u.mV,
-        valence=2,
-    )
-
-
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
-
-
-_DENSITY_UNIT = u.mS / u.cm**2 * u.mV
+    """Potassium at the physiological 140 mM intracellular concentration."""
+    return k_info(size, Ci=140.0)
 
 
 class _MixedPotassiumCalciumTemplateTest:
@@ -91,9 +77,9 @@ class IAHPDe1994Test(_MixedPotassiumCalciumTemplateTest, unittest.TestCase):
 
     def test_reset_state_matches_steady_state(self) -> None:
         ch = AHP_De1994(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=1e-3)
+        ca = ca_info(Ci=1e-3)
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
 
@@ -103,26 +89,26 @@ class IAHPDe1994Test(_MixedPotassiumCalciumTemplateTest, unittest.TestCase):
 
     def test_current_matches_p_squared_form(self) -> None:
         ch = AHP_De1994(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=1e-3)
+        ca = ca_info(Ci=1e-3)
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         i = ch.current(V, k, ca)
         expected = ch.g_max * ch.p.value**2 * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_compute_derivative_uses_first_order_kinetics(self) -> None:
         ch = AHP_De1994(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=1e-3)
+        ca = ca_info(Ci=1e-3)
         ch.init_state(V, k, ca)
         ch.p.value = jnp.array([0.2])
         ch.compute_derivative(V, k, ca)
@@ -149,16 +135,16 @@ class SK_SU2015_DCNTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCase):
 
     def test_reset_state_sets_z_to_zinf(self) -> None:
         ch = SK_SU2015_DCN(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=3e-4)
+        ca = ca_info(Ci=3e-4)
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         self.assertTrue(u.math.allclose(ch.z.value, ch.f_z_inf(V, k, ca), atol=1e-6))
 
     def test_z_inf_uses_direct_formula(self) -> None:
         ch = SK_SU2015_DCN(size=3)
-        V = _V([-60.0, -60.0, -60.0])
+        V = voltage([-60.0, -60.0, -60.0])
         k = _k_info(3)
         ca = IonInfo(
             Ci=jnp.asarray([5.5e-5, 3.2e-4, 1.01e-3]) * u.mM,
@@ -172,7 +158,7 @@ class SK_SU2015_DCNTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCase):
 
     def test_z_tau_uses_direct_formula_and_qdeltat(self) -> None:
         ch = SK_SU2015_DCN(size=3, qdeltat=2.0)
-        V = _V([-60.0, -60.0, -60.0])
+        V = voltage([-60.0, -60.0, -60.0])
         k = _k_info(3)
         ca = IonInfo(
             Ci=jnp.asarray([5.5e-5, 0.00401, 0.00601]) * u.mM,
@@ -194,9 +180,9 @@ class SK_SU2015_DCNTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCase):
 
     def test_compute_derivative_matches_inf_tau_form(self) -> None:
         ch = SK_SU2015_DCN(size=1, qdeltat=2.0)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=3e-4)
+        ca = ca_info(Ci=3e-4)
         ch.init_state(V, k, ca)
         ch.z.value = jnp.array([0.2])
         ch.compute_derivative(V, k, ca)
@@ -205,17 +191,17 @@ class SK_SU2015_DCNTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCase):
 
     def test_current_matches_mod_formula_with_braincell_sign(self) -> None:
         ch = SK_SU2015_DCN(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=3e-4)
+        ca = ca_info(Ci=3e-4)
         ch.init_state(V, k, ca)
         ch.z.value = jnp.array([0.5])
         current = ch.current(V, k, ca)
         expected = ch.g_max * ch.z.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -227,35 +213,35 @@ class Kca3p1_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
 
     def test_reset_state_matches_p_inf(self) -> None:
         ch = Kca3p1_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=1e-3)
+        ca = ca_info(Ci=1e-3)
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         self.assertTrue(u.math.allclose(ch.p.value, ch.p_inf(V, ca), atol=1e-6))
 
     def test_current_matches_g_times_p_times_drive(self) -> None:
         ch = Kca3p1_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=1e-3)
+        ca = ca_info(Ci=1e-3)
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         i = ch.current(V, k, ca)
         expected = ch.g_max * ch.p.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_compute_derivative_runs(self) -> None:
         ch = Kca3p1_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=1e-3)
+        ca = ca_info(Ci=1e-3)
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         ch.p.value = jnp.array([0.3])
@@ -265,9 +251,9 @@ class Kca3p1_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
     def test_compute_derivative_matches_reference_without_temperature_scaling(self) -> None:
         cold = Kca3p1_MA2020_GoC(size=1, temp=u.celsius2kelvin(22.0))
         warm = Kca3p1_MA2020_GoC(size=1, temp=u.celsius2kelvin(37.0))
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info(C=1e-3)
+        ca = ca_info(Ci=1e-3)
 
         for ch in (cold, warm):
             ch.init_state(V, k, ca)
@@ -297,9 +283,9 @@ class Kca3p1InheritedCellVariantTest(unittest.TestCase):
         self.assertIs(registry.get("channel", "Kca3p1_MA2024_PC"), Kca3p1_MA2024_PC)
 
     def test_cell_variants_match_goc_state_derivative_and_current(self) -> None:
-        V = _V([-55.0])
+        V = voltage([-55.0])
         k = _k_info()
-        ca = _ca_info(C=8e-4)
+        ca = ca_info(Ci=8e-4)
         goc = Kca3p1_MA2020_GoC(size=1)
 
         for cls in (Kca3p1_MA2025_BC, Kca3p1_MA2024_PC):
@@ -327,8 +313,8 @@ class Kca3p1InheritedCellVariantTest(unittest.TestCase):
                 i_variant = variant.current(V, k, ca)
                 self.assertTrue(
                     u.math.allclose(
-                        i_variant.to_decimal(_DENSITY_UNIT),
-                        i_goc.to_decimal(_DENSITY_UNIT),
+                        i_variant.to_decimal(DENSITY_UNIT),
+                        i_goc.to_decimal(DENSITY_UNIT),
                         atol=1e-6,
                     )
                 )
@@ -340,9 +326,9 @@ class Kca2p2_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
 
     def test_init_state_creates_independent_microstates(self) -> None:
         ch = Kca2p2_MA2020_GoC(size=2)
-        V = _V([-60.0, -50.0])
+        V = voltage([-60.0, -50.0])
         k = _k_info(2)
-        ca = _ca_info(2)
+        ca = ca_info(2)
         ch.init_state(V, k, ca)
         self.assertEqual(ch.state_names, ("C2", "C3", "C4", "O1", "O2"))
         self.assertEqual(ch.redundant_state, "C1")
@@ -351,9 +337,9 @@ class Kca2p2_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
 
     def test_reset_state_solves_steady_state_with_total_probability_one(self) -> None:
         ch = Kca2p2_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         states = ch.state_values()
@@ -362,9 +348,9 @@ class Kca2p2_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
 
     def test_current_matches_open_states_times_drive(self) -> None:
         ch = Kca2p2_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         ch.init_state(V, k, ca)
         ch.C2.value = jnp.zeros(1)
         ch.C3.value = jnp.zeros(1)
@@ -376,17 +362,17 @@ class Kca2p2_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
         expected = ch.g_max * (states["O1"] + states["O2"]) * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_compute_derivative_runs(self) -> None:
         ch = Kca2p2_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         ch.compute_derivative(V, k, ca)
@@ -406,9 +392,9 @@ class Kca1p1_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
 
     def test_init_state_creates_independent_closed_and_open_states(self) -> None:
         ch = Kca1p1_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         ch.init_state(V, k, ca)
         self.assertEqual(ch.redundant_state, "C0")
         self.assertEqual(ch.state_names, ("C1", "C2", "C3", "C4", "O0", "O1", "O2", "O3", "O4"))
@@ -417,9 +403,9 @@ class Kca1p1_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
 
     def test_reset_state_solves_steady_state_with_total_probability_one(self) -> None:
         ch = Kca1p1_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         states = ch.state_values()
@@ -428,9 +414,9 @@ class Kca1p1_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
 
     def test_current_sums_all_open_states(self) -> None:
         ch = Kca1p1_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         ch.init_state(V, k, ca)
         for i in range(1, 5):
             getattr(ch, f"C{i}").value = jnp.zeros(1)
@@ -441,17 +427,17 @@ class Kca1p1_MA2020_GoCTest(_MixedPotassiumCalciumTemplateTest, unittest.TestCas
         expected = ch.g_max * (states["O0"] + states["O1"] + states["O2"] + states["O3"] + states["O4"]) * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i_val.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i_val.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_compute_derivative_runs(self) -> None:
         ch = Kca1p1_MA2020_GoC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         ch.init_state(V, k, ca)
         ch.reset_state(V, k, ca)
         ch.compute_derivative(V, k, ca)
@@ -488,9 +474,9 @@ class KcaInheritedCellVariantTest(unittest.TestCase):
                 self.assertEqual(cls.__module__, "braincell.channel")
 
     def test_kca2p2_variants_inherit_markov_behavior(self) -> None:
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         for name, cls, base in self.KCA2P2_VARIANTS:
             with self.subTest(name=name):
                 ch = cls(size=1)
@@ -504,16 +490,16 @@ class KcaInheritedCellVariantTest(unittest.TestCase):
                 expected = ch.g_max * (ch.state_values()["O1"] + ch.state_values()["O2"]) * (k.E - V)
                 self.assertTrue(
                     u.math.allclose(
-                        current.to_decimal(_DENSITY_UNIT),
-                        expected.to_decimal(_DENSITY_UNIT),
+                        current.to_decimal(DENSITY_UNIT),
+                        expected.to_decimal(DENSITY_UNIT),
                         atol=1e-6,
                     )
                 )
 
     def test_kca1p1_variants_inherit_markov_behavior(self) -> None:
-        V = _V([-60.0])
+        V = voltage([-60.0])
         k = _k_info()
-        ca = _ca_info()
+        ca = ca_info()
         for name, cls, base in self.KCA1P1_VARIANTS:
             with self.subTest(name=name):
                 ch = cls(size=1)
@@ -532,8 +518,8 @@ class KcaInheritedCellVariantTest(unittest.TestCase):
                 )
                 self.assertTrue(
                     u.math.allclose(
-                        current.to_decimal(_DENSITY_UNIT),
-                        expected.to_decimal(_DENSITY_UNIT),
+                        current.to_decimal(DENSITY_UNIT),
+                        expected.to_decimal(DENSITY_UNIT),
                         atol=1e-6,
                     )
                 )

--- a/braincell/channel/potassium_sodium_test.py
+++ b/braincell/channel/potassium_sodium_test.py
@@ -25,40 +25,18 @@ from braincell._base_channel import IonInfo
 from braincell.channel.potassium import Kv1p5_MA2024_PC
 from braincell.channel.potassium_sodium import Kv1p5_MA2020_GrC
 from braincell.ion import NonSpecific, Potassium, Sodium
-
-
-def _k_info(size: int = 1) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), 0.04) * u.mM,
-        Co=jnp.full((size,), 2.5) * u.mM,
-        E=jnp.full((size,), -90.0) * u.mV,
-        valence=1,
-    )
+from braincell.channel._testing import (
+    DENSITY_UNIT,
+    k_info,
+    na_info,
+    nonspecific_info,
+    voltage,
+)
 
 
 def _na_info(size: int = 1) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), 10.0) * u.mM,
-        Co=jnp.full((size,), 140.0) * u.mM,
-        E=jnp.full((size,), 50.0) * u.mV,
-        valence=1,
-    )
-
-
-def _no_info(size: int = 1) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), 1.0) * u.mM,
-        Co=jnp.full((size,), 1.0) * u.mM,
-        E=jnp.full((size,), 0.0) * u.mV,
-        valence=1,
-    )
-
-
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
-
-
-_DENSITY_UNIT = u.mS / u.cm**2 * u.mV
+    """Sodium at the 10 mM intracellular concentration this pair uses."""
+    return na_info(size, Ci=10.0)
 
 
 class Kv1p5MA20GrCTest(unittest.TestCase):
@@ -78,10 +56,10 @@ class Kv1p5MA20GrCTest(unittest.TestCase):
         temp = u.celsius2kelvin(36.0)
         pc = Kv1p5_MA2024_PC(size=1, temp=temp)
         grc = Kv1p5_MA2020_GrC(size=1, temp=temp)
-        V = _V([-35.0])
-        k = _k_info()
+        V = voltage([-35.0])
+        k = k_info()
         na = _na_info()
-        no = _no_info()
+        no = nonspecific_info()
 
         pc.init_state(V, k)
         grc.init_state(V, k, na, no)
@@ -100,23 +78,23 @@ class Kv1p5MA20GrCTest(unittest.TestCase):
         i_pc = pc.current(V, k)
         components = grc.current_components(V, k, na, no)
         i_grc = grc.current(V, k, na, no)
-        self.assertTrue(u.math.allclose(components["no"].to_decimal(_DENSITY_UNIT), jnp.zeros((1,)), atol=1e-12))
+        self.assertTrue(u.math.allclose(components["no"].to_decimal(DENSITY_UNIT), jnp.zeros((1,)), atol=1e-12))
         self.assertTrue(
             u.math.allclose(
-                components["k"].to_decimal(_DENSITY_UNIT),
-                i_pc.to_decimal(_DENSITY_UNIT),
+                components["k"].to_decimal(DENSITY_UNIT),
+                i_pc.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
-        self.assertTrue(u.math.allclose(i_grc.to_decimal(_DENSITY_UNIT), i_pc.to_decimal(_DENSITY_UNIT), atol=1e-6))
+        self.assertTrue(u.math.allclose(i_grc.to_decimal(DENSITY_UNIT), i_pc.to_decimal(DENSITY_UNIT), atol=1e-6))
 
     def test_nonzero_gnonspec_contributes_nonspecific_component(self) -> None:
         temp = u.celsius2kelvin(25.0)
         ch = Kv1p5_MA2020_GrC(size=1, temp=temp, gnonspec=0.2e-3 * (u.siemens / u.cm**2))
-        V = _V([-20.0])
-        k = _k_info()
+        V = voltage([-20.0])
+        k = k_info()
         na = _na_info()
-        no = _no_info()
+        no = nonspecific_info()
         ch.init_state(V, k, na, no)
         ch.m.value = jnp.array([0.2])
         ch.n.value = jnp.array([0.3])
@@ -131,16 +109,16 @@ class Kv1p5MA20GrCTest(unittest.TestCase):
 
         self.assertTrue(
             u.math.allclose(
-                components["no"].to_decimal(_DENSITY_UNIT),
-                expected_no.to_decimal(_DENSITY_UNIT),
+                components["no"].to_decimal(DENSITY_UNIT),
+                expected_no.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
-        self.assertFalse(u.math.allclose(components["no"].to_decimal(_DENSITY_UNIT), jnp.zeros((1,)), atol=1e-12))
+        self.assertFalse(u.math.allclose(components["no"].to_decimal(DENSITY_UNIT), jnp.zeros((1,)), atol=1e-12))
         self.assertTrue(
             u.math.allclose(
-                total.to_decimal(_DENSITY_UNIT),
-                (components["k"] + components["no"]).to_decimal(_DENSITY_UNIT),
+                total.to_decimal(DENSITY_UNIT),
+                (components["k"] + components["no"]).to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )

--- a/braincell/channel/potassium_test.py
+++ b/braincell/channel/potassium_test.py
@@ -20,7 +20,6 @@ import unittest
 import brainunit as u
 import jax.numpy as jnp
 
-from braincell._base_channel import IonInfo
 from braincell.channel._base import HH
 from braincell.channel.potassium import (
     KDR_Ba2002,
@@ -63,22 +62,12 @@ from braincell.channel.potassium import (
     sKdr_SU2015_DCN,
 )
 from braincell.ion import Potassium
-
-
-def _k_info(size: int = 1) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), 0.04) * u.mM,
-        Co=jnp.full((size,), 2.5) * u.mM,
-        E=jnp.full((size,), -90.0) * u.mV,
-        valence=1,
-    )
-
-
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
-
-
-_DENSITY_UNIT = u.mS / u.cm**2 * u.mV
+from braincell.channel._testing import (
+    DENSITY_UNIT,
+    assert_channels_agree,
+    k_info,
+    voltage,
+)
 
 
 class _P4HHMixin:
@@ -121,16 +110,16 @@ class _P4HHMixin:
 
     def test_init_state_creates_p_shaped_to_size(self) -> None:
         ch = self._make(size=3)
-        V = _V([-60.0, -65.0, -70.0])
-        k = _k_info(3)
+        V = voltage([-60.0, -65.0, -70.0])
+        k = k_info(3)
         ch.init_state(V, k)
         self.assertEqual(ch.p.value.shape, (3,))
         self.assertTrue(u.math.allclose(ch.p.value, jnp.zeros(3)))
 
     def test_reset_state_matches_steady_state(self) -> None:
         ch = self._make(size=1)
-        V = _V([-65.0])
-        k = _k_info()
+        V = voltage([-65.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         alpha = ch.f_p_alpha(V, k)
@@ -139,8 +128,8 @@ class _P4HHMixin:
 
     def test_compute_derivative_matches_hh_alpha_beta_form(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.p.value = jnp.array([0.2])
         ch.compute_derivative(V, k)
@@ -152,30 +141,30 @@ class _P4HHMixin:
 
     def test_current_is_g_max_p4_times_driving_force(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         current = ch.current(V, k)
         expected = ch.g_max * ch.p.value**4 * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_current_is_zero_when_p_zero(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.p.value = jnp.zeros(1)
         current = ch.current(V, k)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
                 jnp.zeros(1),
                 atol=1e-9,
             )
@@ -247,16 +236,16 @@ class _P4QHHMixin:
 
     def test_init_state_creates_p_and_q(self) -> None:
         ch = self._make(size=2)
-        V = _V([-60.0, -70.0])
-        k = _k_info(2)
+        V = voltage([-60.0, -70.0])
+        k = k_info(2)
         ch.init_state(V, k)
         self.assertEqual(ch.p.value.shape, (2,))
         self.assertEqual(ch.q.value.shape, (2,))
 
     def test_reset_state_sets_gates_to_inf(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.p.value, ch.f_p_inf(V, k), atol=1e-6))
@@ -264,8 +253,8 @@ class _P4QHHMixin:
 
     def test_compute_derivative_matches_hh_inf_tau_form(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.p.value = jnp.array([0.2])
         ch.q.value = jnp.array([0.5])
@@ -278,16 +267,16 @@ class _P4QHHMixin:
 
     def test_current_matches_p4_q_formula(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         current = ch.current(V, k)
         expected = ch.g_max * ch.p.value**4 * ch.q.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -329,16 +318,16 @@ class _PQHHMixin:
 
     def test_init_state_creates_p_and_q(self) -> None:
         ch = self._make(size=2)
-        V = _V([-60.0, -70.0])
-        k = _k_info(2)
+        V = voltage([-60.0, -70.0])
+        k = k_info(2)
         ch.init_state(V, k)
         self.assertEqual(ch.p.value.shape, (2,))
         self.assertEqual(ch.q.value.shape, (2,))
 
     def test_reset_state_matches_infinities(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.p.value, ch.f_p_inf(V, k), atol=1e-6))
@@ -346,8 +335,8 @@ class _PQHHMixin:
 
     def test_compute_derivative_matches_hh_inf_tau_form(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.p.value = jnp.array([0.2])
         ch.q.value = jnp.array([0.5])
@@ -360,16 +349,16 @@ class _PQHHMixin:
 
     def test_current_matches_p_q_formula(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         current = ch.current(V, k)
         expected = ch.g_max * ch.p.value * ch.q.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -392,8 +381,8 @@ class KNI_Ya1989Test(unittest.TestCase):
 
     def test_reset_state_matches_p_inf(self) -> None:
         ch = KNI_Ya1989(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.p.value, ch.f_p_inf(V, k), atol=1e-6))
@@ -405,8 +394,8 @@ class KNI_Ya1989Test(unittest.TestCase):
             q10=3.0,
             temp_ref=u.celsius2kelvin(36.0),
         )
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.p.value = jnp.array([0.2])
         ch.compute_derivative(V, k)
@@ -416,16 +405,16 @@ class KNI_Ya1989Test(unittest.TestCase):
 
     def test_current_matches_formula(self) -> None:
         ch = KNI_Ya1989(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         current = ch.current(V, k)
         expected = ch.g_max * ch.p.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -437,21 +426,21 @@ class IKLeakTest(unittest.TestCase):
 
     def test_current_follows_ohms_law(self) -> None:
         ch = K_Leak(size=1, g_max=0.005 * (u.mS / u.cm**2))
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         current = ch.current(V, k)
         expected = ch.g_max * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-9,
             )
         )
 
     def test_compute_derivative_is_noop(self) -> None:
         ch = K_Leak(size=1)
-        self.assertIsNone(ch.compute_derivative(_V([-60.0]), _k_info()))
+        self.assertIsNone(ch.compute_derivative(voltage([-60.0]), k_info()))
 
 
 class K_Kv_testTest(unittest.TestCase):
@@ -470,16 +459,16 @@ class K_Kv_testTest(unittest.TestCase):
 
     def test_reset_state_matches_f_n_inf(self) -> None:
         ch = K_Kv_test(size=1)
-        V = _V([-20.0])
-        k = _k_info()
+        V = voltage([-20.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.n.value, ch.f_n_inf(V, k), atol=1e-6))
 
     def test_compute_derivative_matches_hh_inf_tau_form(self) -> None:
         ch = K_Kv_test(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.n.value = jnp.array([0.25])
         ch.compute_derivative(V, k)
@@ -489,16 +478,16 @@ class K_Kv_testTest(unittest.TestCase):
 
     def test_current_matches_linear_gating(self) -> None:
         ch = K_Kv_test(size=1, g_max=0.1 * (u.mS / u.cm**2))
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         current = ch.current(V, k)
         expected = ch.g_max * ch.n.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -510,8 +499,8 @@ class Kir2p3MA25BCTest(unittest.TestCase):
 
     def test_reset_state_matches_alpha_beta_ratio(self) -> None:
         ch = Kir2p3_MA2025_BC(size=1)
-        V = _V([-75.0])
-        k = _k_info()
+        V = voltage([-75.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         alpha = ch.f_d_alpha(V, k)
@@ -523,8 +512,8 @@ class Kv1p1MA25BCTest(unittest.TestCase):
     def test_matches_template_formulas_without_gating_current(self) -> None:
         temp = u.celsius2kelvin(22.0)
         proto = Kv1p1_MA2025_BC(size=1, temp=temp, gateCurrent=0.0)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
 
         proto.init_state(V, k)
         proto.reset_state(V, k)
@@ -541,8 +530,8 @@ class Kv1p1MA25BCTest(unittest.TestCase):
         expected_current = proto.g_max * proto.n.value**4 * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i_proto.to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                i_proto.to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -550,8 +539,8 @@ class Kv1p1MA25BCTest(unittest.TestCase):
     def test_gating_current_path_matches_manual_formula(self) -> None:
         temp = u.celsius2kelvin(22.0)
         proto = Kv1p1_MA2025_BC(size=1, temp=temp, gateCurrent=1.0)
-        V = _V([-50.0])
-        k = _k_info()
+        V = voltage([-50.0])
+        k = k_info()
 
         proto.init_state(V, k)
         proto.reset_state(V, k)
@@ -568,8 +557,8 @@ class Kv1p1MA25BCTest(unittest.TestCase):
         i_proto = proto.current(V, k)
         self.assertTrue(
             u.math.allclose(
-                i_proto.to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                i_proto.to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -579,8 +568,8 @@ class Kv3p4MA25BCTest(unittest.TestCase):
     def test_matches_template_state_derivative_and_current(self) -> None:
         temp = u.celsius2kelvin(22.0)
         proto = Kv3p4_MA2025_BC(size=1, temp=temp)
-        V = _V([-45.0])
-        k = _k_info()
+        V = voltage([-45.0])
+        k = k_info()
 
         proto.init_state(V, k)
         proto.reset_state(V, k)
@@ -600,8 +589,8 @@ class Kv3p4MA25BCTest(unittest.TestCase):
         expected_current = proto.g_max * (proto.m.value**3) * proto.h.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i_proto.to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                i_proto.to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -611,8 +600,8 @@ class Kv4p3MA25BCTest(unittest.TestCase):
     def test_matches_template_state_derivative_and_current(self) -> None:
         temp = u.celsius2kelvin(30.0)
         proto = Kv4p3_MA2025_BC(size=1, temp=temp)
-        V = _V([-55.0])
-        k = _k_info()
+        V = voltage([-55.0])
+        k = k_info()
 
         proto.init_state(V, k)
         proto.reset_state(V, k)
@@ -632,8 +621,8 @@ class Kv4p3MA25BCTest(unittest.TestCase):
         expected_current = proto.g_max * (proto.a.value**3) * proto.b.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i_proto.to_decimal(_DENSITY_UNIT),
-                expected_current.to_decimal(_DENSITY_UNIT),
+                i_proto.to_decimal(DENSITY_UNIT),
+                expected_current.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -644,27 +633,13 @@ class Kir2p3MA24PCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         bc = Kir2p3_MA2025_BC(size=1, temp=temp)
         pc = Kir2p3_MA2024_PC(size=1, temp=temp)
-        V = _V([-75.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        pc.init_state(V, k)
-        bc.reset_state(V, k)
-        pc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(pc.d.value, bc.d.value, atol=1e-6))
-
-        bc.compute_derivative(V, k)
-        pc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(pc.d.derivative, bc.d.derivative, atol=1e-6 * u.Hz))
-
-        i_bc = bc.current(V, k)
-        i_pc = pc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_pc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            pc,
+            voltage([-75.0]),
+            k_info(),
+            states=("d",),
         )
 
 
@@ -673,49 +648,25 @@ class Kv1p1MA24PCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         bc = Kv1p1_MA2025_BC(size=1, temp=temp, gateCurrent=0.0)
         pc = Kv1p1_MA2024_PC(size=1, temp=temp, gateCurrent=0.0)
-        V = _V([-60.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        pc.init_state(V, k)
-        bc.reset_state(V, k)
-        pc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(pc.n.value, bc.n.value, atol=1e-6))
-
-        bc.compute_derivative(V, k)
-        pc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(pc.n.derivative, bc.n.derivative, atol=1e-6 * u.Hz))
-
-        i_bc = bc.current(V, k)
-        i_pc = pc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_pc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            pc,
+            voltage([-60.0]),
+            k_info(),
+            states=("n",),
         )
 
     def test_matches_bc_variant_with_gating_current(self) -> None:
         temp = u.celsius2kelvin(22.0)
         bc = Kv1p1_MA2025_BC(size=1, temp=temp, gateCurrent=1.0)
         pc = Kv1p1_MA2024_PC(size=1, temp=temp, gateCurrent=1.0)
-        V = _V([-50.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        pc.init_state(V, k)
-        bc.reset_state(V, k)
-        pc.reset_state(V, k)
-
-        i_bc = bc.current(V, k)
-        i_pc = pc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_pc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            pc,
+            voltage([-50.0]),
+            k_info(),
         )
 
 
@@ -730,8 +681,8 @@ class Kv1p5MA24PCTest(unittest.TestCase):
 
     def test_reset_state_matches_mod_steady_state(self) -> None:
         ch = Kv1p5_MA2024_PC(size=1)
-        V = _V([-40.0])
-        k = _k_info()
+        V = voltage([-40.0])
+        k = k_info()
         v = V.to_decimal(u.mV)
         ch.init_state(V, k)
         ch.reset_state(V, k)
@@ -746,8 +697,8 @@ class Kv1p5MA24PCTest(unittest.TestCase):
 
     def test_tau_matches_mod_rates_and_temperature_scaling(self) -> None:
         ch = Kv1p5_MA2024_PC(size=1, temp=u.celsius2kelvin(47.0), Tauact=2.0, Tauinactf=3.0, Tauinacts=4.0)
-        V = _V([-35.0])
-        k = _k_info()
+        V = voltage([-35.0])
+        k = k_info()
         v = V.to_decimal(u.mV)
         q10 = 2.2
 
@@ -762,8 +713,8 @@ class Kv1p5MA24PCTest(unittest.TestCase):
 
     def test_current_matches_enabled_ik_path_only(self) -> None:
         ch = Kv1p5_MA2024_PC(size=1)
-        V = _V([-20.0])
-        k = _k_info()
+        V = voltage([-20.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.m.value = jnp.array([0.2])
         ch.n.value = jnp.array([0.3])
@@ -776,8 +727,8 @@ class Kv1p5MA24PCTest(unittest.TestCase):
 
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -796,8 +747,8 @@ class Kv3p3MA24PCTest(unittest.TestCase):
 
     def test_reset_state_matches_mod_rate_ratio(self) -> None:
         ch = Kv3p3_MA2024_PC(size=1)
-        V = _V([-30.0])
-        k = _k_info()
+        V = voltage([-30.0])
+        k = k_info()
         v = V.to_decimal(u.mV)
         ch.init_state(V, k)
         ch.reset_state(V, k)
@@ -809,8 +760,8 @@ class Kv3p3MA24PCTest(unittest.TestCase):
 
     def test_derivative_uses_alpha_beta_and_temperature_scaling(self) -> None:
         ch = Kv3p3_MA2024_PC(size=1, temp=u.celsius2kelvin(32.0))
-        V = _V([-20.0])
-        k = _k_info()
+        V = voltage([-20.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.n.value = jnp.array([0.35])
 
@@ -824,8 +775,8 @@ class Kv3p3MA24PCTest(unittest.TestCase):
 
     def test_current_matches_default_ik_path(self) -> None:
         ch = Kv3p3_MA2024_PC(size=1, gateCurrent=0.0)
-        V = _V([-20.0])
-        k = _k_info()
+        V = voltage([-20.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.n.value = jnp.array([0.4])
 
@@ -834,16 +785,16 @@ class Kv3p3MA24PCTest(unittest.TestCase):
 
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_gating_current_path_matches_mod_formula(self) -> None:
         ch = Kv3p3_MA2024_PC(size=1, gateCurrent=1.0)
-        V = _V([-10.0])
-        k = _k_info()
+        V = voltage([-10.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.n.value = jnp.array([0.35])
 
@@ -859,8 +810,8 @@ class Kv3p3MA24PCTest(unittest.TestCase):
         current = ch.current(V, k)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -871,29 +822,13 @@ class Kv3p4MA24PCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         bc = Kv3p4_MA2025_BC(size=1, temp=temp)
         pc = Kv3p4_MA2024_PC(size=1, temp=temp)
-        V = _V([-45.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        pc.init_state(V, k)
-        bc.reset_state(V, k)
-        pc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(pc.m.value, bc.m.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(pc.h.value, bc.h.value, atol=1e-6))
-
-        bc.compute_derivative(V, k)
-        pc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(pc.m.derivative, bc.m.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(pc.h.derivative, bc.h.derivative, atol=1e-6 * u.Hz))
-
-        i_bc = bc.current(V, k)
-        i_pc = pc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_pc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            pc,
+            voltage([-45.0]),
+            k_info(),
+            states=("m", "h"),
         )
 
 
@@ -902,29 +837,13 @@ class Kv4p3MA24PCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         bc = Kv4p3_MA2025_BC(size=1, temp=temp)
         pc = Kv4p3_MA2024_PC(size=1, temp=temp)
-        V = _V([-55.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        pc.init_state(V, k)
-        bc.reset_state(V, k)
-        pc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(pc.a.value, bc.a.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(pc.b.value, bc.b.value, atol=1e-6))
-
-        bc.compute_derivative(V, k)
-        pc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(pc.a.derivative, bc.a.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(pc.b.derivative, bc.b.derivative, atol=1e-6 * u.Hz))
-
-        i_bc = bc.current(V, k)
-        i_pc = pc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_pc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            pc,
+            voltage([-55.0]),
+            k_info(),
+            states=("a", "b"),
         )
 
 
@@ -934,24 +853,24 @@ class KMRI21SCTest(unittest.TestCase):
 
     def test_reset_state_matches_f_n_inf(self) -> None:
         ch = KM_RI2021_SC(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.n.value, ch.f_n_inf(V, k), atol=1e-6))
 
     def test_current_matches_linear_formula(self) -> None:
         ch = KM_RI2021_SC(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         i = ch.current(V, k)
         expected = ch.g_max * ch.n.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -959,8 +878,8 @@ class KMRI21SCTest(unittest.TestCase):
     def test_matches_template_gate_dynamics(self) -> None:
         temp = u.celsius2kelvin(30.0)
         proto = KM_RI2021_SC(size=1, temp=temp)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
 
         proto.init_state(V, k)
         proto.reset_state(V, k)
@@ -979,27 +898,13 @@ class Kir2p3RI21SCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         bc = Kir2p3_MA2025_BC(size=1, temp=temp)
         sc = Kir2p3_RI2021_SC(size=1, temp=temp)
-        V = _V([-75.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        sc.init_state(V, k)
-        bc.reset_state(V, k)
-        sc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(sc.d.value, bc.d.value, atol=1e-6))
-
-        bc.compute_derivative(V, k)
-        sc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(sc.d.derivative, bc.d.derivative, atol=1e-6 * u.Hz))
-
-        i_bc = bc.current(V, k)
-        i_sc = sc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_sc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            sc,
+            voltage([-75.0]),
+            k_info(),
+            states=("d",),
         )
 
 
@@ -1009,32 +914,32 @@ class fKdrSU15DCNTest(unittest.TestCase):
 
     def test_reset_state_matches_f_m_inf(self) -> None:
         ch = fKdr_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, k), atol=1e-6))
 
     def test_current_matches_linear_formula(self) -> None:
         ch = fKdr_SU2015_DCN(size=1)
-        V = _V([-40.0])
-        k = _k_info()
+        V = voltage([-40.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.m.value = jnp.array([0.5])
         i = ch.current(V, k)
         expected = ch.g_max * (ch.m.value**4) * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_tau_matches_mod_formula(self) -> None:
         ch = fKdr_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         v = V.to_decimal(u.mV)
         expected = 13.9 / (jnp.exp((v + 40.0) / 12.0) + jnp.exp((v + 40.0) / -13.0)) + 0.1
         self.assertTrue(u.math.allclose(ch.f_m_tau(V, k), expected, atol=1e-6))
@@ -1046,24 +951,24 @@ class sKdrSU15DCNTest(unittest.TestCase):
 
     def test_reset_state_matches_f_m_inf(self) -> None:
         ch = sKdr_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, k), atol=1e-6))
 
     def test_current_matches_linear_formula(self) -> None:
         ch = sKdr_SU2015_DCN(size=1)
-        V = _V([-40.0])
-        k = _k_info()
+        V = voltage([-40.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.m.value = jnp.array([0.5])
         i = ch.current(V, k)
         expected = ch.g_max * (ch.m.value**4) * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -1071,8 +976,8 @@ class sKdrSU15DCNTest(unittest.TestCase):
     def test_tau_matches_mod_formula_and_differs_from_fast_kdr(self) -> None:
         slow = sKdr_SU2015_DCN(size=1)
         fast = fKdr_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         v = V.to_decimal(u.mV)
         expected = 14.95 / (jnp.exp((v + 50.0) / 21.74) + jnp.exp((v + 50.0) / -13.91)) + 0.05
         self.assertTrue(u.math.allclose(slow.f_m_tau(V, k), expected, atol=1e-6))
@@ -1084,27 +989,13 @@ class KMMA20GoCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         sc = KM_RI2021_SC(size=1, temp=temp)
         goc = KM_MA2020_GoC(size=1, temp=temp)
-        V = _V([-60.0])
-        k = _k_info()
-
-        sc.init_state(V, k)
-        goc.init_state(V, k)
-        sc.reset_state(V, k)
-        goc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(goc.n.value, sc.n.value, atol=1e-6))
-
-        sc.compute_derivative(V, k)
-        goc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(goc.n.derivative, sc.n.derivative, atol=1e-6 * u.Hz))
-
-        i_sc = sc.current(V, k)
-        i_goc = goc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_goc.to_decimal(_DENSITY_UNIT),
-                i_sc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            sc,
+            goc,
+            voltage([-60.0]),
+            k_info(),
+            states=("n",),
         )
 
 
@@ -1113,49 +1004,25 @@ class Kv1p1MA20GoCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         sc = Kv1p1_RI2021_SC(size=1, temp=temp, gateCurrent=0.0)
         goc = Kv1p1_MA2020_GoC(size=1, temp=temp, gateCurrent=0.0)
-        V = _V([-60.0])
-        k = _k_info()
-
-        sc.init_state(V, k)
-        goc.init_state(V, k)
-        sc.reset_state(V, k)
-        goc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(goc.n.value, sc.n.value, atol=1e-6))
-
-        sc.compute_derivative(V, k)
-        goc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(goc.n.derivative, sc.n.derivative, atol=1e-6 * u.Hz))
-
-        i_sc = sc.current(V, k)
-        i_goc = goc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_goc.to_decimal(_DENSITY_UNIT),
-                i_sc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            sc,
+            goc,
+            voltage([-60.0]),
+            k_info(),
+            states=("n",),
         )
 
     def test_matches_sc_variant_with_gating_current(self) -> None:
         temp = u.celsius2kelvin(22.0)
         sc = Kv1p1_RI2021_SC(size=1, temp=temp, gateCurrent=1.0)
         goc = Kv1p1_MA2020_GoC(size=1, temp=temp, gateCurrent=1.0)
-        V = _V([-50.0])
-        k = _k_info()
-
-        sc.init_state(V, k)
-        goc.init_state(V, k)
-        sc.reset_state(V, k)
-        goc.reset_state(V, k)
-
-        i_sc = sc.current(V, k)
-        i_goc = goc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_goc.to_decimal(_DENSITY_UNIT),
-                i_sc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            sc,
+            goc,
+            voltage([-50.0]),
+            k_info(),
         )
 
 
@@ -1164,29 +1031,13 @@ class Kv3p4MA20GoCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         sc = Kv3p4_RI2021_SC(size=1, temp=temp)
         goc = Kv3p4_MA2020_GoC(size=1, temp=temp)
-        V = _V([-45.0])
-        k = _k_info()
-
-        sc.init_state(V, k)
-        goc.init_state(V, k)
-        sc.reset_state(V, k)
-        goc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(goc.m.value, sc.m.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(goc.h.value, sc.h.value, atol=1e-6))
-
-        sc.compute_derivative(V, k)
-        goc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(goc.m.derivative, sc.m.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(goc.h.derivative, sc.h.derivative, atol=1e-6 * u.Hz))
-
-        i_sc = sc.current(V, k)
-        i_goc = goc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_goc.to_decimal(_DENSITY_UNIT),
-                i_sc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            sc,
+            goc,
+            voltage([-45.0]),
+            k_info(),
+            states=("m", "h"),
         )
 
 
@@ -1195,29 +1046,13 @@ class Kv4p3MA20GoCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         sc = Kv4p3_RI2021_SC(size=1, temp=temp)
         goc = Kv4p3_MA2020_GoC(size=1)
-        V = _V([-55.0])
-        k = _k_info()
-
-        sc.init_state(V, k)
-        goc.init_state(V, k)
-        sc.reset_state(V, k)
-        goc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(goc.a.value, sc.a.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(goc.b.value, sc.b.value, atol=1e-6))
-
-        sc.compute_derivative(V, k)
-        goc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(goc.a.derivative, sc.a.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(goc.b.derivative, sc.b.derivative, atol=1e-6 * u.Hz))
-
-        i_sc = sc.current(V, k)
-        i_goc = goc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_goc.to_decimal(_DENSITY_UNIT),
-                i_sc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            sc,
+            goc,
+            voltage([-55.0]),
+            k_info(),
+            states=("a", "b"),
         )
 
 
@@ -1226,27 +1061,13 @@ class KMMA20GrCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         goc = KM_MA2020_GoC(size=1, temp=temp)
         grc = KM_MA2020_GrC(size=1, temp=temp)
-        V = _V([-60.0])
-        k = _k_info()
-
-        goc.init_state(V, k)
-        grc.init_state(V, k)
-        goc.reset_state(V, k)
-        grc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(grc.n.value, goc.n.value, atol=1e-6))
-
-        goc.compute_derivative(V, k)
-        grc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(grc.n.derivative, goc.n.derivative, atol=1e-6 * u.Hz))
-
-        i_goc = goc.current(V, k)
-        i_grc = grc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_grc.to_decimal(_DENSITY_UNIT),
-                i_goc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            goc,
+            grc,
+            voltage([-60.0]),
+            k_info(),
+            states=("n",),
         )
 
 
@@ -1255,27 +1076,13 @@ class Kir2p3MA20GrCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         sc = Kir2p3_RI2021_SC(size=1, temp=temp)
         grc = Kir2p3_MA2020_GrC(size=1, temp=temp)
-        V = _V([-75.0])
-        k = _k_info()
-
-        sc.init_state(V, k)
-        grc.init_state(V, k)
-        sc.reset_state(V, k)
-        grc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(grc.d.value, sc.d.value, atol=1e-6))
-
-        sc.compute_derivative(V, k)
-        grc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(grc.d.derivative, sc.d.derivative, atol=1e-6 * u.Hz))
-
-        i_sc = sc.current(V, k)
-        i_grc = grc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_grc.to_decimal(_DENSITY_UNIT),
-                i_sc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            sc,
+            grc,
+            voltage([-75.0]),
+            k_info(),
+            states=("d",),
         )
 
 
@@ -1284,49 +1091,25 @@ class Kv1p1MA20GrCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         goc = Kv1p1_MA2020_GoC(size=1, temp=temp, gateCurrent=0.0)
         grc = Kv1p1_MA2020_GrC(size=1, temp=temp, gateCurrent=0.0)
-        V = _V([-60.0])
-        k = _k_info()
-
-        goc.init_state(V, k)
-        grc.init_state(V, k)
-        goc.reset_state(V, k)
-        grc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(grc.n.value, goc.n.value, atol=1e-6))
-
-        goc.compute_derivative(V, k)
-        grc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(grc.n.derivative, goc.n.derivative, atol=1e-6 * u.Hz))
-
-        i_goc = goc.current(V, k)
-        i_grc = grc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_grc.to_decimal(_DENSITY_UNIT),
-                i_goc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            goc,
+            grc,
+            voltage([-60.0]),
+            k_info(),
+            states=("n",),
         )
 
     def test_matches_goc_variant_with_gating_current(self) -> None:
         temp = u.celsius2kelvin(22.0)
         goc = Kv1p1_MA2020_GoC(size=1, temp=temp, gateCurrent=1.0)
         grc = Kv1p1_MA2020_GrC(size=1, temp=temp, gateCurrent=1.0)
-        V = _V([-50.0])
-        k = _k_info()
-
-        goc.init_state(V, k)
-        grc.init_state(V, k)
-        goc.reset_state(V, k)
-        grc.reset_state(V, k)
-
-        i_goc = goc.current(V, k)
-        i_grc = grc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_grc.to_decimal(_DENSITY_UNIT),
-                i_goc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            goc,
+            grc,
+            voltage([-50.0]),
+            k_info(),
         )
 
 
@@ -1336,8 +1119,8 @@ class Kv2p20010MA20GrCTest(unittest.TestCase):
 
     def test_reset_state_matches_inf_functions(self) -> None:
         ch = Kv2p2_0010_MA2020_GrC(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, k), atol=1e-6))
@@ -1345,8 +1128,8 @@ class Kv2p20010MA20GrCTest(unittest.TestCase):
 
     def test_current_matches_linear_formula(self) -> None:
         ch = Kv2p2_0010_MA2020_GrC(size=1)
-        V = _V([-40.0])
-        k = _k_info()
+        V = voltage([-40.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -1354,16 +1137,16 @@ class Kv2p20010MA20GrCTest(unittest.TestCase):
         expected = ch.g_max * ch.m.value * ch.h.value * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_tau_matches_mod_formula(self) -> None:
         ch = Kv2p2_0010_MA2020_GrC(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         v = V.to_decimal(u.mV)
         expected_m_tau = 130.0 / (1.0 + jnp.exp((v + 46.56) / -44.14))
         expected_h_tau = 10000.0 / (1.0 + jnp.exp((v + 46.56) / -44.14))
@@ -1376,29 +1159,13 @@ class Kv3p4MA20GrCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         goc = Kv3p4_MA2020_GoC(size=1, temp=temp)
         grc = Kv3p4_MA2020_GrC(size=1, temp=temp)
-        V = _V([-45.0])
-        k = _k_info()
-
-        goc.init_state(V, k)
-        grc.init_state(V, k)
-        goc.reset_state(V, k)
-        grc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(grc.m.value, goc.m.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(grc.h.value, goc.h.value, atol=1e-6))
-
-        goc.compute_derivative(V, k)
-        grc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(grc.m.derivative, goc.m.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(grc.h.derivative, goc.h.derivative, atol=1e-6 * u.Hz))
-
-        i_goc = goc.current(V, k)
-        i_grc = grc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_grc.to_decimal(_DENSITY_UNIT),
-                i_goc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            goc,
+            grc,
+            voltage([-45.0]),
+            k_info(),
+            states=("m", "h"),
         )
 
 
@@ -1407,29 +1174,13 @@ class Kv4p3MA20GrCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         goc = Kv4p3_MA2020_GoC(size=1, temp=temp)
         grc = Kv4p3_MA2020_GrC(size=1)
-        V = _V([-55.0])
-        k = _k_info()
-
-        goc.init_state(V, k)
-        grc.init_state(V, k)
-        goc.reset_state(V, k)
-        grc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(grc.a.value, goc.a.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(grc.b.value, goc.b.value, atol=1e-6))
-
-        goc.compute_derivative(V, k)
-        grc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(grc.a.derivative, goc.a.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(grc.b.derivative, goc.b.derivative, atol=1e-6 * u.Hz))
-
-        i_goc = goc.current(V, k)
-        i_grc = grc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_grc.to_decimal(_DENSITY_UNIT),
-                i_goc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            goc,
+            grc,
+            voltage([-55.0]),
+            k_info(),
+            states=("a", "b"),
         )
 
 
@@ -1438,49 +1189,25 @@ class Kv1p1RI21SCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         bc = Kv1p1_MA2025_BC(size=1, temp=temp, gateCurrent=0.0)
         sc = Kv1p1_RI2021_SC(size=1, temp=temp, gateCurrent=0.0)
-        V = _V([-60.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        sc.init_state(V, k)
-        bc.reset_state(V, k)
-        sc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(sc.n.value, bc.n.value, atol=1e-6))
-
-        bc.compute_derivative(V, k)
-        sc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(sc.n.derivative, bc.n.derivative, atol=1e-6 * u.Hz))
-
-        i_bc = bc.current(V, k)
-        i_sc = sc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_sc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            sc,
+            voltage([-60.0]),
+            k_info(),
+            states=("n",),
         )
 
     def test_matches_bc_variant_with_gating_current(self) -> None:
         temp = u.celsius2kelvin(22.0)
         bc = Kv1p1_MA2025_BC(size=1, temp=temp, gateCurrent=1.0)
         sc = Kv1p1_RI2021_SC(size=1, temp=temp, gateCurrent=1.0)
-        V = _V([-50.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        sc.init_state(V, k)
-        bc.reset_state(V, k)
-        sc.reset_state(V, k)
-
-        i_bc = bc.current(V, k)
-        i_sc = sc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_sc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            sc,
+            voltage([-50.0]),
+            k_info(),
         )
 
 
@@ -1489,29 +1216,13 @@ class Kv3p4RI21SCTest(unittest.TestCase):
         temp = u.celsius2kelvin(22.0)
         bc = Kv3p4_MA2025_BC(size=1, temp=temp)
         sc = Kv3p4_RI2021_SC(size=1, temp=temp)
-        V = _V([-45.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        sc.init_state(V, k)
-        bc.reset_state(V, k)
-        sc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(sc.m.value, bc.m.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(sc.h.value, bc.h.value, atol=1e-6))
-
-        bc.compute_derivative(V, k)
-        sc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(sc.m.derivative, bc.m.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(sc.h.derivative, bc.h.derivative, atol=1e-6 * u.Hz))
-
-        i_bc = bc.current(V, k)
-        i_sc = sc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_sc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            sc,
+            voltage([-45.0]),
+            k_info(),
+            states=("m", "h"),
         )
 
 
@@ -1520,29 +1231,13 @@ class Kv4p3RI21SCTest(unittest.TestCase):
         temp = u.celsius2kelvin(30.0)
         bc = Kv4p3_MA2025_BC(size=1, temp=temp)
         sc = Kv4p3_RI2021_SC(size=1, temp=temp)
-        V = _V([-55.0])
-        k = _k_info()
-
-        bc.init_state(V, k)
-        sc.init_state(V, k)
-        bc.reset_state(V, k)
-        sc.reset_state(V, k)
-        self.assertTrue(u.math.allclose(sc.a.value, bc.a.value, atol=1e-6))
-        self.assertTrue(u.math.allclose(sc.b.value, bc.b.value, atol=1e-6))
-
-        bc.compute_derivative(V, k)
-        sc.compute_derivative(V, k)
-        self.assertTrue(u.math.allclose(sc.a.derivative, bc.a.derivative, atol=1e-6 * u.Hz))
-        self.assertTrue(u.math.allclose(sc.b.derivative, bc.b.derivative, atol=1e-6 * u.Hz))
-
-        i_bc = bc.current(V, k)
-        i_sc = sc.current(V, k)
-        self.assertTrue(
-            u.math.allclose(
-                i_sc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
-                atol=1e-6,
-            )
+        assert_channels_agree(
+            self,
+            bc,
+            sc,
+            voltage([-55.0]),
+            k_info(),
+            states=("a", "b"),
         )
 
 
@@ -1552,31 +1247,31 @@ class KdrZH19IOTest(unittest.TestCase):
 
     def test_reset_state_matches_f_n_inf(self) -> None:
         ch = Kdr_ZH2019_IO(size=1)
-        V = _V([-60.0])
-        k = _k_info()
+        V = voltage([-60.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.reset_state(V, k)
         self.assertTrue(u.math.allclose(ch.n.value, ch.f_n_inf(V, k), atol=1e-6))
 
     def test_current_matches_linear_formula(self) -> None:
         ch = Kdr_ZH2019_IO(size=1)
-        V = _V([-40.0])
-        k = _k_info()
+        V = voltage([-40.0])
+        k = k_info()
         ch.init_state(V, k)
         ch.n.value = jnp.array([0.5])
         i = ch.current(V, k)
         expected = ch.g_max * (ch.n.value**4) * (k.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_small_denominator_branch_is_stable(self) -> None:
         ch = Kdr_ZH2019_IO(size=1)
-        self.assertTrue(u.math.allclose(ch._n_alpha(_V([-41.0])), jnp.array([10.0]), atol=1e-6))
+        self.assertTrue(u.math.allclose(ch._n_alpha(voltage([-41.0])), jnp.array([10.0]), atol=1e-6))
 
     def test_rate_stays_accurate_just_off_the_singularity(self) -> None:
         # `x / (1 - exp(-x))` loses most of its float32 significand for
@@ -1585,7 +1280,7 @@ class KdrZH19IOTest(unittest.TestCase):
         # threshold, and compare against the analytic value `1 + x/2`.
         ch = Kdr_ZH2019_IO(size=1)
         offsets = jnp.array([-1.0e-3, -1.0e-5, 1.0e-5, 1.0e-3])
-        n_alpha = ch._n_alpha(_V(-41.0 + offsets))
+        n_alpha = ch._n_alpha(voltage(-41.0 + offsets))
         self.assertTrue(u.math.allclose(n_alpha, 10.0 * (1.0 + (offsets / 10.0) / 2.0), atol=1e-5))
 
 

--- a/braincell/channel/sodium.py
+++ b/braincell/channel/sodium.py
@@ -24,7 +24,7 @@ import brainunit as u
 
 from braincell._base_channel import IonInfo
 from braincell._typing import ArrayLike, Initializer, Size
-from braincell.channel._base import Gate, Markov, OhmicHH, q10_factor
+from braincell.channel._base import Gate, OhmicHH, OhmicMarkov, is_disabled, q10_factor
 from braincell.ion import Sodium
 from braincell.mech import register_channel
 
@@ -714,7 +714,7 @@ class Na_ZH2019_IO(OhmicHH):
 
 
 @register_channel("Nav1p6_MA2020_GoC")
-class Nav1p6_MA2020_GoC(Markov):
+class Nav1p6_MA2020_GoC(OhmicMarkov):
     r"""Resurgent Nav1.6 sodium current, Golgi-cell parameterisation.
 
     The 13-state Raman & Bean [1]_ / Khaliq et al. [2]_ resurgent
@@ -848,6 +848,7 @@ class Nav1p6_MA2020_GoC(Markov):
         ("O", "I6", "fin", "bin"),
     )
     dependent_state = "I6"
+    open_states = ("O",)
 
     def __init__(
         self,
@@ -887,9 +888,6 @@ class Nav1p6_MA2020_GoC(Markov):
 
         self.alfac = (self.Oon / self.Con) ** (1 / 4)
         self.btfac = (self.Ooff / self.Coff) ** (1 / 4)
-
-    def current(self, V, Na: IonInfo):
-        return self.g_max * self.O.value * (Na.E - V)
 
     f01 = lambda self, V: 4 * self.alpha * u.math.exp((V / u.mV) / self.x1) * self.phi
     f02 = lambda self, V: 3 * self.alpha * u.math.exp((V / u.mV) / self.x1) * self.phi
@@ -1305,7 +1303,11 @@ class Nav1p1_MA2025_BC(Nav1p6_MA2020_GoC):
         self.alfac = (self.Oon / self.Con) ** (1 / 4)
 
     def current(self, V, Na: IonInfo):
-        conductive = self.g_max * self.O.value * (Na.E - V)
+        conductive = super().current(V, Na)
+        if is_disabled(self.gateCurrent):
+            # The shipped default. Tracing the gating-current branch anyway
+            # would emit ~30 equations that the ``where`` then discards.
+            return conductive
         gate_flip = (
             self.f01(V) * self.C1.value
             + (self.f02(V) - self.b01(V)) * self.C2.value
@@ -1397,7 +1399,7 @@ class Nav1p1_RI2021_SC(Nav1p1_MA2025_BC):
 
 
 @register_channel("Nav_MA2020_GrC")
-class Nav_MA2020_GrC(Markov):
+class Nav_MA2020_GrC(OhmicMarkov):
     r"""Resurgent Nav sodium current, granule-cell parameterisation.
 
     A 13-state Raman & Bean (2001) [2]_-style resurgent sodium Markov
@@ -1544,6 +1546,7 @@ class Nav_MA2020_GrC(Markov):
         ("I5", "I6", "f1n", "b1n"),
     )
     dependent_state = "I6"
+    open_states = ("O",)
 
     def __init__(
         self,
@@ -1577,9 +1580,6 @@ class Nav_MA2020_GrC(Markov):
         self.n2 = 3.279
         self.n3 = 1.83
         self.n4 = 0.738
-
-    def current(self, V, Na: IonInfo):
-        return self.g_max * self.O.value * (Na.E - V)
 
     def init_state(self, V, Na: IonInfo, batch_size: int = None):
         super().init_state(V, Na, batch_size=batch_size)
@@ -1636,7 +1636,7 @@ class Nav_MA2020_GrC(Markov):
 
 
 @register_channel("NaFHF_MA2020_GrC")
-class NaFHF_MA2020_GrC(Markov):
+class NaFHF_MA2020_GrC(Nav_MA2020_GrC):
     r"""Resurgent Nav sodium current with slow block, granule-cell model.
 
     The same 13-state Raman & Bean (2001) [2]_-style resurgent sodium
@@ -1652,8 +1652,8 @@ class NaFHF_MA2020_GrC(Markov):
     :math:`\theta`, :math:`\gamma`, :math:`\delta`, :math:`\varepsilon`,
     :math:`C_{on}`, :math:`C_{off}`, :math:`O_{on}`, :math:`O_{off}`,
     :math:`a`, :math:`b`) and the ``C1``-``C5``/``I1``-``I5``/``O``/
-    ``OB``/``I6`` transition-rate formulas are exactly as given on
-    :class:`Nav_MA2020_GrC`. The added ``L3``-``L6`` branch uses two
+    ``OB``/``I6`` transition-rate formulas are inherited unchanged
+    from :class:`Nav_MA2020_GrC`. The added ``L3``-``L6`` branch uses two
     further constant rate factors :math:`L_{on} = \phi A_{Lon}` and
     :math:`L_{off} = \phi A_{Loff}` and fixed scale factors
     :math:`c = 20.0`, :math:`d = 0.075`:
@@ -1707,6 +1707,13 @@ class NaFHF_MA2020_GrC(Markov):
     ``Nav_MA20_GrC.mod``'s "Based on Raman 13 state model. Adapted
     from Magistretti et al, 2006." attribution, per the bibliography.
 
+    This class subclasses :class:`Nav_MA2020_GrC` and declares only
+    what the slow-blocked branch adds: its own ``__init__``, the
+    ``L``-branch rate methods, and a complete ``pairs`` tuple. ``pairs``
+    is re-declared in full rather than appended to the parent's,
+    because :class:`Markov` resolves it per class and a partial
+    declaration would silently drop the inherited transitions.
+
     This class ships ``ACon = 0.025`` and ``AOoff = 0.002`` -- unlike
     :class:`Nav_MA2020_GrC`, these values match the bibliography's
     cross-checked fingerprint for the ``MA2020`` granule sodium pair
@@ -1738,9 +1745,6 @@ class NaFHF_MA2020_GrC(Markov):
     """
 
     __module__ = "braincell.channel"
-    reset_to_steady_state = True
-    root_type = Sodium
-
     pairs = (
         ("C1", "C2", "f01", "b01"),
         ("C2", "C3", "f02", "b02"),
@@ -1767,7 +1771,6 @@ class NaFHF_MA2020_GrC(Markov):
         ("O", "I6", "fin", "bin"),
         ("I5", "I6", "f1n", "b1n"),
     )
-    dependent_state = "I6"
 
     def __init__(
         self,
@@ -1806,73 +1809,20 @@ class NaFHF_MA2020_GrC(Markov):
         self.c = 20.0
         self.d = 0.075
 
-    def current(self, V, Na: IonInfo):
-        return self.g_max * self.O.value * (Na.E - V)
-
-    def init_state(self, V, Na: IonInfo, batch_size: int = None):
-        super().init_state(V, Na, batch_size=batch_size)
-        self.reset_steady_state(V, Na, batch_size=batch_size)
-
-    alfa = lambda self, V: self.phi * self.Aalfa * u.math.exp((V / u.mV) / self.Valfa)
-    beta = lambda self, V: self.phi * self.Abeta * u.math.exp(-(V / u.mV) / self.Vbeta)
-    teta = lambda self, V: self.phi * self.Ateta * u.math.exp(-(V / u.mV) / self.Vteta)
-    gamma = lambda self, V: self.phi * self.Agamma
-    delta = lambda self, V: self.phi * self.Adelta
-    epsilon = lambda self, V: self.phi * self.Aepsilon
-    Con = lambda self, V: self.phi * self.ACon
-    Coff = lambda self, V: self.phi * self.ACoff
-    Oon = lambda self, V: self.phi * self.AOon
-    Ooff = lambda self, V: self.phi * self.AOoff
-    a_factor = lambda self, V: (self.Oon(V) / self.Con(V)) ** 0.25
-    b_factor = lambda self, V: (self.Ooff(V) / self.Coff(V)) ** 0.25
     Lon = lambda self, V: self.phi * self.ALon
     Loff = lambda self, V: self.phi * self.ALoff
 
-    f01 = lambda self, V: self.n1 * self.alfa(V)
-    f02 = lambda self, V: self.n2 * self.alfa(V)
-    f03 = lambda self, V: self.n3 * self.alfa(V)
-    f04 = lambda self, V: self.n4 * self.alfa(V)
-    f0O = lambda self, V: self.gamma(V)
-    fip = lambda self, V: self.epsilon(V)
-    f11 = lambda self, V: self.n1 * self.alfa(V) * self.a_factor(V)
-    f12 = lambda self, V: self.n2 * self.alfa(V) * self.a_factor(V)
-    f13 = lambda self, V: self.n3 * self.alfa(V) * self.a_factor(V)
-    f14 = lambda self, V: self.n4 * self.alfa(V) * self.a_factor(V)
-    f1n = lambda self, V: self.gamma(V)
     f33 = lambda self, V: self.n3 * self.alfa(V) * self.c
     f34 = lambda self, V: self.n4 * self.alfa(V) * self.c
     f3n = lambda self, V: self.gamma(V)
-    fi1 = lambda self, V: self.Con(V)
-    fi2 = lambda self, V: self.Con(V) * self.a_factor(V)
-    fi3 = lambda self, V: self.Con(V) * self.a_factor(V) ** 2
-    fi4 = lambda self, V: self.Con(V) * self.a_factor(V) ** 3
-    fi5 = lambda self, V: self.Con(V) * self.a_factor(V) ** 4
-    fin = lambda self, V: self.Oon(V)
     fl3 = lambda self, V: self.Lon(V)
     fl4 = lambda self, V: self.Lon(V) * self.c
     fl5 = lambda self, V: self.Lon(V) * self.c**2
     fl6 = lambda self, V: self.Lon(V) * self.c**2
 
-    b01 = lambda self, V: self.n4 * self.beta(V)
-    b02 = lambda self, V: self.n3 * self.beta(V)
-    b03 = lambda self, V: self.n2 * self.beta(V)
-    b04 = lambda self, V: self.n1 * self.beta(V)
-    b0O = lambda self, V: self.delta(V)
-    bip = lambda self, V: self.teta(V)
-    b11 = lambda self, V: self.n4 * self.beta(V) * self.b_factor(V)
-    b12 = lambda self, V: self.n3 * self.beta(V) * self.b_factor(V)
-    b13 = lambda self, V: self.n2 * self.beta(V) * self.b_factor(V)
-    b14 = lambda self, V: self.n1 * self.beta(V) * self.b_factor(V)
-    b1n = lambda self, V: self.delta(V)
     b33 = lambda self, V: self.n2 * self.alfa(V) * self.d
     b34 = lambda self, V: self.n1 * self.alfa(V) * self.d
     b3n = lambda self, V: self.delta(V)
-    bi1 = lambda self, V: self.Coff(V)
-    bi2 = lambda self, V: self.Coff(V) * self.b_factor(V)
-    bi3 = lambda self, V: self.Coff(V) * self.b_factor(V) ** 2
-    bi4 = lambda self, V: self.Coff(V) * self.b_factor(V) ** 3
-    bi5 = lambda self, V: self.Coff(V) * self.b_factor(V) ** 4
-    bin = lambda self, V: self.Ooff(V)
     bl3 = lambda self, V: self.Loff(V)
     bl4 = lambda self, V: self.Loff(V) * self.d
     bl5 = lambda self, V: self.Loff(V) * self.d**2

--- a/braincell/channel/sodium_test.py
+++ b/braincell/channel/sodium_test.py
@@ -20,8 +20,8 @@ import unittest
 import brainstate
 import brainunit as u
 import jax.numpy as jnp
+import pytest
 
-from braincell._base_channel import IonInfo
 from braincell.channel._base import HH, Markov
 from braincell.channel.sodium import (
     Na_Ba2002,
@@ -40,24 +40,27 @@ from braincell.channel.sodium import (
     Nav_MA2020_GrC,
 )
 from braincell.ion import Sodium
-
-brainstate.environ.set(precision=64)
-
-
-def _na_info(size: int = 1) -> IonInfo:
-    return IonInfo(
-        Ci=jnp.full((size,), 0.04) * u.mM,
-        Co=jnp.full((size,), 140.0) * u.mM,
-        E=jnp.full((size,), 50.0) * u.mV,
-        valence=1,
-    )
+from braincell.channel._testing import (
+    DENSITY_UNIT,
+    na_info,
+    voltage,
+)
 
 
-def _V(values, unit=u.mV):
-    return jnp.asarray(values) * unit
+@pytest.fixture(autouse=True)
+def _float64():
+    """Run this module's tests at 64-bit precision.
 
-
-_DENSITY_UNIT = u.mS / u.cm**2 * u.mV
+    The 13-state Nav steady-state solves are ill-conditioned enough that
+    ``reset_state`` misses its stationary distribution at 32 bit. This used to
+    be a bare ``brainstate.environ.set(precision=64)`` at module scope, which
+    is process-global: it silently changed precision for every test module
+    pytest collected afterwards, making their results depend on collection
+    order. Autouse at module scope keeps the setting where it is needed and
+    restores 32 bit on the way out.
+    """
+    with brainstate.environ.context(precision=64):
+        yield
 
 
 def _assert_markov_probability_total(testcase, channel, size: int) -> None:
@@ -122,8 +125,8 @@ class _HHNaMixin:
 
     def test_init_state_creates_gates_shaped_to_size(self) -> None:
         ch = self._make(size=4)
-        V = _V([-60.0, -55.0, -50.0, -45.0])
-        na = _na_info(4)
+        V = voltage([-60.0, -55.0, -50.0, -45.0])
+        na = na_info(4)
 
         ch.init_state(V, na)
         self.assertEqual(ch.p.value.shape, (4,))
@@ -133,8 +136,8 @@ class _HHNaMixin:
 
     def test_reset_state_sets_gates_to_steady_state(self) -> None:
         ch = self._make(size=1)
-        V = _V([-65.0])
-        na = _na_info()
+        V = voltage([-65.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.reset_state(V, na)
 
@@ -149,8 +152,8 @@ class _HHNaMixin:
 
     def test_compute_derivative_matches_hh_equation(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.reset_state(V, na)
         ch.p.value = jnp.array([0.1])
@@ -171,8 +174,8 @@ class _HHNaMixin:
 
     def test_current_matches_p3q_formula(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.reset_state(V, na)
 
@@ -183,8 +186,8 @@ class _HHNaMixin:
 
     def test_current_is_zero_when_gates_closed(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.p.value = jnp.zeros(1)
         ch.q.value = jnp.zeros(1)
@@ -205,10 +208,10 @@ class Na_Ba2002Test(_HHNaMixin, unittest.TestCase):
     def test_V_sh_shifts_rate_functions(self) -> None:
         ch_a = Na_Ba2002(size=1, V_sh=-50.0 * u.mV)
         ch_b = Na_Ba2002(size=1, V_sh=-60.0 * u.mV)
-        na = _na_info()
+        na = na_info()
 
-        V = _V([-55.0])
-        V_shifted = _V([-45.0])
+        V = voltage([-55.0])
+        V_shifted = voltage([-45.0])
         self.assertTrue(u.math.allclose(ch_a.f_p_alpha(V_shifted, na), ch_b.f_p_alpha(V, na), atol=1e-6))
 
 
@@ -226,8 +229,8 @@ class NaFSU15DCNTest(unittest.TestCase):
 
     def test_reset_state_matches_inf_functions(self) -> None:
         ch = NaF_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.reset_state(V, na)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, na), atol=1e-6))
@@ -235,8 +238,8 @@ class NaFSU15DCNTest(unittest.TestCase):
 
     def test_current_matches_linear_formula(self) -> None:
         ch = NaF_SU2015_DCN(size=1)
-        V = _V([-40.0])
-        na = _na_info()
+        V = voltage([-40.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -244,16 +247,16 @@ class NaFSU15DCNTest(unittest.TestCase):
         expected = ch.g_max * (ch.m.value**3) * ch.h.value * (na.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_tau_matches_mod_formula(self) -> None:
         ch = NaF_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         v = V.to_decimal(u.mV)
         expected_m_tau = 5.83 / (jnp.exp((v - 6.4) / -9.0) + jnp.exp((v + 97.0) / 17.0)) + 0.025
         expected_h_tau = 16.67 / (jnp.exp((v - 8.3) / -29.0) + jnp.exp((v + 66.0) / 9.0)) + 0.2
@@ -267,8 +270,8 @@ class NaPSU15DCNTest(unittest.TestCase):
 
     def test_reset_state_matches_inf_functions(self) -> None:
         ch = NaP_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.reset_state(V, na)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, na), atol=1e-6))
@@ -276,8 +279,8 @@ class NaPSU15DCNTest(unittest.TestCase):
 
     def test_current_matches_linear_formula(self) -> None:
         ch = NaP_SU2015_DCN(size=1)
-        V = _V([-50.0])
-        na = _na_info()
+        V = voltage([-50.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -285,16 +288,16 @@ class NaPSU15DCNTest(unittest.TestCase):
         expected = ch.g_max * (ch.m.value**3) * ch.h.value * (na.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_tau_matches_mod_formula(self) -> None:
         ch = NaP_SU2015_DCN(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         v = V.to_decimal(u.mV)
         expected_h_tau = 1750.0 / (1.0 + jnp.exp((v + 65.0) / -8.0)) + 250.0
         self.assertTrue(u.math.allclose(ch.f_m_tau(V, na), jnp.array(50.0), atol=1e-6))
@@ -307,8 +310,8 @@ class NaZH19IOTest(unittest.TestCase):
 
     def test_reset_state_matches_inf_functions(self) -> None:
         ch = Na_ZH2019_IO(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.reset_state(V, na)
         self.assertTrue(u.math.allclose(ch.m.value, ch.f_m_inf(V, na), atol=1e-6))
@@ -316,8 +319,8 @@ class NaZH19IOTest(unittest.TestCase):
 
     def test_current_matches_linear_formula(self) -> None:
         ch = Na_ZH2019_IO(size=1)
-        V = _V([-40.0])
-        na = _na_info()
+        V = voltage([-40.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.m.value = jnp.array([0.5])
         ch.h.value = jnp.array([0.25])
@@ -325,16 +328,16 @@ class NaZH19IOTest(unittest.TestCase):
         expected = ch.g_max * (ch.m.value**3) * ch.h.value * (na.E - V)
         self.assertTrue(
             u.math.allclose(
-                i.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_small_denominator_branches_are_stable(self) -> None:
         ch = Na_ZH2019_IO(size=1)
-        self.assertTrue(u.math.allclose(ch._m_alpha(_V([-41.0])), jnp.array([1.0]), atol=1e-6))
-        self.assertTrue(u.math.allclose(ch._h_beta(_V([-50.0])), jnp.array([10.0]), atol=1e-6))
+        self.assertTrue(u.math.allclose(ch._m_alpha(voltage([-41.0])), jnp.array([1.0]), atol=1e-6))
+        self.assertTrue(u.math.allclose(ch._h_beta(voltage([-50.0])), jnp.array([10.0]), atol=1e-6))
 
     def test_rates_stay_accurate_just_off_the_singularity(self) -> None:
         # `x / (1 - exp(-x))` loses most of its float32 significand for
@@ -343,9 +346,9 @@ class NaZH19IOTest(unittest.TestCase):
         # threshold, and compare against the analytic value `1 + x/2`.
         ch = Na_ZH2019_IO(size=1)
         offsets = jnp.array([-1.0e-3, -1.0e-5, 1.0e-5, 1.0e-3])
-        m_alpha = ch._m_alpha(_V(-41.0 + offsets))
+        m_alpha = ch._m_alpha(voltage(-41.0 + offsets))
         self.assertTrue(u.math.allclose(m_alpha, 1.0 + (offsets / 10.0) / 2.0, atol=1e-6))
-        h_beta = ch._h_beta(_V(-50.0 + offsets))
+        h_beta = ch._h_beta(voltage(-50.0 + offsets))
         self.assertTrue(u.math.allclose(h_beta, 10.0 * (1.0 + (offsets / 10.0) / 2.0), atol=1e-5))
 
 
@@ -407,8 +410,8 @@ class _Nav1p6Mixin:
 
     def test_init_state_derives_visible_state_list_from_pairs(self) -> None:
         ch = self._make(size=3)
-        V = _V([-60.0, -50.0, -40.0])
-        na = _na_info(3)
+        V = voltage([-60.0, -50.0, -40.0])
+        na = na_info(3)
 
         ch.init_state(V, na)
 
@@ -426,8 +429,8 @@ class _Nav1p6Mixin:
 
     def test_state_values_reconstructs_hidden_state_from_probability_conservation(self) -> None:
         ch = self._make(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
 
         ch.init_state(V, na)
         ch.C1.value = jnp.array([0.2])
@@ -450,8 +453,8 @@ class _Nav1p6Mixin:
 
     def test_current_uses_open_state_only(self) -> None:
         proto = self._make(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
 
         proto.init_state(V, na)
         proto.reset_state(V, na)
@@ -461,16 +464,16 @@ class _Nav1p6Mixin:
         expected = proto.g_max * proto.O.value * (na.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_compute_derivative_matches_manual_markov_balance(self) -> None:
         proto = self._make(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         proto.init_state(V, na)
         _seed_states(proto)
@@ -492,8 +495,8 @@ class _Nav1p6Mixin:
 
     def test_reset_steady_state_produces_stationary_distribution(self) -> None:
         proto = self._make(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         proto.init_state(V, na)
         proto.reset_steady_state(V, na)
@@ -516,8 +519,8 @@ class _Nav1p6Mixin:
 
     def test_make_integration_updates_states_and_keeps_them_finite(self) -> None:
         proto = self._make(size=2, solver="euler")
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         proto.init_state(V, na)
         _seed_states(proto)
@@ -545,8 +548,8 @@ class Nav1p6MA24PCTest(_Nav1p6Mixin, unittest.TestCase):
     def test_matches_goc_implementation_under_same_conditions(self) -> None:
         goc = Nav1p6_MA2020_GoC(size=2)
         pc = Nav1p6_MA2024_PC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         goc.init_state(V, na)
         pc.init_state(V, na)
@@ -573,8 +576,8 @@ class Nav1p6MA24PCTest(_Nav1p6Mixin, unittest.TestCase):
         i_pc = pc.current(V, na)
         self.assertTrue(
             u.math.allclose(
-                i_goc.to_decimal(_DENSITY_UNIT),
-                i_pc.to_decimal(_DENSITY_UNIT),
+                i_goc.to_decimal(DENSITY_UNIT),
+                i_pc.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -584,8 +587,8 @@ class Nav1p6MA25BCTest(_Nav1p6Mixin, unittest.TestCase):
     CLS = Nav1p6_MA2025_BC
 
     def test_reset_state_uses_steady_state_initialization(self) -> None:
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         reset = Nav1p6_MA2025_BC(size=2)
         steady = Nav1p6_MA2025_BC(size=2)
 
@@ -612,8 +615,8 @@ class Nav1p6MA25BCTest(_Nav1p6Mixin, unittest.TestCase):
     def test_matches_goc_implementation_under_same_conditions(self) -> None:
         goc = Nav1p6_MA2020_GoC(size=2)
         bc = Nav1p6_MA2025_BC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         goc.init_state(V, na)
         bc.init_state(V, na)
@@ -640,8 +643,8 @@ class Nav1p6MA25BCTest(_Nav1p6Mixin, unittest.TestCase):
         i_bc = bc.current(V, na)
         self.assertTrue(
             u.math.allclose(
-                i_goc.to_decimal(_DENSITY_UNIT),
-                i_bc.to_decimal(_DENSITY_UNIT),
+                i_goc.to_decimal(DENSITY_UNIT),
+                i_bc.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -651,8 +654,8 @@ class Nav1p6RI21SCTest(_Nav1p6Mixin, unittest.TestCase):
     CLS = Nav1p6_RI2021_SC
 
     def test_reset_state_uses_steady_state_initialization(self) -> None:
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         reset = Nav1p6_RI2021_SC(size=2)
         steady = Nav1p6_RI2021_SC(size=2)
 
@@ -679,8 +682,8 @@ class Nav1p6RI21SCTest(_Nav1p6Mixin, unittest.TestCase):
     def test_matches_goc_implementation_under_same_conditions(self) -> None:
         goc = Nav1p6_MA2020_GoC(size=2)
         sc = Nav1p6_RI2021_SC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         goc.init_state(V, na)
         sc.init_state(V, na)
@@ -707,8 +710,8 @@ class Nav1p6RI21SCTest(_Nav1p6Mixin, unittest.TestCase):
         i_sc = sc.current(V, na)
         self.assertTrue(
             u.math.allclose(
-                i_goc.to_decimal(_DENSITY_UNIT),
-                i_sc.to_decimal(_DENSITY_UNIT),
+                i_goc.to_decimal(DENSITY_UNIT),
+                i_sc.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -736,8 +739,8 @@ class _Nav1p1Mixin:
 
     def test_init_state_derives_visible_state_list_from_pairs(self) -> None:
         ch = self._make(size=3)
-        V = _V([-60.0, -50.0, -40.0])
-        na = _na_info(3)
+        V = voltage([-60.0, -50.0, -40.0])
+        na = na_info(3)
 
         ch.init_state(V, na)
 
@@ -759,8 +762,8 @@ class _Nav1p1Mixin:
 
     def test_compute_derivative_matches_manual_markov_balance(self) -> None:
         proto = self._make(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         proto.init_state(V, na)
         _seed_states(proto)
@@ -777,8 +780,8 @@ class _Nav1p1Mixin:
 
     def test_current_uses_open_state_when_gate_current_is_off(self) -> None:
         proto = self._make(size=1, gateCurrent=0.0)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
 
         proto.init_state(V, na)
         proto.reset_state(V, na)
@@ -788,16 +791,16 @@ class _Nav1p1Mixin:
         expected = proto.g_max * proto.O.value * (na.E - V)
         self.assertTrue(
             u.math.allclose(
-                i_proto.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                i_proto.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_gate_current_path_matches_manual_formula(self) -> None:
         ch = self._make(size=1, gateCurrent=1.0)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.C1.value = jnp.array([0.12])
         ch.C2.value = jnp.array([0.08])
@@ -830,8 +833,8 @@ class _Nav1p1Mixin:
         current = ch.current(V, na)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -842,8 +845,8 @@ class _Nav1p1Mixin:
 
     def test_reset_steady_state_produces_stationary_distribution(self) -> None:
         proto = self._make(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         proto.init_state(V, na)
         proto.reset_steady_state(V, na)
@@ -865,8 +868,8 @@ class _Nav1p1Mixin:
 
     def test_make_integration_updates_states_and_keeps_them_finite(self) -> None:
         proto = self._make(size=2, solver="euler", gateCurrent=0.0)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         proto.init_state(V, na)
         _seed_states(proto)
@@ -888,8 +891,8 @@ class Nav1p1MA25BCTest(_Nav1p1Mixin, unittest.TestCase):
     CLS = Nav1p1_MA2025_BC
 
     def test_reset_state_uses_steady_state_initialization(self) -> None:
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         reset = Nav1p1_MA2025_BC(size=2)
         steady = Nav1p1_MA2025_BC(size=2)
 
@@ -918,8 +921,8 @@ class Nav1p1RI21SCTest(_Nav1p1Mixin, unittest.TestCase):
     CLS = Nav1p1_RI2021_SC
 
     def test_reset_state_uses_steady_state_initialization(self) -> None:
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         reset = Nav1p1_RI2021_SC(size=2)
         steady = Nav1p1_RI2021_SC(size=2)
 
@@ -946,8 +949,8 @@ class Nav1p1RI21SCTest(_Nav1p1Mixin, unittest.TestCase):
     def test_matches_bc_implementation_under_same_conditions(self) -> None:
         bc = Nav1p1_MA2025_BC(size=2)
         sc = Nav1p1_RI2021_SC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
 
         bc.init_state(V, na)
         sc.init_state(V, na)
@@ -974,8 +977,8 @@ class Nav1p1RI21SCTest(_Nav1p1Mixin, unittest.TestCase):
         i_sc = sc.current(V, na)
         self.assertTrue(
             u.math.allclose(
-                i_bc.to_decimal(_DENSITY_UNIT),
-                i_sc.to_decimal(_DENSITY_UNIT),
+                i_bc.to_decimal(DENSITY_UNIT),
+                i_sc.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
@@ -996,8 +999,8 @@ class NavMA20GrCTest(unittest.TestCase):
 
     def test_init_state_and_hidden_state_layout(self) -> None:
         ch = Nav_MA2020_GrC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         ch.init_state(V, na)
 
         self.assertEqual(
@@ -1010,7 +1013,7 @@ class NavMA20GrCTest(unittest.TestCase):
 
     def test_rate_formulas_follow_mod_definition(self) -> None:
         ch = Nav_MA2020_GrC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         factor = 3 ** (((ch.temp - u.celsius2kelvin(20.0)) / u.kelvin) / 10.0)
         alfa = factor * ch.Aalfa * u.math.exp((V / u.mV) / ch.Valfa)
         beta = factor * ch.Abeta * u.math.exp(-(V / u.mV) / ch.Vbeta)
@@ -1021,8 +1024,8 @@ class NavMA20GrCTest(unittest.TestCase):
 
     def test_current_uses_open_state_only(self) -> None:
         ch = Nav_MA2020_GrC(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.O.value = jnp.array([0.2])
         ch.OB.value = jnp.array([0.7])
@@ -1030,16 +1033,16 @@ class NavMA20GrCTest(unittest.TestCase):
         expected = ch.g_max * ch.O.value * (na.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_selected_derivatives_match_manual_markov_balance(self) -> None:
         ch = Nav_MA2020_GrC(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         values = {
             "C1": 0.12,
@@ -1074,8 +1077,8 @@ class NavMA20GrCTest(unittest.TestCase):
 
     def test_reset_steady_state_produces_stationary_distribution(self) -> None:
         ch = Nav_MA2020_GrC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         ch.init_state(V, na)
         ch.reset_steady_state(V, na)
         _assert_markov_probability_total(self, ch, 2)
@@ -1083,8 +1086,8 @@ class NavMA20GrCTest(unittest.TestCase):
 
     def test_init_state_uses_steady_state_initialization(self) -> None:
         ch = Nav_MA2020_GrC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         ch.init_state(V, na)
         _assert_markov_probability_total(self, ch, 2)
         _assert_markov_stationary(self, ch, V, na, 2)
@@ -1092,8 +1095,8 @@ class NavMA20GrCTest(unittest.TestCase):
     def test_reset_state_uses_steady_state_initialization(self) -> None:
         reset = Nav_MA2020_GrC(size=2)
         steady = Nav_MA2020_GrC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         reset.init_state(V, na)
         steady.init_state(V, na)
         reset.reset_state(V, na)
@@ -1120,8 +1123,8 @@ class NaFHFMA20GrCTest(unittest.TestCase):
 
     def test_init_state_and_hidden_state_layout(self) -> None:
         ch = NaFHF_MA2020_GrC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         ch.init_state(V, na)
 
         self.assertEqual(
@@ -1134,7 +1137,7 @@ class NaFHFMA20GrCTest(unittest.TestCase):
 
     def test_extended_rate_formulas_follow_mod_definition(self) -> None:
         ch = NaFHF_MA2020_GrC(size=1)
-        V = _V([-60.0])
+        V = voltage([-60.0])
         factor = 3 ** (((ch.temp - u.celsius2kelvin(20.0)) / u.kelvin) / 10.0)
         alfa = factor * ch.Aalfa * u.math.exp((V / u.mV) / ch.Valfa)
         self.assertTrue(u.math.allclose(ch.f33(V), ch.n3 * alfa * ch.c, atol=1e-6))
@@ -1144,8 +1147,8 @@ class NaFHFMA20GrCTest(unittest.TestCase):
 
     def test_current_uses_open_state_only(self) -> None:
         ch = NaFHF_MA2020_GrC(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         ch.O.value = jnp.array([0.2])
         ch.OB.value = jnp.array([0.5])
@@ -1154,16 +1157,16 @@ class NaFHFMA20GrCTest(unittest.TestCase):
         expected = ch.g_max * ch.O.value * (na.E - V)
         self.assertTrue(
             u.math.allclose(
-                current.to_decimal(_DENSITY_UNIT),
-                expected.to_decimal(_DENSITY_UNIT),
+                current.to_decimal(DENSITY_UNIT),
+                expected.to_decimal(DENSITY_UNIT),
                 atol=1e-6,
             )
         )
 
     def test_selected_long_inactivation_derivatives_match_manual_balance(self) -> None:
         ch = NaFHF_MA2020_GrC(size=1)
-        V = _V([-60.0])
-        na = _na_info()
+        V = voltage([-60.0])
+        na = na_info()
         ch.init_state(V, na)
         values = {
             "C1": 0.08,
@@ -1199,8 +1202,8 @@ class NaFHFMA20GrCTest(unittest.TestCase):
 
     def test_reset_steady_state_produces_stationary_distribution(self) -> None:
         ch = NaFHF_MA2020_GrC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         ch.init_state(V, na)
         ch.reset_steady_state(V, na)
         _assert_markov_probability_total(self, ch, 2)
@@ -1208,8 +1211,8 @@ class NaFHFMA20GrCTest(unittest.TestCase):
 
     def test_init_state_uses_steady_state_initialization(self) -> None:
         ch = NaFHF_MA2020_GrC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         ch.init_state(V, na)
         _assert_markov_probability_total(self, ch, 2)
         _assert_markov_stationary(self, ch, V, na, 2)
@@ -1217,8 +1220,8 @@ class NaFHFMA20GrCTest(unittest.TestCase):
     def test_reset_state_uses_steady_state_initialization(self) -> None:
         reset = NaFHF_MA2020_GrC(size=2)
         steady = NaFHF_MA2020_GrC(size=2)
-        V = _V([-60.0, -50.0])
-        na = _na_info(2)
+        V = voltage([-60.0, -50.0])
+        na = na_info(2)
         reset.init_state(V, na)
         steady.init_state(V, na)
         reset.reset_state(V, na)

--- a/docs/apis/braincell.channel.rst
+++ b/docs/apis/braincell.channel.rst
@@ -4,6 +4,35 @@
 .. currentmodule:: braincell.channel
 .. automodule:: braincell.channel
 
+Channel Templates
+-----------------
+
+The catalogue below is built from a handful of templates. A new channel
+declares its gates or transitions and its rate functions, and inherits the
+current law from one of these.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+   Gate
+   Transition
+   HH
+   OhmicHH
+   GhkHH
+   Markov
+   OhmicMarkov
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+
+   ghk_flux
+   q10_factor
+   freeze_gradient
+
+
 Calcium Channels
 ----------------
 
@@ -24,6 +53,7 @@ Calcium Channels
    CaLVA_SU2015_DCN
    CaL_SU2015_DCN
    Ca_ZH2019_IO
+   Ca_ZH2019_IO_Frozen
    Cav1p2_MA2020_GoC
    Cav1p2_MA2025_BC
    Cav1p3_MA2020_GoC
@@ -31,9 +61,12 @@ Calcium Channels
    Cav2p1_MA2024_PC
    Cav2p1_MA2024_PC_Frozen
    Cav2p1_MA2025_BC
+   Cav2p1_MA2025_BC_Frozen
    Cav2p1_RI2021_SC
+   Cav2p1_RI2021_SC_Frozen
    Cav2p3_MA2020_GoC
    Cav3p1_MA2020_GoC
+   Cav3p1_MA2020_GoC_Frozen
    Cav3p1_MA2024_PC
    Cav3p1_MA2024_PC_Frozen
    Cav3p1Test_PC24

--- a/docs/design/cell.md
+++ b/docs/design/cell.md
@@ -256,7 +256,7 @@
 - `Cell.init_state()` 负责 runtime 编译与 state 创建
 - `Cell` 已直接接管 `reset_state/pre_integral/compute_derivative/post_integral/update`
 - `CellRuntimeState` 退化为内部编译缓存，不再作为公开主接口
-- `braincell.mech.Channel("IL")` 与 `braincell.mech.Channel("INa_HH1952")` 已能创建真实 runtime channel，并绑定到默认 `na/k/ca`
+- `braincell.mech.Channel("IL")` 与 `braincell.mech.Channel("Na_HH1952")` 已能创建真实 runtime channel，并绑定到默认 `na/k/ca`
 - `Cell` 已可直接查询 `layouts/get_state/get_point_state/get_cv_state/get_runtime_node/get_ion`
 - `Cell.V` 的公开尺寸现在固定为 `pop_size + (n_cv,)`；`pop_size` 默认 `(1,)` 且不允许为空
 - runtime channel / ion 仍按 `node_tree` 的 `n_point = n_cv + n_branch + 1` 创建，公开尺寸为 `pop_size + (n_point,)`
@@ -280,7 +280,7 @@
 - 已打通 `Channel("IL", ...) -> CellRuntimeState.runtime_nodes -> braincell.channel.IL(size=(n_point,))`
 - 当前 `set_state(layout_id, var_name, value)` 会同步更新 bridge buffer 和已注册的 `IL` runtime node 参数
 - 已增加默认全局固定 ion 容器：`runtime.ions["na" | "k" | "ca"]`
-- 已打通 `Channel("INa_HH1952", ...) -> runtime.get_runtime_node(layout_id) -> runtime.get_ion("na").channels["INa"]`
+- 已打通 `Channel("Na_HH1952", ...) -> runtime.get_runtime_node(layout_id) -> runtime.get_ion("na").channels["Na"]`
 - 当前 `INa_HH1952` spec 里的 `temp` 会在 runtime bridge 中转换成底层构造参数 `phi`
 - 当前仍只支持 dense runtime；`k/ca` 容器已创建但还未绑定新的真实 channel
 - 下一步优先做更多 ion-bound channel 映射，或者设计 `cell.ion[...]` / `cell.soma.channel[...]` 这种更直接的 facade

--- a/docs/specs/2026-09-02-channel-simplification.md
+++ b/docs/specs/2026-09-02-channel-simplification.md
@@ -1,0 +1,787 @@
+# `braincell.channel` simplification
+
+Iteration 6 of the module-by-module simplification sweep. Written before any
+code was edited; the plan below is what the implementation follows, and the
+"Verification" section is filled in from real command output afterwards.
+
+## Scope and method
+
+Target: the whole `braincell/channel/` package — eight production modules and
+the eight co-located `*_test.py` files.
+
+The package is a *documented catalogue*. Measured before starting:
+
+| | total lines | docstrings | comments | blank | code |
+|---|---|---|---|---|---|
+| production (8 files) | 17 006 | 11 670 | 285 | 2 044 | 2 227 |
+| tests (8 files) | 6 991 | 34 | 187 | 1 091 | 5 669 |
+
+So the docstrings are the package — 11 670 lines of NumPy-doc carrying
+literature references, NMODL provenance, and the reasoning behind constants.
+**No docstring is deleted or shortened by this change.** A class that becomes a
+subclass keeps its full docstring verbatim; the docstring moves only when the
+code it documents moves.
+
+That table also sets the priorities. `potassium.py` is 5 501 lines of which 311
+are code; there is no meaningful "shrink `potassium.py`" work. The code volume
+is concentrated in `_base.py` (497), `sodium.py` (502), `calcium.py` (773) and,
+above all, in the tests (5 669).
+
+Four independent reviews were run over the package (reuse, simplification,
+efficiency, altitude). Every load-bearing claim from those reviews was
+re-verified here by execution — see "What the reviews got wrong" for the ones
+that did not survive.
+
+### Numerical safety net
+
+Before touching anything, a fingerprint harness recorded, for all **113**
+concrete channel classes: constructor success, MRO, post-`reset_state` state
+values, `current`, `conductance_factor`, `state_values`, every state derivative
+after a deterministic off-steady-state perturbation, and the traced-equation
+count of `current` and `compute_derivative`. Baseline: 113/113 fingerprinted,
+318 non-zero derivative entries, **8 826** traced equations in total.
+
+The stated goal for every production change below is **bit-identical output**.
+The fingerprint comparison is what proves it, and any deviation is reported in
+"Numerical effect" rather than waved away.
+
+## Bugs fixed
+
+1. **`README.md` quick-start does not run.** Lines 99 and 102 call
+   `mech.Channel("INa_Ba2002", ...)` and `mech.Channel("ICaL_IS2008", ...)`.
+   Those names are not in the mechanism registry — only the 20 module-level
+   `__getattr__` aliases ever carried the old spellings, and the registry was
+   never part of that shim:
+
+   ```
+   >>> get_registry().get("channel", "INa_Ba2002")
+   KeyError: No 'channel' mechanism registered as 'INa_Ba2002'.
+             Did you mean ['Na_Ba2002', 'KDR_Ba2002']?
+   ```
+
+   Fixed to `"Na_Ba2002"` / `"CaL_IS2008"`.
+
+2. **`sodium_test.py` sets 64-bit precision process-wide at import.**
+   `brainstate.environ.set(precision=64)` at module scope changes float
+   precision for every test module collected after it, so results depend on
+   collection order. Scoped to the tests that need it.
+
+3. **Three vacuous tests.** `calcium_test.py`'s three
+   `test_current_uses_frozen_voltage` methods have the body
+   `ch = X(size=1); self.assertTrue(callable(ch.current))`. A bound method is
+   always callable; the test cannot fail and never checks the frozen voltage
+   its name promises. Given the real assertion (the one
+   `Cav3p1FrozenMA20GoCTest.test_current_matches_unfrozen_value` already uses).
+
+4. **`Markov.compute_derivative` accumulates a derivative that is discarded.**
+   The dependent state's derivative is built up across every transition pair
+   and then never read, because only independent states are written back.
+
+5. **`is_disabled` raised `TracerBoolConversionError` under `jit`.** Found by
+   the fingerprint harness after the fast path landed, not by the test suite.
+   The predicate tested a *concrete* flag with `u.math.any(...)`, but under an
+   open trace every jax operation returns a tracer regardless of whether its
+   inputs are concrete, so `bool()` on the result raised. That broke
+   `current()` under `jit`/`for_loop` -- the execution model AGENTS.md
+   mandates -- for all eight gating-current channels (`Kv1p1_*` x5,
+   `Kv3p3_MA2024_PC`, `Nav1p1_*` x2). The test suite never caught it because
+   nothing traced those channels' `current`. Fixed by running the test in
+   numpy, which stages nothing; two regression tests were added first, at the
+   predicate level and at the channel level.
+
+## Breaking changes
+
+Every one of these deletes the old spelling outright — no deprecation shim, no
+alias, no `warnings.warn` bridge. All in-repo callers are updated in this same
+change.
+
+1. **`braincell.channel._DEPRECATED_ALIASES` and the module `__getattr__` are
+   deleted.** The 20 pre-normalisation names (`INa_HH1952`, `IKDR_Ba2002`,
+   `ICaN_IS2008`, …) no longer resolve; `braincell.channel.INa_HH1952` raises
+   `AttributeError`. Verified repo-wide first: every remaining occurrence of
+   the 20 names is prose (provenance sentences in docstrings, planning notes in
+   `docs/design/`, `TODO.md`) or a tutorial cell that *defines its own*
+   `class ICaT_HP1992(...)`. The only code that read the shim was its own three
+   tests. `IL` is untouched — that is a real current name, not an old alias.
+
+2. **`Markov` subclasses must declare `dependent_state`.** The implicit
+   fallback to "the last state discovered while scanning `pairs`" and its
+   `DeprecationWarning` are gone; omitting the declaration is now a
+   `ValueError` at class-creation time. All 18 shipped Markov channels already
+   declare it (verified by walking `Markov.__subclasses__()` transitively), so
+   nothing in the catalogue changes. The old regression test that asserted "no
+   shipped channel relies on the fallback" is deleted — the new check *is* that
+   guarantee, enforced earlier and unconditionally.
+
+3. **Dead constructor parameters removed.** `V_sh` on `Cav1p2_MA2020_GoC`,
+   `Cav1p3_MA2020_GoC`, `Cav3p1_MA2020_GoC` and `Cav3p1_MA2024_PC_Frozen`, and
+   `BBiD` on `Kv2p2_0010_MA2020_GrC`. Each is documented in its own docstring
+   as "accepted, stored, and never read". All default to a neutral value
+   (`0 mV`, `10.0`), and no method or class-level lambda reads them, so removal
+   changes no number — it only stops the constructor from silently swallowing a
+   value the caller believes is doing something. The `Notes` paragraph
+   explaining the mod-file provenance stays.
+
+4. **Class re-parenting.** Several published channels become subclasses of the
+   channel they were copy-pasted from. This is a breaking change only in the
+   `__mro__` sense — every public name, constructor signature, default and
+   registry key is preserved, and the fingerprint proves the numbers are
+   unchanged. Any code doing `isinstance`/`issubclass` against the old flat
+   hierarchy sees more `True` answers than before, never fewer.
+
+5. **`K_Leak.current` reports a different unit spelling.** `mS*mV/cm^2`
+   becomes `10.0^-2 * A/m^2`. The mantissas are bit-identical and the
+   dimensions are the same, so arithmetic and `to_decimal` are unaffected —
+   but code comparing `u.get_unit(...)` by `repr`, or printing the current,
+   sees the new spelling. It is the spelling 99 of the 113 channels already
+   use.
+
+6. **`sodium_test.py` no longer sets 64-bit precision process-wide.**
+   `sodium_test.py`'s module-scope `brainstate.environ.set(precision=64)` is
+   replaced by a module-scoped autouse fixture. Any test module that was
+   silently inheriting 64-bit precision because it happened to be collected
+   after `sodium_test.py` now runs at the project default; the full suite is
+   green either way.
+
+## Altitude
+
+### `GhkHH`: the missing third current template
+
+`HH` is gating-only and `OhmicHH` adds an ohmic driving force, which 63
+concrete classes take unchanged. The 12 constant-field (GHK) calcium channels
+had no such template, so they carried **6 hand-written `current()` bodies**
+that vary along four orthogonal axes:
+
+| classes | GHK helper | voltage shift | frozen | scale |
+|---|---|---|---|---|
+| `Cav2p1_{MA2024_PC, MA2025_BC, RI2021_SC}` | `ghk_flux` | yes | no | `g_max` |
+| `Cav2p1_*_Frozen` (3) | `_cav3p1_nmodl_ghk_flux` | yes | yes | `g_max` |
+| `Cav3p1_{MA2020_GoC, MA2024_PC}` | `_cav3p1_nmodl_ghk_flux` | no | no | `g_max` |
+| `Cav3p1_*_Frozen` (2) | `_cav3p1_nmodl_ghk_flux` | no | yes | `g_max` |
+| `Cav3p3_{MA2024_PC, RI2021_SC}` | `_cav3p3_nmodl_ghk_flux` | yes | no | `g_scale * perm` |
+| `Cav3p3_MA2024_PC_Frozen` | `_cav3p3_nmodl_ghk_flux` | yes | yes | `g_scale * perm` |
+
+Rows 3 and 4 are the same cell of that table written twice — the tell that this
+is a product of independent axes, not six distinct behaviours.
+
+`GhkHH(HH)` lands in `_base.py` with the four axes as declarations:
+
+```python
+class GhkHH(HH):
+    ghk = staticmethod(ghk_flux)
+    freeze_drive_gradient: ClassVar[bool] = False
+
+    def permeability(self):
+        return self.g_max
+
+    def current(self, V, ion):
+        drive_V = freeze_gradient(V) if type(self).freeze_drive_gradient else V
+        drive = type(self).ghk(
+            V=self._shifted_voltage(drive_V), ci=ion.Ci, co=ion.Co,
+            z=self.z, temp=self.temp,
+        )
+        return -self.permeability() * self.conductance_factor(V, ion) * drive
+```
+
+`HH._shifted_voltage` gains a default of `return V`, so the classes that do not
+shift declare nothing and the four that do keep their existing two-line
+override. The expression tree is identical to every one of the six bodies it
+replaces, so the result is bit-identical.
+
+**The freeze is applied to `V` before the shift, never after.** Forward values
+agree either way, but `stop_gradient(V) - V_sh` leaves a live gradient path to
+`V_sh` that `stop_gradient(V - V_sh)` would kill. The template preserves the
+existing order.
+
+### `OhmicMarkov`: the missing sibling of `OhmicHH`
+
+`Markov` is documented as the sibling of `HH`, but `HH` got `OhmicHH` and
+`Markov` never got its counterpart — so 16 of the 18 Markov classes reach the
+identical ohmic law through three hand-written `current()` bodies, and `Markov`
+consequently has no `reversal_potential()` hook at all.
+
+The ohmic current expression is extracted from `OhmicHH` into a private
+`_OhmicCurrent` mixin holding `reversal_potential` and `current`. Then
+`OhmicHH = _OhmicCurrent + HH` (unchanged behaviour) and `OhmicMarkov =
+_OhmicCurrent + Markov`, where `conductance_factor` sums the states named by a
+new `open_states` declaration. Left-to-right summation in declaration order
+reproduces the existing parenthesisation exactly.
+
+The two `Nav1p1_*` classes add a gating current on top; they keep their own
+`current()` and take the conductive term from `super().current(...)`.
+
+### Fixed reversal potentials stop being five copies of one override
+
+Five channels overrode `reversal_potential` with the identical two-line body
+`return self.E`. Four of them (`HCN_HM1992`, `HCN1_MA2025_BC`,
+`HCN_SU2015_DCN`, `HCN_ZH2019_IO`) do so for one structural reason: their
+`root_type` is `HHTypedNeuron`, so `current` is called with no ions at all and
+`ions[0].E` would raise `IndexError`. That is a property of the *template*, not
+of the four classes, so it moves into the template:
+
+```python
+return ions[0].E if ions else self.E
+```
+
+`ions` is a Python tuple, so the branch resolves at trace time and costs
+nothing. The four overrides are deleted. The fifth, `CaL_SU2015_DCN`, keeps
+its override: it *does* receive a calcium ion and deliberately ignores its
+reversal potential, which is a real per-class decision and not the same fact.
+
+An earlier draft added a `_FixedReversal` mixin for this. Generalising the
+template is the better altitude — one line instead of a class, no new name in
+the MRO, and a channel that forgets to set `self.E` now gets an
+`AttributeError` naming the attribute instead of an `IndexError` on a tuple.
+
+This is also cheaper: the five `Kca1p1_*` classes currently call
+`state_values()`, which reconstructs the dependent state (`conserve` minus a
+nine-term sum) purely to throw it away. `OhmicMarkov.conductance_factor` reads
+the independent states directly and only falls back to `state_values()` if a
+declared open state *is* the dependent one — which no shipped scheme does.
+
+### Freezing becomes a declaration, not a copy-pasted class
+
+Three `*_Frozen` calcium classes are standalone `HH` subclasses that re-declare
+an entire published channel — constructor, defaults, gates, and every rate
+method — so that one line of `current()` can differ. Verified by MRO-resolved
+method comparison:
+
+```
+Cav3p1_MA2024_PC_Frozen vs Cav3p1_MA2024_PC : differing = ['current']
+Cav3p3_MA2024_PC_Frozen vs Cav3p3_MA2024_PC : differing = ['current']
+Cav2p1_MA2024_PC_Frozen vs Cav2p1_MA2024_PC : differing = ['current']
+```
+
+`current` is the *only* difference in all three cases. The fourth frozen class,
+`Cav3p1_MA2020_GoC_Frozen`, already does it correctly as a three-line subclass —
+and `calcium.py`'s own docstring names the defect: *"The two frozen variants
+therefore compute the same numbers while sharing no code, and a change to
+`Cav3p1_MA2020_GoC` propagates to one of them and not to the other."*
+
+With `GhkHH` in place all four collapse to the pure-alias form the rest of the
+catalogue already uses — `class Cav3p1_MA2024_PC_Frozen(Cav3p1_MA2024_PC):
+freeze_drive_gradient = True` — carrying their docstrings unchanged.
+
+`Cav2p1_MA2024_PC_Frozen` additionally declares `ghk = staticmethod(
+_cav3p1_nmodl_ghk_flux)`, because it deliberately uses different physical
+constants from its unfrozen parent. That divergence is real and published —
+measured at up to **5.4e-4** relative over V ∈ [-100, 60] mV — so it must
+survive re-parenting as an explicit declaration rather than be inherited away.
+
+### Registry keys stop being a second source of truth by convention alone
+
+`@register_channel("Name")` repeats the class name at 112 sites in this package
+(138 repo-wide) and there is no case where the two differ. Making the argument
+optional is a `braincell/mech` change and belongs to a later iteration; what
+lands here is the guard that closes the drift hole today — a package-scope test
+asserting that every channel registered from `braincell.channel` is registered
+under its own `__name__`.
+
+## Shared declaration tables and reuse
+
+### `_base.py`: one steady-state solver instead of two
+
+`Markov._solve_steady_state_jax` (75 lines) and `_solve_steady_state_host`
+(79 lines) are line-for-line parallel; 48 lines are identical, including a
+13-line rate-resolution loop that is identical down to its comment. Every
+difference is mechanical (`jnp` vs `np`, functional scatter vs in-place, one
+`jax.device_get`).
+
+The backend-independent prologue — flattening `conserve` and resolving every
+transition rate — is hoisted into one shared helper. Each solver keeps only its
+own generator assembly and validation.
+
+The `try/except (ConcretizationTypeError, TracerArrayConversionError)`
+dispatch in `_solve_steady_state` **stays**, and the shared helper is called
+only after the host path's existing `jax.device_get(template)` guard, so the
+abort point does not move. See "What the reviews got wrong" — the case for
+replacing the dispatch did not survive measurement.
+
+### Sibling channels that were copy-pasted become subclasses
+
+Verified pairwise by comparing constructor signatures, defaults, `gates`,
+`root_type`, and the source of every method resolved through the MRO:
+
+| becomes a subclass of | entire difference |
+|---|---|
+| `CaHT_HM1992(CaT_HM1992)` | `V_sh` default (`25.0` vs `-3.0` mV) |
+| `KA2_HM1992(KA1_HM1992)` | `g_max` default + `f_p_inf` |
+| `KK2B_HM1992(KK2A_HM1992)` | `f_q_tau` |
+| `sKdr_SU2015_DCN(fKdr_SU2015_DCN)` | `f_m_inf`, `f_m_tau` |
+| `NaFHF_MA2020_GrC(Nav_MA2020_GrC)` | 2 constants, 16 extra rate methods, longer `pairs` |
+| `Cav3p1_MA2024_PC_Frozen(Cav3p1_MA2024_PC)` | `freeze_drive_gradient` |
+| `Cav3p3_MA2024_PC_Frozen(Cav3p3_MA2024_PC)` | `freeze_drive_gradient` |
+| `Cav2p1_*_Frozen(_FrozenCav3p1Ghk, Cav2p1_*)` | `freeze_drive_gradient` + `ghk` |
+| `K_Leak(OhmicHH)` | `gates = ()`, `g_max`/`E` defaults |
+
+Every retained method is moved verbatim, so each is bit-identical. The 51
+members `NaFHF_MA2020_GrC` now inherits were confirmed byte-identical to their
+`Nav_MA2020_GrC` counterparts by AST comparison before deletion, not by eye.
+
+Three candidates on the plan did **not** survive measurement and were solved a
+different way instead:
+
+- **`Kv3p3_MA2024_PC(Kv1p1_MA2025_BC)`** -- rejected on altitude. Kv3.3 is a
+  different protein from Kv1.1 and eight rate constants differ, so the
+  inheritance would assert a relationship that is not there. What the two
+  actually share is the *gating-current current law*, which moved to an
+  `_ExpRateGateCurrent` mixin that both mix in alongside `HH`.
+- **`HCN2_MA2020_GoC(HCN1_MA2020_GoC)`** -- same objection: two isoforms,
+  neither a specialisation of the other. Both now derive from a private
+  `_FastSlowHCN(HH)` template carrying the gates, the constructor and all six
+  shared formulas; each isoform declares its eleven kinetic constants (moved
+  from `__init__` to class attributes, since neither `.mod` exposes them as
+  `RANGE` variables) and its own `r(V)`.
+- **`Cav3p1Test_PC24(Cav3p1_MA2020_GoC)`** -- not viable. `g_max` carries
+  different *dimensions* in the two classes (`S/cm^2` vs `cm/s`) and all four
+  rate functions differ.
+
+`K_Leak` is the one re-parenting that is not bit-identical, and only in unit
+spelling: `OhmicHH.current` multiplies one more factor than the two-factor body
+it replaces, so `array * Unit` becomes `array * Quantity` and brainunit
+canonicalises `mS*mV/cm^2` to `10.0^-2 * A/m^2`. The mantissas are bit-identical
+(see "Numerical effect"), and the new spelling is the one 99 of the 113 channels
+already report.
+
+`NaFHF_MA2020_GrC` re-declares `pairs` in full rather than appending to its
+parent's tuple. `pairs` order determines `_resolved_state_names` order, which
+drives both the generator-matrix column permutation in the steady-state solve
+and the per-pair accumulation order in `compute_derivative`; appending would be
+a last-ulp change to a published model.
+
+### `braincell/channel/_testing.py`
+
+`braincell/channel` is the only tested package in the repo with no
+package-local `_testing.py`, and it pays for it: `_V` is defined six times,
+`_DENSITY_UNIT` six times, `_k_info` four times, `_ca_info` three, `_na_info`
+twice — 21 helper definitions backing 700+ call sites.
+
+The copies have **drifted**, and two of them are physically wrong:
+
+| helper | copies | divergence |
+|---|---|---|
+| `_V` | 6 | byte-identical, and byte-identical to `braincell.ion._testing.V` |
+| `_DENSITY_UNIT` | 6 | byte-identical |
+| `_k_info` | 4 | three use `Ci = 0.04 mM`, one uses `140.0 mM` |
+| `_na_info` | 2 | `0.04 mM` vs `10.0 mM` |
+| `_ca_info` | 3 | three different `Ci` defaults; one carries a dead `e_mV` alias |
+
+`0.04 mM` is the resting *calcium* concentration; as an intracellular sodium or
+potassium concentration it is unphysical and was copy-pasted in. The new
+`_testing.py` exports `voltage` (re-exported from `braincell.ion._testing.V`,
+following the `vis/_testing.py` → `io/_testing.py` precedent AGENTS.md
+documents, and spelled out because every test body binds a local `V`),
+`DENSITY_UNIT`, `k_info`, `na_info`, `ca_info` and `nonspecific_info` with the
+concentrations as keyword arguments.
+
+**No existing test's numbers change.** The two modules that relied on an
+outlier value keep it, as a two-line documented wrapper naming the reason:
+`potassium_calcium_test._k_info` pins `Ci = 140 mM` and
+`potassium_sodium_test._na_info` pins `Ci = 10 mM`. The point of consolidating
+is that the outlier is now a visible, justified override instead of a silent
+per-file default.
+
+`_testing.py` also carries `assert_channels_agree(case, expected, actual, V,
+*ions, states=(...))` — reset both channels, compare every named state, its
+derivative, and the current density. That is the entire body of the
+"cell-type variant matches its sibling" test, which this package had written
+out by hand 24 times.
+
+### Test bodies become tables
+
+The four largest test files are 4 900 lines of code, much of it one assertion
+body copy-pasted across sibling variant classes. The idiom for fixing it
+already exists in the package —
+`potassium_calcium_test.py`'s `KcaInheritedCellVariantTest` drives a
+`VARIANTS = ((name, cls, base), ...)` tuple through `subTest`, and
+`potassium_test.py` already has `_P4HHMixin` / `_P4QHHMixin` / `_PQHHMixin`.
+
+Applied to `potassium_test.py`'s 17 single-purpose variant classes (21 test
+bodies over five shapes) and `hyperpolarization_activated_test.py`'s three HCN1
+variant classes, which become `_HCN1VariantTests` plus a
+`_HCN1DerivedVariantTests` subclass carrying the one assertion that only the
+two derived variants can make. `sodium_test.py` already had `_HHNaMixin`,
+`_Nav1p6Mixin` and `_Nav1p1Mixin`; its two remaining standalone classes
+(`NavMA20GrCTest`, `NaFHFMA20GrCTest`) are left alone because the two channels
+now differ structurally, not just in constants.
+
+`potassium_test.py` loses 480 net lines. The rewrite was done mechanically:
+each candidate body was parsed, matched against the exact expected statement
+sequence, and skipped rather than guessed at if anything failed to match — four
+of the 25 `test_matches_*` bodies did not match and were left untouched.
+
+## Efficiency
+
+**Every win here is a tracing win, and none is claimed as a runtime win.** That
+distinction was tested, not assumed. XLA's CSE and algebraic simplifier remove
+the duplicates before execution: `Nav1p6_MA2020_GoC.compute_derivative` emits 22
+`exp` in its jaxpr and **5** `exponential` in the optimized HLO, and
+hand-deduplicating the rate table down to 8 jaxpr `exp` still gives **5**. For
+the structural rewrites below the optimized-HLO op inventory is byte-identical
+(`multiply` 111/111, `add` 43/43). A 1000-step interleaved runtime A/B gave
++11.1%, +1.0%, -10.4% across three channels — noise, and nothing is claimed
+from it. There is also no host-device transfer on any hot path; all
+`jax.device_get` use is confined to the reset-time steady-state solve.
+
+What that buys is model-build and compile latency, which is what a user of this
+package actually waits on.
+
+| # | change | measured |
+|---|---|---|
+| 1 | `Markov.make_integration` short-circuits the `for_loop` when `substeps == 1` | trace **1187 -> 964 ms** across all 18 Markov classes (**-18.7%**), every class improved 15.0-23.2% |
+| 2 | `q10_factor` results memoised per instance instead of recomputed per rate call | `Kca1p1_MA2020_GoC` 24.17 -> 18.68 ms (-22.7%), `Kca2p2_RI2021_SC` 10.40 -> 6.50 ms (-37.5%); ~41 ms over the 10 Kca classes, ~18 ms over the 92 HH channels via `gate_phi` |
+| 3 | gating-current `where` skipped when `gateCurrent` is concrete and uniformly zero | `current()` trace **3.13 -> 1.22 ms (-61%)**, jaxpr **25 -> 5 eqns (-80%)** |
+| 4 | `Markov.compute_derivative` binds `states[src] * forward` once instead of twice | trace 283 -> 261 ms across 18 classes (-7.8%); jaxpr `Nav1p6` 339 -> 283 (-17%), `NaFHF` 408 -> 339 |
+| 5 | `Markov.compute_derivative` stops accumulating the dependent state's derivative | ~26 traced ops built and discarded per step for a 13-pair `Kca1p1_*` |
+| 6 | accumulators start from the first term instead of `_state_zero()` | `_state_zero()` costs 66.8 us eager; 188 calls across the Markov catalogue ~ 12.6 ms |
+| 7 | `OhmicMarkov.conductance_factor` reads independent open states directly | drops the dependent-state reconstruction (`conserve` minus a nine-term sum) from every `Kca1p1_*` `current()` |
+| 8 | `HH.conductance_factor` starts the product from the first gate, not `1.0` | one wasted `mul` per HH channel per trace, 92 across the catalogue |
+| 9 | `_INVERSE_TIME_DIM` hoisted to module scope; `_as_gate_quantity` builds `expected` lazily | `u.get_dim(1 / u.ms)` costs 14.9 us vs 0.02 us cached, x318 per full-catalogue trace ~ 4.8 ms |
+
+Change 3 preserves the documented contract that "``gateCurrent`` may be an
+array and the choice stays traceable": the fast path is taken only when the
+flag is concrete *and* uniformly zero, otherwise the `u.math.where` runs
+unchanged.
+
+Changes 2 and 6 need care about staleness. `braincell._compute.bindings`
+rebinds channel parameters at runtime via `setattr` and then calls
+`_on_param_updated`. `Nav1p6_MA2020_GoC` already precomputes `self.phi` in
+`__init__` and would therefore go stale if `temp` were written at runtime — a
+latent bug nobody has hit. The memo added here is keyed on the *identity* of
+the values it was computed from, so a rebind invalidates it automatically; that
+is the same self-healing cache shape used for the radial-shell geometry factors
+in `braincell/ion/_base.py`.
+
+Baseline for comparison: **8 826** traced equations across the 113 classes;
+per-model trace / first-`jit` / steady-state step timings recorded for 19
+representative channels.
+
+## Numerical effect
+
+The fingerprint was re-run after every structural change and compared against
+the baseline. Over the 113 classes and the six numeric fields per class
+(`states`, `current`, `conductance_factor`, `state_values`,
+`current_perturbed`, `derivatives`):
+
+**Every numeric value is bit-identical.** The comparison reports 21 changed
+entries, and all 21 are accounted for:
+
+| entries | what changed | why |
+|---|---|---|
+| 19 | `conductance_factor` newly present on the `Kca2p2_*`, `Kca1p1_*`, `Nav1p6_*`, `Nav1p1_*`, `Nav_MA2020_GrC`, `NaFHF_MA2020_GrC` classes | plain `Markov` had no such method; `OhmicMarkov` adds it. Nothing changed value — the field went from absent to present |
+| 2 | `K_Leak.current` and `K_Leak.current_perturbed` unit spelling, `mS * mV / cm^2` → `10.0^-2 * A / m^2` | `K_Leak` moved to `OhmicHH`, adding a third factor to the product; the mantissas are bit-identical (`-0.09999999403953552`, `-0.17499999701976776`, `-0.3499999940395355` before and after) |
+
+No `current`, `current_perturbed`, `states`, `state_values` or `derivatives`
+value changed on any of the 113 classes.
+
+The unit-spelling change is a real, if cosmetic, breaking change and is listed
+as one. It also *reduces* the catalogue's spelling divergence: the baseline
+reported currents in four different spellings (99 x `10.0^-2 * A/m^2`,
+9 x `10.0^1 * A/m^2`, 2 x `mA/cm^2`, 2 x `mS*mV/cm^2`), and `K_Leak` moves from
+a two-member outlier to the 99-member majority. `IL` is now the last
+`mS*mV/cm^2` channel; normalising all four spellings is recorded for the
+whole-package iteration.
+
+## Deliberately not changed
+
+Each of these was investigated and rejected; the reason is recorded so the next
+sweep does not re-litigate it.
+
+1. **The three GHK helpers are not merged.** `ghk_flux`,
+   `_cav3p1_nmodl_ghk_flux` and `_cav3p3_nmodl_ghk_flux` use different Faraday
+   and gas constants and different Kelvin offsets, taken verbatim from
+   `Cav3p1_MA20_GoC.mod` and `Cav3p3_RI21_SC.mod`. Measured divergence over
+   V ∈ [-100, 60] mV: shared vs cav3p1 **5.36e-4**, shared vs cav3p3
+   **1.60e-3**, cav3p1 vs cav3p3 **2.14e-3**. The constants are load-bearing
+   and the classes are validated against NEURON. What `GhkHH` fixes is that the
+   *choice* of helper is now a declaration instead of a copy-pasted call.
+
+   Separately: `_cav3p3_nmodl_ghk_flux` writes the flux in the reciprocal
+   algebraic direction (`co - ci·e^{+w}`, negated). Substituting its own
+   constants into the Goldman form agrees to **8.7e-16** relative — it is the
+   same equation transcribed in its mod file's idiom, not a different one. That
+   is exactly why it must not be folded into the shared body: the merge would
+   buy three lines and cost bit-for-bit invariance.
+
+2. **`CaHVA_SU2015_DCN` / `CaLVA_SU2015_DCN` do not join `GhkHH`.** They inline
+   a GHK block with hardcoded `4.47814e6` / `-23.20764929` constants and,
+   unlike all three helpers, **no singularity guard** — `drive = … / (1.0 - A)`
+   is a bare 0/0 at V = 0. Adding the guard is a behaviour change to a
+   published model, so it is a separate decision from this refactor. Recorded
+   as a known defect.
+
+   The conversion was implemented and then **reverted**, because it changed the
+   reported unit. `GhkHH.current` multiplies three operands where these two
+   bodies multiply the drive by a bare `u.mA / u.cm**2` at the end;
+   `array * Unit` attaches the unit verbatim while `array * Quantity` goes
+   through unit arithmetic and canonicalises, so `mA/cm^2` became
+   `10.0^1 * A/m^2` with bit-identical mantissas. These are the only two
+   channels in the catalogue reporting `mA/cm^2`, and silently re-spelling a
+   published model's output unit is not a simplification. The duplication is
+   removed a different way: the shared constant-field block is extracted into
+   `_su2015_dcn_ghk_drive(V, ci, co, temp)`, which returns a bare magnitude, so
+   each class keeps its own one-line `current` and its own `array * Unit`.
+
+3. **The declarative parameter table.** `self.X = braintools.init.param(X,
+   self.varshape, allow_none=False)` appears **241 times** in this package,
+   character-identical modulo the attribute name, and 414 times repo-wide.
+   `Synapse.__init__` in `braincell/_base_channel.py` already contains exactly
+   that loop. Lifting it onto `IonChannel` would remove ~175 lines here and
+   ~300 repo-wide — but `IonChannel` is a root module and `braincell/ion`
+   carries 169 of the remaining sites, so this belongs to the root-module and
+   whole-package iterations, not to a per-package one.
+
+4. **`Markov` gains no temperature declaration.** `phi` is hand-applied at ~70
+   Markov rate sites (34 in `Nav1p6_MA2020_GoC` alone), which `Gate`-style
+   `q10` / `temp_ref` on `Markov` would collapse into one multiplication inside
+   `_transition_rate`. But only the sites that write `phi` as the *last* factor
+   migrate bit-identically (60 of 70); `Kca2p2_*` puts it mid-expression and
+   `Nav_MA2020_GrC` / `NaFHF_MA2020_GrC` put it first. A partial migration
+   leaves the mechanism half-adopted, which is worse than either end state.
+
+5. **`register_channel`'s name argument stays mandatory.** Making it default to
+   `cls.__name__` is a `braincell/mech` change touching 138 sites across three
+   packages. Deferred to the whole-package iteration; the drift guard added
+   here is the interim.
+
+6. **`OhmicHH` gains no `conductance_scale` hook.** Four classes insert a single
+   extra factor into the ohmic product. A hook would add one traced multiply to
+   all 63 classes that use `OhmicHH.current` unchanged, and overriding
+   `conductance_factor` instead reassociates the product. Neither trade is
+   worth eight lines.
+
+7. **`LeakageChannel` is not re-based on `OhmicHH`.** `OhmicHH` with
+   `gates = ()` is bit-identical to `IL` (verified: `x * 1.0` is exact in
+   IEEE-754), so the leak hierarchy is arguably redundant. But
+   `LeakageChannel` is a public, documented extension point whose contract is
+   "`current` raises until you implement it", it is imported by
+   `docs/tutorials/channel.ipynb`, and `leaky_test.py` pins that contract.
+   What lands here is the subset with no contract change: five of
+   `LeakageChannel`'s six lifecycle overrides merely repeat `IonChannel`'s own
+   no-ops and are deleted, leaving `root_type` and the one `compute_derivative`
+   no-op that is the class's actual content. `K_Leak` is a separate case and
+   *does* move to `OhmicHH` with `gates = ()`: it was never a `LeakageChannel`
+   (its `root_type` is `Potassium` and its lifecycle methods take `(V, K)`,
+   not `(V)`), so it duplicated the no-ops without being able to inherit them.
+   `IL` stays on `LeakageChannel`.
+
+8. **The 65 inline Boltzmann expressions stay inline.** They resolve to 47
+   distinct expressions, varying in sign convention and in whether the slope
+   divides or multiplies. A `_boltzmann(V, v_half, k)` helper would turn each
+   site into an argument list that no longer visually matches the `.. math::`
+   block directly above it — and for a transcribed `.mod` file, that literal
+   correspondence *is* the provenance evidence.
+
+9. **`potassium.py`'s `_sigm` is neither promoted nor deleted.** It has three
+   call sites and is named in five docstrings; removing it means editing those
+   docstrings for a two-line function, and promoting it runs into item 8.
+
+10. **`_rate_ion_count`'s `*args` branch is not dead.** It has real users:
+    `_base_test.py`'s `test_gate_method_with_varargs_receives_every_ion` and
+    eight methods in
+    `examples/single_compartment/SC07_Straital_beta_oscillation_2011.py`.
+    Removing it would silently change the documented semantics of
+    `f_x_inf(self, V, *ions)` from "receive every ion" to "receive none".
+
+11. **`calcium_test.py`'s `_cav3p1_nmodl_ghk_flux` is not deduplicated against
+    the production helper.** It inlines `9.6485e4`, `8.3145` and `0.04 K` as
+    literals precisely so that
+    `test_current_uses_nmodl_constants_not_generic_ghk` and
+    `test_current_matches_ghk_formula` are independent oracles. Importing the
+    production constants would make both tautological.
+
+12. **`__init__.py` keeps its explicit import block.** Replacing 143 lines of
+    `from .calcium import (...)` with star-imports is exactly equivalent —
+    every submodule defines `__all__` — but costs IDE navigation, mypy
+    resolution and Sphinx discovery across a 130-name public API, and the
+    existing `ChannelReExportTest` already closes the drift hole. What does
+    change is that `__all__` is built from the names actually imported rather
+    than from a second concatenation of the submodules' `__all__`, so one of
+    the two drift guards becomes true by construction.
+
+13. **The rate tables are not hand-CSE'd.** 1 987 of the 7 129 traced equations
+    the catalogue emits (28%) are exact duplicates — 179 of 408 in
+    `NaFHF_MA2020_GrC` alone. A hand-written shared-exponential rewrite of
+    `Nav1p6_MA2020_GoC` cut its jaxpr 339 -> 274 (-19%) and its trace time
+    16.86 -> 14.52 ms (-14%) with bit-identical derivatives — but the optimized
+    HLO kept **5** `exponential` either way and compile time did not move
+    (127.9 -> 133.7 ms, noise). The price is rewriting rate tables that are
+    deliberately transcribed line-by-line from published `.mod` sources, which
+    is exactly the literal correspondence item 8 argues is worth keeping. The
+    nine changes in "Efficiency" get most of the same trace-time benefit from
+    ~20 lines in `_base.py`.
+
+14. **The dimension checks stay on the per-evaluation path.** `_as_markov_rate`
+    and `_check_derivative` look like a cost paid every step forever. They are
+    not: under this repo's mandated `brainstate.transform` execution model the
+    body is traced once. Instrumented over `for_loop` rollouts of 50 and 500
+    steps, the call counts were identical (`_check_derivative` 5,
+    `_as_gate_quantity` 8, `_rate_ion_count` 10) — they are Python-level
+    operations on unit metadata that emit no XLA ops. Moving them earlier would
+    lose the ability to catch a dimensioned `phi` or `conserve`, which are read
+    off the instance and cannot be checked at class-creation time.
+
+## What the reviews got wrong
+
+- One review reported that `Cav2p1_MA2024_PC_Frozen` could simply inherit its
+  parent's `current()`. It cannot: the frozen class calls
+  `_cav3p1_nmodl_ghk_flux` where the unfrozen one calls the shared `ghk_flux`,
+  a deliberate and documented difference measured at up to 5.4e-4 relative.
+  Acting on it would have silently changed a published model by 0.05%. The
+  helper choice is carried through as an explicit class-level declaration
+  instead.
+
+- One review recommended keeping `_DEPRECATED_ALIASES` on the grounds that it
+  maps Python attribute names, a different namespace from the mech registry's
+  aliases. That is true but does not save it: the shim has zero users, and its
+  half-coverage is precisely what let `README.md` ship a broken example for the
+  registry path while the attribute path kept working.
+
+- One review's first diff of the frozen classes compared only methods defined
+  in each class *body*, which made the parents look like they defined nothing.
+  Re-run with MRO resolution, the result is the much stronger claim used above:
+  `current` is the sole difference in all three cases.
+
+- One review argued the `try/except` dispatch in `_solve_steady_state`
+  evaluates every rate method twice under `jit` — once staged into a jaxpr that
+  is thrown away when `device_get` raises, then again for real — and should be
+  replaced with an explicit `is_traced_value` check. **Measured false.**
+  Instrumenting `_transition_rate` shows a traced reset makes exactly **34**
+  calls for `Nav1p6_MA2020_GoC`, the same as a concrete reset: the host path
+  aborts at `jax.device_get(template)` *before* the rate loop begins. The
+  dispatch is also not a loser on speed — the host solve is **15.5 ms vs
+  39.0 ms** for the JAX path on `Kca1p1`, 2.4x faster, which is the reason it
+  exists. This was on the way into the implementation plan before the
+  measurement arrived; the plan now keeps the dispatch and dedupes only the
+  shared prologue, and the shared helper is invoked *after* the existing
+  `device_get` guard so the abort point does not move.
+
+  The residual objection is real but small and is left alone: a
+  `ConcretizationTypeError` raised from inside a user's own rate function
+  (`if V > 0: ...`) is still swallowed and the whole solve retried on the JAX
+  path, where it will raise again.
+
+## Tests
+
+- New `braincell/channel/_testing.py` holding the shared fixtures
+  (`voltage`, `DENSITY_UNIT`, four `*_info` builders) and
+  `assert_channels_agree`.
+- New tests for `GhkHH` and `OhmicMarkov` in `_base_test.py`: axis-by-axis
+  coverage of `ghk`, `_shifted_voltage`, `freeze_drive_gradient` and
+  `permeability`, and of `open_states` including the dependent-open-state
+  fallback that no shipped scheme exercises.
+- New test that `Markov.__init_subclass__` rejects a subclass declaring `pairs`
+  without `dependent_state`.
+- New package-scope guard in `__init___test.py` that every channel registered
+  from this package uses its own class name as the registry key.
+- Deleted: the three `_DEPRECATED_ALIASES` tests, the `dependent_state`
+  fallback tests, the "no shipped channel relies on the fallback" test (now
+  enforced structurally), and one `_base_test.py` clip test that is a
+  byte-identical prefix of the test immediately below it.
+- Rewritten: three vacuous `test_current_uses_frozen_voltage` bodies, replaced
+  by `_FrozenVariantTests`, which asserts what the names promised — that the
+  gradient through the GHK drive is actually zero, via `jax.grad`.
+- New: two regression tests for the `is_disabled` tracing bug, one at the
+  predicate level (`make_jaxpr` around a concrete flag) and one at the channel
+  level (`jax.make_jaxpr(Kv1p1_MA2025_BC.current)`).
+- New: `_HCN1VariantTests` / `_HCN1DerivedVariantTests`, replacing three
+  hand-written HCN1 variant test classes.
+
+## Docs
+
+- `README.md`: the two broken `mech.Channel(...)` names.
+- `docs/apis/braincell.channel.rst`: a new "Channel Templates" section listing
+  `Gate`, `Transition`, `HH`, `OhmicHH`, `GhkHH`, `Markov`, `OhmicMarkov`,
+  `ghk_flux`, `q10_factor` and `freeze_gradient`, plus the four `*_Frozen`
+  classes that were in `__all__` but undocumented.
+- `docs/design/cell.md`: two more `Channel("INa_HH1952")` occurrences of the
+  same broken-name bug as the README.
+
+## Verification
+
+### Size
+
+Line counts are a poor proxy in a package that is 70% docstring, so both are
+reported. "code" excludes docstrings, comments and blank lines.
+
+| | total | docstring | code |
+|---|---|---|---|
+| production, before | 17 006 | 11 741 | 4 022 |
+| production, after | 17 145 | 12 078 | **3 772** (−250, −6.2%) |
+| tests, before | 7 019 | 34 | 5 665 |
+| tests, after | 6 879 | 88 | **5 492** (−173, −3.1%) |
+
+Docstrings grew by 391 lines: no existing docstring was deleted or shortened,
+and the new templates (`GhkHH`, `OhmicMarkov`, `_FastSlowHCN`,
+`_ExpRateGateCurrent`, `_testing.py`) are documented to the same standard as
+the catalogue they serve.
+
+### Numerics
+
+```
+$ PYTHONPATH=$PWD python /tmp/chan_fingerprint.py /tmp/chan_final.json
+wrote /tmp/chan_final.json: 113 classes, 113 fully fingerprinted
+
+$ python /tmp/chan_diff.py /tmp/chan_before.json /tmp/chan_final.json
+NUMERIC DIFFS: 21
+   K_Leak current
+     before: ['mS * mV / cm^2', [-0.09999999403953552, -0.17499999701976776, -0.3499999940395355]]
+     after : ['10.0^-2 * A / m^2', [-0.09999999403953552, -0.17499999701976776, -0.3499999940395355]]
+   K_Leak current_perturbed
+     before: ['mS * mV / cm^2', [-0.09999999403953552, -0.17499999701976776, -0.3499999940395355]]
+     after : ['10.0^-2 * A / m^2', [-0.09999999403953552, -0.17499999701976776, -0.3499999940395355]]
+   (19 further entries: conductance_factor, absent before / present after)
+traced eqns: 8826 -> 7535  (-14.63%)
+```
+
+### Tracing
+
+Traced equations over `current` + `compute_derivative` for all 113 classes:
+**8 826 → 7 535 (−14.63%)**.
+
+Wall-clock, 19 representative channels:
+
+| | before | after | |
+|---|---|---|---|
+| jaxpr equations | 1 467 | 1 278 | −12.9% |
+| trace | 150.63 ms | 89.86 ms | −40.4% |
+| first `jit` | 803.08 ms | 618.36 ms | −23.0% |
+| steady-state step | 1.84 ms | 1.52 ms | −17.5% |
+
+**The step-time column is not claimed as a win.** It is single-run
+microbenchmark noise: `Na_HH1952`, which this change does not touch at all,
+moved 0.223 → 0.061 ms in the same run. Only the equation counts are
+deterministic; the trace and first-`jit` columns track them and are
+directionally trustworthy. Runtime is unchanged, as the "Efficiency" section
+argues it must be.
+
+### Tests
+
+```
+$ pytest braincell/channel -q
+684 passed, 20 subtests passed
+
+$ pytest braincell/ -q
+2751 passed, 15 skipped
+
+$ pre-commit run --files <every changed file>
+check for added large files..............................................Passed
+check python ast.........................................................Passed
+check for merge conflicts................................................Passed
+debug statements (python)................................................Passed
+fix end of files.........................................................Passed
+trim trailing whitespace.................................................Passed
+ruff (legacy alias)......................................................Passed
+ruff format..............................................................Passed
+```
+
+`pytest braincell/channel` was 682 before this change and is 684 after: the
+consolidations are net-neutral on test count (a mixin runs the same assertions
+against the same classes), and the two added tests are the `is_disabled`
+tracing regressions.
+
+### Docs
+
+`docs/apis/braincell.channel.rst` gained a "Channel Templates" section and the
+four `*_Frozen` classes it had been missing; a check that every name in
+`braincell.channel.__all__` appears in the `rst` now reports nothing missing.


### PR DESCRIPTION
Iteration 6 of the module-by-module simplification sweep. Full spec:
`docs/specs/2026-09-02-channel-simplification.md`.

`braincell/channel` is a documented catalogue — 17 000 lines of which ~11 700
are docstrings and ~4 000 are code. **No docstring is deleted or shortened.**
The work is in the 4 000 lines of code, and in the tests.

## Templates

`HH` covered gating and `OhmicHH` added an ohmic driving force. Two current
laws had no template, so they lived as copy-pasted `current()` bodies:

- **`GhkHH`** — the constant-field (GHK) law, with the four axes the 12
  calcium channels actually vary along as declarations: `ghk` (which
  transcription of the constant-field equation), `_shifted_voltage`,
  `freeze_drive_gradient`, and `permeability()`. Six hand-written bodies
  collapse to one.
- **`OhmicMarkov`** — the sibling `Markov` never got. The ohmic expression
  moves into a shared `_OhmicCurrent` mixin, so `OhmicHH = _OhmicCurrent + HH`
  and `OhmicMarkov = _OhmicCurrent + Markov`, where `conductance_factor` sums
  the states named by a new `open_states` declaration.
- **`_OhmicCurrent.reversal_potential`** falls back to `self.E` when called
  with no ions. Four channels whose `root_type` is `HHTypedNeuron` were each
  overriding it with the identical two lines.
- **`_FastSlowHCN`** and **`_ExpRateGateCurrent`** carry the two remaining
  duplicated current laws.

## Bugs fixed

1. **`is_disabled` raised `TracerBoolConversionError` under `jit`.** The
   predicate inspected a *concrete* flag with `u.math.any(...)`, but under an
   open trace every jax op returns a tracer regardless of its inputs, so
   `bool()` raised. That made `current()` unusable under `jit`/`for_loop` — the
   mandated execution model — for all eight gating-current channels
   (`Kv1p1_*` ×5, `Kv3p3_MA2024_PC`, `Nav1p1_*` ×2). Found by the fingerprint
   harness, not by the suite. Fixed by testing in numpy; two regression tests
   added first.
2. **`README.md` quick-start does not run.** `mech.Channel("INa_Ba2002")` and
   `mech.Channel("ICaL_IS2008")` are not registry keys. Same bug twice more in
   `docs/design/cell.md`.
3. **`sodium_test.py` set `precision=64` process-wide at module scope**, so
   every test module collected after it silently inherited 64-bit. Now a
   module-scoped autouse fixture.

## Tests

New `braincell/channel/_testing.py`: `voltage` (re-exported from
`braincell.ion._testing.V`), `DENSITY_UNIT`, four `*_info` builders, and
`assert_channels_agree`. It replaces 21 duplicated helper definitions whose
copies had drifted — three files built potassium with `Ci = 0.04 mM` and one
with `140 mM`. **No test's numbers change:** the two modules that relied on an
outlier keep it as a two-line wrapper naming the reason.

21 potassium variant tests, three HCN1 variant classes and six frozen-calcium
test classes collapse onto shared mixins. The potassium rewrite was mechanical:
each body was parsed and matched against the exact expected statement sequence,
and skipped rather than guessed at when it did not match.

## Breaking changes

No deprecation shims, no aliases, no warnings — every old spelling is deleted
and every in-repo caller is updated in this PR.

1. **`braincell.channel._DEPRECATED_ALIASES` and the module `__getattr__` are
   gone.** The 20 pre-normalisation names (`INa_HH1952`, `IKDR_Ba2002`, …) no
   longer resolve. The shim had zero users, and its half-coverage is what let
   `README.md` ship a broken registry example while the attribute path kept
   working. `IL` is untouched — a real name, not an alias.
2. **`Markov` subclasses must declare `dependent_state`.** The implicit
   "last state discovered while scanning `pairs`" fallback and its
   `DeprecationWarning` are gone; omitting it is now a `ValueError` at
   class-creation time. All 18 shipped Markov channels already declare it.
3. **Dead constructor parameters removed** — `V_sh` on four calcium classes and
   `BBiD` on `Kv2p2_0010_MA2020_GrC`, each documented in its own docstring as
   "accepted, stored, and never read".
4. **Class re-parenting.** Nine published channels become subclasses of the
   channel they were copy-pasted from. Breaking only in the `__mro__` sense:
   every public name, signature, default and registry key is preserved.
5. **`K_Leak.current` reports a different unit spelling** — `mS*mV/cm^2` becomes
   `10.0^-2 * A/m^2`. Mantissas are bit-identical and dimensions unchanged;
   this is the spelling 99 of the 113 channels already use.
6. **`sodium_test.py` no longer sets 64-bit precision process-wide** (see
   above).

## Verification

**Every numeric value is bit-identical.** A fingerprint harness recorded, for
all 113 concrete channel classes, the post-`reset_state` state values,
`current`, `conductance_factor`, `state_values`, every state derivative after a
deterministic off-steady-state perturbation, and traced-equation counts.

```
$ python /tmp/chan_diff.py /tmp/chan_before.json /tmp/chan_final.json
NUMERIC DIFFS: 21
   K_Leak current
     before: ['mS * mV / cm^2', [-0.09999999403953552, -0.17499999701976776, -0.3499999940395355]]
     after : ['10.0^-2 * A / m^2', [-0.09999999403953552, -0.17499999701976776, -0.3499999940395355]]
   K_Leak current_perturbed
     before: ['mS * mV / cm^2', [-0.09999999403953552, -0.17499999701976776, -0.3499999940395355]]
     after : ['10.0^-2 * A / m^2', [-0.09999999403953552, -0.17499999701976776, -0.3499999940395355]]
   (19 further entries: conductance_factor, absent before / present after)
traced eqns: 8826 -> 7535  (-14.63%)
```

All 21 are accounted for: 19 are `conductance_factor` going from *absent* to
*present* (plain `Markov` had no such method), and 2 are the `K_Leak` unit
spelling with bit-identical mantissas.

| | before | after | |
|---|---|---|---|
| traced equations, 113 classes | 8 826 | 7 535 | −14.6% |
| production code lines (ex-docstrings) | 4 022 | 3 772 | −6.2% |
| test code lines | 5 665 | 5 492 | −3.1% |
| trace time, 19 channels | 150.6 ms | 89.9 ms | −40.4% |
| first `jit`, 19 channels | 803.1 ms | 618.4 ms | −23.0% |

**No runtime win is claimed.** XLA's CSE removes the duplicates before
execution; the step-time column of the same benchmark moved by −17% but
`Na_HH1952`, untouched by this change, moved 0.223 → 0.061 ms in the same run.
Only the equation counts are deterministic.

```
$ pytest braincell/channel -q
684 passed, 20 subtests passed

$ pytest braincell/ -q
2751 passed, 15 skipped

$ pre-commit run --files <every changed file>
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
(all 8 hooks Passed)
```

682 → 684 in `braincell/channel`: the consolidations are net-neutral on test
count, and the two added tests are the `is_disabled` tracing regressions.