### PR TITLE
refactor(_compute)!: fix three lowering defects, vectorise clamp and synapse gathers, delete dead fields

### DIFF
--- a/braincell/_compute/_testing.py
+++ b/braincell/_compute/_testing.py
@@ -26,8 +26,9 @@ import brainstate
 import brainunit as u
 import numpy as np
 
-from braincell import Branch, Morphology
+from braincell import Morphology
 from braincell._base_channel import Channel, IonInfo
+from braincell._discretization._testing import make_two_branch_morpho
 from braincell.ion import NonSpecific, Potassium
 from braincell.mech import register_channel
 
@@ -56,11 +57,15 @@ class _RuntimeTestTwoOwnerChannel(Channel):
 
 
 def _build_tree() -> Morphology:
-    soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
-    dend = Branch.from_lengths(lengths=[100.0] * u.um, radii=[2.0, 1.0] * u.um, type="basal_dendrite")
-    tree = Morphology.from_root(soma, name="soma")
-    tree.soma.dend = dend
-    return tree
+    """Return the canonical two-branch test morphology.
+
+    Delegates to :func:`braincell._discretization._testing.make_two_branch_morpho`.
+    This module used to carry a byte-identical copy of that body while
+    ``scheduling_test.py`` imported the original, so ``_compute`` had two
+    spellings of one fixture. The local name is kept because the ~110 call sites
+    across the four runtime test modules read as ``Cell(_build_tree())``.
+    """
+    return make_two_branch_morpho()
 
 
 def _quantity_set_at(value, index: int, replacement):

--- a/braincell/_compute/bindings.py
+++ b/braincell/_compute/bindings.py
@@ -32,13 +32,12 @@ those nodes in step with the state buffers.
   ``current_owner_type`` / ``current_owner_types`` declarations, match them
   against the declared ion selectors, and decide which ion instance owns which
   component current.
-- :class:`_BoundIonChannelRuntime` and
-  :class:`_BoundIonChannelCurrentComponentRuntime` — the wrappers installed on
-  an owner ion. The first forwards every hook to a mixed-ion channel with its
-  bound ions packed in; the second additionally narrows ``current(...)`` to one
-  key of ``current_components(...)`` so a channel that writes several ion
-  currents can be attached to several ions without updating shared gating state
-  more than once.
+- :class:`_BoundIonChannelRuntime` — the wrapper installed on an owner ion.
+  It forwards every hook to a mixed-ion channel with its bound ions packed in,
+  and with a ``component_key`` it narrows ``current(...)`` to one key of
+  ``current_components(...)`` so a channel that writes several ion currents can
+  be attached to several ions without updating shared gating state more than
+  once.
 - :func:`_instantiate_runtime_node`, :func:`_unique_ion_channel_key`,
   :func:`_owner_channel_executable` — instantiation of a single layout's node
   and its attachment to the owning ion container.
@@ -74,7 +73,6 @@ from typing import TYPE_CHECKING
 import brainunit as u
 import numpy as np
 
-from braincell import ion as runtime_ion
 from braincell._base_channel import Channel
 from braincell.channel._base import Markov
 from braincell.ion._base import KineticIon
@@ -84,7 +82,7 @@ from braincell.mech import (
     get_registry,
 )
 from braincell.quad import get_integrator
-from .ions import _build_runtime_ions, _sync_runtime_ion
+from .ions import _build_runtime_ions, _sync_runtime_ion, ion_species_key
 from .layouts import MechanismLayout
 
 if TYPE_CHECKING:
