### PR TITLE
refactor(_discretization): fix an id()-keyed cache that misplaced synapses, collapse three duplicated subsystems

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -565,7 +565,7 @@ internal dependencies · status · open work**.
   - `braincell/cv/_policy.py` — `CVPolicy` ABC plus `CVPerBranch`,
     `MaxCVLen`, `DLambda`, `CVPolicyByTypeRule`, `CompositeByTypePolicy`.
   - `braincell/_discretization/topology.py` — `NodeTree`, `Node`, `NodeEdge`,
-    `build_node_tree`, `locate_node_on_branch`.
+    `build_node_tree`.
   - `braincell/_compute/scheduling.py` — `NodeScheduling`,
     `build_node_scheduling` (DHS grouping for vectorized parent
     traversal lives here too).

--- a/braincell/_discretization/base.py
+++ b/braincell/_discretization/base.py
@@ -38,9 +38,10 @@ import brainunit as u
 import numpy as np
 
 from braincell.filter import RegionMask
-from braincell.mech import CVContext, Density, Point
+from braincell.mech import CableProperty, CVContext, Density, Point
 
 if TYPE_CHECKING:
+    from braincell._discretization.geometry import _GeoCV
     from braincell._discretization.mechanism import PaintRule, PlaceRule
     from braincell._discretization.policy import CVPolicy
     from braincell.morph.morphology import Morphology