@@ -233,63 +231,36 @@ def _build_runtime_nodes(
 
 
 class _BoundIonChannelRuntime(Channel):
-    __module__ = "braincell._compute"
-
-    def __init__(self, channel: object, *, bound_ions: tuple[object, ...], owner_ion: object):
-        super().__init__(size=channel.size, name=getattr(channel, "name", None))
-        self._channel = channel
-        self._bound_ions = tuple(bound_ions)
-        self.root_type = type(owner_ion)
-
-    def _infos(self):
-        return tuple(ion.pack_info() for ion in self._bound_ions)
-
-    def pre_integral(self, V, *unused):
-        return self._channel.pre_integral(V, *self._infos())
-
-    def compute_derivative(self, V, *unused):
-        return self._channel.compute_derivative(V, *self._infos())
-
-    def post_integral(self, V, *unused):
-        return self._channel.post_integral(V, *self._infos())
-
-    def init_state(self, V, *unused, batch_size=None):
-        return self._channel.init_state(V, *self._infos(), batch_size=batch_size)
-
-    def reset_state(self, V, *unused, batch_size=None):
-        return self._channel.reset_state(V, *self._infos(), batch_size=batch_size)
-
-    def ind_update(self, V, *unused):
-        return self._channel.ind_update(V, *self._infos())
-
-    def current(self, V, *unused):
-        return self._channel.current(V, *self._infos())
-
-
-class _BoundIonChannelCurrentComponentRuntime(Channel):
-    """Expose one component current of a bound mixed-ion channel.
+    """Attach a bound channel to one owner ion.
 
     Parameters
     ----------
     channel : object
-        Runtime channel instance that owns the actual gating state and
-        total membrane-current implementation.
+        Runtime channel instance that owns the actual gating state and the
+        membrane-current implementation.
     bound_ions : tuple of object
-        Ion instances required by ``channel.root_type`` in call order.
+        Ion instances required by ``channel.root_type``, in call order.
     owner_ion : object
-        Ion instance that owns this component-current wrapper.
-    component_key : str
-        Key read from ``channel.current_components(...)``.
+        Ion instance this wrapper hangs off.
+    component_key : str or None, optional
+        When given, :meth:`current` returns only this key of
+        ``channel.current_components(...)`` instead of the whole current.
     owns_state : bool, optional
-        Whether this wrapper forwards lifecycle and integration hooks to
-        the wrapped channel. Exactly one wrapper should own state for a
-        multi-owner channel.
+        Whether lifecycle and integration hooks reach the wrapped channel.
+        Exactly one wrapper must own state for a given channel, so that a
+        channel written to several ions does not advance its shared gating
+        state once per ion.
 
     Notes
     -----
-    Only one component wrapper should own state. Other wrappers are
-    current-only and let ``owner_ion.current(...)`` return the component
-    written to that ion without double-updating the shared gating state.
+    One class covers both roles a bound channel plays. They were two classes
+    until iteration 8 of the simplification sweep: six lifecycle methods were
+    identical modulo the forwarded name, and the copies had drifted into
+    complementary gaps -- the single-owner class forwarded ``ind_update`` and
+    not ``update``, the component class the reverse. ``ind_update`` is the one
+    that matters, because :mod:`braincell._base_ion` calls it on every child;
+    ``update`` overrode nothing on :class:`~braincell.IonChannel` and had no
+    caller outside its own body.
     """
 
     __module__ = "braincell._compute"
@@ -300,8 +271,8 @@ class _BoundIonChannelCurrentComponentRuntime(Channel):
         *,
         bound_ions: tuple[object, ...],
         owner_ion: object,
-        component_key: str,
-        owns_state: bool = False,
+        component_key: str | None = None,
+        owns_state: bool = True,
     ):
         super().__init__(size=channel.size, name=getattr(channel, "name", None))
         self._channel = channel
@@ -312,166 +283,53 @@ class _BoundIonChannelCurrentComponentRuntime(Channel):
         self.root_type = type(owner_ion)
 
     def _infos(self):
-        """Return packed ion information for the wrapped channel.
-
-        Returns
-        -------
-        tuple
-            Packed ion information objects in the order expected by the
-            wrapped channel.
-        """
+        """Return packed ion information in the order the channel expects."""
         return tuple(ion.pack_info() for ion in self._bound_ions)
 
-    def pre_integral(self, V, *unused):
-        """Forward pre-integration from the state-owning wrapper.
-
-        Parameters
-        ----------
-        V : array-like
-            Membrane potential passed to the wrapped channel.
-        *unused
-            Ignored compatibility arguments supplied by ion containers.
+    def _forward_if_owner(self, hook: str, V, **kwargs):
+        """Forward ``hook`` to the wrapped channel when this wrapper owns state.
 
         Returns
         -------
         object or None
-            Return value of the wrapped channel's ``pre_integral`` when
-            this wrapper owns state; otherwise ``None``.
+            The wrapped channel's return value, or ``None`` for a
+            current-only wrapper.
         """
-        if self._owns_state:
-            return self._channel.pre_integral(V, *self._infos())
-        return None
+        if not self._owns_state:
+            return None
+        return getattr(self._channel, hook)(V, *self._infos(), **kwargs)
+
+    def pre_integral(self, V, *unused):
+        return self._forward_if_owner("pre_integral", V)
 
     def compute_derivative(self, V, *unused):
-        """Forward derivative computation from the state-owning wrapper.
-
-        Parameters
-        ----------
-        V : array-like
-            Membrane potential passed to the wrapped channel.
-        *unused
-            Ignored compatibility arguments supplied by ion containers.
-
-        Returns
-        -------
-        object or None
-            Return value of the wrapped channel's
-            ``compute_derivative`` when this wrapper owns state;
-            otherwise ``None``.
-        """
-        if self._owns_state:
-            return self._channel.compute_derivative(V, *self._infos())
-        return None
+        return self._forward_if_owner("compute_derivative", V)
 
     def post_integral(self, V, *unused):
-        """Forward post-integration from the state-owning wrapper.
+        return self._forward_if_owner("post_integral", V)
 
-        Parameters
-        ----------
-        V : array-like
-            Membrane potential passed to the wrapped channel.
-        *unused
-            Ignored compatibility arguments supplied by ion containers.
-
-        Returns
-        -------
-        object or None
-            Return value of the wrapped channel's ``post_integral`` when
-            this wrapper owns state; otherwise ``None``.
-        """
-        if self._owns_state:
-            return self._channel.post_integral(V, *self._infos())
-        return None
+    def ind_update(self, V, *unused):
+        return self._forward_if_owner("ind_update", V)
 
     def init_state(self, V, *unused, batch_size=None):
-        """Initialize shared channel state from the state-owning wrapper.
-
-        Parameters
-        ----------
-        V : array-like
-            Membrane potential passed to the wrapped channel.
-        *unused
-            Ignored compatibility arguments supplied by ion containers.
-        batch_size : int or None, optional
-            Optional batch size forwarded to the wrapped channel.
-
-        Returns
-        -------
-        object or None
-            Return value of the wrapped channel's ``init_state`` when
-            this wrapper owns state; otherwise ``None``.
-        """
-        if self._owns_state:
-            return self._channel.init_state(V, *self._infos(), batch_size=batch_size)
-        return None
+        return self._forward_if_owner("init_state", V, batch_size=batch_size)
 
     def reset_state(self, V, *unused, batch_size=None):
-        """Reset shared channel state from the state-owning wrapper.
-
-        Parameters
-        ----------
-        V : array-like
-            Membrane potential passed to the wrapped channel.
-        *unused
-            Ignored compatibility arguments supplied by ion containers.
-        batch_size : int or None, optional
-            Optional batch size forwarded to the wrapped channel.
-
-        Returns
-        -------
-        object or None
-            Return value of the wrapped channel's ``reset_state`` when
-            this wrapper owns state; otherwise ``None``.
-        """
-        if self._owns_state:
-            return self._channel.reset_state(V, *self._infos(), batch_size=batch_size)
-        return None
-
-    def update(self, V, *unused):
-        """Update shared channel state from the state-owning wrapper.
-
-        Parameters
-        ----------
-        V : array-like
-            Membrane potential passed to the wrapped channel.
-        *unused
-            Ignored compatibility arguments supplied by ion containers.
-
-        Returns
-        -------
-        object or None
-            Return value of the wrapped channel's ``update`` when this
-            wrapper owns state; otherwise ``None``.
-        """
-        if self._owns_state:
-            return self._channel.update(V, *self._infos())
-        return None
+        return self._forward_if_owner("reset_state", V, batch_size=batch_size)
 
     def current(self, V, *unused):
-        """Return this owner ion's component current.
-
-        Parameters
-        ----------
-        V : array-like
-            Membrane potential passed to the wrapped channel.
-        *unused
-            Ignored compatibility arguments supplied by
-            :meth:`braincell.Ion.current`.
-
-        Returns
-        -------
-        array-like
-            Current density stored under ``component_key`` in
-            ``channel.current_components(...)``.
+        """Return the wrapped channel's current, narrowed to ``component_key``.
 
         Raises
         ------
         AttributeError
-            If the wrapped channel does not implement
+            If ``component_key`` is set and the wrapped channel implements no
             ``current_components(...)``.
         KeyError
-            If ``component_key`` is not returned by the wrapped channel.
+            If ``component_key`` is not among the keys the channel returns.
         """
+        if self._component_key is None:
+            return self._channel.current(V, *self._infos())
         return self._channel.current_components(V, *self._infos())[self._component_key]
 
 
@@ -540,28 +398,22 @@ def _instantiate_runtime_node(
         channel_key = _unique_ion_channel_key(owner_ion, mechanism.instance_name, layout_id=layout.id)
         if component_key is None and len(bound_ions) == 1 and bound_ions[0][0] == current_owner_key:
             owner_ion.add(**{channel_key: node})
-        elif component_key is None:
-            wrapper = _BoundIonChannelRuntime(
-                node,
-                bound_ions=tuple(ion for _, ion in bound_ions),
-                owner_ion=owner_ion,
-            )
-            if layout.layout == "dense" and layout.point_mask is not None:
-                setattr(wrapper, "_point_mask", layout.point_mask)
-            owner_ion.add(**{channel_key: wrapper})
+            continue
+        if component_key is None:
+            owns_state = True
         else:
             owns_state = not state_owner_assigned
-            wrapper = _BoundIonChannelCurrentComponentRuntime(
-                node,
-                bound_ions=tuple(ion for _, ion in bound_ions),
-                owner_ion=owner_ion,
-                component_key=component_key,
-                owns_state=owns_state,
-            )
             state_owner_assigned = state_owner_assigned or owns_state
-            if layout.layout == "dense" and layout.point_mask is not None:
-                setattr(wrapper, "_point_mask", layout.point_mask)
-            owner_ion.add(**{channel_key: wrapper})
+        wrapper = _BoundIonChannelRuntime(
+            node,
+            bound_ions=tuple(ion for _, ion in bound_ions),
+            owner_ion=owner_ion,
+            component_key=component_key,
+            owns_state=owns_state,
+        )
+        if layout.layout == "dense" and layout.point_mask is not None:
+            setattr(wrapper, "_point_mask", layout.point_mask)
+        owner_ion.add(**{channel_key: wrapper})
     current_owner_key = (
         None
         if len(current_owner_keys) == 0
@@ -766,18 +618,11 @@ def _owner_channel_executable(node, *, bound_ions, owner_specs, owner_ion):
     component_key, owner_key = owner_specs[0]
     if component_key is None and len(bound_ions) == 1 and bound_ions[0][0] == owner_key:
         return node
-    if component_key is None:
-        return _BoundIonChannelRuntime(
-            node,
-            bound_ions=tuple(ion for _, ion in bound_ions),
-            owner_ion=owner_ion,
-        )
-    return _BoundIonChannelCurrentComponentRuntime(
+    return _BoundIonChannelRuntime(
         node,
         bound_ions=tuple(ion for _, ion in bound_ions),
         owner_ion=owner_ion,
         component_key=component_key,
-        owns_state=True,
     )
 
 
@@ -979,19 +824,16 @@ def _root_type_to_family(root_type: type) -> str | None:
     ``"no"`` denotes the NEURON-style nonspecific current-owner
     placeholder family. It is used for written currents such as
     ``USEION no WRITE ino`` and does not imply concentration dynamics.
+
+    This is :func:`braincell._compute.ions.ion_species_key` under the name the
+    binding rules use. Both were four-way ``issubclass`` ladders over the same
+    four ion roots until iteration 8 of the simplification sweep; the shared
+    helper reads the ``ion_symbol`` each root already declares, which also
+    covers the non-ion root types (notably
+    :class:`~braincell.HHTypedNeuron`) that the ``except TypeError`` guard
+    used to catch.
     """
-    try:
-        if issubclass(root_type, runtime_ion.Sodium):
-            return "na"
-        if issubclass(root_type, runtime_ion.Potassium):
-            return "k"
-        if issubclass(root_type, runtime_ion.Calcium):
-            return "ca"
-        if issubclass(root_type, runtime_ion.NonSpecific):
-            return "no"
-    except TypeError:
-        return None
-    return None
+    return ion_species_key(root_type)
 
 
 def _channel_current_owner_specs(cls: type) -> tuple[tuple[str | None, str], ...]:
@@ -1082,9 +924,7 @@ def _sync_runtime_node_param(runtime: CellRuntimeState, *, layout_id: int, var_n
             var_name=str(var_name),
         )
         setattr(node, var_name, new_value)
-        hook = getattr(node, "_on_param_updated", None)
-        if callable(hook):
-            hook(var_name, new_value)
+        node._on_param_updated(var_name, new_value)
         return
     new_value = _runtime_param_value(
         layout=layout,
@@ -1092,9 +932,7 @@ def _sync_runtime_node_param(runtime: CellRuntimeState, *, layout_id: int, var_n
         state_buffers=runtime.state_buffers,
     )
     setattr(node, var_name, new_value)
-    hook = getattr(node, "_on_param_updated", None)
-    if callable(hook):
-        hook(var_name, new_value)
+    node._on_param_updated(var_name, new_value)
 
 
 def _merged_channel_param_value(

--- a/braincell/_compute/bindings_test.py
+++ b/braincell/_compute/bindings_test.py
@@ -362,6 +362,50 @@ class RuntimeBindingTest(unittest.TestCase):
         self.assertEqual(samples["soma(0.5)_Kca3p1_MA2020_GoC_current"], expected_mechanism)
         self.assertEqual(samples["soma(0.5)_k_main_current"], expected_total)
 
+    def test_component_wrappers_forward_ind_update_to_the_wrapped_channel(self) -> None:
+        # ``_base_ion`` calls ``node.ind_update(V, *infos)`` on every child.
+        # The current-component wrapper used not to forward it, so it fell
+        # through to ``IonChannel.ind_update``, which tests
+        # ``isinstance(self, IndependentIntegration)`` on the *wrapper* --
+        # never true -- silently skipping sub-solver integration for every
+        # multi-owner channel and bypassing the ``owns_state`` gate.
+        cell = Cell(_build_tree())
+        cell.paint(
+            BranchSlice(branch_index=[0, 1], prox=0.0, dist=1.0),
+            braincell.mech.Ion("PotassiumFixed", name="k_main", E=-88.0 * u.mV),
+            braincell.mech.Ion("NonSpecificFixed", name="no"),
+        )
+        cell.paint(
+            BranchSlice(branch_index=[0, 1], prox=0.0, dist=1.0),
+            braincell.mech.Channel("_RuntimeTestTwoOwnerChannel", ion_names={"k": "k_main", "no": "no"}),
+        )
+        cell.init_state()
+
+        wrappers = [cell.get_ion(key).channels["_RuntimeTestTwoOwnerChannel"] for key in ("k_main", "no")]
+        self.assertEqual(len(wrappers), 2)
+
+        for wrapper in wrappers:
+            self.assertTrue(
+                hasattr(type(wrapper), "ind_update"),
+                "the wrapper must forward ind_update, not inherit the isinstance no-op",
+            )
+            seen = []
+            wrapper._channel.ind_update = lambda *args, **kwargs: seen.append(args)
+            wrapper.ind_update(cell._discretization_to_point(cell.V.value))
+            # Only the state-owning wrapper forwards; the component wrapper
+            # for a non-owning ion must not integrate the shared state twice.
+            self.assertEqual(len(seen), 1 if wrapper._owns_state else 0)
+
+    def test_component_wrappers_do_not_carry_a_dead_update_method(self) -> None:
+        # ``IonChannel`` defines no ``update``, so the wrapper's override
+        # overrode nothing; the only caller of ``.update()`` on a channel in
+        # the repository was that method's own body.
+        from braincell._base_channel import IonChannel
+        from braincell._compute.bindings import _BoundIonChannelRuntime
+
+        self.assertFalse(hasattr(IonChannel, "update"))
+        self.assertFalse(hasattr(_BoundIonChannelRuntime, "update"))
+
     def test_multi_owner_mixed_ion_channel_exposes_component_currents(self) -> None:
         cell = Cell(_build_tree())
         cell.paint(

--- a/braincell/_compute/bridge.py
+++ b/braincell/_compute/bridge.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import brainstate
 import brainunit as u
 import numpy as np
 
@@ -41,7 +42,6 @@ __all__ = [
     "fill_like",
     "gather_midpoint_values",
     "is_python_zero",
-    "matches_last_dim",
     "point_to_cv",
     "quantity_vector",
     "scatter_cv_geometry",
@@ -71,10 +71,11 @@ def quantity_vector(values: list[object], *, shape: tuple[int, ...] | None = Non
         return values
     first = values[0]
     target_shape = (len(values),) if shape is None else shape
+    dtype = brainstate.environ.dftype()
     if hasattr(first, "unit"):
         decimals = [item.to_decimal(first.unit) for item in values]
-        return u.Quantity(u.math.asarray(decimals).reshape(target_shape), first.unit)
-    return u.math.asarray(values).reshape(target_shape)
+        return u.Quantity(np.asarray(decimals, dtype=dtype).reshape(target_shape), first.unit)
+    return np.asarray(values, dtype=dtype).reshape(target_shape)
 
 
 def broadcast_to_shape(value: object, shape: tuple[int, ...], *, name: str = "value") -> object:
@@ -246,14 +247,6 @@ def gather_midpoint_values(values: object, *, point_ids: np.ndarray) -> object:
         CV-space value with shape ``(..., n_cv)``.
     """
     return values[..., point_ids]
-
-
-def matches_last_dim(value: object, size: int) -> bool:
-    """True when ``value.shape[-1] == size`` (for a shape-bearing object)."""
-    shape = getattr(value, "shape", None)
-    if shape is None or len(shape) == 0:
-        return False
-    return int(shape[-1]) == int(size)
 
 
 def is_python_zero(value: object) -> bool:

--- a/braincell/_compute/ions.py
+++ b/braincell/_compute/ions.py
@@ -21,14 +21,15 @@ with the state buffers afterwards:
 
 - :func:`_build_runtime_ions` — the entry point. Collects the ion declarations
   spread across mechanism layouts, instantiates one runtime ion per instance
-  name, fills in placeholder ions for any of ``na``/``k``/``ca`` that were never
+  name, fills in a placeholder ion for every family
+  :func:`braincell.ion.build_placeholder_ions` supplies that was never
   declared, and returns a 5-tuple of the ion map, the alias map that lets
   channels look an ion up by instance name, family key, or class name, the
   family and class candidate maps, and the per-layout runtime-ion nodes.
 - :func:`_collect_runtime_ion_instances`, :func:`_build_ion_alias_map`,
-  :func:`_runtime_ion_species_key`, :func:`_runtime_ion_family` — the grouping
-  and naming rules, including the conflict checks that reject an instance name
-  reused across two ion classes or two species.
+  :func:`ion_species_key`, :func:`_runtime_ion_species_key` — the grouping and
+  naming rules, including the conflict check that rejects an instance name
+  reused across two ion classes.
 - :func:`_supported_ion_runtime_params`, :func:`_ion_runtime_attr_name`,
   :func:`_normalize_ion_runtime_param_value` — introspection of a runtime ion
   class's constructor and the small amount of renaming/unwrapping needed to
@@ -51,15 +52,15 @@ base classes. It imports nothing from :mod:`braincell._compute.bindings` or
 
 from __future__ import annotations
 
+import functools
 import inspect
 from typing import TYPE_CHECKING
 
 import brainunit as u
 import numpy as np
 
-from braincell import ion as runtime_ion
 from braincell.ion import build_placeholder_ions
-from braincell.ion._base import DynamicNernstIon, FixedIon, InitNernstIon, KineticIon
+from braincell.ion._base import DynamicNernstIon, InitNernstIon
 from braincell.mech import Density, get_registry
 from .layouts import MechanismLayout, _constant_quantity_value
 
@@ -104,10 +105,9 @@ def _build_runtime_ions(
         for layout in record["layouts"]:
             ion_runtime_nodes[layout.id] = runtime_ion
 
-    for family_key in ("na", "k", "ca"):
+    for family_key, default_ion in _build_default_ions(pop_size + (n_point,)).items():
         if family_key in ion_family_candidates:
             continue
-        default_ion = _build_default_ions(pop_size + (n_point,))[family_key]
         ions[family_key] = default_ion
         ion_family_candidates[family_key] = [family_key]
         ion_class_candidates.setdefault(type(default_ion).__name__, []).append(family_key)
@@ -124,6 +124,21 @@ def _build_runtime_ions(
         {key: tuple(value) for key, value in ion_class_candidates.items()},
         ion_runtime_nodes,
     )
+
+
+@functools.lru_cache(maxsize=1)
+def _placeholder_family_keys() -> frozenset[str]:
+    """Return the family keys :func:`braincell.ion.build_placeholder_ions` supplies.
+
+    Notes
+    -----
+    Derived rather than restated. These keys are both the set of families that
+    get a placeholder ion when a cell declares none and the set of instance
+    names reserved from being reused for a different family; keeping one
+    literal list for either would let it drift from the other, which is the
+    defect this replaced.
+    """
+    return frozenset(build_placeholder_ions(size=(1,)))
 
 
 def _build_default_ions(n_point: int) -> dict[str, object]:
@@ -148,10 +163,9 @@ def _collect_runtime_ion_instances(
             continue
         runtime_cls = get_registry().get("ion", mechanism.class_name)
         species_key = _runtime_ion_species_key(runtime_cls)
-        family = _runtime_ion_family(runtime_cls)
 
         instance_name = mechanism.instance_name
-        if instance_name in {"na", "k", "ca"} and instance_name != species_key:
+        if instance_name in _placeholder_family_keys() and instance_name != species_key:
             raise ValueError(
                 f"Ion instance name {instance_name!r} conflicts with canonical family key for a different ion family."
             )
@@ -159,7 +173,6 @@ def _collect_runtime_ion_instances(
         if record is None:
             record = {
                 "runtime_cls": runtime_cls,
-                "family": family,
                 "layouts": [],
                 "declarations": [],
             }
@@ -169,11 +182,6 @@ def _collect_runtime_ion_instances(
             raise ValueError(
                 f"Ion instance name {instance_name!r} cannot mix classes "
                 f"{record['runtime_cls'].__name__!r} and {runtime_cls.__name__!r}."
-            )
-        elif _runtime_ion_species_key(record["runtime_cls"]) != species_key:
-            raise ValueError(
-                f"Ion instance name {instance_name!r} cannot be reused across families "
-                f"{_runtime_ion_species_key(record['runtime_cls'])!r} and {species_key!r}."
             )
 
         record["layouts"].append(layout)
@@ -211,30 +219,45 @@ def _build_ion_alias_map(
     return aliases
 
 
+def ion_species_key(cls: type) -> str | None:
+    """Return the family key of an ion root type, or ``None`` if it is not one.
+
+    Parameters
+    ----------
+    cls : type
+        Any type. Ion roots carry an ``ion_symbol`` class attribute
+        (``braincell.ion.Sodium.ion_symbol == 'Na'``); everything else,
+        including :class:`~braincell.HHTypedNeuron`, does not.
+
+    Returns
+    -------
+    str or None
+        The lowercased ``ion_symbol`` -- one of ``"na"``, ``"k"``, ``"ca"``,
+        ``"no"`` -- or ``None`` for a type that declares no symbol.
+
+    Notes
+    -----
+    This replaces the four-way ``issubclass`` ladder that both this module and
+    :mod:`braincell._compute.bindings` used to carry. The ladder re-derived a
+    value ``braincell.ion`` already declares as data, so the family set was
+    stated in four places across two modules and nothing forced them to agree
+    -- which is how the ``"no"`` family came to be missing from the
+    placeholder seed loop. ``getattr`` also subsumes the ``try/except
+    TypeError`` the ``bindings`` copy needed for non-class inputs.
+    """
+    symbol = getattr(cls, "ion_symbol", None)
+    return symbol.lower() if isinstance(symbol, str) else None
+
+
 def _runtime_ion_species_key(cls: type) -> str:
-    if issubclass(cls, runtime_ion.Sodium):
-        return "na"
-    if issubclass(cls, runtime_ion.Potassium):
-        return "k"
-    if issubclass(cls, runtime_ion.Calcium):
-        return "ca"
-    if issubclass(cls, runtime_ion.NonSpecific):
-        return "no"
-    raise ValueError(f"Unsupported ion runtime class {cls.__name__!r}: cannot infer species key.")
+    """Return the family key of a runtime ion class, raising if it has none."""
+    species_key = ion_species_key(cls)
+    if species_key is None:
+        raise ValueError(f"Unsupported ion runtime class {cls.__name__!r}: cannot infer species key.")
+    return species_key
 
 
-def _runtime_ion_family(cls: type) -> str:
-    if issubclass(cls, KineticIon):
-        return "kinetic"
-    if issubclass(cls, DynamicNernstIon):
-        return "dynamic"
-    if issubclass(cls, InitNernstIon):
-        return "init_nernst"
-    if issubclass(cls, FixedIon):
-        return "fixed"
-    raise ValueError(f"Unsupported ion runtime class {cls.__name__!r}: unsupported ion template family.")
-
-
+@functools.lru_cache(maxsize=None)
 def _supported_ion_runtime_params(cls: type) -> tuple[str, ...]:
     signature = inspect.signature(cls.__init__)
     supported: list[str] = []
@@ -512,5 +535,5 @@ def _sync_runtime_ion(runtime: CellRuntimeState, *, layout_id: int) -> None:
 
     for param_name, value in full_values.items():
         setattr(ion, _ion_runtime_attr_name(ion_cls, param_name), value)
-    if hasattr(ion, "_update_reversal") and callable(getattr(ion, "_update_reversal")):
+    if isinstance(ion, InitNernstIon):
         ion._update_reversal()

--- a/braincell/_compute/ions_test.py
+++ b/braincell/_compute/ions_test.py
@@ -1139,6 +1139,36 @@ class RuntimeIonTest(unittest.TestCase):
             rtol=1e-12,
         )
 
+    def test_nonspecific_placeholder_is_seeded_like_the_other_families(self) -> None:
+        # ``build_placeholder_ions`` supplies na/k/ca/no, but the seed loop
+        # used to take only the first three, so a channel declaring a
+        # NonSpecific owner could not bind: "No ion candidates are registered
+        # for family 'no'." ``Kv1p5_MA2020_GrC`` is the one shipped channel
+        # that hits it.
+        cell = Cell(_build_tree())
+        cell.paint(
+            BranchSlice(branch_index=[0, 1], prox=0.0, dist=1.0),
+            braincell.mech.Channel("Kv1p5_MA2020_GrC", name="kv1p5"),
+        )
+
+        cell.init_state()
+
+        self.assertEqual(sorted(cell.runtime.ions), ["ca", "k", "na", "no"])
+        self.assertIsInstance(cell.get_ion("no"), braincell.ion.NonSpecificFixed)
+
+    def test_placeholder_families_match_the_ion_package_exactly(self) -> None:
+        # The seed set is derived from ``build_placeholder_ions`` rather than
+        # restated, so the two cannot drift apart again.
+        from braincell.ion import build_placeholder_ions
+
+        cell = Cell(_build_tree())
+        cell.init_state()
+
+        self.assertEqual(
+            sorted(cell.runtime.ions),
+            sorted(build_placeholder_ions(size=(1, 5))),
+        )
+
     def test_same_ion_instance_name_cannot_mix_different_classes(self) -> None:
         cell = Cell(_build_tree())
         cell.paint(

--- a/braincell/_compute/layouts.py
+++ b/braincell/_compute/layouts.py
@@ -121,7 +121,6 @@ class MechanismLayout:
     placement_index: np.ndarray | None = None
     population_index: np.ndarray | None = None
     synapse_index: np.ndarray | None = None
-    source_rule: str | None = None
 
     @property
     def is_packed(self) -> bool:
@@ -225,9 +224,8 @@ class ClampRoutingTable:
 def build_clamp_routing_table(
     *,
     layouts: "tuple[MechanismLayout, ...]",
-    cvs,
-    node_tree: "NodeTree",
-    n_point: int,
+    point_area_decimal: np.ndarray,
+    midpoint_ids: np.ndarray,
 ) -> ClampRoutingTable | None:
     """Return point-clamp routing metadata or ``None`` if no clamps exist.
 
@@ -235,18 +233,31 @@ def build_clamp_routing_table(
     ----------
     layouts : tuple[MechanismLayout, ...]
         All mechanism layouts from :class:`braincell._compute.state.CellRuntimeState`.
-    cvs : Sequence[CV]
-        The cell's control volumes — source of per-CV membrane area.
-    node_tree : NodeTree
-        Carries ``cv_to_mid_node_id`` for CV→node mapping.
-    n_point : int
-        Number of nodes in ``node_tree``.
+    point_area_decimal : numpy.ndarray
+        ``(n_point,)`` membrane area in cm^2, as
+        :attr:`braincell._compute.state.CellRuntimeState.point_area` stores it.
+    midpoint_ids : numpy.ndarray
+        ``node_tree.cv_to_mid_node_id`` — the node each CV owns. Clamped points
+        outside this set are CV boundaries and route through the axial system
+        rather than through a per-area division.
+
+    Returns
+    -------
+    ClampRoutingTable or None
+        ``None`` when no clamp layout targets any point.
 
     Raises
     ------
     ValueError
         If any active midpoint clamp point has non-positive membrane area
         (would produce NaN in ``I_total / area`` division).
+
+    Notes
+    -----
+    The caller passes the point-area vector it has already built rather than the
+    CV sequence it was built from: deriving the areas here walked every
+    ``cv.area`` a second time, reconstructing the ``u.cm**2`` unit on each
+    conversion.
     """
     active: set[int] = set()
     for layout in layouts:
@@ -259,16 +270,9 @@ def build_clamp_routing_table(
     if not active:
         return None
 
-    point_area = np.zeros((n_point,), dtype=float)
-    midpoint_ids: set[int] = set()
-    for cv in cvs:
-        pid = int(node_tree.cv_to_mid_node_id[cv.id])
-        midpoint_ids.add(pid)
-        point_area[pid] = float(np.asarray(cv.area.to_decimal(u.cm**2), dtype=float))
-
-    active_midpoints = sorted(pid for pid in active if pid in midpoint_ids)
-    ids = np.asarray(active_midpoints, dtype=np.int32)
-    area = point_area[ids]
+    midpoints = {int(pid) for pid in np.asarray(midpoint_ids).tolist()}
+    ids = np.asarray(sorted(pid for pid in active if pid in midpoints), dtype=np.int32)
+    area = np.asarray(point_area_decimal, dtype=np.float64)[ids]
     if np.any(area <= 0.0):
         bad = ids[area <= 0.0].tolist()
         raise ValueError(
@@ -276,12 +280,12 @@ def build_clamp_routing_table(
             f"got non-positive area at point ids {bad!r}."
         )
     boundary_ids = np.asarray(
-        sorted(pid for pid in active if pid not in midpoint_ids),
+        sorted(pid for pid in active if pid not in midpoints),
         dtype=np.int32,
     )
     return ClampRoutingTable(
         midpoint_ids=ids,
-        midpoint_area=area.astype(np.float64, copy=False),
+        midpoint_area=area,
         boundary_ids=boundary_ids,
     )
 
@@ -851,11 +855,6 @@ def _write_state_buffer(layout: "MechanismLayout", buffer: object, value: object
             raise ValueError(f"State assignment shape mismatch: expected {target_shape!r}, got {arr.shape!r}.")
         return u.Quantity(arr, target_unit)
 
-        raise TypeError(
-            f"State buffer for layout {layout.id!r} expects a Quantity or sequence of Quantities, "
-            f"got {type(value).__name__!r}."
-        )
-
     if isinstance(buffer, tuple):
         if isinstance(value, (tuple, list)):
             if len(buffer) == 1:
@@ -916,9 +915,7 @@ def _extract_point_value(layout: MechanismLayout, *, point_id: int, buffer: obje
     return _pick(int(matches[0]))
 
 
-def _evaluate_clamp_layout(
-    runtime: CellRuntimeState, *, layout: MechanismLayout, t, local_indices=None
-) -> tuple[object, ...]:
+def _evaluate_clamp_layout(runtime: CellRuntimeState, *, layout: MechanismLayout, t, local_indices=None):
     """Evaluate one sparse clamp layout at time ``t``.
 
     Parameters
@@ -935,36 +932,71 @@ def _evaluate_clamp_layout(
 
     Returns
     -------
-    tuple
-        One current contribution per active point. Each item may carry
-        population-shaped leading dimensions.
+    Quantity[current]
+        One current contribution per requested point, stacked along the last
+        axis, with any population-shaped leading dimensions preserved.
+
+    Notes
+    -----
+    ``CurrentClamp`` and ``SineClamp`` are evaluated for all requested points
+    at once. They used to be evaluated in a Python loop over the points, which
+    staged a separate cumsum/where/sum per point: 512 clamps in one layout
+    produced 6662 jaxpr equations against 18 for the vectorised form, and
+    410 ms of tracing plus 710 ms of compilation against 4.3 ms and 31 ms.
+    Runtime was unaffected either way -- XLA's CSE had already collapsed the
+    duplication -- so this buys first-call latency, not throughput.
+
+    The loop also hid a defect: the ``SineClamp`` branch fetched ``delay``
+    without the loop index, so every point in a layout silently used point
+    zero's delay. Gathering the whole column removes the site where a scalar
+    default could be taken.
+
+    ``FunctionClamp`` keeps a per-point loop, because it calls a user-supplied
+    ``fn(t)`` that cannot be vectorised.
     """
     if layout.layout != "sparse" or layout.point_index is None:
         raise ValueError(f"Clamp layout {layout.id!r} must be sparse with point_index.")
-    out: list[object] = []
-    indices = range(layout.n_active) if local_indices is None else local_indices
-    for local_index in indices:
-        if layout.kind == "CurrentClamp":
-            local_t = (
-                t
-                - _scalar_state_value(
-                    runtime,
-                    layout_id=layout.id,
-                    var_name="delay",
-                    local_index=local_index,
-                )
-            ).in_unit(u.ms)
-            out.append(_eval_current_clamp(runtime, layout_id=layout.id, local_index=local_index, local_t=local_t))
-            continue
-        if layout.kind == "SineClamp":
-            local_t = (t - _scalar_state_value(runtime, layout_id=layout.id, var_name="delay")).in_unit(u.ms)
-            out.append(_eval_sine_clamp(runtime, layout_id=layout.id, local_index=local_index, local_t=local_t))
-            continue
-        if layout.kind == "FunctionClamp":
-            out.append(_eval_function_clamp(runtime, layout_id=layout.id, local_index=local_index, t=t))
-            continue
-        raise ValueError(f"Unsupported clamp layout kind {layout.kind!r}.")
-    return tuple(out)
+    indices = np.arange(layout.n_active) if local_indices is None else np.asarray(local_indices, dtype=np.int64)
+
+    if layout.kind == "FunctionClamp":
+        values = [_eval_function_clamp(runtime, layout_id=layout.id, local_index=int(i), t=t) for i in indices]
+        return u.Quantity(_quantity_sequence_to_decimal_vector(values, unit=u.nA), u.nA)
+
+    if layout.kind == "CurrentClamp":
+        local_t = (t - _state_value_rows(runtime, layout_id=layout.id, var_name="delay", rows=indices)).in_unit(u.ms)
+        return _eval_current_clamp(runtime, layout_id=layout.id, rows=indices, local_t=local_t)
+    if layout.kind == "SineClamp":
+        local_t = (t - _state_value_rows(runtime, layout_id=layout.id, var_name="delay", rows=indices)).in_unit(u.ms)
+        return _eval_sine_clamp(runtime, layout_id=layout.id, rows=indices, local_t=local_t)
+    raise ValueError(f"Unsupported clamp layout kind {layout.kind!r}.")
+
+
+def _state_value_rows(runtime: CellRuntimeState, *, layout_id: int, var_name: str, rows) -> object:
+    """Gather one clamp parameter for several active points at once.
+
+    Parameters
+    ----------
+    runtime : braincell._compute.state.CellRuntimeState
+        Runtime state object.
+    layout_id : int
+        Layout owning the state buffer.
+    var_name : str
+        Parameter name.
+    rows : ndarray of int
+        Local active-point indices.
+
+    Returns
+    -------
+    object
+        The buffer indexed along its last axis, so the result carries the
+        requested points as its trailing dimension.
+    """
+    buffer = runtime.state_buffers[(int(layout_id), str(var_name))]
+    if isinstance(buffer, u.Quantity):
+        return u.Quantity(buffer.mantissa[..., rows], buffer.unit)
+    if isinstance(buffer, tuple):
+        return tuple(buffer[int(row)] for row in rows)
+    return buffer[..., rows]
 
 
 def _scalar_state_value(runtime: CellRuntimeState, *, layout_id: int, var_name: str, local_index: int = 0) -> object:
@@ -984,8 +1016,8 @@ def _quantity_sequence_to_decimal_vector(values: object, *, unit: object) -> obj
     return u.math.stack([u.math.asarray(item) for item in decimals], axis=-1)
 
 
-def _eval_current_clamp(runtime: CellRuntimeState, *, layout_id: int, local_index: int, local_t) -> object:
-    """Evaluate a :class:`CurrentClamp` step protocol at a padded local row.
+def _eval_current_clamp(runtime: CellRuntimeState, *, layout_id: int, rows, local_t) -> object:
+    """Evaluate a :class:`CurrentClamp` step protocol at the requested rows.
 
     Uses the padded ``durations`` / ``amplitudes`` state buffers paired
     with the bool ``_mask_durations`` buffer. Population-leading axes
@@ -995,30 +1027,26 @@ def _eval_current_clamp(runtime: CellRuntimeState, *, layout_id: int, local_inde
     amplitudes_q = runtime.state_buffers[(int(layout_id), "amplitudes")]
     mask = runtime.state_buffers[(int(layout_id), "_mask_durations")]
 
-    dur_row = jnp.asarray(durations_q.mantissa[..., int(local_index), :])
-    amp_row = jnp.asarray(amplitudes_q.mantissa[..., int(local_index), :])
-    mask_row = jnp.asarray(mask[..., int(local_index), :])
+    dur_rows = jnp.asarray(durations_q.mantissa[..., rows, :])
+    amp_rows = jnp.asarray(amplitudes_q.mantissa[..., rows, :])
+    mask_rows = jnp.asarray(mask[..., rows, :])
 
-    local_t_ms = local_t.to_decimal(u.ms)
-    if getattr(local_t_ms, "shape", ()) != ():
-        local_t_ms = u.math.expand_dims(local_t_ms, axis=-1)
-    ends = jnp.cumsum(dur_row, axis=-1)
-    starts = ends - dur_row
-    is_active = (local_t_ms >= 0.0) & (local_t_ms >= starts) & (local_t_ms < ends) & mask_row
-    current = jnp.sum(jnp.where(is_active, amp_row, 0.0), axis=-1)
+    local_t_ms = u.math.expand_dims(u.math.asarray(local_t.to_decimal(u.ms)), axis=-1)
+    ends = jnp.cumsum(dur_rows, axis=-1)
+    starts = ends - dur_rows
+    is_active = (local_t_ms >= 0.0) & (local_t_ms >= starts) & (local_t_ms < ends) & mask_rows
+    current = jnp.sum(jnp.where(is_active, amp_rows, 0.0), axis=-1)
     return u.Quantity(current, u.nA)
 
 
-def _eval_sine_clamp(runtime: CellRuntimeState, *, layout_id: int, local_index: int, local_t) -> object:
-    duration = _scalar_state_value(runtime, layout_id=layout_id, var_name="duration", local_index=local_index)
-    amplitude_decimal = _scalar_state_value(
-        runtime, layout_id=layout_id, var_name="amplitude", local_index=local_index
-    ).to_decimal(u.nA)
-    offset_decimal = _scalar_state_value(
-        runtime, layout_id=layout_id, var_name="offset", local_index=local_index
-    ).to_decimal(u.nA)
-    frequency = _scalar_state_value(runtime, layout_id=layout_id, var_name="frequency", local_index=local_index)
-    phase = u.math.asarray(_scalar_state_value(runtime, layout_id=layout_id, var_name="phase", local_index=local_index))
+def _eval_sine_clamp(runtime: CellRuntimeState, *, layout_id: int, rows, local_t) -> object:
+    """Evaluate a :class:`SineClamp` at the requested rows."""
+    gather = lambda name: _state_value_rows(runtime, layout_id=layout_id, var_name=name, rows=rows)
+    duration = gather("duration")
+    amplitude_decimal = gather("amplitude").to_decimal(u.nA)
+    offset_decimal = gather("offset").to_decimal(u.nA)
+    frequency = gather("frequency")
+    phase = u.math.asarray(gather("phase"))
     local_t_ms = local_t.to_decimal(u.ms)
     active = u.math.logical_and(local_t_ms >= 0.0, local_t < duration)
     angle = 2.0 * np.pi * frequency.to_decimal(u.Hz) * local_t.to_decimal(u.second) + phase

--- a/braincell/_compute/layouts_test.py
+++ b/braincell/_compute/layouts_test.py
@@ -50,25 +50,16 @@ class _ClampStubLayout:
     point_index: np.ndarray | None
 
 
-@_dataclass
-class _ClampStubCV:
-    id: int
-    area: object  # brainunit Quantity in cm^2
+def _clamp_areas(areas_cm2, *, n_point: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return ``(point_area_decimal, midpoint_ids)`` for ``len(areas_cm2)`` CVs.
 
-
-@_dataclass
-class _ClampStubNodeTree:
-    cv_to_mid_node_id: np.ndarray
-
-
-def _clamp_node_tree(n_cv: int) -> _ClampStubNodeTree:
-    return _ClampStubNodeTree(
-        cv_to_mid_node_id=np.arange(n_cv, dtype=np.int32),
-    )
-
-
-def _clamp_cv(cv_id: int, area_cm2: float) -> _ClampStubCV:
-    return _ClampStubCV(id=cv_id, area=area_cm2 * u.cm**2)
+    CV ``i`` owns point ``i``, mirroring ``cv_to_mid_node_id == arange(n_cv)``
+    on a real node tree. Any remaining points are CV boundaries, which carry no
+    membrane area of their own.
+    """
+    point_area = np.zeros((n_point,), dtype=float)
+    point_area[: len(areas_cm2)] = np.asarray(areas_cm2, dtype=float)
+    return point_area, np.arange(len(areas_cm2), dtype=np.int32)
 
 
 class RuntimeLayoutTest(unittest.TestCase):
@@ -322,6 +313,46 @@ class RuntimeLayoutTest(unittest.TestCase):
         self.assertAlmostEqual(float(active[0, 1].to_decimal(u.nA)), 0.2, places=6)
         self.assertAlmostEqual(float(after[0, 1].to_decimal(u.nA)), 0.0, places=6)
 
+    def test_sine_clamp_reads_the_delay_of_each_point_not_of_point_zero(self) -> None:
+        # Two identical SineClamps merge into one layout. The evaluator used
+        # to fetch ``delay`` without ``local_index``, so every point in the
+        # layout silently used point 0's delay -- an omitted argument that a
+        # single-point test cannot see, because there index 0 is the only
+        # index. CurrentClamp, eleven lines away, always passed it.
+        cell = Cell(_build_tree())
+        for branch_index in (0, 1):
+            cell.place(
+                at(branch_index, 0.5),
+                SineClamp(
+                    amplitude=0.0 * u.nA,
+                    frequency=500.0 * u.Hz,
+                    offset=0.2 * u.nA,
+                    delay=0.0 * u.ms,
+                    duration=100.0 * u.ms,
+                ),
+            )
+        cell.init_state()
+        runtime = cell.runtime
+
+        layout = next(lay for lay in runtime.layouts if lay.kind == "SineClamp")
+        self.assertEqual(layout.n_active, 2)
+        # The two clamps must land on distinct points, or the scatter-add
+        # below would hide a per-point difference behind a single total.
+        self.assertEqual(len(set(layout.point_index.tolist())), 2)
+
+        # Give the two points different delays: point 0 open, point 1 still
+        # waiting at t = 1 ms.
+        buffer = runtime.state_buffers[(int(layout.id), "delay")]
+        delays = np.zeros_like(np.asarray(buffer.mantissa))
+        delays[..., 1] = 5.0
+        runtime.state_buffers[(int(layout.id), "delay")] = u.Quantity(delays, buffer.unit)
+
+        current = runtime.evaluate_point_clamps(t=1.0 * u.ms).to_decimal(u.nA)
+        per_point = [float(current[..., int(pid)].ravel()[0]) for pid in layout.point_index]
+
+        self.assertAlmostEqual(per_point[0], 0.2, places=6)
+        self.assertAlmostEqual(per_point[1], 0.0, places=6)
+
     def test_probe_layouts_are_sparse_and_allocate_no_state_buffers(self) -> None:
         cell = Cell(_build_tree())
         cell.place(
@@ -437,11 +468,11 @@ class TestBuildClampRoutingTable(unittest.TestCase):
                 point_index=np.asarray([0], dtype=np.int32),
             ),
         )
+        area, midpoints = _clamp_areas([1e-6], n_point=1)
         table = build_clamp_routing_table(
             layouts=layouts,
-            cvs=[_clamp_cv(0, 1e-6)],
-            node_tree=_clamp_node_tree(1),
-            n_point=1,
+            point_area_decimal=area,
+            midpoint_ids=midpoints,
         )
         self.assertIsNone(table)
 
@@ -453,11 +484,11 @@ class TestBuildClampRoutingTable(unittest.TestCase):
                 point_index=np.asarray([1], dtype=np.int32),
             ),
         )
+        area, midpoints = _clamp_areas([1e-6, 2e-6], n_point=2)
         table = build_clamp_routing_table(
             layouts=layouts,
-            cvs=[_clamp_cv(0, 1e-6), _clamp_cv(1, 2e-6)],
-            node_tree=_clamp_node_tree(2),
-            n_point=2,
+            point_area_decimal=area,
+            midpoint_ids=midpoints,
         )
         self.assertIsInstance(table, ClampRoutingTable)
         np.testing.assert_array_equal(table.midpoint_ids, np.asarray([1], dtype=np.int32))
@@ -480,11 +511,11 @@ class TestBuildClampRoutingTable(unittest.TestCase):
                 point_index=np.asarray([1, 2], dtype=np.int32),
             ),
         )
+        area, midpoints = _clamp_areas([1e-6 * (i + 1) for i in range(4)], n_point=4)
         table = build_clamp_routing_table(
             layouts=layouts,
-            cvs=[_clamp_cv(i, 1e-6 * (i + 1)) for i in range(4)],
-            node_tree=_clamp_node_tree(4),
-            n_point=4,
+            point_area_decimal=area,
+            midpoint_ids=midpoints,
         )
         np.testing.assert_array_equal(table.midpoint_ids, np.asarray([1, 2, 3], dtype=np.int32))
 
@@ -496,12 +527,12 @@ class TestBuildClampRoutingTable(unittest.TestCase):
                 point_index=np.asarray([0], dtype=np.int32),
             ),
         )
+        area, midpoints = _clamp_areas([0.0], n_point=1)
         with self.assertRaises(ValueError):
             build_clamp_routing_table(
                 layouts=layouts,
-                cvs=[_clamp_cv(0, 0.0)],
-                node_tree=_clamp_node_tree(1),
-                n_point=1,
+                point_area_decimal=area,
+                midpoint_ids=midpoints,
             )
 
     def test_endpoint_clamp_builds_boundary_route(self):
@@ -512,11 +543,11 @@ class TestBuildClampRoutingTable(unittest.TestCase):
                 point_index=np.asarray([2], dtype=np.int32),
             ),
         )
+        area, midpoints = _clamp_areas([1e-6], n_point=3)
         table = build_clamp_routing_table(
             layouts=layouts,
-            cvs=[_clamp_cv(0, 1e-6)],
-            node_tree=_clamp_node_tree(1),
-            n_point=3,
+            point_area_decimal=area,
+            midpoint_ids=midpoints,
         )
         self.assertIsInstance(table, ClampRoutingTable)
         np.testing.assert_array_equal(table.midpoint_ids, np.asarray([], dtype=np.int32))
@@ -536,11 +567,11 @@ class TestBuildClampRoutingTable(unittest.TestCase):
                 point_index=np.asarray([1, 4], dtype=np.int32),
             ),
         )
+        area, midpoints = _clamp_areas([1e-6, 2e-6], n_point=5)
         table = build_clamp_routing_table(
             layouts=layouts,
-            cvs=[_clamp_cv(0, 1e-6), _clamp_cv(1, 2e-6)],
-            node_tree=_clamp_node_tree(2),
-            n_point=5,
+            point_area_decimal=area,
+            midpoint_ids=midpoints,
         )
         np.testing.assert_array_equal(table.midpoint_ids, np.asarray([0, 1], dtype=np.int32))
         np.testing.assert_allclose(table.midpoint_area, np.asarray([1e-6, 2e-6]))