@@ -54,7 +55,11 @@ __all__ = [
     "CVEdge",
     "CVPointMechanism",
     "CVTree",
+    "DEFAULT_CABLE",
     "Discretization",
+    "EPS_AREA_UM2",
+    "EPS_LEN_UM",
+    "EPS_PARAM",
     "Half",
     "Node",
     "NodeEdge",
@@ -68,7 +73,23 @@ __all__ = [
     "locate_cv_on_branch",
 ]
 
-_EPS_PARAM = 1e-9
+# The comparison tolerances for the whole discretization layer. They live
+# here, in the one module that imports no sibling at module scope, so that
+# every stage compares against the same numbers rather than against four
+# separately declared copies that happen to be equal today.
+EPS_PARAM = 1e-9  # tolerance for a normalized branch coordinate in [0, 1]
+EPS_LEN_UM = 1e-6  # tolerance for a physical length in um
+EPS_AREA_UM2 = 1e-9  # tolerance for a lateral area in um^2
+
+# The package default cable properties, applied by ``default_paint_rules()``
+# and assumed by ``DLambda`` when sizing CVs. One object, because a policy
+# that sizes CVs for one set of electrics while lowering applies another is
+# silently wrong and no test compares the two.
+DEFAULT_CABLE = CableProperty(
+    resting_potential=-65.0 * u.mV,
+    membrane_capacitance=1.0 * (u.uF / u.cm**2),
+    axial_resistivity=100.0 * (u.ohm * u.cm),
+)
 
 
 @dataclass(frozen=True)
@@ -359,13 +380,19 @@ class NodeEdgeRole:
         Source CV id.
     half : {"prox", "dist"}
         Which half of the source CV contributes to the edge.
-    r_axial : brainunit.Quantity
-        Axial resistance carried by that half-edge.
+
+    Notes
+    -----
+    The half-edge's axial resistance is deliberately *not* stored here. It
+    is ``cvs[cv_id].r_axial_prox`` or ``.r_axial_dist`` -- a select on a
+    field the CV already owns -- and the one consumer that needs it
+    (``braincell.quad._staggered``) performs that select itself from the CV
+    tuple. Materializing it per role built a ``Quantity`` per edge on every
+    discretization that nothing ever read.
     """
 
     cv_id: int
     half: Half
-    r_axial: u.Quantity
 
 
 @dataclass(frozen=True)
@@ -404,9 +431,6 @@ class NodeTree:
         Id of the unique root node.
     cv_to_mid_node_id : numpy.ndarray
         ``(n_cv,)`` array mapping each CV id to its midpoint node id.
-    branch_endpoint_node_id : numpy.ndarray
-        ``(n_branch, 2)`` array mapping each branch to its proximal and
-        distal endpoint node ids.
 
     Notes
     -----
@@ -419,7 +443,6 @@ class NodeTree:
     edges: tuple[NodeEdge, ...]
     root_node_id: int
     cv_to_mid_node_id: np.ndarray
-    branch_endpoint_node_id: np.ndarray
 
     def __repr__(self) -> str:
         return f"NodeTree(n_nodes={len(self.nodes)!r}, n_edges={len(self.edges)!r}, root_node_id={self.root_node_id!r})"
@@ -485,24 +508,48 @@ class Discretization:
         """
         return self.node_tree.nodes
 
-    def locate_cv(self, *, branch_id: int, x: float) -> int:
-        """Return the CV that owns one normalized branch location."""
-        ids = self.cv_tree.branch_to_cv_ids[int(branch_id)]
-        return locate_cv_on_branch(
-            ids,
-            self.cvs,
-            x=float(x),
-        )
-
 
 def locate_cv_on_branch(
     ids: tuple[int, ...],
-    cvs: tuple[CV, ...],
+    cvs: "tuple[CV, ...] | tuple[_GeoCV, ...]",
     *,
     x: float,
-    epsilon: float = _EPS_PARAM,
+    epsilon: float = EPS_PARAM,
 ) -> int:
-    """Return the CV owning a normalized coordinate on one branch."""
+    """Return the CV owning a normalized coordinate on one branch.
+
+    Parameters
+    ----------
+    ids : tuple of int
+        Ordered CV ids tiling one branch, indexing into ``cvs``.
+    cvs : tuple of CV or tuple of _GeoCV
+        CV records indexed by CV id. Only ``.prox`` and ``.dist`` are read,
+        so the geometry-stage and finalized records are interchangeable
+        here.
+    x : float
+        Normalized branch coordinate in ``[0, 1]``.
+    epsilon : float, optional
+        Comparison tolerance. The default is ``EPS_PARAM``.
+
+    Returns
+    -------
+    int
+        Owning CV id.
+
+    Raises
+    ------
+    ValueError
+        If ``ids`` is empty, or if ``x`` falls in no CV interval -- which
+        means the caller passed a tiling that :func:`validate_bounds` would
+        have rejected.
+
+    Notes
+    -----
+    The tiling is half-open, so a coordinate landing exactly on an internal
+    CV boundary belongs to the distal CV. The two endpoint guards make
+    ``x = 0`` and ``x = 1`` resolve to the terminal CVs rather than falling
+    off either end of that convention.
+    """
     if not ids:
         raise ValueError("Cannot locate a CV on an empty branch tiling.")
     if x <= 0.0 + epsilon:

--- a/braincell/_discretization/base_test.py
+++ b/braincell/_discretization/base_test.py
@@ -26,7 +26,7 @@ from braincell._discretization._testing import (
     make_branch,
     make_single_branch_morpho,
 )
-from braincell._discretization.base import build_discretization
+from braincell._discretization.base import EPS_PARAM, build_discretization, locate_cv_on_branch
 from braincell._discretization.mechanism import (
     PlaceRule,
     _coverage_fraction,
@@ -55,6 +55,60 @@ def _build_cvs(morpho, *, policy, paint_rules, place_rules):
         paint_rules=paint_rules,
         place_rules=place_rules,
     ).cvs
+
+
+class _FakeCV:
+    """Minimal stand-in exposing the two fields the locator reads."""
+
+    def __init__(self, id_: int, prox: float, dist: float) -> None:
+        self.id = id_
+        self.prox = prox
+        self.dist = dist
+
+
+class LocateCVOnBranchTest(unittest.TestCase):
+    """Cover the single CV locator shared by every stage of the layer.
+
+    These cases previously lived in ``node_build_test.py`` and
+    ``geometry_test.py``, against two more implementations of this
+    function. Both duplicates are gone; the tests moved to the surviving
+    definition's sibling.
+    """
+
+    def _cvs(self, tiles):
+        return tuple(_FakeCV(i, p, d) for i, (p, d) in enumerate(tiles))
+
+    def test_interior_x_lands_in_matching_cv(self) -> None:
+        cvs = self._cvs([(0.0, 0.3), (0.3, 0.7), (0.7, 1.0)])
+        got = locate_cv_on_branch((0, 1, 2), cvs, x=0.5, epsilon=EPS_PARAM)
+        self.assertEqual(got, 1)
+
+    def test_x_near_one_returns_last_cv(self) -> None:
+        cvs = self._cvs([(0.0, 0.3), (0.3, 0.7), (0.7, 1.0)])
+        got = locate_cv_on_branch((0, 1, 2), cvs, x=0.999, epsilon=EPS_PARAM)
+        self.assertEqual(got, 2)
+
+    def test_internal_boundary_belongs_to_the_distal_cv(self) -> None:
+        """The tiling is half-open, so a boundary hit resolves distally."""
+        cvs = self._cvs([(0.0, 0.3), (0.3, 0.7), (0.7, 1.0)])
+        self.assertEqual(locate_cv_on_branch((0, 1, 2), cvs, x=0.3, epsilon=EPS_PARAM), 1)
+        self.assertEqual(locate_cv_on_branch((0, 1, 2), cvs, x=0.7, epsilon=EPS_PARAM), 2)
+
+    def test_x_in_gap_between_tiles_raises(self) -> None:
+        cvs = self._cvs([(0.0, 0.4), (0.6, 1.0)])
+        with self.assertRaises(ValueError) as ctx:
+            locate_cv_on_branch((0, 1), cvs, x=0.5, epsilon=EPS_PARAM)
+        self.assertIn("0.5", str(ctx.exception))
+
+    def test_x_outside_a_partial_tiling_raises_rather_than_snapping(self) -> None:
+        """A branch tiling that does not reach ``x`` is an error, not a clamp."""
+        cvs = self._cvs([(0.2, 0.8)])
+        with self.assertRaises(ValueError):
+            locate_cv_on_branch((0,), cvs, x=0.1, epsilon=EPS_PARAM)
+
+    def test_empty_tiling_raises(self) -> None:
+        with self.assertRaisesRegex(ValueError, "empty branch tiling"):
+            locate_cv_on_branch((), (), x=0.5, epsilon=EPS_PARAM)
 
 
 class CVShapeTest(unittest.TestCase):

--- a/braincell/_discretization/context.py
+++ b/braincell/_discretization/context.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 # ==============================================================================
 
-"""Build public CV spatial contexts from geometry or finalized CV records."""
+"""Build public CV spatial contexts from geometry-stage CV records."""
 
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
 
 import brainunit as u
 
@@ -23,12 +24,15 @@ from braincell.mech import CVContext
 from braincell.morph._spatial import MorphologySpatialGeometry, interpolate_branch
 from braincell.morph.morphology import Morphology
 
+if TYPE_CHECKING:
+    from .geometry import _GeoCV
+
 __all__ = ["build_cv_contexts"]
 
 
 def build_cv_contexts(
     morpho: Morphology,
-    cvs: Sequence[object],
+    cvs: "Sequence[_GeoCV]",
 ) -> tuple[CVContext, ...]:
     """Build one :class:`~braincell.mech.CVContext` per control volume.
 
@@ -36,13 +40,31 @@ def build_cv_contexts(
     ----------
     morpho : Morphology
         Morphology that owns the control volumes.
-    cvs : sequence of object
-        Geometry-stage ``_GeoCV`` records or finalized public ``CV`` records.
+    cvs : sequence of _GeoCV
+        Geometry-stage records in any order, with distinct ids covering
+        ``range(len(cvs))``.
 
     Returns
     -------
     tuple of CVContext
         Contexts ordered by stable control-volume id.
+
+    Raises
+    ------
+    TypeError
+        If ``morpho`` is not a :class:`Morphology`.
+    ValueError
+        If a CV id is out of range or repeated, or if a CV names a branch
+        the morphology does not have.
+
+    Notes
+    -----
+    ``_GeoCV`` is the only accepted input. This function used to also claim
+    to take finalized public ``CV`` records, and paid for the claim with a
+    ``getattr`` shim per quantity that translated between the two field
+    spellings -- but both call sites pass ``CVGeometryResult.geos``, and
+    ``_GeoCV`` declares only the scalar spelling, so the ``CV`` half of that
+    shim was unreachable.
     """
     if not isinstance(morpho, Morphology):
         raise TypeError(f"build_cv_contexts(...) expects Morphology, got {type(morpho).__name__!s}.")
@@ -51,61 +73,41 @@ def build_cv_contexts(
 
     n_branches = len(morpho.branches)
     geometry = MorphologySpatialGeometry.build(morpho)
+    um2 = u.um**2
 
     contexts: list[CVContext | None] = [None] * len(cvs)
     for source in cvs:
-        cv_id = int(getattr(source, "id"))
+        cv_id = int(source.id)
         if not 0 <= cv_id < len(contexts):
             raise ValueError(f"CV id {cv_id!r} is outside [0, {len(contexts)!r}).")
         if contexts[cv_id] is not None:
             raise ValueError(f"Duplicate CV id {cv_id!r}.")
 
-        branch_id = int(getattr(source, "branch_id"))
+        branch_id = int(source.branch_id)
         if not 0 <= branch_id < n_branches:
             raise ValueError(f"CV {cv_id!r} has invalid branch id {branch_id!r}.")
-        midpoint = float(
-            getattr(
-                source,
-                "midpoint",
-                0.5 * (float(getattr(source, "prox")) + float(getattr(source, "dist"))),
-            )
-        )
-        branch_type = str(getattr(source, "branch_type"))
 
-        radius_mid = _source_quantity(source, "radius_mid", "r_mid_um", u.um)
+        midpoint = source.midpoint
         _, local_position = interpolate_branch(morpho, branch_id, midpoint)
         contexts[cv_id] = CVContext(
             cv_id=cv_id,
             branch_id=branch_id,
             branch_name=str(morpho.branch(index=branch_id).name),
-            branch_type=branch_type,
-            prox=float(getattr(source, "prox")),
-            dist=float(getattr(source, "dist")),
+            branch_type=str(source.branch_type),
+            prox=float(source.prox),
+            dist=float(source.dist),
             midpoint=midpoint,
-            length=_source_quantity(source, "length", "length_um", u.um),
-            area=_source_quantity(source, "area", "lateral_area_um2", u.um**2),
-            radius_prox=_source_quantity(source, "radius_prox", "r_prox_um", u.um),
-            radius_mid=radius_mid,
-            radius_dist=_source_quantity(source, "radius_dist", "r_dist_um", u.um),
-            diam_arc_mean=_source_quantity(
-                source,
-                "diam_arc_mean",
-                "diam_arc_mean_um",
-                u.um,
-            ),
+            length=u.Quantity(float(source.length_um), u.um),
+            area=u.Quantity(float(source.lateral_area_um2), um2),
+            radius_prox=u.Quantity(float(source.r_prox_um), u.um),
+            radius_mid=u.Quantity(float(source.r_mid_um), u.um),
+            radius_dist=u.Quantity(float(source.r_dist_um), u.um),
+            diam_arc_mean=u.Quantity(float(source.diam_arc_mean_um), u.um),
             path_distance_to_root=geometry.path_distance_to_root(branch_id, midpoint),
             path_distance_from_soma=geometry.path_distance_from_soma(branch_id, midpoint),
             _local_position=local_position,
         )
 
-    if any(context is None for context in contexts):
-        missing = [index for index, context in enumerate(contexts) if context is None]
-        raise ValueError(f"Missing CV context records for ids {missing!r}.")
+    # Every iteration either raised or wrote a distinct in-range index, so
+    # ``len(cvs)`` distinct indices into ``len(cvs)`` slots leave none empty.
     return tuple(context for context in contexts if context is not None)
-
-
-def _source_quantity(source: object, quantity_name: str, scalar_name: str, unit):
-    value = getattr(source, quantity_name, None)
-    if value is not None:
-        return u.Quantity(float(value.to_decimal(unit)), unit)
-    return u.Quantity(float(getattr(source, scalar_name)), unit)

--- a/braincell/_discretization/geometry.py
+++ b/braincell/_discretization/geometry.py
@@ -21,29 +21,18 @@ time data: they carry geometric and topological facts, but no runtime
 state or instantiated mechanism objects.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 import brainunit as u
 import numpy as np
 
-from braincell.morph.branch import Branch
+from braincell.morph.branch import Branch, frustum_areas_um2, length_weighted_mean_radius_um
 from braincell.morph.morphology import Morphology
-
-EPS_PARAM = 1e-9
-EPS_LEN_UM = 1e-6
-EPS_AREA_UM2 = 1e-9
+from .base import EPS_LEN_UM, EPS_PARAM, locate_cv_on_branch
 
 __all__ = [
     "CVGeometryResult",
-    "EPS_AREA_UM2",
-    "EPS_LEN_UM",
-    "EPS_PARAM",
-    "_Frustum",
-    "_GeoCV",
-    "_build_frusta",
-    "_lateral_area_um2",
     "build_cv_geometry",
-    "locate_cv_on_branch",
     "validate_bounds",
     "validate_connectivity",
     "validate_morphology",
@@ -99,8 +88,6 @@ class _GeoCV:
         Proximal normalized branch coordinate.
     dist : float
         Distal normalized branch coordinate.
-    midpoint : float
-        Midpoint coordinate in normalized branch coordinates.
     parent_cv : int or None
         Parent CV id, or ``None`` for the root CV.
     children_cv : tuple of int
@@ -130,7 +117,6 @@ class _GeoCV:
     branch_type: str
     prox: float
     dist: float
-    midpoint: float
     parent_cv: int | None
     children_cv: tuple[int, ...]
     length_um: float
@@ -142,6 +128,16 @@ class _GeoCV:
     r_mid_um: float
     diam_arc_mean_um: float
     r_dist_um: float
+
+    @property
+    def midpoint(self) -> float:
+        """Midpoint coordinate in normalized branch coordinates.
+
+        Derived rather than stored: it is the arithmetic mean of the CV
+        bounds by construction, so a stored copy is one more field to
+        hand-copy on every rebuild and one more chance to drift.
+        """
+        return 0.5 * (self.prox + self.dist)
 
 
 @dataclass(frozen=True)
@@ -327,13 +323,40 @@ def _boundary_radii_um(frusta: tuple[_Frustum, ...]) -> tuple[float, float]:
     return frusta[0].r_prox_um, frusta[-1].r_dist_um
 
 
+def _frustum_arrays(frusta: tuple[_Frustum, ...]) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Unpack frusta into the ``(lengths, r0, r1)`` arrays ``morph.branch`` takes.
+
+    Parameters
+    ----------
+    frusta : tuple of _Frustum
+        Clipped geometry slices, in proximal-to-distal order.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        Lengths, proximal radii and distal radii in micrometres.
+    """
+    count = len(frusta)
+    return (
+        np.fromiter((piece.length_um for piece in frusta), dtype=float, count=count),
+        np.fromiter((piece.r_prox_um for piece in frusta), dtype=float, count=count),
+        np.fromiter((piece.r_dist_um for piece in frusta), dtype=float, count=count),
+    )
+
+
 def _lateral_area_um2(frusta: tuple[_Frustum, ...]) -> float:
-    total = 0.0
-    pi = float(np.pi)
-    for piece in frusta:
-        slant = float(np.sqrt(piece.length_um**2 + (piece.r_dist_um - piece.r_prox_um) ** 2))
-        total += pi * (piece.r_prox_um + piece.r_dist_um) * slant
-    return total
+    """Return the total lateral membrane area of ``frusta`` in um^2.
+
+    Notes
+    -----
+    The frustum formula itself lives in :mod:`braincell.morph.branch`, which
+    declares itself the single definition of this geometry -- that is what
+    makes ``Morphology.total_area == sum(b.branch.area)`` a consequence
+    rather than a coincidence. A CV's area decides every conductance on it,
+    so a second hand-written copy here would let the discretization and the
+    morphology disagree about the same surface without any test noticing.
+    """
+    return float(np.sum(frustum_areas_um2(*_frustum_arrays(frusta))))
 
 
 def _axial_factor_per_cm(frusta: tuple[_Frustum, ...]) -> float:
@@ -369,14 +392,19 @@ def _midpoint_radius_um(frusta: tuple[_Frustum, ...]) -> float:
 
 
 def _arc_weighted_mean_diam_um(frusta: tuple[_Frustum, ...]) -> float:
-    """Return the arc-length-weighted mean diameter across ``frusta``."""
+    """Return the arc-length-weighted mean diameter across ``frusta``.
+
+    Notes
+    -----
+    This is exactly twice ``morph.branch.length_weighted_mean_radius_um``,
+    which is the shared definition of the same weighting. A CV whose frusta
+    sum to no measurable length has no arc to weight by, so it falls back to
+    its end radii rather than dividing by zero.
+    """
     total_length_um = sum(piece.length_um for piece in frusta)
     if total_length_um <= EPS_LEN_UM:
         return frusta[0].r_prox_um + frusta[-1].r_dist_um
-    weighted = 0.0
-    for piece in frusta:
-        weighted += (piece.r_prox_um + piece.r_dist_um) * piece.length_um
-    return weighted / total_length_um
+    return 2.0 * length_weighted_mean_radius_um(*_frustum_arrays(frusta))
 
 
 def _split_frusta(
@@ -567,50 +595,6 @@ def validate_connectivity(
         visited.update(path)
 
 
-def locate_cv_on_branch(
-    ids: tuple[int, ...],
-    geos: list[_GeoCV] | tuple[_GeoCV, ...],
-    *,
-    x: float,
-) -> int:
-    """Return the CV id that owns one branch coordinate.
-
-    Parameters
-    ----------
-    ids : tuple of int
-        Ordered CV ids on one branch.
-    geos : sequence of _GeoCV
-        Geometry records indexed by CV id.
-    x : float
-        Normalized branch coordinate.
-
-    Returns
-    -------
-    int
-        Owning CV id.
-
-    Raises
-    ------
-    ValueError
-        If ``x`` falls in no CV interval.
-    """
-    if x <= 0.0 + EPS_PARAM:
-        return ids[0]
-    if x >= 1.0 - EPS_PARAM:
-        return ids[-1]
-    for cv_id in ids:
-        geo = geos[cv_id]
-        if geo.prox - EPS_PARAM <= x < geo.dist - EPS_PARAM:
-            return cv_id
-    for cv_id in ids:
-        geo = geos[cv_id]
-        if abs(x - geo.dist) <= EPS_PARAM:
-            return cv_id
-    raise ValueError(
-        f"x={x!r} not owned by any CV in branch; bounds are {[(geos[i].prox, geos[i].dist) for i in ids]!r}."
-    )
-
-
 def build_cv_geometry(
     morpho: Morphology,
     bounds_by_branch: tuple[tuple[tuple[float, float], ...], ...],
@@ -670,7 +654,6 @@ def build_cv_geometry(
                     branch_type=branch.type,
                     prox=prox_f,
                     dist=dist_f,
-                    midpoint=midpoint,
                     parent_cv=None,
                     children_cv=(),
                     length_um=length_um,
@@ -707,27 +690,12 @@ def build_cv_geometry(
         if child_cv not in children_by_cv[parent_cv]:
             children_by_cv[parent_cv].append(child_cv)
 
+    # Only the two tree-linkage fields are known at this point; every other
+    # field was final when the record was built. ``replace`` names just those
+    # two, so a field added to ``_GeoCV`` later cannot be silently dropped
+    # here the way a hand-written 17-field rebuild would drop it.
     finalized = tuple(
-        _GeoCV(
-            id=geo.id,
-            branch_id=geo.branch_id,
-            branch_type=geo.branch_type,
-            prox=geo.prox,
-            dist=geo.dist,
-            midpoint=geo.midpoint,
-            parent_cv=parent_by_cv[geo.id],
-            children_cv=tuple(children_by_cv[geo.id]),
-            length_um=geo.length_um,
-            lateral_area_um2=geo.lateral_area_um2,
-            axial_factor_total_per_cm=geo.axial_factor_total_per_cm,
-            axial_factor_prox_per_cm=geo.axial_factor_prox_per_cm,
-            axial_factor_dist_per_cm=geo.axial_factor_dist_per_cm,
-            r_prox_um=geo.r_prox_um,
-            r_mid_um=geo.r_mid_um,
-            diam_arc_mean_um=geo.diam_arc_mean_um,
-            r_dist_um=geo.r_dist_um,
-        )
-        for geo in geos
+        replace(geo, parent_cv=parent_by_cv[geo.id], children_cv=tuple(children_by_cv[geo.id])) for geo in geos
     )
     validate_connectivity(finalized, branch_to_cv_ids, morpho)
     return CVGeometryResult(

--- a/braincell/_discretization/geometry_test.py
+++ b/braincell/_discretization/geometry_test.py
@@ -27,14 +27,12 @@ from braincell._discretization._testing import (
 )
 from braincell._discretization.geometry import (
     _Frustum,
-    _GeoCV,
     _axial_factor_per_cm,
     _boundary_radii_um,
     _build_frusta,
     _lateral_area_um2,
     _midpoint_radius_um,
     _split_frusta,
-    locate_cv_on_branch as _locate_cv_on_branch,
     validate_bounds as _validate_bounds,
     validate_connectivity as _validate_connectivity,
     validate_morphology as _validate_morpho,
@@ -284,32 +282,6 @@ class BuildGeoTest(unittest.TestCase):
         self.assertEqual(len(geos), 3)
         self.assertEqual(geos[2].parent_cv, 1)
         self.assertIn(2, geos[1].children_cv)
-
-
-class LocateCVOnBranchTest(unittest.TestCase):
-    def test_raises_on_bad_bounds(self) -> None:
-        g = _GeoCV(
-            id=0,
-            branch_id=0,
-            branch_type="soma",
-            prox=0.2,
-            dist=0.8,
-            midpoint=0.5,
-            parent_cv=None,
-            children_cv=(),
-            length_um=6.0,
-            lateral_area_um2=1.0,
-            axial_factor_total_per_cm=1.0,
-            axial_factor_prox_per_cm=0.5,
-            axial_factor_dist_per_cm=0.5,
-            r_prox_um=1.0,
-            r_mid_um=1.0,
-            diam_arc_mean_um=2.0,
-            r_dist_um=1.0,
-        )
-        # x=0.9 and x=0.1 are out of [0.2, 0.8] — raise, not snap.
-        with self.assertRaises(ValueError):
-            _locate_cv_on_branch((0,), (g,), x=0.1)
 
 
 # =============================================================================

--- a/braincell/_discretization/mechanism.py
+++ b/braincell/_discretization/mechanism.py
@@ -41,12 +41,10 @@ from braincell.mech import (
     StateProbe,
 )
 from braincell.morph.morphology import Morphology
-from .base import CVPointMechanism, Position
+from .base import DEFAULT_CABLE, EPS_AREA_UM2, EPS_PARAM, CVPointMechanism, Position
 from .context import build_cv_contexts
 from .geometry import (
     CVGeometryResult,
-    EPS_AREA_UM2,
-    EPS_PARAM,
     _GeoCV,
     _build_frusta,
     _lateral_area_um2,
@@ -62,12 +60,6 @@ __all__ = [
     "normalize_paint_rules",
     "normalize_place_rule",
 ]
-
-_DEFAULT_CABLE = CableProperty(
-    resting_potential=-65.0 * u.mV,
-    membrane_capacitance=1.0 * (u.uF / u.cm**2),
-    axial_resistivity=100.0 * (u.ohm * u.cm),
-)
 
 
 @dataclass(frozen=True)
@@ -124,40 +116,59 @@ class _RegionCVCoverage:
 
 
 class _RegionCache:
-    """Per-build cache of region / locset evaluation outputs."""
+    """Per-build cache of region / locset evaluation outputs.
+
+    Notes
+    -----
+    Entries are keyed by expression *value*, which is both a correctness
+    requirement and a hit-rate win over keying on ``id()``.
+
+    An ``id`` is unique only among *live* objects, and neither the mask
+    dicts nor the callers retain the expression they were keyed on.
+    :func:`build_cv_mechanisms` resolves an aligned :class:`LocsetBatch` by
+    indexing it inside a generator expression, so every member is a
+    temporary that dies the moment :meth:`points` returns; CPython then
+    hands the next member the freed address and an ``id`` cache replays the
+    previous member's locations onto it.
+
+    In the other direction, two ``AllRegion()`` instances from two separate
+    ``cell.paint(...)`` calls compare equal but never share an ``id``, so an
+    ``id`` cache re-walks the whole morphology once per paint rule.
+
+    Both stores are :class:`~braincell.filter.SelectionCache` instances so
+    that this memoization -- including the fall-through for expressions
+    carrying an unhashable payload -- is the one implementation the filter
+    package already owns. They are separate from ``_selection`` because they
+    hold different values for the same keys: ``_selection`` maps an
+    expression to its mask, these map it to what lowering derives from it.
+    """
 
     def __init__(self, morpho: Morphology) -> None:
         self._morpho = morpho
         self._selection = SelectionCache()
-        self._region_by_id: dict[int, dict[int, tuple[tuple[float, float], ...]]] = {}
-        self._locset_by_id: dict[int, tuple[tuple[int, float, str], ...]] = {}
+        self._intervals = SelectionCache()
+        self._points = SelectionCache()
 
     def intervals(self, region: RegionExpr) -> dict[int, tuple[tuple[float, float], ...]]:
-        key = id(region)
-        cached = self._region_by_id.get(key)
-        if cached is not None:
-            return cached
+        return self._intervals.evaluated(region, self._morpho, lambda: self._compute_intervals(region))
+
+    def _compute_intervals(self, region: RegionExpr) -> dict[int, tuple[tuple[float, float], ...]]:
         mask = region.evaluate(self._morpho, cache=self._selection)
         grouped: dict[int, list[tuple[float, float]]] = {}
         for branch_id, prox, dist in mask.intervals:
             grouped.setdefault(int(branch_id), []).append((float(prox), float(dist)))
-        result = {bid: tuple(ranges) for bid, ranges in grouped.items()}
-        self._region_by_id[key] = result
-        return result
+        return {bid: tuple(ranges) for bid, ranges in grouped.items()}
 
     def points(self, locset: LocsetExpr | LocsetMask) -> tuple[tuple[int, float, str], ...]:
-        key = id(locset)
-        cached = self._locset_by_id.get(key)
-        if cached is not None:
-            return cached
+        return self._points.evaluated(locset, self._morpho, lambda: self._compute_points(locset))
+
+    def _compute_points(self, locset: LocsetExpr | LocsetMask) -> tuple[tuple[int, float, str], ...]:
         mask = locset.evaluate(self._morpho, cache=self._selection) if isinstance(locset, LocsetExpr) else locset
         names = mask.resolved_display_names(self._morpho)
-        result = tuple(
+        return tuple(
             (int(branch_id), float(branch_x), str(name))
             for branch_id, branch_x, name in zip(mask.branch_id, mask.branch_x, names)
         )
-        self._locset_by_id[key] = result
-        return result
 
 
 def default_paint_rules() -> tuple[PaintRule, ...]:
@@ -169,7 +180,7 @@ def default_paint_rules() -> tuple[PaintRule, ...]:
         One global rule applying the package default cable properties to
         ``AllRegion()``.
     """
-    return (PaintRule(region=AllRegion(), mechanism=_DEFAULT_CABLE),)
+    return (PaintRule(region=AllRegion(), mechanism=DEFAULT_CABLE),)
 
 
 def normalize_paint_rules(
@@ -483,7 +494,7 @@ def _apply_place(
 
 def _init_bucket() -> _MechBucket:
     return _MechBucket(
-        cable=_DEFAULT_CABLE,
+        cable=DEFAULT_CABLE,
         density_by_key={},
         points=[],
         point_roles=[],

--- a/braincell/_discretization/mechanism_test.py
+++ b/braincell/_discretization/mechanism_test.py
@@ -18,12 +18,15 @@
 import unittest
 
 import brainunit as u
+import numpy as np
 
 from braincell._discretization._testing import (
     build_geo,
     make_cable,
     make_single_branch_morpho,
+    make_two_branch_morpho,
 )
+from braincell._discretization.base import DEFAULT_CABLE
 from braincell._discretization.geometry import (
     CVGeometryResult,
     _GeoCV,
@@ -32,7 +35,6 @@ from braincell._discretization.geometry import (
 from braincell._discretization.mechanism import (
     PaintRule,
     PlaceRule,
-    _DEFAULT_CABLE,
     _MechBucket,
     _RegionCache,
     _apply_density,
@@ -47,6 +49,7 @@ from braincell._discretization.mechanism import (
     normalize_place_rule,
 )
 from braincell.filter import AllRegion, AtLocation, BranchSlice
+from braincell.filter.locset import LocsetBatch
 from braincell.mech import CableProperty, Channel, CurrentClamp, Ion, StateProbe
 from braincell.morph.morphology import Morphology
 
@@ -244,6 +247,29 @@ class RegionCacheTest(unittest.TestCase):
         self.assertIs(a, b)
         self.assertEqual(a, ((0, 0.5, "soma(0.5)"),))
 
+    def test_points_does_not_alias_distinct_temporary_locsets(self) -> None:
+        """Each batch member must get its own locations, not the previous one's.
+
+        ``build_cv_mechanisms`` feeds this cache freshly built ``LocsetBatch``
+        members inside a generator expression, so each argument is unreferenced
+        the moment ``points`` returns. A cache keyed on ``id()`` therefore hands
+        member *n* whatever member *n-1* left at the same reused address. The
+        two tests above never caught it because they hold their locset in a
+        local, which keeps the address unique.
+        """
+        morpho = make_two_branch_morpho()
+        batch = LocsetBatch.from_columns(
+            np.asarray([[0], [1], [0], [1]], dtype=np.int64),
+            np.asarray([[0.1], [0.9], [0.2], [0.8]], dtype=float),
+            None,
+        )
+        cache = _RegionCache(morpho)
+        got = [cache.points(batch[index]) for index in range(len(batch))]
+        self.assertEqual(
+            [tuple((bid, round(x, 6)) for bid, x, _ in row) for row in got],
+            [((0, 0.1),), ((1, 0.9),), ((0, 0.2),), ((1, 0.8),)],
+        )
+
 
 # =============================================================================
 # Mechanism lowering
@@ -279,7 +305,6 @@ class CoverageFractionTest(unittest.TestCase):
             branch_type="soma",
             prox=0.0,
             dist=0.5,
-            midpoint=0.25,
             parent_cv=None,
             children_cv=(),
             length_um=5.0,
@@ -301,21 +326,21 @@ class CoverageFractionTest(unittest.TestCase):
 class ApplyDensityTest(unittest.TestCase):
     def test_channel_full_coverage_no_scaling(self) -> None:
         ch = Channel("IL", g_max=0.1 * (u.mS / u.cm**2), E=-70 * u.mV)
-        bucket = _MechBucket(cable=_DEFAULT_CABLE, density_by_key={}, points=[])
+        bucket = _MechBucket(cable=DEFAULT_CABLE, density_by_key={}, points=[])
         _apply_density(bucket, ch, region_key=AllRegion(), fraction=1.0)
         stored = next(iter(bucket.density_by_key.values()))
         self.assertEqual(stored.coverage_area_fraction, 1.0)
 
     def test_channel_half_coverage_records_fraction(self) -> None:
         ch = Channel("IL", g_max=0.1 * (u.mS / u.cm**2), E=-70 * u.mV)
-        bucket = _MechBucket(cable=_DEFAULT_CABLE, density_by_key={}, points=[])
+        bucket = _MechBucket(cable=DEFAULT_CABLE, density_by_key={}, points=[])
         _apply_density(bucket, ch, region_key=AllRegion(), fraction=0.5)
         stored = next(iter(bucket.density_by_key.values()))
         self.assertEqual(stored.coverage_area_fraction, 0.5)
 
     def test_ion_ignores_coverage(self) -> None:
         ion = Ion("SodiumFixed")
-        bucket = _MechBucket(cable=_DEFAULT_CABLE, density_by_key={}, points=[])
+        bucket = _MechBucket(cable=DEFAULT_CABLE, density_by_key={}, points=[])
         _apply_density(bucket, ion, region_key=AllRegion(), fraction=0.5)
         stored = next(iter(bucket.density_by_key.values()))
         self.assertEqual(stored.coverage_area_fraction, 1.0)
@@ -323,7 +348,7 @@ class ApplyDensityTest(unittest.TestCase):
     def test_same_key_replaces(self) -> None:
         c1 = Channel("IL", g_max=0.1 * (u.mS / u.cm**2), E=-70 * u.mV)
         c2 = Channel("IL", g_max=0.2 * (u.mS / u.cm**2), E=-70 * u.mV)
-        bucket = _MechBucket(cable=_DEFAULT_CABLE, density_by_key={}, points=[])
+        bucket = _MechBucket(cable=DEFAULT_CABLE, density_by_key={}, points=[])
         region = AllRegion()
         _apply_density(bucket, c1, region_key=region, fraction=1.0)
         _apply_density(bucket, c2, region_key=region, fraction=1.0)
@@ -352,7 +377,7 @@ class ResolvePointNameTest(unittest.TestCase):
 class ApplyPlaceTest(unittest.TestCase):
     def test_auto_generated_duplicate_gets_stable_placement_suffix(self) -> None:
         seen: set[str] = set()
-        bucket = _MechBucket(cable=_DEFAULT_CABLE, density_by_key={}, points=[])
+        bucket = _MechBucket(cable=DEFAULT_CABLE, density_by_key={}, points=[])
         probe = StateProbe(field="v")
         _apply_place(bucket, probe, display_name="loc_0", placement_id=0, seen_names=seen)
         _apply_place(bucket, probe, display_name="loc_0", placement_id=1, seen_names=seen)
@@ -363,7 +388,7 @@ class ApplyPlaceTest(unittest.TestCase):
 
     def test_user_named_duplicate_allowed(self) -> None:
         seen: set[str] = set()
-        bucket = _MechBucket(cable=_DEFAULT_CABLE, density_by_key={}, points=[])
+        bucket = _MechBucket(cable=DEFAULT_CABLE, density_by_key={}, points=[])
         a = StateProbe(field="v", name="dup")
         b = StateProbe(field="v", name="dup")
         _apply_place(bucket, a, display_name="loc_0", seen_names=seen)

--- a/braincell/_discretization/node_build.py
+++ b/braincell/_discretization/node_build.py
@@ -28,6 +28,7 @@ import numpy as np
 from braincell.morph.morphology import Morphology
 from .base import (
     CV,
+    EPS_PARAM,
     Node,
     NodeEdge,
     NodeEdgeRole,
@@ -37,14 +38,8 @@ from .base import (
     locate_cv_on_branch,
 )
 
-__all__ = [
-    "_EPS_PARAM",
-    "_locate_branch_cv_by_x",
-    "build_node_tree_from_cvs",
-    "locate_node_on_branch",
-]
+__all__ = ["build_node_tree_from_cvs"]
 
-_EPS_PARAM = 1e-9
 _POSITION_ORDER = {"prox": 0, "mid": 1, "dist": 2}
 
 
@@ -150,7 +145,6 @@ def build_node_tree_from_cvs(
         if branch.parent is None:
             attachment_node_id = root_node_id
             attach_x = 0.0
-            ordered_cv_ids = branch_cv_ids
         else:
             edge = edge_by_child_branch[branch_id]
             attachment_node_id = _resolve_attachment_node(
@@ -162,13 +156,22 @@ def build_node_tree_from_cvs(
                 cvs=cvs,
             )
             attach_x = float(edge.child_x)
-            ordered_cv_ids = branch_cv_ids if attach_x <= _EPS_PARAM else tuple(reversed(branch_cv_ids))
+
+        # The branch is walked from ``attach_x`` towards ``1 - attach_x``. That
+        # one direction fixes everything downstream: the CV order, which end
+        # each endpoint node sits at, and which half of a CV an edge role
+        # covers. It is constant for the whole branch, so it is decided here
+        # rather than re-derived from ``attach_x`` at each of the four sites.
+        walk_from_prox = attach_x <= EPS_PARAM
+        ordered_cv_ids = branch_cv_ids if walk_from_prox else tuple(reversed(branch_cv_ids))
+        entry_side: Position = "prox" if walk_from_prox else "dist"
+        exit_side: Position = "dist" if walk_from_prox else "prox"
 
         first_cv_id = ordered_cv_ids[0]
         add_node_role(
             attachment_node_id,
             cv_id=first_cv_id,
-            position=_entry_position_for_walk(attach_x),
+            position=entry_side,
         )
         branch_endpoint_node_id_by_x[(branch_id, float(attach_x))] = attachment_node_id
 
@@ -180,7 +183,7 @@ def build_node_tree_from_cvs(
         terminal_cv_id = ordered_cv_ids[-1]
         terminal_node_id = new_node(
             cv_id=terminal_cv_id,
-            position=_exit_position_for_walk(attach_x),
+            position=exit_side,
         )
         branch_endpoint_node_id_by_x[(branch_id, float(1.0 - attach_x))] = terminal_node_id
 
@@ -196,22 +199,17 @@ def build_node_tree_from_cvs(
                 parent_node_id,
                 midpoint_node_id,
                 cv_id=cv_id,
-                half=_entry_half_for_walk(attach_x),
+                half=entry_side,
             )
             add_edge_role(
                 midpoint_node_id,
                 child_node_id,
                 cv_id=cv_id,
-                half=_exit_half_for_walk(attach_x),
+                half=exit_side,
             )
 
     if np.any(cv_to_mid_node_id < 0):
         raise ValueError("Node tree is missing CV midpoint nodes.")
-
-    branch_endpoint_node_id = _build_branch_endpoint_node_id(
-        branch_endpoint_node_id_by_x=branch_endpoint_node_id_by_x,
-        n_branches=len(morpho.branches),
-    )
 
     node_roles = tuple(
         tuple(
@@ -260,11 +258,7 @@ def build_node_tree_from_cvs(
             parent_node_id=parent_node_id,
             child_node_id=child_node_id,
             roles=tuple(
-                NodeEdgeRole(
-                    cv_id=cv_id,
-                    half=half,
-                    r_axial=_role_axial_resistance(cvs, cv_id=cv_id, half=half),
-                )
+                NodeEdgeRole(cv_id=cv_id, half=half)
                 for cv_id, half in sorted(
                     cv_roles,
                     key=lambda item: (item[0], item[1]),
@@ -281,47 +275,6 @@ def build_node_tree_from_cvs(
         edges=edges,
         root_node_id=root_node_id,
         cv_to_mid_node_id=cv_to_mid_node_id,
-        branch_endpoint_node_id=branch_endpoint_node_id,
-    )
-
-
-def locate_node_on_branch(
-    node_tree: NodeTree,
-    *,
-    cvs: tuple[CV, ...],
-    branch_id: int,
-    x: float,
-) -> int:
-    """Return the node id selected by a branch coordinate.
-
-    Parameters
-    ----------
-    node_tree : NodeTree
-        Node tree defining midpoint and endpoint node ids.
-    cvs : tuple of CV
-        Source CV tuple used to resolve interior ownership.
-    branch_id : int
-        Branch id to query.
-    x : float
-        Normalized branch coordinate.
-
-    Returns
-    -------
-    int
-        Selected node id.
-    """
-
-    cv_ids_by_branch = _group_cv_ids_by_branch(
-        cvs=cvs,
-        n_branches=node_tree.branch_endpoint_node_id.shape[0],
-    )
-    return _locate_node_id_on_branch(
-        int(branch_id),
-        float(x),
-        cvs=cvs,
-        cv_ids_by_branch=cv_ids_by_branch,
-        cv_to_mid_node_id=node_tree.cv_to_mid_node_id,
-        branch_endpoint_node_id=node_tree.branch_endpoint_node_id,
     )
 
 
@@ -336,20 +289,6 @@ def _group_cv_ids_by_branch(
     return tuple(tuple(ids) for ids in grouped)
 
 
-def _build_branch_endpoint_node_id(
-    *,
-    branch_endpoint_node_id_by_x: dict[tuple[int, float], int],
-    n_branches: int,
-) -> np.ndarray:
-    endpoint_ids = np.full((n_branches, 2), -1, dtype=np.int32)
-    for branch_id in range(n_branches):
-        endpoint_ids[branch_id, 0] = branch_endpoint_node_id_by_x[(branch_id, 0.0)]
-        endpoint_ids[branch_id, 1] = branch_endpoint_node_id_by_x[(branch_id, 1.0)]
-    if np.any(endpoint_ids < 0):
-        raise ValueError("Node tree is missing branch endpoint nodes.")
-    return endpoint_ids
-
-
 def _resolve_attachment_node(
     parent_branch_id: int,
     *,
@@ -359,95 +298,14 @@ def _resolve_attachment_node(
     cv_ids_by_branch: tuple[tuple[int, ...], ...],
     cvs: tuple[CV, ...],
 ) -> int:
-    if parent_x <= 0.0 + _EPS_PARAM:
+    if parent_x <= 0.0 + EPS_PARAM:
         return branch_endpoint_node_id_by_x[(parent_branch_id, 0.0)]
-    if parent_x >= 1.0 - _EPS_PARAM:
+    if parent_x >= 1.0 - EPS_PARAM:
         return branch_endpoint_node_id_by_x[(parent_branch_id, 1.0)]
-    cv_id = _locate_branch_cv_by_x(
+    cv_id = locate_cv_on_branch(
         cv_ids_by_branch[parent_branch_id],
         cvs,
         x=float(parent_x),
-        epsilon=_EPS_PARAM,
+        epsilon=EPS_PARAM,
     )
     return int(cv_to_mid_node_id[cv_id])
-
-
-def _locate_node_id_on_branch(
-    branch_id: int,
-    x: float,
-    *,
-    cvs: tuple[CV, ...],
-    cv_ids_by_branch: tuple[tuple[int, ...], ...],
-    cv_to_mid_node_id: np.ndarray,
-    branch_endpoint_node_id: np.ndarray,
-) -> int:
-    if x <= 0.0 + _EPS_PARAM:
-        return int(branch_endpoint_node_id[int(branch_id), 0])
-    if x >= 1.0 - _EPS_PARAM:
-        return int(branch_endpoint_node_id[int(branch_id), 1])
-    cv_id = _locate_branch_cv_by_x(
-        cv_ids_by_branch[int(branch_id)],
-        cvs,
-        x=float(x),
-        epsilon=_EPS_PARAM,
-    )
-    return int(cv_to_mid_node_id[cv_id])
-
-
-def _locate_branch_cv_by_x(
-    ids: tuple[int, ...],
-    cvs: tuple[CV, ...],
-    *,
-    x: float,
-    epsilon: float,
-) -> int:
-    """Return the CV id whose normalized half-open interval contains ``x``.
-
-    Parameters
-    ----------
-    ids : tuple of int
-        Ordered CV ids on one branch.
-    cvs : tuple of CV
-        Source CV tuple indexed by CV id.
-    x : float
-        Normalized branch coordinate.
-    epsilon : float
-        Comparison tolerance.
-
-    Returns
-    -------
-    int
-        Owning CV id.
-    """
-
-    return locate_cv_on_branch(ids, cvs, x=x, epsilon=epsilon)
-
-
-def _entry_half_for_walk(attach_x: float) -> str:
-    return "prox" if attach_x <= _EPS_PARAM else "dist"
-
-
-def _exit_half_for_walk(attach_x: float) -> str:
-    return "dist" if attach_x <= _EPS_PARAM else "prox"
-
-
-def _entry_position_for_walk(attach_x: float) -> Position:
-    return "prox" if attach_x <= _EPS_PARAM else "dist"
-
-
-def _exit_position_for_walk(attach_x: float) -> Position:
-    return "dist" if attach_x <= _EPS_PARAM else "prox"
-
-
-def _role_axial_resistance(
-    cvs: tuple[CV, ...],
-    *,
-    cv_id: int,
-    half: str,
-):
-    cv = cvs[int(cv_id)]
-    if half == "prox":
-        return cv.r_axial_prox
-    if half == "dist":
-        return cv.r_axial_dist
-    raise ValueError(f"Unsupported half {half!r}.")

--- a/braincell/_discretization/node_build_test.py
+++ b/braincell/_discretization/node_build_test.py
@@ -20,11 +20,7 @@ import unittest
 from braincell._discretization import CVPerBranch
 from braincell._discretization._testing import make_two_branch_morpho
 from braincell._discretization.base import build_discretization
-from braincell._discretization.node_build import (
-    _EPS_PARAM,
-    _locate_branch_cv_by_x,
-    build_node_tree_from_cvs as build_node_tree,
-)
+from braincell._discretization.node_build import build_node_tree_from_cvs as build_node_tree
 
 
 class BuildNodeTreeEdgeHalves(unittest.TestCase):
@@ -60,37 +56,6 @@ class BuildNodeTreeEdgeHalves(unittest.TestCase):
                 ["dist", "prox"],
                 f"CV {cv_id} must record exactly one prox and one dist edge role; got {halves!r}.",
             )
-
-
-class _FakeCV:
-    def __init__(self, id_: int, prox: float, dist: float) -> None:
-        self.id = id_
-        self.prox = prox
-        self.dist = dist
-
-
-class LocateBranchCVByX(unittest.TestCase):
-    def _cvs(self, tiles):
-        return tuple(_FakeCV(i, p, d) for i, (p, d) in enumerate(tiles))
-
-    def test_interior_x_lands_in_matching_cv(self) -> None:
-        cvs = self._cvs([(0.0, 0.3), (0.3, 0.7), (0.7, 1.0)])
-        ids = (0, 1, 2)
-        got = _locate_branch_cv_by_x(ids, cvs, x=0.5, epsilon=_EPS_PARAM)
-        self.assertEqual(got, 1)
-
-    def test_x_near_one_returns_last_cv(self) -> None:
-        cvs = self._cvs([(0.0, 0.3), (0.3, 0.7), (0.7, 1.0)])
-        ids = (0, 1, 2)
-        got = _locate_branch_cv_by_x(ids, cvs, x=0.999, epsilon=_EPS_PARAM)
-        self.assertEqual(got, 2)
-
-    def test_x_in_gap_between_tiles_raises(self) -> None:
-        cvs = self._cvs([(0.0, 0.4), (0.6, 1.0)])
-        ids = (0, 1)
-        with self.assertRaises(ValueError) as ctx:
-            _locate_branch_cv_by_x(ids, cvs, x=0.5, epsilon=_EPS_PARAM)
-        self.assertIn("0.5", str(ctx.exception))
 
 
 class VocabularyLock(unittest.TestCase):

--- a/braincell/_discretization/policy.py
+++ b/braincell/_discretization/policy.py
@@ -24,23 +24,17 @@ from braincell.mech import CableProperty
 from braincell.mech._params import quantity_hashable
 from braincell.morph.branch import branch_class_for_type
 from braincell.morph.morphology import Morphology
+from .base import DEFAULT_CABLE, EPS_LEN_UM, EPS_PARAM
 
 if TYPE_CHECKING:
     from .mechanism import PaintRule
 
-EPS_PARAM = 1e-9  # tolerance for normalized x in [0, 1]
-EPS_LEN_UM = 1e-6  # tolerance for physical μm lengths
 # d_lambda space-constant prefactor yielding μm from sqrt(cm·Ω·cm/(Hz·µF)).
 # The numerical value 1e5 = sqrt(1e-6 cm⁴/F) · (cm→µm conversion); see
 # Hines & Carnevale 2001 §5 / NEURON d_lambda derivation.
 _D_LAMBDA_UM_FACTOR = 1.0e5
 Bounds = tuple[tuple[float, float], ...]
 BoundsByBranch = tuple[Bounds, ...]
-_DEFAULT_D_LAMBDA_CABLE = CableProperty(
-    resting_potential=-65.0 * u.mV,
-    membrane_capacitance=1.0 * (u.uF / u.cm**2),
-    axial_resistivity=100.0 * (u.ohm * u.cm),
-)
 
 
 @dataclass(frozen=True)
@@ -428,7 +422,7 @@ def _bounds_from_d_lambda(
     n_cv = int(np.ceil((electrotonic_length / d_lambda) - EPS_PARAM))
     n_cv = max(1, n_cv)
     n_cv = _promote_to_odd(n_cv, keep_odd=keep_odd)
-    return tuple((float(offset) / float(n_cv), float(offset + 1) / float(n_cv)) for offset in range(n_cv))
+    return _uniform_bounds_for_count(n_cv)
 
 
 def _resolve_branch_cable_properties(
@@ -437,7 +431,7 @@ def _resolve_branch_cable_properties(
     paint_rules: tuple["PaintRule", ...] | None,
 ) -> tuple[tuple[float, float], ...]:
     branch_intervals: list[list[tuple[float, float, CableProperty]]] = [
-        [(0.0, 1.0, _DEFAULT_D_LAMBDA_CABLE)] for _ in morpho.branches
+        [(0.0, 1.0, DEFAULT_CABLE)] for _ in morpho.branches
     ]
     for rule in paint_rules or ():
         mechanism = getattr(rule, "mechanism", None)

--- a/braincell/_multi_compartment/cell_test.py
+++ b/braincell/_multi_compartment/cell_test.py
@@ -16,14 +16,11 @@
 """Unit tests for :class:`braincell.Cell`."""
 
 import unittest
-from unittest import mock
 
 import brainstate
 import brainunit as u
 import jax
 import jax.numpy as jnp
-import matplotlib.axes
-import matplotlib.pyplot as plt
 import numpy as np
 
 import braincell
@@ -42,7 +39,7 @@ from braincell import (
     connect,
 )
 from braincell._multi_compartment import cell as cell_module
-from braincell.filter import AllRegion, BranchSlice, RootLocation, at
+from braincell.filter import AllRegion, LocsetBatch, RootLocation, at
 from braincell.mech import StateProbe
 from braincell.quad import DiffEqSingleState, DiffEqState, get_integrator
 
@@ -1095,6 +1092,62 @@ class CellPopulationAxisIsMandatoryTest(unittest.TestCase):
                 cell = Cell(_soma_tree(), cv_policy=CVPerBranch(), pop_size=pop_size)
                 cell.init_state()
                 self.assertEqual(tuple(cell.V.value.shape), expected + (cell.n_cv,))
+
+
+class AlignedBatchPlacementLandsEachMemberOnItsOwnLocationTest(unittest.TestCase):
+    """An aligned ``LocsetBatch`` must place member *n* at member *n*'s location.
+
+    ``build_cv_mechanisms`` resolves the batch by indexing it inside a generator
+    expression, so every ``LocsetBatch`` member is a temporary that dies as soon
+    as it has been resolved. While ``_RegionCache`` keyed its results on
+    ``id()``, CPython reused the freed address for the next member and the cache
+    replayed the previous member's locations -- silently placing synapses on the
+    wrong branch and the wrong CV for every member after the first. Nothing
+    caught it: the only other ``LocsetBatch`` coverage drives ``.loc()``, which
+    does not go through that cache.
+    """
+
+    def _two_branch_cell(self, pop_size: int, *, cv_per_branch: int = 1) -> Cell:
+        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        dend = Branch.from_lengths(lengths=[100.0] * u.um, radii=[5.0, 0.5] * u.um, type="dendrite")
+        tree = Morphology.from_root(soma, name="soma")
+        tree.soma.dend = dend
+        return Cell(tree, pop_size=pop_size, cv_policy=CVPerBranch(cv_per_branch=cv_per_branch))
+
+    def test_each_population_member_keeps_its_own_branch_and_x(self) -> None:
+        expected = ((0, 0.1), (1, 0.9), (0, 0.2), (1, 0.8))
+        cell = self._two_branch_cell(len(expected))
+        batch = LocsetBatch.from_columns(
+            np.asarray([[branch] for branch, _ in expected], dtype=np.int64),
+            np.asarray([[x] for _, x in expected], dtype=float),
+        )
+        cell[np.arange(len(expected))].place(
+            batch,
+            mech.Synapse("ExpSyn", name="syn", tau=5.0 * u.ms, e=0.0 * u.mV),
+        )
+
+        placed = {
+            int(placement.population_index): (int(placement.branch_id), round(float(placement.branch_x), 6))
+            for placement in cell._discretization.point_placements
+        }
+        self.assertEqual(placed, dict(enumerate(expected)))
+
+    def test_members_on_the_same_branch_still_land_on_distinct_cvs(self) -> None:
+        expected = ((1, 0.1), (1, 0.5), (1, 0.9))
+        cell = self._two_branch_cell(len(expected), cv_per_branch=3)
+        batch = LocsetBatch.from_columns(
+            np.asarray([[branch] for branch, _ in expected], dtype=np.int64),
+            np.asarray([[x] for _, x in expected], dtype=float),
+        )
+        cell[np.arange(len(expected))].place(
+            batch,
+            mech.Synapse("ExpSyn", name="syn", tau=5.0 * u.ms, e=0.0 * u.mV),
+        )
+
+        cv_by_member = {
+            int(placement.population_index): int(placement.cv_id) for placement in cell._discretization.point_placements
+        }
+        self.assertEqual(len(set(cv_by_member.values())), len(expected), cv_by_member)
 
 
 def _hh_cell(pop_size, *, calcium: bool = True) -> Cell:

--- a/braincell/filter/cache.py
+++ b/braincell/filter/cache.py
@@ -28,9 +28,13 @@ _MISS = object()
 class SelectionCache:
     """Scratch space threaded through a whole selection expression tree.
 
-    Sub-expression memoization is the whole of it: :meth:`evaluated` lets a
-    composite reuse an operand's mask instead of walking the morphology
-    again, so ``(A | B) & (A | C)`` evaluates ``A`` once rather than twice.
+    Memoization keyed by expression value is the whole of it:
+    :meth:`evaluated` lets a composite reuse an operand's mask instead of
+    walking the morphology again, so ``(A | B) & (A | C)`` evaluates ``A``
+    once rather than twice. Consumers that derive something *from* a mask
+    can memoize that too, by giving it its own cache instance rather than
+    sharing the keyspace holding the masks -- see ``_RegionCache`` in
+    ``braincell._discretization.mechanism``.
 
     Notes
     -----
@@ -57,18 +61,20 @@ class SelectionCache:
 
         Parameters
         ----------
-        expr : RegionExpr or LocsetExpr
+        expr : RegionExpr or LocsetExpr or LocsetMask
             The expression being evaluated. Used as the memo key, so the
-            result is shared between operands that compare equal.
+            result is shared between operands that compare equal -- and,
+            just as importantly, *not* shared between two that do not.
         morpho : braincell.Morphology
             Morphology the result belongs to.
         evaluate : callable
-            Zero-argument thunk producing the mask when there is no hit.
+            Zero-argument thunk producing the value when there is no hit.
 
         Returns
         -------
-        RegionMask or LocsetMask
-            The freshly computed or previously memoized mask.
+        object
+            The freshly computed or previously memoized value -- a mask for
+            the sub-expression cache, whatever the thunk returns otherwise.
 
         Notes
         -----

--- a/docs/design/module-dependency-map.md
+++ b/docs/design/module-dependency-map.md
@@ -38,7 +38,7 @@ flowchart TD
     PROBES["probes.py<br/>sample_probe(s)"]
     RUN["run.py<br/>RunResult / run"]
     CVBASE["`_discretization.base`<br/>CV / Node / Discretization<br/>build_discretization"]
-    CVNODE["`_discretization.node_build`<br/>build_node_tree_from_cvs<br/>locate_node_on_branch"]
+    CVNODE["`_discretization.node_build`<br/>build_node_tree_from_cvs"]
     CVPOLICY["`_discretization.policy`<br/>CVPolicy / CVPerBranch / ..."]
     CVGEOM["`_discretization.geometry`<br/>CVGeometryResult<br/>build_cv_geometry"]
     CVMECH["`_discretization.mechanism`<br/>PaintRule / PlaceRule<br/>normalize / merge"]
@@ -74,7 +74,7 @@ flowchart TD
 ```mermaid
 flowchart TD
     BASE["base.py<br/>CV / Node / Discretization<br/>build_discretization(...)"]
-    NODEBUILD["node_build.py<br/>build_node_tree_from_cvs<br/>locate_node_on_branch"]
+    NODEBUILD["node_build.py<br/>build_node_tree_from_cvs"]
     POLICY["policy.py<br/>CVPolicy<br/>CVPerBranch / MaxCVLen / DLambda"]
     GEOM["geometry.py<br/>CVGeometryResult<br/>build_cv_geometry"]
     MECHLOWER["mechanism.py<br/>PaintRule / PlaceRule<br/>normalize / merge"]
@@ -105,7 +105,7 @@ flowchart TD
 
 - `CV`：`region`、`diam_mid`、`...`
 - `build_discretization(...)`
-- `NodeTree` / `build_node_tree_from_cvs(...)` / `locate_node_on_branch(...)`
+- `NodeTree` / `build_node_tree_from_cvs(...)`
 - `PaintRule` / `PlaceRule`
 - `normalize_paint_rules(...)` / `normalize_place_rule(...)`
 - `merge_paint_rules(...)` / `merge_place_rules(...)`

--- a/docs/specs/2026-09-02-discretization-simplification.md
+++ b/docs/specs/2026-09-02-discretization-simplification.md
@@ -1,0 +1,433 @@
+# `braincell/_discretization` simplification
+
+Iteration 9 of the module-by-module simplification sweep. Written before any
+code changed; the Verification section at the end is filled in afterwards.
+
+## Baseline
+
+`braincell/_discretization` is the static, declaration-time layer between
+`braincell.morph` (the geometric tree) and `braincell._compute` (the runtime
+lowering layer). It resolves a CV policy into branch-wise bounds, assembles the
+physical CV facts, attaches normalized mechanism declarations, and derives the
+point-space node tree.
+
+| module | lines | role |
+| --- | --- | --- |
+| `geometry.py` | 736 | frusta, CV physical facts, morphology/bounds validation |
+| `mechanism.py` | 702 | paint/place rule normalization and lowering onto CVs |
+| `base.py` | 694 | the frozen record types and `build_discretization` |
+| `policy.py` | 520 | the five CV policies |
+| `node_build.py` | 453 | CV tree to node tree |
+| `context.py` | 111 | one `CVContext` per CV |
+| `__init__.py` | 75 | export surface |
+| `_testing.py` | 73 | shared fixtures |
+
+Tests: `pytest braincell/_discretization -q` -> **117 passed in 12.33s**.
+
+`build_discretization` cost, min of 5 runs, on a soma with N tapering basal
+dendrites:
+
+| branches | CVs | nodes | build |
+| --- | --- | --- | --- |
+| 5 | 10 | 16 | 2.5 ms |
+| 41 | 328 | 370 | 72.9 ms |
+| 121 | 3025 | 3147 | 670.8 ms |
+
+Roughly linear at ~0.22 ms per CV. For scale, `Cell.init_state()` on the same
+41-branch morphology measured 150.7 ms in iteration 8, so this layer is a large
+share of cell construction rather than a rounding error.
+
+## Findings
+
+Every claim below was re-verified independently of the review that raised it.
+"Verified by running" means a script executed against this worktree;
+"verified by reading" means source comparison or a control-flow argument.
+
+### 1. `locate_node_on_branch` is a dead subsystem, and it is the only reason a per-branch array is built
+
+`git grep locate_node_on_branch` over **all tracked files** returns its own
+`def` (`node_build.py:288`), its `__all__` entry, `TODO.md:568`, and three lines
+of `docs/design/module-dependency-map.md`. No code caller, no test.
+
+It is also the only reader of `NodeTree.branch_endpoint_node_id`: that field is
+produced at `node_build.py:211`, stored at `:284`, and read only at `:316` and
+`:324` — both inside `locate_node_on_branch`. So an `(n_branch, 2)` int32 array
+is built and carried on every discretization for a function nothing calls.
+
+`branch_endpoint_node_id_by_x` is a *different*, live thing —
+`_resolve_attachment_node` reads it during the build. It stays.
+
+### 2. One CV-locating algorithm under three names
+
+| site | form |
+| --- | --- |
+| `base.py:498` | `locate_cv_on_branch(ids, cvs, *, x, epsilon=_EPS_PARAM)` — imported by `network/lowering.py`, `network/event.py`, `_multi_compartment/{field_resolution,selection}.py` |
+| `geometry.py:570` | a second `locate_cv_on_branch(ids, geos, *, x)` — no empty-`ids` guard, hardcoded epsilon, plus a trailing fallback loop |
+| `node_build.py:397` | `_locate_branch_cv_by_x` — 27 lines whose body is `return locate_cv_on_branch(ids, cvs, x=x, epsilon=epsilon)` |
+
+Both real implementations read only `.prox`/`.dist`, so the `_GeoCV`/`CV` split
+is not a reason for two of them.
+
+Verified by running: 16,065 probes across five policies — a 401-point uniform
+sweep per branch plus every exact CV boundary at ±1e-10, ±1e-9 and ±1e-8 —
+gave **0 disagreements**, neither implementation ever raised, and the
+`geometry` fallback loop **never fired**. The review reproduced this
+independently at 506,285 probes over random non-uniform tilings, also with 0
+disagreements and 0 fallback hits, and instrumented the whole
+`_discretization`/`_multi_compartment`/`network` suite: 402 calls, 1 reaching
+the fallback, from `geometry_test.py:312`, which deliberately passes a
+non-tiling bound — where both versions raise `ValueError` anyway.
+
+That fallback is unreachable by construction: `validate_bounds`
+(`geometry.py:497`) guarantees each branch tiling is contiguous, starts at 0.0,
+ends at 1.0, and has every CV wider than `EPS_PARAM`, under which the first
+loop always returns.
+
+### 3. Two hand-written copies of formulas `morph/branch.py` declares as the single definition
+
+`braincell/morph/branch.py:40-46` carries an explicit comment: these frustum
+functions "are the single definition of that geometry ... Keeping the formulas
+here is what makes `Morphology.total_area == sum(b.branch.area)` a consequence
+rather than a coincidence that two hand-written copies have to maintain."
+
+`_discretization/geometry.py` is that second copy, twice:
+
+- `_lateral_area_um2` (`:330`) sums `pi * (r0 + r1) * sqrt(L^2 + (r1 - r0)^2)`
+  in a Python loop — the body of `frustum_areas_um2` (`branch.py:49`).
+- `_arc_weighted_mean_diam_um` (`:371`) computes `sum((r0 + r1) * L) / sum(L)`,
+  which is `2 *` `length_weighted_mean_radius_um` (`branch.py:96`).
+
+Verified by reading (formula identity) and by running: over 76 CVs spanning
+four policies on a morphology with a taper, a 3-D-point branch and a
+zero-length jump segment, **max relative error 0.000e+00** for both.
+
+This is the highest-consequence duplication in the package: `_lateral_area_um2`
+decides membrane area, so a divergence silently changes every conductance, and
+`diam_arc_mean` feeds the calcium shell models.
+
+### 4. `NodeEdgeRole.r_axial` is written for every edge role and read nowhere
+
+`git grep -E '\.r_axial\b'` over all tracked files: the only hits are
+`CV.r_axial` (a documented public field, printed in
+`docs/tutorials/cell.ipynb:303` — **live, keep**) and
+`cv.r_axial_prox`/`cv.r_axial_dist` in `quad/_staggered.py:561`. There is no
+reader of `role.r_axial` anywhere, and no `asdict`/`fields` reflection that
+could reach it.
+
+`_role_axial_resistance` (`node_build.py:442`) allocates a `u.Quantity` per edge
+role at every discretization to populate it. Its body is, verbatim, the select
+that `_staggered.py:561` performs anyway:
+
+```python
+resistance = cv.r_axial_prox if role.half == "prox" else cv.r_axial_dist
+```
+
+Its trailing `raise ValueError(f"Unsupported half {half!r}.")` is unreachable:
+`half` reaches it only from `_entry_half_for_walk`/`_exit_half_for_walk`, which
+return `"prox"` or `"dist"` and nothing else.
+
+### 5. `Discretization.locate_cv` has no caller
+
+`git grep '\.locate_cv('` over all tracked files finds exactly one call,
+`geometry.locate_cv(...)` at `mechanism.py:684` — that is
+`CVGeometryResult.locate_cv`, a different class. The `Discretization` method has
+no caller, no test, and no doc reference. Every consumer that needs this
+imports `locate_cv_on_branch` from `base` directly.
+
+### 6. The package default cable property is defined twice
+
+`policy._DEFAULT_D_LAMBDA_CABLE` (`:39`) and `mechanism._DEFAULT_CABLE` (`:66`)
+are distinct objects that compare **equal** (verified by running). `DLambda`
+sizes CVs from one while lowering applies the other, so editing one makes the
+discretization silently no longer match the electrics it was sized for, with no
+test to catch it.
+
+### 7. Four copies of the tolerance constants
+
+`EPS_PARAM`/`_EPS_PARAM = 1e-9` is declared in `geometry.py:32`, `policy.py:31`,
+`base.py:71` and `node_build.py:47`; `EPS_LEN_UM = 1e-6` in `geometry.py:33` and
+`policy.py:32`. All copies compare equal (verified by running). `mechanism.py`
+already does the right thing and imports `EPS_PARAM` from `geometry`.
+
+### 8. `context.py` pays for a second input shape that never arrives
+
+`build_cv_contexts`' docstring promises "``_GeoCV`` records **or** finalized
+public ``CV`` records", and pays for it with `getattr(source, "midpoint", ...)`
+and a `_source_quantity(source, quantity_name, scalar_name, unit)` shim called
+six times per CV. Both call sites (`base.py:586`, `mechanism.py:581`) pass
+`geometry.geos`, and `git grep build_cv_contexts` finds no others.
+
+`_GeoCV` declares `midpoint` and the scalar spellings (`length_um`,
+`lateral_area_um2`, `r_mid_um`, ...) and **none** of the `Quantity` spellings
+(`length`, `area`, `radius_mid`, ...). So `_source_quantity`'s first branch is
+statically unreachable, and the `midpoint` default — `0.5 * (prox + dist)` — is
+an eagerly evaluated default argument, computed once per CV and always
+discarded.
+
+The `contexts[i] is None` check at `:101-103` is likewise unreachable: the loop
+runs `len(cvs)` times and each iteration either raises or writes a distinct
+in-range index, so N distinct indices into N slots leave none empty.
+
+### 9. The CV midpoint radius is computed twice, and one answer is thrown away
+
+`context.py:76` calls `interpolate_branch(morpho, branch_id, midpoint)` and
+discards its first return value with `_`, then reads the same number out of
+`_GeoCV.r_mid_um`, which `geometry._midpoint_radius_um` computed by walking the
+frusta. Verified by running: over 100 CVs across four policies the two agree to
+**8.9e-16 um**.
+
+### 10. `_bounds_from_d_lambda` re-inlines `_uniform_bounds_for_count`
+
+`policy.py:431` and `policy.py:399` are byte-identical (verified by
+`inspect.getsource`), and outputs match for `n_cv = 1..200`. The sibling
+`_bounds_from_max_len_um` calls the helper correctly — this is the one call site
+of two that forgot.
+
+### 11. Four one-line helpers in `node_build` that are one boolean
+
+`_entry_half_for_walk`/`_entry_position_for_walk` have byte-identical bodies
+differing only in return annotation, as do `_exit_half_for_walk`/
+`_exit_position_for_walk`; and `_exit_*` is the exact complement of `_entry_*`.
+Verified by running over `{0.0, -0.0, 1e-12, 1e-9, 1e-9+1e-15, 0.25, 0.5, 0.75,
+1.0}`: all three identities hold on every probe. Both `_half_` variants are
+re-called inside the per-CV loop (`:199`, `:205`) with an `attach_x` that is
+fixed for the whole branch.
+
+### 12. `__all__` entries that publish private names
+
+`geometry.__all__` lists `_Frustum`, `_GeoCV`, `_build_frusta` and
+`_lateral_area_um2`; `node_build.__all__` lists `_EPS_PARAM` and
+`_locate_branch_cv_by_x` (verified by running). `__all__` is the declared public
+surface, so an underscore entry contradicts itself and makes `import *`
+re-export internals. The symbols are genuinely used by siblings and tests — the
+entries go, not the symbols.
+
+### 13. `_GeoCV.midpoint` is always derivable
+
+Verified by running: `midpoint == 0.5 * (prox + dist)` for **100/100** CVs
+across four policies, 0 violations. As a stored field it must be hand-copied in
+the 17-field rebuild at `geometry.py:723` and in the test literal at
+`geometry_test.py:290-308`.
+
+### 14. `build_cv_geometry` retypes all 17 `_GeoCV` fields to change two
+
+`geometry.py:710-731` is a 22-line generator that rebuilds every field by hand
+solely to fill `parent_cv` and `children_cv`. Any field added to `_GeoCV` later
+must be added here too or it is silently dropped.
+
+## The bug this iteration found
+
+Finding 8 above led to a live correctness defect, so it is written up on its
+own. `_RegionCache.points` keyed its memo on `id(locset)` while retaining no
+reference to the key, and `build_cv_mechanisms` (`mechanism.py:668`) feeds it
+freshly built `LocsetBatch` members from inside a generator expression:
+
+```python
+location_groups = zip(
+    (cache.points(rule.locset[index]) for index in range(len(rule.locset))),
+    ((int(index),) for index in rule.population_indices),
+)
+```
+
+Each member is unreferenced the moment `points` returns, CPython reuses the
+freed address for the next one, and the cache hands member *n* member *n-1*'s
+locations. Reproduced end to end through the public API — four population
+members, each declared on its own branch and coordinate:
+
+```
+expected: {0: (0, 0.1), 1: (1, 0.9), 2: (0, 0.2), 3: (1, 0.8)}
+actual  : {0: (0, 0.1), 1: (1, 0.9), 2: (1, 0.9), 3: (1, 0.9)}
+```
+
+Two of four members get their synapse on the wrong branch and the wrong CV,
+silently. The existing `LocsetBatch` coverage never caught it because it
+drives `.loc()`, which does not go through this cache, and because the two
+`_RegionCache` tests hold their locset in a local — which keeps the address
+unique and hides the aliasing.
+
+Per AGENTS.md rule 4 the regression tests were written and confirmed failing
+first: one unit test in `mechanism_test.py`, and two end-to-end tests in
+`_multi_compartment/cell_test.py` (the second failed as `{0: 3, 1: 4, 2: 4}`,
+two members sharing a CV).
+
+`_RegionCache.intervals` carried the same `id()` pattern. It is safe today
+only because `paint_rules` happens to hold its regions alive for the whole
+build — an invariant nothing states or enforces. Both are now value-keyed.
+
+## Changes
+
+Each numbered item refers to the finding above.
+
+**Correctness**
+
+- `_RegionCache` keys both memos by expression **value**, via two
+  `filter.SelectionCache` instances rather than a second memo
+  implementation. `SelectionCache` already provides exactly this — value
+  keying, a morphology-revision guard, and a fall-through for unhashable
+  payloads. Its docstring is broadened to say that a consumer deriving
+  something *from* a mask may memoize that too in its own instance.
+
+**Duplication removed** (2, 3, 6, 7, 10, 11)
+
+- One `locate_cv_on_branch`, in `base.py`. The `geometry.py` copy and the
+  `node_build._locate_branch_cv_by_x` pass-through are gone; `geometry.py`
+  imports the survivor. The removed copy's trailing fallback loop went with
+  it: `validate_bounds` guarantees each branch tiling is contiguous, starts
+  at 0.0, ends at 1.0, and has every CV wider than `EPS_PARAM`, under which
+  the first loop always returns — measured at 0 hits across 522,350 probes
+  and the whole test suite.
+- `geometry._lateral_area_um2` and `_arc_weighted_mean_diam_um` now call
+  `morph.branch.frustum_areas_um2` and `length_weighted_mean_radius_um`,
+  the module that declares itself the single definition of frustum
+  geometry. A new `_frustum_arrays` helper unpacks frusta into the arrays
+  those take. Verified bit-identical: **max relative error 0.000e+00** over
+  45 CVs across four policies, on a morphology with a taper, a
+  multi-segment branch and a zero-length radius jump.
+- One `DEFAULT_CABLE`, in `base.py`. `DLambda` sized CVs from
+  `policy._DEFAULT_D_LAMBDA_CABLE` while lowering applied
+  `mechanism._DEFAULT_CABLE`; they were equal, and nothing tested that.
+- One copy of `EPS_PARAM` / `EPS_LEN_UM` / `EPS_AREA_UM2`, in `base.py` —
+  the only module in the package that imports no sibling at module scope.
+  `geometry`, `policy`, `node_build` and `mechanism` import them.
+- `_bounds_from_d_lambda` calls `_uniform_bounds_for_count` instead of
+  re-inlining its body.
+- The four one-line walk helpers in `node_build` collapse to one
+  `walk_from_prox` boolean computed once per branch, next to the
+  `ordered_cv_ids` reversal it already governed.
+
+**Dead code removed** (1, 4, 5, 12)
+
+- `locate_node_on_branch`, its private callee `_locate_node_id_on_branch`,
+  `_build_branch_endpoint_node_id`, and `NodeTree.branch_endpoint_node_id`.
+  Nothing called any of them; the field's only readers were inside the dead
+  function, so an `(n_branch, 2)` int32 array was built on every
+  discretization for a function with no caller. The live, differently named
+  `branch_endpoint_node_id_by_x` stays.
+- `NodeEdgeRole.r_axial` and `_role_axial_resistance`, which allocated a
+  `u.Quantity` per edge role on every discretization. Nothing read the
+  field; the one consumer that needs the value (`quad/_staggered.py:561`)
+  performs the same `prox`/`dist` select on the CV itself.
+- `Discretization.locate_cv`, a third spelling no caller picked.
+- Private names removed from `geometry.__all__` and `node_build.__all__`.
+  The symbols stay — they are used by siblings and tests — but `__all__` is
+  the declared public surface and an underscore entry contradicts itself.
+
+**Simplified** (8, 13, 14)
+
+- `build_cv_contexts` takes `_GeoCV` only. Its docstring promised finalized
+  `CV` records too and paid for the promise with a `_source_quantity` shim
+  called six times per CV — but both call sites pass
+  `CVGeometryResult.geos`, and `_GeoCV` declares only the scalar spellings,
+  so the `CV` branch was statically unreachable. The `contexts[i] is None`
+  check went too: the loop writes `len(cvs)` distinct in-range indices into
+  `len(cvs)` slots, so none can be left empty. `u.um**2` is hoisted out of
+  the per-CV loop.
+- `_GeoCV.midpoint` becomes a property. It equalled `0.5 * (prox + dist)`
+  for 100/100 CVs across four policies, and as a stored field it had to be
+  hand-copied in the 17-field rebuild and in every test literal.
+- `build_cv_geometry` finalizes with `dataclasses.replace(geo, parent_cv=…,
+  children_cv=…)` instead of retyping all 17 fields to change two. A field
+  added to `_GeoCV` later can no longer be silently dropped there.
+
+**Tests**
+
+- The locator tests move to `base_test.py`, the surviving definition's
+  sibling, merged from the two files that tested the two deleted copies.
+  Two cases are added: the half-open internal-boundary convention, and the
+  empty-tiling guard.
+
+## Breaking changes
+
+All are internal to `braincell` and every in-repo caller is updated in this
+PR. No deprecation shims or aliases were added; the old spellings are gone.
+
+| Removed | Replacement |
+| --- | --- |
+| `_discretization.node_build.locate_node_on_branch` | none — no caller existed |
+| `_discretization.base.Discretization.locate_cv` | `locate_cv_on_branch(cv_tree.branch_to_cv_ids[b], cvs, x=…)` |
+| `_discretization.geometry.locate_cv_on_branch` | `_discretization.base.locate_cv_on_branch` |
+| `_discretization.node_build._locate_branch_cv_by_x` | `_discretization.base.locate_cv_on_branch` |
+| `NodeTree.branch_endpoint_node_id` | none — no reader outside the deleted function |
+| `NodeEdgeRole.r_axial` | `cvs[role.cv_id].r_axial_prox` / `.r_axial_dist` |
+| `_GeoCV.midpoint` as a constructor argument | derived; drop the argument |
+| `geometry.EPS_PARAM`, `EPS_LEN_UM`, `EPS_AREA_UM2` | same names from `_discretization.base` |
+| `policy._DEFAULT_D_LAMBDA_CABLE`, `mechanism._DEFAULT_CABLE` | `_discretization.base.DEFAULT_CABLE` |
+| `node_build._EPS_PARAM` | `_discretization.base.EPS_PARAM` |
+| `build_cv_contexts` accepting public `CV` records | pass `CVGeometryResult.geos` |
+
+`docs/design/module-dependency-map.md` still lists `locate_node_on_branch`
+in three places; those lines are updated in this PR.
+
+## Considered and declined
+
+**Finding 9 — the CV midpoint radius is computed twice.** The measurement
+holds: `interpolate_branch`'s discarded first return and `_GeoCV.r_mid_um`
+agree to **8.9e-16 um** over 100 CVs. But `r_mid_um` is the single stored
+value that feeds *both* `CV.radius_mid` (in `base.py`) and
+`CVContext.radius_mid` (in `context.py`). Switching `context.py` to the
+interpolated value would leave those two public fields computed by two
+different code paths — a worse duplication than the discard it removes. The
+right fix is to pick one source for both, which is a `base.py` + `context.py`
+change better made with iteration 11's view of `CV` construction.
+
+**The claimed cache-hit speedup.** The review that raised the `_RegionCache`
+keying also predicted "+12.3 ms per duplicated region at 3405 CVs". It does
+not reproduce: **1160.1 ms → 1157.7 ms** at 4 `AllRegion()` paint rules on a
+3003-CV morphology, inside the run-to-run noise. The reason is that
+`_compute_intervals` evaluates through `self._selection`, which was already
+value-keyed, so the outer `id()` cache only ever saved the cheap regrouping
+loop over `mask.intervals`. The change is justified by the correctness bug
+alone and is not claimed as an optimization.
+
+## Deferred to later iterations of the sweep
+
+- **Iteration 11 (`_multi_compartment`).** `field_resolution.locset_cv_ids`
+  rebuilds a branch-to-CV map locally that `CVTree.branch_to_cv_ids` already
+  holds. Also carried: the coverage-fraction divergence — `vis` highlights
+  use length-based overlap while physics uses area-based, giving 0.500000 vs
+  0.704545 on a tapering dendrite (they agree exactly with no taper).
+- **Iteration 14 (whole package).** `morph._spatial` is imported across a
+  package boundary by `context.py`.
+
+## Verification
+
+Run from the worktree with `PYTHONPATH=$PWD JAX_PLATFORMS=cpu`.
+
+Regression tests written first, against unmodified code:
+
+```
+braincell/_discretization/mechanism_test.py    1 failed, 38 deselected
+braincell/_multi_compartment/cell_test.py      2 failed, 85 deselected
+  AssertionError: {0: (0, 0.1), 1: (1, 0.9), 2: (1, 0.9), 3: (1, 0.9)} != {0: (0, 0.1), 1: (1, ...
+  AssertionError: 2 != 3 : {0: 3, 1: 4, 2: 4}
+```
+
+After the fix:
+
+```
+$ pytest braincell/_discretization -q
+120 passed, 9 warnings in 8.42s
+
+$ pytest braincell/ -q
+2804 passed, 15 skipped, 408 warnings, 410 subtests passed in 233.84s (0:03:53)
+```
+
+Baseline was 117 and 2799 passed; the delta is the six added tests less the
+duplicates merged when the locator tests were consolidated.
+
+Numerical equivalence of the frustum-formula reuse, over 45 CVs across four
+policies on a morphology with a taper, a multi-segment branch and a
+zero-length radius jump:
+
+```
+max rel error, area     : 0.000e+00
+max rel error, mean diam: 0.000e+00
+```
+
+Build cost is unchanged — this iteration removed duplication, not work:
+
+| branches | CVs | before | after | per CV |
+| --- | --- | --- | --- | --- |
+| 5 | 10 | 2.5 ms | 2.8 ms | — |
+| 41 | 328 / 361 | 72.9 ms | 80.3 ms | 0.2223 → 0.2224 ms |
+| 121 | 3025 / 3003 | 670.8 ms | 677.7 ms | 0.2217 → 0.2257 ms |


### PR DESCRIPTION
Iteration 9 of the module-by-module simplification sweep. Spec:
`docs/specs/2026-09-02-discretization-simplification.md`, written before any
code changed.

## A live correctness bug

`_RegionCache.points` keyed its memo on `id(locset)` while retaining no
reference to the key, and `build_cv_mechanisms` feeds it freshly built
`LocsetBatch` members from inside a generator expression. Each member is
unreferenced the moment `points` returns, CPython reuses the freed address,
and the cache hands member *n* member *n-1*'s locations.

Reproduced end to end through the public API — four population members, each
declared on its own branch and coordinate:

```
expected: {0: (0, 0.1), 1: (1, 0.9), 2: (0, 0.2), 3: (1, 0.8)}
actual  : {0: (0, 0.1), 1: (1, 0.9), 2: (1, 0.9), 3: (1, 0.9)}
```

Two of four members get their synapse on the wrong branch and the wrong CV,
silently. Existing `LocsetBatch` coverage missed it because it drives
`.loc()`, which does not use this cache; the two `_RegionCache` tests missed
it because they hold their locset in a local, which keeps the address unique.

Per AGENTS.md rule 4 the three regression tests were written and confirmed
failing first, then the fix keys both caches by **value** — via
`filter.SelectionCache`, which already provides value keying, a
morphology-revision guard, and an unhashable fall-through, rather than a
second memo implementation. `_RegionCache.intervals` carried the same
pattern, safe today only because `paint_rules` happens to keep its regions
alive for the whole build.

## Duplication removed

- **One `locate_cv_on_branch`**, in `base.py`, down from three. The deleted
  `geometry.py` copy's trailing fallback loop is unreachable given
  `validate_bounds` — 0 hits across 522,350 probes and the whole suite.
- **`geometry` no longer hand-copies the frustum formulas** that
  `morph/branch.py` explicitly declares as their single definition. CV area
  decides every conductance on the CV, so a divergence here would be silent.
  Verified bit-identical: max relative error `0.000e+00` over 45 CVs across
  four policies, on a morphology with a taper, a multi-segment branch and a
  zero-length radius jump.
- **One `DEFAULT_CABLE`.** `DLambda` had been sizing CVs from one object
  while lowering applied a different, equal one, with no test comparing them.
- **One copy of the tolerances** (`EPS_PARAM`, `EPS_LEN_UM`, `EPS_AREA_UM2`).
- `_bounds_from_d_lambda` calls `_uniform_bounds_for_count`; the four
  one-line walk helpers in `node_build` become one `walk_from_prox` boolean.

## Dead code removed

`locate_node_on_branch` plus the `(n_branch, 2)` int32 array built on every
discretization solely for it; `NodeEdgeRole.r_axial` plus the `u.Quantity`
allocated per edge role to fill a field nothing read;
`Discretization.locate_cv`; and private names in two `__all__`s.

## Simplified

`build_cv_contexts` takes `_GeoCV` only — its dual-shape `_source_quantity`
shim, called six times per CV, had a statically unreachable branch, and both
call sites pass `CVGeometryResult.geos`. `_GeoCV.midpoint` becomes a derived
property. `build_cv_geometry` finalizes with `replace()` instead of retyping
all 17 fields to change two.

## Breaking changes

All internal to `braincell`; every in-repo caller, test and doc is updated in
this PR. No shims, aliases or warnings — the old spellings are gone.

| Removed | Replacement |
| --- | --- |
| `node_build.locate_node_on_branch` | none — no caller existed |
| `Discretization.locate_cv` | `locate_cv_on_branch(cv_tree.branch_to_cv_ids[b], cvs, x=…)` |
| `geometry.locate_cv_on_branch` | `base.locate_cv_on_branch` |
| `node_build._locate_branch_cv_by_x` | `base.locate_cv_on_branch` |
| `NodeTree.branch_endpoint_node_id` | none — no reader outside the deleted function |
| `NodeEdgeRole.r_axial` | `cvs[role.cv_id].r_axial_prox` / `.r_axial_dist` |
| `_GeoCV.midpoint` as a constructor argument | derived; drop the argument |
| `geometry.EPS_PARAM` / `EPS_LEN_UM` / `EPS_AREA_UM2` | same names from `base` |
| `policy._DEFAULT_D_LAMBDA_CABLE`, `mechanism._DEFAULT_CABLE` | `base.DEFAULT_CABLE` |
| `node_build._EPS_PARAM` | `base.EPS_PARAM` |
| `build_cv_contexts` accepting public `CV` records | pass `CVGeometryResult.geos` |

## Declined, with the measurement

The review that raised the cache keying also predicted "+12.3 ms per
duplicated region at 3405 CVs". **It does not reproduce**: 1160.1 ms →
1157.7 ms at 4 `AllRegion()` paint rules on a 3003-CV morphology, inside the
noise — the inner `_selection` cache was already value-keyed, so the outer
one only ever saved a cheap regrouping loop. The change is justified by the
correctness bug alone and is not claimed as an optimization.

Also declined: rewiring the duplicate CV-midpoint-radius computation. The two
values agree to 8.9e-16 um, but `r_mid_um` is the single stored source
feeding both `CV.radius_mid` and `CVContext.radius_mid`; splitting them
across two code paths would be worse. Deferred to iteration 11.

## Verification

Regression tests first, against unmodified code:

```
mechanism_test.py    1 failed, 38 deselected
cell_test.py         2 failed, 85 deselected
  AssertionError: {0: (0, 0.1), 1: (1, 0.9), 2: (1, 0.9), 3: (1, 0.9)} != ...
  AssertionError: 2 != 3 : {0: 3, 1: 4, 2: 4}
```

After:

```
$ pytest braincell/_discretization -q
120 passed, 9 warnings in 8.42s

$ pytest braincell/ -q
2804 passed, 15 skipped, 408 warnings, 410 subtests passed in 224.40s (0:03:44)
```

All 12 pre-commit hooks pass. Build cost is unchanged at ~0.222 ms/CV — this
iteration removed duplication, not work.

Incidental: four unused imports in `cell_test.py` that pre-date this branch
are removed, because the `ruff` hook runs on changed files and that file is
now changed.

## Summary by Sourcery

Fix discretization cache correctness and simplify the subsystem by consolidating duplicated geometry, lookup, configuration, and node-building logic.

Bug Fixes:
- Fix discretization placement errors caused by id()-keyed region and locset caches reusing results for distinct temporary expressions.

Enhancements:
- Consolidate CV location lookup, geometry formulas, default cable properties, tolerances, and node-walk logic into single shared definitions.
- Remove unused discretization APIs, node-tree data, edge-role resistance fields, and other dead code.
- Simplify CV geometry finalization and context construction around the geometry-stage records.
- Preserve existing discretization behavior while eliminating duplicated implementations and maintaining build performance.

Documentation:
- Document the discretization simplification findings, design decisions, breaking internal API removals, and verification results.
- Update the module dependency map and TODO references to reflect the reduced discretization surface.

Tests:
- Add regression coverage for temporary LocsetBatch members being mapped to their own branches, coordinates, and CVs.
- Consolidate and extend CV-location tests, including boundary and empty-tiling behavior.

Chores:
- Remove stale unused imports from the affected cell tests.