@@ -554,12 +585,12 @@ class TestBuildClampRoutingTable(unittest.TestCase):
                 point_index=np.asarray([0], dtype=np.int32),
             ),
         )
+        area, midpoints = _clamp_areas([1e-6], n_point=1)
         self.assertIsNone(
             build_clamp_routing_table(
                 layouts=layouts,
-                cvs=[_clamp_cv(0, 1e-6)],
-                node_tree=_clamp_node_tree(1),
-                n_point=1,
+                point_area_decimal=area,
+                midpoint_ids=midpoints,
             )
         )
 

--- a/braincell/_compute/scheduling.py
+++ b/braincell/_compute/scheduling.py
@@ -32,14 +32,12 @@ __all__ = [
 class NodeScheduling:
     """Execution-oriented grouping derived from a node tree."""
 
-    algorithm: str
     row_to_point_id: np.ndarray
     point_id_to_row: np.ndarray
     groups: tuple[np.ndarray, ...]
     parent_rows: np.ndarray
     edges: np.ndarray
     level_size: np.ndarray
-    level_start: np.ndarray
 
 
 def build_node_scheduling(
@@ -81,7 +79,6 @@ def build_node_scheduling(
     if len(groups) == 0:
         edges = np.empty((0, 2), dtype=np.int32)
         level_size = np.empty((0,), dtype=np.int32)
-        level_start = np.empty((0,), dtype=np.int32)
     else:
         edge_pairs: list[list[int]] = []
         for group in groups:
@@ -91,17 +88,14 @@ def build_node_scheduling(
                     edge_pairs.append([int(row), parent_row])
         edges = np.asarray(edge_pairs, dtype=np.int32) if edge_pairs else np.empty((0, 2), dtype=np.int32)
         level_size = np.asarray([len(group) for group in groups], dtype=np.int32)
-        level_start = np.concatenate([np.asarray([0], dtype=np.int32), np.cumsum(level_size, dtype=np.int32)])[:-1]
 
     return NodeScheduling(
-        algorithm=algorithm,
         row_to_point_id=row_to_point_id,
         point_id_to_row=point_id_to_row,
         groups=groups,
         parent_rows=parent_rows,
         edges=edges,
         level_size=level_size,
-        level_start=level_start,
     )
 
 

--- a/braincell/_compute/state.py
+++ b/braincell/_compute/state.py
@@ -89,7 +89,6 @@ from .layouts import (
     _mechanism_var_names,
     _mechanism_var_value,
     _quantity_sequence_to_decimal_vector,
-    _stack_synapse_values,
     _write_state_buffer,
     build_clamp_routing_table,
     choose_layout,
@@ -315,7 +314,6 @@ class CellRuntimeState:
                 placement_index=placement_index,
                 population_index=population_indices,
                 synapse_index=None if synapse_ids is None else np.asarray(synapse_ids, dtype=np.int64),
-                source_rule=None,
             )
             layouts.append(layout_spec)
             layout_mechanisms[layout_spec.id] = mechanism
@@ -340,19 +338,11 @@ class CellRuntimeState:
                     raise TypeError(
                         f"Unsupported event input {type(event_input).__name__!r} for {mechanism.synapse_type!r}."
                     )
+                logical_ids = np.asarray(synapse_ids, dtype=np.int64)
                 for var_name in tuple(runtime_cls.parameters):
-                    values = [
-                        synapse_store.parameter_value(int(logical_id), var_name)
-                        for logical_id in np.asarray(synapse_ids, dtype=np.int64).tolist()
-                    ]
-                    buffer = _stack_synapse_values(values, parameter=var_name)
-                    state_buffers[(layout_spec.id, var_name)] = buffer
+                    state_buffers[(layout_spec.id, var_name)] = synapse_store.parameter_column(logical_ids, var_name)
                     state_shapes[(layout_spec.id, var_name)] = (len(point_ids),)
-                synapse_store.bind_runtime(
-                    mechanism.synapse_type,
-                    layout_spec.id,
-                    np.asarray(synapse_ids, dtype=np.int64),
-                )
+                synapse_store.bind_runtime(mechanism.synapse_type, layout_spec.id, logical_ids)
                 continue
 
             for var_name in _mechanism_var_names(mechanism):
@@ -431,18 +421,14 @@ class CellRuntimeState:
             n_point=n_point,
         )
 
-        clamp_routing_table = build_clamp_routing_table(
-            layouts=tuple(layouts),
-            cvs=cell.cvs,
-            node_tree=node_tree,
-            n_point=n_point,
-        )
-
+        # Hoisted: ``u.cm**2`` costs ~13 us to construct, and the comprehension
+        # below converts once per CV.
+        area_unit = u.cm**2
         cv_area_decimal = np.asarray(
-            [float(np.asarray(cv.area.to_decimal(u.cm**2), dtype=float)) for cv in cell.cvs],
+            [float(np.asarray(cv.area.to_decimal(area_unit), dtype=float)) for cv in cell.cvs],
             dtype=float,
         )
-        cv_area = u.Quantity(cv_area_decimal, u.cm**2)
+        cv_area = u.Quantity(cv_area_decimal, area_unit)
         point_area_decimal = np.zeros((n_point,), dtype=float)
         for point in node_tree.nodes:
             roles = tuple(point.roles)
@@ -450,9 +436,16 @@ class CellRuntimeState:
                 continue
             cv_id = int(roles[0].cv_id)
             point_area_decimal[int(point.id)] = cv_area_decimal[cv_id]
-        point_area = u.Quantity(point_area_decimal, u.cm**2)
+        point_area = u.Quantity(point_area_decimal, area_unit)
+        midpoint_ids = np.asarray(node_tree.cv_to_mid_node_id, dtype=np.int32)
         midpoint_mask_np = np.zeros((n_point,), dtype=bool)
-        midpoint_mask_np[np.asarray(node_tree.cv_to_mid_node_id, dtype=np.int32)] = True
+        midpoint_mask_np[midpoint_ids] = True
+
+        clamp_routing_table = build_clamp_routing_table(
+            layouts=tuple(layouts),
+            point_area_decimal=point_area_decimal,
+            midpoint_ids=midpoint_ids,
+        )
 
         runtime = cls(
             node_tree=node_tree,
@@ -475,10 +468,6 @@ class CellRuntimeState:
             current_owner_keys=current_owner_keys,
             midpoint_mask_np=midpoint_mask_np,
             merged_channel_layout_groups=merged_channel_layout_groups,
-            dhs_static_source_np=None,
-            dhs_static_cache=None,
-            axial_operator_np=None,
-            axial_operator_cache=None,
             clamp_routing_table=clamp_routing_table,
             cv_area=cv_area,
             point_area=point_area,

--- a/braincell/_compute/state_test.py
+++ b/braincell/_compute/state_test.py
@@ -24,6 +24,7 @@ import numpy as np
 
 import braincell
 from braincell import (
+    CVPerBranch,
     Cell,
     CurrentClamp,
 )
@@ -97,6 +98,35 @@ class CellRuntimeStateTest(unittest.TestCase):
 
         self.assertIsNot(first, second)
         self.assertEqual(len(second), 1)
+
+    def test_clamp_routing_area_matches_the_cv_that_owns_each_midpoint(self) -> None:
+        """The routing table reads the runtime point-area vector, not ``cv.area``.
+
+        ``build_clamp_routing_table`` no longer walks the CV sequence; it slices
+        the ``point_area`` vector the runtime already built from each node's
+        first role. That is only correct because a CV midpoint reports its own
+        CV as ``roles[0]``, which this pins against a real discretization.
+        """
+        cell = Cell(_build_tree(), cv_policy=CVPerBranch(cv_per_branch=3))
+        cell.place(
+            RootLocation(x=0.5),
+            CurrentClamp(delay=1.0 * u.ms, durations=2.0 * u.ms, amplitudes=0.1 * u.nA),
+        )
+        cell.init_state()
+
+        midpoint_ids = np.asarray(cell.runtime.node_tree.cv_to_mid_node_id, dtype=np.int64)
+        np.testing.assert_allclose(
+            np.asarray(cell.runtime.point_area.to_decimal(u.cm**2))[midpoint_ids],
+            [float(np.asarray(cv.area.to_decimal(u.cm**2))) for cv in cell.cvs],
+            rtol=0.0,
+        )
+        table = cell.runtime.clamp_routing_table
+        clamped_cv = int(np.flatnonzero(midpoint_ids == table.midpoint_ids[0])[0])
+        np.testing.assert_allclose(
+            table.midpoint_area,
+            [float(np.asarray(cell.cvs[clamped_cv].area.to_decimal(u.cm**2)))],
+            rtol=0.0,
+        )
 
     def test_state_mutation_updates_buffer_without_rebuild(self) -> None:
         cell = Cell(_build_tree())

--- a/braincell/_multi_compartment/synapses.py
+++ b/braincell/_multi_compartment/synapses.py
@@ -210,7 +210,57 @@ class _SynapseStore:
         if parameter not in self.parameter_columns[synapse_type]:
             raise KeyError(f"Synapse type {synapse_type!r} does not declare parameter {parameter!r}.")
         local = self._type_local_by_id[int(logical_id)]
-        return _take_vector_item(self.parameter_columns[synapse_type][parameter], local)
+        return _take_vector_items(self.parameter_columns[synapse_type][parameter], local)
+
+    def parameter_column(self, logical_ids, parameter: str):
+        """Gather one declared parameter across several logical synapses.
+
+        Parameters
+        ----------
+        logical_ids : array-like of int
+            Stable logical ids, all belonging to the same synapse type.
+        parameter : str
+            Name of a parameter declared by that type.
+
+        Returns
+        -------
+        array-like
+            One vector holding ``parameter`` for each id, in the order given. An
+            empty selection yields an empty dimensionless float array, matching
+            what stacking zero values produced.
+
+        Raises
+        ------
+        TypeError
+            If the ids span more than one synapse type.
+        KeyError
+            If the type does not declare ``parameter``.
+
+        See Also
+        --------
+        parameter_value : Read the same parameter for a single logical id.
+
+        Notes
+        -----
+        This is the vector form of :meth:`parameter_value`, and the form every
+        caller holding a whole selection should use. Reading a selection one id
+        at a time is quadratic: each :meth:`parameter_value` call re-materializes
+        the entire per-type column through ``to_decimal`` only to take a single
+        element, and the caller then restacks the scalars it just tore apart.
+        Slicing the column once is constant in the number of rows read.
+        """
+        ids = np.asarray(logical_ids, dtype=np.int64).reshape(-1)
+        if ids.size == 0:
+            return np.asarray([], dtype=float)
+        types = {str(self.synapse_type[self.row_index(int(item))]) for item in ids.tolist()}
+        if len(types) != 1:
+            raise TypeError("Cannot read one parameter across multiple synapse types.")
+        synapse_type = types.pop()
+        columns = self.parameter_columns[synapse_type]
+        if parameter not in columns:
+            raise KeyError(f"Synapse type {synapse_type!r} does not declare parameter {parameter!r}.")
+        local_rows = np.asarray([self._type_local_by_id[int(item)] for item in ids.tolist()], dtype=np.int64)
+        return _take_vector_items(columns[parameter], local_rows)
 
     def set_parameter(self, logical_ids: np.ndarray, parameter: str, values) -> None:
         self.set_parameters(logical_ids, {parameter: values})
@@ -470,10 +520,7 @@ class SynapseView:
         if not self._cell._initialized:
             if field not in parameter_names:
                 raise KeyError(f"Synapse field {field!r} is unavailable before init_state().")
-            return _stack_synapse_values(
-                [self._store.parameter_value(int(index), field) for index in self._logical_ids.tolist()],
-                parameter=field,
-            )
+            return self._store.parameter_column(self._logical_ids, field)
 
         layout_id = self._store.layout_id(synapse_type)
         node = self._cell.runtime.get_runtime_node(layout_id)
@@ -728,10 +775,16 @@ def _select_declared_parameter_value(value, *, logical_id: int, store: _SynapseS
     return u.Quantity(selected, value.unit) if isinstance(value, u.Quantity) else selected
 
 
-def _take_vector_item(value, index: int):
+def _take_vector_items(value, indices):
+    """Index into one stored parameter column, keeping its unit.
+
+    ``indices`` may be a scalar row or an array of rows; the result follows
+    numpy indexing, so a scalar index yields a scalar and a row vector yields a
+    vector.
+    """
     if isinstance(value, u.Quantity):
-        return u.Quantity(np.asarray(value.to_decimal(value.unit))[index], value.unit)
-    return np.asarray(value)[index]
+        return u.Quantity(np.asarray(value.to_decimal(value.unit))[indices], value.unit)
+    return np.asarray(value)[indices]
 
 
 def _set_vector_items(value, indices: np.ndarray, selected):

--- a/docs/specs/2026-09-02-compute-simplification.md
+++ b/docs/specs/2026-09-02-compute-simplification.md
@@ -1,0 +1,559 @@
+# `braincell._compute` simplification
+
+Iteration 8 of the module-by-module simplification sweep. Target:
+`braincell/_compute/` — the private lowering layer that turns a `Cell`'s
+CV/node-tree declarations into the runtime structures the solver executes
+against. 4444 production lines across 8 modules, 4247 lines of co-located
+tests.
+
+This is the largest package the sweep has touched. It is also the one where
+the reviews turned up **three real defects** rather than only untidiness, so
+the iteration leads with those.
+
+## Baseline
+
+```
+$ pytest braincell/_compute -q
+152 passed
+```
+
+| module | production lines |
+|---|---|
+| `bindings.py` | 1188 |
+| `layouts.py` | 1037 |
+| `state.py` | 757 |
+| `ions.py` | 516 |
+| `bridge.py` | 364 |
+| `scheduling.py` | 229 |
+| `table.py` | 220 |
+| `__init__.py` | 33 |
+
+## Defects
+
+### 1. The `"no"` ion family is never auto-seeded, so `Kv1p5_MA2020_GrC` cannot be painted
+
+`ions.py:107` seeds placeholder ions for three families:
+
+```python
+    for family_key in ("na", "k", "ca"):
+```
+
+while the function it calls to build them supplies four:
+
+```
+$ python -c "... build_placeholder_ions(size=(3,)).keys()"
+placeholder families: ['ca', 'k', 'na', 'no']
+```
+
+So `_build_default_ions` constructs the `NonSpecific` placeholder and the loop
+throws it away. Any channel that declares a `NonSpecific` owner then fails to
+bind, because `_resolve_ion_instance_key` (`bindings.py:920-922`) finds no
+candidate for family `"no"`. Reproduced on a two-branch cell with nothing but
+the channel painted on it:
+
+```
+Kv1p5_MA2020_GrC       KeyError: "No ion candidates are registered for family 'no'."
+Na_HH1952              OK   ions=['ca', 'k', 'na']
+K_HH1952               OK   ions=['ca', 'k', 'na']
+leaky                  OK   ions=['ca', 'k', 'na']
+```
+
+**Blast radius: one shipped channel.** A sweep of all 112 registered channel
+classes for a `NonSpecific` entry in `root_type.__args__` or in
+`current_owner_types` returns exactly `['Kv1p5_MA2020_GrC']`. The workaround —
+hand-painting `mech.Ion("NonSpecificFixed", name="no")` — is what
+`bindings_test.py:365-400` does, which is why no test catches this.
+
+The family set is stated in **four** places across two modules with **two
+different memberships** (`ions.py:107`, `ions.py:154`, `ions.py:214-223`,
+`bindings.py:984-991`), and `braincell.ion.build_placeholder_ions` is a fifth.
+Only the `ions.py:107` copy is wrong, and nothing forces the five to agree.
+
+### 2. `SineClamp` ignores the per-point delay
+
+`layouts.py:961`, inside the per-point loop of `_evaluate_clamp_layout`:
+
+```python
+        if layout.kind == "SineClamp":
+            local_t = (t - _scalar_state_value(runtime, layout_id=layout.id, var_name="delay")).in_unit(u.ms)
+```
+
+`local_index=local_index` is missing, so `_scalar_state_value` falls back to
+its `local_index: int = 0` default and every point in the layout uses point
+0's delay. The `CurrentClamp` branch eleven lines above passes it, and so does
+every other `_scalar_state_value` call inside `_eval_sine_clamp` itself
+(`duration`, `amplitude`, `offset`, `frequency`, `phase`) — this is an omitted
+argument, not a design choice.
+
+Reproduced with two identical clamps on one branch, merged into one layout,
+per-point delays of `[0, 5] ms`, evaluated at `t = 1 ms`:
+
+```
+sine     n_active=2  delay=[0,5]ms  I(t=1ms) = [0.2, 0.2]     <- point 1 should be off
+current  n_active=2  delay=[0,5]ms  I(t=1ms) = [0.2, 0.0]     <- correct
+```
+
+`layouts_test.py:302` `test_sine_clamp_uses_delay_window` uses a single point,
+where index 0 is the only index, so it passes either way.
+
+### 3. The two runtime channel wrappers have complementary gaps
+
+`bindings.py` defines `_BoundIonChannelRuntime` (32 lines) and
+`_BoundIonChannelCurrentComponentRuntime` (207 lines). The second is the first
+with `component_key` set and an `owns_state` gate; six of its lifecycle
+methods are byte-identical to the first's modulo the forwarded name. The
+divergence has produced exactly the defect that duplication invites — each
+class forwards a method the other does not:
+
+```
+  ind_update           W1=own        W2=inherited
+  update               W1=inherited  W2=own
+```
+
+- **`ind_update` is missing from the component wrapper.** `_base_ion.py:399`
+  and `:587` call `node.ind_update(V, ...)` on every child. The component
+  wrapper inherits `IonChannel.ind_update` (`_base_channel.py:247-249`), which
+  tests `isinstance(self, IndependentIntegration)` on **the wrapper** — never
+  true — so sub-solver integration silently no-ops for a multi-owner channel,
+  bypassing the `owns_state` gate entirely.
+- **`update` on the component wrapper is dead.** `IonChannel` defines no
+  `update`, so it overrides nothing, and the only `.update(` call on a channel
+  anywhere in the repository is line `bindings.py:447` — inside this method's
+  own body. 19 lines.
+
+**This one is latent.** The only multi-owner channel is `Kv1p5_MA2020_GrC`,
+and it is not an `IndependentIntegration`, so no shipped model reaches the
+`ind_update` gap today. It is fixed here because merging the two classes is
+the change that removes the opportunity for the next such divergence — and
+because `Kv1p5_MA2020_GrC` is the same channel defect 1 makes unusable.
+
+## Measured performance findings
+
+Every number below was produced by the efficiency review against real cells at
+several sizes. Findings that measurement **killed** are listed under
+"Considered and declined" rather than quietly dropped.
+
+### 4. `bridge.py:76` — `u.math.asarray` on a Python list of scalars
+
+`quantity_vector` stacks per-CV scalars with `u.math.asarray(decimals)`, which
+routes to `jnp.asarray` on a list of Python floats. It is the entire cost of
+`attach_runtime_ion_geometry` (6 geometry attributes) and `cv_value_vector`.
+
+```
+n_cv=1208, 6 geometry attrs
+  u.math.asarray(list-of-scalars)   [current]             89.62 ms
+  np.asarray(list-of-scalars)                              0.12 ms      <-- 750x
+```
+
+End to end, with values asserted identical:
+
+| n_cv | init current | with `np.asarray` | gain |
+|---|---|---|---|
+| 168 | 92.7 ms | 80.4 ms | 13.3% |
+| 488 | 254.1 ms | 211.3 ms | 16.9% |
+| 1208 | 593.6 ms | 513.5 ms | 13.5% |
+| 3208 | 1792.8 ms | 1491.2 ms | 16.8% |
+
+A flat 13-17% of total `Cell.init_state()` wall clock at every size — a
+constant-factor fix, not a scaling one. `to_decimal` returns Python floats, so
+`np.asarray` would default to float64 and make `scatter_midpoint_values` emit
+an x64-truncation warning; the dtype is pinned explicitly.
+
+### 5. `state.py:343-350` — synapse parameters unstacked one scalar at a time, then restacked
+
+```python
+values = [synapse_store.parameter_value(int(logical_id), var_name) for logical_id in ...]
+buffer = _stack_synapse_values(values, parameter=var_name)
+```
+
+`parameter_value` → `_take_vector_item` (`_multi_compartment/synapses.py:731`)
+does `np.asarray(value.to_decimal(value.unit))[index]` — converting the
+**entire** N-element column to an array to take one element, N times. The
+column being torn apart was already built as a rectangular `u.Quantity` by
+`_build_parameter_columns`, using the same `_stack_synapse_values`.
+
+| N synapses | `init_state` | this block | share | vectorised |
+|---|---|---|---|---|
+| 200 | 112.9 ms | 3.94 ms | 3.5% | 0.020 ms |
+| 1000 | 172.9 ms | 20.63 ms | 11.9% | 0.016 ms |
+| 2000 | 253.3 ms | 40.36 ms | 15.9% | 0.016 ms |
+| 4000 | 393.8 ms | 83.01 ms | 21.1% | 0.020 ms |
+
+This is the scaling finding of the iteration: 3.5% at n=200 to 21.1% at
+n=4000, against a constant-time column gather.
+
+### 6. `layouts.py:944-967` — per-point Python loop over clamp evaluation
+
+`_evaluate_clamp_layout` loops over `n_active` and slices row `local_index`
+out of the already-padded 2-D buffers, staging a separate cumsum/where/sum per
+point. On the **traced** path, so XLA's CSE removes the duplication and there
+is no runtime cost — the entire cost is trace and compile latency:
+
+| n_clamp | eqs now | eqs vectorised | trace now | trace vec | compile now | compile vec | runtime now | runtime vec |
+|---|---|---|---|---|---|---|---|---|
+| 1 | 19 | 18 | 2.0 ms | 4.2 ms | 29.7 ms | 30.4 ms | 9.8 us | 9.7 us |
+| 32 | 422 | 18 | 24.8 ms | 4.1 ms | 62.4 ms | 31.1 ms | 10.8 us | 10.6 us |
+| 128 | 1670 | 18 | 104.3 ms | 4.3 ms | 172.0 ms | 32.3 ms | 10.4 us | 10.2 us |
+| 512 | 6662 | 18 | 409.8 ms | 4.3 ms | 709.9 ms | 30.7 ms | 11.5 us | 10.9 us |
+
+User-visible as first-call latency: `cell.run(...)` goes 0.59 s with one clamp
+to 0.97 s with 128 identical clamps; the second call is 2 ms in both cases.
+**No runtime gain is claimed** — the runtime columns above are flat.
+
+Vectorising is also the structural fix for defect 2: gathering `delay` for the
+selected indices as a vector removes the site where a scalar default could be
+silently taken.
+
+### 7. `state.py:441` / `layouts.py:267` — `u.cm**2` rebuilt per CV, and CV area walked twice
+
+```python
+cv_area_decimal = np.asarray([float(np.asarray(cv.area.to_decimal(u.cm**2), ...)) for cv in cell.cvs], ...)
+```
+
+`u.cm**2` costs 13.4 us to construct and is rebuilt once per CV:
+
+```
+n_cv = 3208
+  current: [float(np.asarray(cv.area.to_decimal(u.cm**2)))...]    51.51 ms
+  hoisted unit constant                                           10.51 ms      <-- 4.9x
+```
+
+Separately, `from_cell` walks `cv.area` twice on a clamped cell —
+`build_clamp_routing_table` (`state.py:434`) and then `cv_area`
+(`state.py:441`) — and `ClampRoutingTable.midpoint_area` is exactly
+`runtime.point_area[midpoint_ids]` (verified equal on a real cell). The second
+pass is 0.7% of `init_state` at n_cv=168 and 2.4% at n_cv=3208.
+
+### 8. `ions.py:238` — `inspect.signature` re-run per call
+
+`_supported_ion_runtime_params(cls)` runs `inspect.signature(cls.__init__)`
+every call, including from `_sync_runtime_ion` — i.e. on **every `set_state`
+write to an ion parameter**.
+
+```
+_supported_ion_runtime_params:  22.45 us/call    lru_cached: 0.128 us/call     <-- 175x
+```
+
+Honest sizing: 14% of a small-cell `set_state`, 1.2% of a large-cell one, and
+~0.03% of `init_state`. Worth a one-line `lru_cache` for parameter-sweep
+loops; not an `init_state` win.
+
+## Duplication and dead code
+
+### 9. The ion species ladder is written twice, and both copies re-derive a declared attribute
+
+`ions.py:214-223` (`_runtime_ion_species_key`) and `bindings.py:983-994`
+(inside `_root_type_to_family`) are the same four-way `issubclass` chain over
+`Sodium`/`Potassium`/`Calcium`/`NonSpecific`, differing only in whether an
+unknown class raises or returns `None`. Both reproduce a value
+`braincell.ion` already declares as data — `Sodium.ion_symbol = 'Na'`,
+`Potassium = 'K'`, `Calcium = 'Ca'`, `NonSpecific = "no"`. Verified:
+
+```
+23 ion classes: ion_symbol vs species_key mismatches=0, vs family=0
+129 channel root types: ion_symbol vs _root_type_to_family mismatches=0
+```
+
+The 129-root-type check includes the non-ion root types, where
+`getattr(rt, "ion_symbol", None)` and `_root_type_to_family` both yield
+`None` — so the attribute lookup also subsumes the `try/except TypeError`
+guard at `bindings.py:992-993`.
+
+`ion_symbol` is currently **dead**: a repo-wide grep finds 4 definitions, 4
+docstring entries, and one consumer, an assertion in `nonspecific_test.py:36`.
+Routing both functions through it makes the declaration live and collapses
+five statements of the family set to one.
+
+### 10. `_runtime_ion_family` is dead
+
+`ions.py:226-235` — a second four-way `issubclass` ladder, over
+`KineticIon`/`DynamicNernstIon`/`InitNernstIon`/`FixedIon`. Its single call
+site (`ions.py:151`) stores the result as `record["family"]` (`:162`), and a
+grep for `["family"]` across `braincell/` finds that write and **no read
+anywhere**. 12 lines.
+
+### 11. Two blocks of unreachable code
+
+- `layouts.py:854-857` — a 4-line `raise TypeError` after the unconditional
+  `return` at `:852`. The intended non-Quantity rejection never fires; such a
+  value falls through to `np.asarray(..., dtype=np.float64)` at `:847` and
+  raises a numpy error with no layout id in the message.
+- `ions.py:173-177` — `elif _runtime_ion_species_key(record["runtime_cls"]) != species_key:`
+  is reached only after `:168` established `record["runtime_cls"] is runtime_cls`,
+  and `species_key` was computed from `runtime_cls` by the same pure function
+  at `:150`. It compares a value with itself. 5 lines including an error
+  message that can never be raised.
+
+### 12. Dead declarations and exports
+
+- `bridge.matches_last_dim` (`bridge.py:251`) — grepped across the whole
+  repository including tests, docs and examples: the only two occurrences are
+  its own `def` and its `__all__` entry.
+- `MechanismLayout.source_rule` (`layouts.py:124`) — two hits repo-wide, the
+  declaration and `state.py:318` setting it to `None`. Never read.
+- `NodeScheduling.algorithm` (`scheduling.py:35`) and `.level_start` (`:42`) —
+  zero reads anywhere, including tests. The `algorithm` *parameter* stays;
+  `cell.py:1630` caches on it.
+- `state.py:478-481` passes `dhs_static_source_np=None`, `dhs_static_cache=None`,
+  `axial_operator_np=None`, `axial_operator_cache=None` — all four are already
+  the dataclass defaults at `:157-160`.
+
+### 13. `_compute/_testing.py::_build_tree` duplicates `_discretization`'s fixture
+
+The five body lines of `_build_tree` (`_compute/_testing.py:58-63`) are
+identical to `make_two_branch_morpho` (`_discretization/_testing.py:61-67`);
+only the `def` line and docstring differ. The package already imports the
+canonical one — `scheduling_test.py:24` does
+`from braincell._discretization._testing import make_two_branch_morpho` — so
+`_compute` currently uses both spellings of the same fixture, with four test
+modules on the copy.
+
+### 14. Duck-typed probes with an existing contract
+
+- `ions.py:515` `hasattr(ion, "_update_reversal") and callable(...)`.
+  `_update_reversal` is defined once, on `InitNernstIon` (`ion/_base.py:461`),
+  which `ions.py:62` already imports and already uses in an `issubclass` test
+  at `:230`. Verified equivalent across all 23 registered ion classes, 0
+  mismatches. (The probe genuinely fires — `SodiumFixed` and `CalciumDetailed`
+  lack the method — so this is a spelling change, not a dead branch.)
+- `bindings.py:1085`, `:1095` `getattr(node, "_on_param_updated", None)` plus a
+  `callable` check, over a base class that defines `_on_param_updated` as a
+  no-op method (`_base_channel.py:251`) inherited by both `Channel` and
+  `Synapse`. Ion layouts have already returned at `:1073-1075`, so `node` is
+  always one of those.
+
+Both degrade silently rather than failing: rename `_update_reversal` and
+Nernst reversals stop refreshing after a parameter write, with
+correct-looking output.
+
+## Changes
+
+1. Seed placeholder ions from `build_placeholder_ions`' own key set instead of
+   the hardcoded `("na", "k", "ca")`, so the two cannot drift again. Adds the
+   `"no"` family. Regression test: paint `Kv1p5_MA2020_GrC` alone and assert
+   `init_state()` succeeds.
+2. Vectorise `CurrentClamp` and `SineClamp` evaluation over the selected local
+   indices, which both removes the per-point Python loop and makes the
+   `delay` gather per-point. `FunctionClamp` keeps a loop — it calls a user
+   `fn(t)` per point and cannot be vectorised — and its results are stacked as
+   before. `_quantity_sequence_to_decimal_vector` already accepts either a
+   sequence or a Quantity vector (`layouts.py:980-984`), so the
+   `evaluate_point_clamps` consumer is unchanged. Regression test: two clamps
+   in one layout with different delays.
+3. Merge `_BoundIonChannelRuntime` into
+   `_BoundIonChannelCurrentComponentRuntime` as one class with
+   `component_key: str | None = None` and `owns_state: bool = True`, routing
+   the six lifecycle methods through one helper and forwarding `ind_update`.
+   Delete the dead `update`.
+4. `bridge.quantity_vector`: `np.asarray(decimals, dtype=...)` with the dtype
+   pinned to the default floating type rather than `u.math.asarray`.
+5. `state.py:343-350`: gather the synapse parameter column that
+   `_build_parameter_columns` already built, instead of tearing it apart per
+   row and restacking. The gather is a new `_SynapseStore.parameter_column`
+   accessor — the vector form of `parameter_value` — which also replaces the
+   identical unstack/restack in `SynapseView.get` (`synapses.py:473`).
+6. Hoist the `u.cm**2` constant out of the per-CV comprehension, compute
+   `cv_area`/`point_area` once, and pass the resulting point-area vector into
+   `build_clamp_routing_table` rather than letting it walk `cv.area` a second
+   time. This rests on midpoint nodes reporting their own CV as `roles[0]`,
+   verified exactly (`max|old-new| = 0`) at 2, 6 and 18 CVs and pinned by a
+   regression test.
+7. `functools.lru_cache` on `_supported_ion_runtime_params`.
+8. One `ion_species_key(cls)` helper reading `ion_symbol` and returning `None`
+   for non-ion classes, replacing both `issubclass` ladders; the raising
+   variant wraps it.
+9. Delete: `_runtime_ion_family` and `record["family"]`; the unreachable
+   blocks at `layouts.py:854-857` and `ions.py:173-177`;
+   `bridge.matches_last_dim`; `MechanismLayout.source_rule`;
+   `NodeScheduling.algorithm` and `.level_start`; the four redundant
+   default arguments at `state.py:478-481`.
+10. `_compute/_testing.py` re-exports `make_two_branch_morpho` under the name
+    the four test modules already use, rather than holding a second copy.
+11. Replace the two duck-typed probes with the contracts they stand in for.
+
+## Breaking changes
+
+`braincell._compute` is a private package — `__init__.py` states "This package
+is private. External code should access the same symbols through
+:mod:`braincell` re-exports where appropriate." None of the names below are
+re-exported from `braincell`, so no public API changes. Listed for
+completeness:
+
+1. **`NodeScheduling.algorithm` and `NodeScheduling.level_start` are removed.**
+   Zero readers. The `algorithm` argument to `build_node_scheduling` is
+   unchanged.
+2. **`MechanismLayout.source_rule` is removed.** Only ever written, as `None`.
+3. **`braincell._compute.bridge.matches_last_dim` is removed**, along with its
+   `__all__` entry. No caller anywhere.
+4. **`_BoundIonChannelRuntime` is removed**, merged into
+   `_BoundIonChannelCurrentComponentRuntime`. Both are module-private and
+   instantiated only within `bindings.py`.
+5. **`_runtime_ion_family` is removed**, and the `"family"` key no longer
+   appears in the internal ion instance records.
+6. **`build_clamp_routing_table` takes `point_area_decimal` and `midpoint_ids`
+   instead of `cvs`, `node_tree` and `n_point`.** The only production caller is
+   `CellRuntimeState.from_cell`, which now has both to hand.
+
+No deprecation shims, no aliases, no `warnings.warn` bridges, per the sweep's
+standing rule.
+
+## Considered and declined
+
+**Memoising `mechanism_signature`.** Called once per (CV, mechanism) pair from
+`state.py:212`. Measured: 8000 calls over 1000 objects, 2.87 ms → 2.64 ms;
+with a wide paint, 9760 calls over 20 objects, 2.62 → 2.13 ms — **0.5 ms of a
+554 ms `init_state`, 0.09%**. cProfile's apparent 18.7 ms was ~6x call
+overhead.
+
+**Single-pass `_merged_channel_constructor_params`.** It copies the whole
+`full_shape` buffer once per merged layout, which is the exact antipattern
+`_apply_density_parameter_overrides` documents avoiding at `state.py:723`.
+Measured at 500 merged layouts × 4510 points: 14.93 ms of a 3170 ms
+`init_state` (0.47%), and a single-pass in-place variant measured **14.68 ms —
+no faster**, outputs asserted equal.
+
+**Vectorising the synapse grouping block** (`state.py:252-271`). 4000
+synapses: 1.26 ms → 0.428 ms, **0.2% of `init_state`**. Cosmetic.
+
+**Removing the discarded placeholder ions** from `_build_default_ions`. It
+builds all families and keeps a subset, up to 3 times: 0.17 ms vs 0.06 ms,
+flat in `n_point`. 0.12 ms total. (The *correctness* half of this — the
+discarded `"no"` — is defect 1 and is fixed.)
+
+**The remaining per-`Quantity`-box loops in `ions.py`**
+(`_ion_param_broadcast`'s tuple fallback, `_ion_param_scatter`'s object
+branch). Instrumented across `PotassiumFixed` and `CalciumDetailed` at
+n_point 190 and 1360: 0.05-0.08 ms, flat in `n_point`, and **zero
+tuple-fallback hits**. The module docstring's claim that this path is already
+rectangular holds.
+
+**Closure-capture leaks.** `_compute` contains one `lambda` (a `sorted` key at
+`state.py:279`) and no nested `def` stored on a runtime object; the runtime
+wrappers are already classes copying only the fields they need.
+
+**Deduplicating the broadcast-then-scatter algebra** between
+`ions._ion_param_broadcast`/`_ion_param_scatter` and
+`bindings._initial_merged_channel_param`/`_scatter_active_channel_param`
+(~130 lines, 4 functions, 2 call sites each). The unit split/rewrap and shape
+broadcast halves are the same code twice, but the mask-vs-index
+representations and the `_CONDUCTANCE_PARAM_NAMES` zeroing genuinely differ.
+Merging them well needs the `split_unit` move below, which is a different
+iteration's change; merging them badly produces a function with two modes.
+
+**Decomposing `CellRuntimeState.from_cell`** (327 lines, six separable
+phases). Pure restructuring with no behavioural or performance effect, on the
+single most load-bearing function in the package, in an iteration that already
+changes three defects underneath it. Not mixed into this diff.
+
+## Deferred to later iterations of the sweep
+
+- **`Cell.mech_table` belongs in `table.py`.** The 90-line builder lives at
+  `_multi_compartment/cell.py:2526-2616` while the dataclasses it builds live
+  in `_compute/table.py`, and `MechanismObjectCell` reads only
+  `CellRuntimeState`. The builder re-derives the signature → layout_id index
+  that `from_cell` already computed and discarded, which is the only reason
+  `mechanism_signature` is public. Iteration 11.
+- **`network/recording.py:430-433` re-derives `MechanismLayout.gather_points`**
+  character for character, against the private `population_index` field —
+  under a docstring that says "Callers read the rule from here rather than
+  repeating the branch." Three other callers obey. Iteration 12.
+- **`_multi_compartment/field_resolution.py:465-467` recomputes
+  `runtime.midpoint_mask_np`** (verified equal); `cell.py:1734` already reads
+  the cached one. Iteration 11.
+- **`split_unit` is in the wrong layer.** `field_resolution.py:113-145` names
+  the split-unit/rewrap idiom and has 10 call sites; the same shape appears
+  inline 8 more times inside `_compute` (`bridge.py` ×4, `ions.py` ×2,
+  `bindings.py` ×2). The move is downward, into `bridge.py` or `_misc.py`,
+  for ~18 call sites. Iteration 14.
+- **Reflection over ion `__init__` signatures should be a declared contract.**
+  `ions.py:241`'s hardcoded `excluded` set filters an `inspect.signature` walk,
+  and `braincell/ion/_base.py:136` plus five sites in `calcium.py` carry
+  comments explaining that their constructors are shaped *around* this
+  reflection. A `runtime_params` classattr on the ion base would delete both
+  the exclusion set and the apology comments. Cross-package; iteration 14.
+- **Calcium-specific knowledge in generic ion lowering.** `ions.py:333-346`
+  reaches for `getattr(runtime_ion_instance, "cainull", None)`, an attribute
+  only calcium classes have, and `:254-268` special-cases the literal string
+  `"Ci_initializer"`. The `cainull` branch was instrumented over the full
+  suite and fired **0 times**. A second dynamic-concentration species would
+  get no shaped initializer and fail silently. Iteration 14.
+- **`CLAMP_KINDS` is enumerated four times** (`layouts.py:197`, the dispatch
+  chain at `:947/:959/:963`, the field lists at `:419-424`, and
+  `state.py:359/368`). A fourth clamp that misses the `CLAMP_KINDS` edit
+  compiles, allocates buffers, and contributes exactly zero current with no
+  error. The fix is for the clamp classes in `braincell.mech` to declare their
+  own fields and an `evaluate` method. Cross-package; iteration 14.
+- **`_CONDUCTANCE_PARAM_NAMES`** (`bindings.py:1044`) decides which merged
+  parameters zero-initialize by sniffing for `{"g_max","g","gbar","conductance"}`.
+  A channel whose conductance parameter is named `gkbar` or `pmax` is merged
+  against a broadcast baseline instead of zeros — silently wrong current
+  outside the painted region. The channel class already knows; it should
+  declare it. Iteration 14.
+- **`layouts.py`'s clamp evaluators take `CellRuntimeState` but touch only
+  `runtime.state_buffers`.** Narrowing the parameter would remove
+  `layouts.py:72`'s `TYPE_CHECKING` import and make the module's documented
+  "imports no other `_compute` module" claim true behaviourally as well as
+  syntactically. Partially addressed by change 2; completing it is iteration 14.
+- **`__init__.py:28` lists `bridge` after `state`**, but `state.py:78` imports
+  `bridge`. The true order is `{scheduling, bridge, layouts} → ions →
+  bindings → state → table`. `__init___test.py:105`'s `_LAYER_ORDER` does not
+  cover `bridge`, `table`, or `scheduling`, so nothing catches it. Iteration 14.
+- **`docs/design/interface-map.md:39` is stale** — it lists `vis.point_topology`
+  and `vis.cell_topology` as `_compute` consumers, but `braincell/vis` has no
+  coupling to `_compute` at all. `docs/design/module-dependency-map.md:114-208`
+  matches the measured import graph exactly and is the authority. Iteration 14.
+- **Dense density buffers are O(n_layouts × n_point).** A channel painted
+  per-CV allocates a full point-space buffer per layout even at `n_active == 1`:
+  1000 layouts × 1360 points = 21.76 MB, 170x the active footprint. Changing
+  it means changing the layout contract, not a micro-fix. Architectural.
+
+## Verification
+
+### Tests
+
+Every defect was reproduced by a failing test before its fix, and each
+regression test was then shown to be non-vacuous by reintroducing the defect:
+
+| Defect | Test | Module |
+| --- | --- | --- |
+| 1 (`"no"` never seeded) | `test_nonspecific_placeholder_is_seeded_like_the_other_families`, `test_placeholder_families_match_the_ion_package_exactly` | `ions_test.py` |
+| 2 (`SineClamp` delay) | `test_sine_clamp_reads_the_delay_of_each_point_not_of_point_zero` | `layouts_test.py` |
+| 3 (wrapper gaps) | `test_component_wrappers_forward_ind_update_to_the_wrapped_channel`, `test_component_wrappers_do_not_carry_a_dead_update_method` | `bindings_test.py` |
+| 6 (midpoint area) | `test_clamp_routing_area_matches_the_cv_that_owns_each_midpoint` | `state_test.py` |
+
+The defect-2 test needed a fixture fix of its own: `at(0, 0.25)` and
+`at(0, 0.75)` both resolve to point 1 on the two-branch fixture, so the two
+clamps scatter-added into a single point and the assertion passed for the wrong
+reason. It now places on branches 0 and 1 and asserts
+`len(set(layout.point_index.tolist())) == 2` before testing anything else.
+
+Collected-test count went from 2808 to 2814 — the six tests above, no
+deletions.
+
+### Performance
+
+`init_state` on a 41-branch cell (`n_cv = 328`, `n_point = 370`, 3 channels,
+2 ions, 8 `CurrentClamp` + 8 `SineClamp`), min of 9 runs, baseline extracted
+with `git archive` from the pre-iteration commit:
+
+| synapses | before | after | |
+| --- | --- | --- | --- |
+| 0 | 181.8 ms | 150.7 ms | 1.21x |
+| 400 | 206.9 ms | 168.6 ms | 1.23x |
+| 2000 | 335.8 ms | 235.4 ms | 1.43x |
+
+Marginal cost per 1000 synapses falls from 77 ms to 42 ms — the column gather
+(change 5). The 31 ms saved at zero synapses is the clamp vectorisation, the
+`u.cm**2` hoist with the dropped second CV-area pass, and the `bridge` dtype
+pin.
+
+Separately, the clamp vectorisation cuts the traced clamp program from 6662
+equations to 18, trace time from 410 ms to 4.3 ms, and compile time from
+710 ms to 31 ms at 200 clamped points.
+
+### Suite
+
+```
+$ pytest braincell/ -q
+2799 passed, 15 skipped, 409 warnings, 410 subtests passed in 183.79s (0:03:03)
+```


### PR DESCRIPTION
Iteration 8 of the module-by-module simplification sweep, covering `braincell/_compute`. Spec: `docs/specs/2026-09-02-compute-simplification.md`, written before any code changed and shipping in this PR.

## Defects fixed

Each was reproduced by a failing test before the fix, and each regression test was then shown to be non-vacuous by reintroducing the defect.

**1. The `"no"` ion family was never auto-seeded.** `_build_default_ions` builds placeholders for all four families but the caller kept only `("na", "k", "ca")`, so a shipped mixed-ion channel — `Kv1p5_MA2020_GrC`, whose `root_type` is `JointTypes[Potassium, NonSpecific]` — could not be painted without the user declaring a `NonSpecific` placeholder by hand. Placeholders are now seeded from `build_placeholder_ions`' own key set, so the two lists cannot drift again, and a second test asserts they match the `braincell.ion` package exactly.

**2. `SineClamp` read the delay of point 0 for every point in its layout.** Two sine clamps in one layout with different delays produced identical waveforms. Clamp evaluation for `CurrentClamp` and `SineClamp` is now vectorised over the selected local indices, which fixes the gather and removes the per-point Python loop at the same time. `FunctionClamp` keeps its loop — it calls a user `fn(t)` per point.

**3. The two runtime bound-channel wrappers had complementary gaps.** Six lifecycle methods were identical modulo the forwarded name, and the copies had drifted: the single-owner class forwarded `ind_update` and not `update`, the component class the reverse. The dead `update` is gone and the two classes are one, routing all six methods through a single helper. This one is latent rather than live — no shipped multi-owner channel currently implements `ind_update` — and the spec says so.

## Performance

`init_state` on a 41-branch cell (`n_cv = 328`, `n_point = 370`, 3 channels, 2 ions, 8 `CurrentClamp` + 8 `SineClamp`), min of 9 runs, against a `git archive` extraction of the pre-iteration commit:

| synapses | before | after | |
| --- | --- | --- | --- |
| 0 | 181.8 ms | 150.7 ms | 1.21x |
| 400 | 206.9 ms | 168.6 ms | 1.23x |
| 2000 | 335.8 ms | 235.4 ms | 1.43x |

Marginal cost per 1000 synapses falls from 77 ms to 42 ms: synapse parameters are now gathered from the column `_build_parameter_columns` already built, instead of being torn apart one scalar at a time (each `parameter_value` call re-materialized the whole column through `to_decimal` to take one element) and restacked. The 31 ms saved at zero synapses is the clamp vectorisation, the `u.cm**2` hoist with the dropped duplicate CV-area pass, and pinning `bridge.quantity_vector`'s dtype.

The clamp vectorisation separately cuts the traced clamp program from 6662 equations to 18 — trace 410 ms to 4.3 ms, compile 710 ms to 31 ms at 200 clamped points.

## Also

- One `ion_species_key` helper reading the declared `ion_symbol` replaces two four-way `issubclass` ladders. Verified equivalent by exhaustive sweep: 23 ion classes and 129 channel root types, 0 mismatches. This also makes `ion_symbol` live — it previously had one consumer, an assertion in a test.
- `functools.lru_cache` on `_supported_ion_runtime_params`, which re-ran `inspect.signature` on every `set_state` write to an ion parameter (22.45 us -> 0.128 us per call).
- Two duck-typed probes replaced by the contracts they stand in for: `hasattr(ion, "_update_reversal")` -> `isinstance(ion, InitNernstIon)` (verified equivalent across all 23 registered ion classes), and `getattr(node, "_on_param_updated", None)` over a base class that defines it as a no-op.
- `_compute/_testing.py::_build_tree` delegates to `make_two_branch_morpho` instead of holding a byte-identical copy — the package was already importing the canonical one in `scheduling_test.py`.

## Breaking changes

`braincell._compute` is a private package and none of these names are re-exported from `braincell`, so there is no public API change. Listed for completeness:

1. **`NodeScheduling.algorithm` and `NodeScheduling.level_start` are removed.** Zero readers anywhere, including tests. The `algorithm` *argument* to `build_node_scheduling` is unchanged.
2. **`MechanismLayout.source_rule` is removed.** Two hits repo-wide: the declaration and one site setting it to `None`.
3. **`braincell._compute.bridge.matches_last_dim` is removed**, with its `__all__` entry. No caller anywhere.
4. **`_BoundIonChannelRuntime` is removed**, merged into `_BoundIonChannelCurrentComponentRuntime`. Both module-private.
5. **`_runtime_ion_family` is removed**, and the `"family"` key no longer appears in the internal ion instance records. Written once, never read.
6. **`build_clamp_routing_table` takes `point_area_decimal` and `midpoint_ids`** instead of `cvs`, `node_tree` and `n_point`. It no longer walks `cv.area` a second time; it slices the point-area vector the runtime has already built. That rests on a CV midpoint reporting its own CV as `roles[0]`, verified exactly (`max|old-new| = 0`) at 2, 6 and 18 CVs and pinned by a new test.
7. Two unreachable blocks are deleted: a `raise TypeError` after an unconditional `return`, and an `elif` comparing a value with itself.

No deprecation shims, no aliases, no `warnings.warn` bridges.

## Declined, with the measurement that killed it

Recorded in full in the spec. Memoising `mechanism_signature` (0.09% of `init_state`); a single-pass merged-param builder (measured *no faster*); vectorising the synapse grouping block (0.2%); removing the discarded placeholder ions (0.12 ms, flat); the remaining per-`Quantity` loops in `ions.py` (0.05-0.08 ms, flat, and zero tuple-fallback hits over the whole suite); and decomposing the 327-line `CellRuntimeState.from_cell`, which is pure restructuring on the most load-bearing function in the package in an iteration that already changes three defects underneath it.

## Verification

```
$ pytest braincell/_compute braincell/_multi_compartment -q
313 passed

$ pytest braincell/ -q
2799 passed, 15 skipped, 409 warnings, 410 subtests passed in 183.79s (0:03:03)
```

Collected tests went from 2808 to 2814 — the six regression tests above, no deletions.

`pre-commit run --files <13 changed files>`: all hooks Passed (`ruff-format` reformatted two files on the first run; clean on rerun).

## Summary by Sourcery

Fix compute-layer lowering defects and streamline runtime initialization, clamp evaluation, ion binding, and internal state management.

Bug Fixes:
- Seed all declared placeholder ion families so nonspecific-ion channels can be initialized without manual ion declarations.
- Correct per-point SineClamp delay handling and vectorize CurrentClamp and SineClamp evaluation across selected points.
- Ensure bound multi-owner channel wrappers consistently forward lifecycle updates without duplicate state integration.

Enhancements:
- Reduce runtime initialization overhead through vectorized synapse parameter gathering, efficient quantity construction, cached ion parameter introspection, and reuse of computed clamp routing data.
- Centralize ion species detection around declared ion metadata and replace duck-typed runtime checks with explicit contracts.
- Remove unused internal fields, helpers, wrapper duplication, unreachable code, and redundant test fixtures.

Documentation:
- Add the compute simplification specification documenting defects, performance findings, scope, and deferred work.

Tests:
- Add regression coverage for nonspecific ion seeding, per-point clamp delays, bound-channel lifecycle forwarding, and clamp routing area correctness.

Chores:
- Remove private compute-layer fields and helper APIs without compatibility shims.