### PR TITLE
refactor(_single_compartment): one channel walk and one named IndependentIntegration predicate

### DIFF
--- a/braincell/_single_compartment/base.py
+++ b/braincell/_single_compartment/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Optional, Callable, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import brainstate
 import braintools
@@ -48,7 +48,7 @@ class SingleCompartment(HHTypedNeuron):
 
     .. math::
 
-        {braincell \over dt} = \phi_x {x_\infty (V) - x \over \tau_x(V)}
+        {d x \over dt} = \phi_x {x_\infty (V) - x \over \tau_x(V)}
 
     where :math:`x \in [M, N]`, :math:`\phi_x` is a temperature-dependent factor,
     :math:`x_\infty` is the steady state, and :math:`\tau_x` is the time constant.
@@ -147,6 +147,44 @@ class SingleCompartment(HHTypedNeuron):
         """
         return 1
 
+    def _ion_channels(self) -> Dict[str, IonChannel]:
+        """Return the directly attached ion channels, keyed by attribute name.
+
+        The one spelling of this graph walk. It is a walk rather than a
+        stored list because ``HHTypedNeuron.__init__`` only records the
+        channels passed to it as keyword arguments, while a channel may also
+        be assigned as an attribute afterwards.
+
+        Returns
+        -------
+        dict of str to IonChannel
+            Channels one level below this neuron, in attribute order.
+        """
+        return self.nodes(IonChannel, allowed_hierarchy=(1, 1))
+
+    @staticmethod
+    def _neuron_driven(channels: Dict[str, IonChannel]) -> List[IonChannel]:
+        """Select the channels whose integration this neuron drives.
+
+        A channel carrying the :class:`~braincell.IndependentIntegration`
+        marker advances its own state in ``ind_update``, so the neuron's
+        ``pre_integral`` / ``compute_derivative`` / ``post_integral`` hooks
+        must skip it — stepping it there as well would integrate it twice
+        per step. :meth:`update` deliberately does the opposite and calls
+        ``ind_update`` on every channel, including these.
+
+        Parameters
+        ----------
+        channels : dict of str to IonChannel
+            The result of :meth:`_ion_channels`.
+
+        Returns
+        -------
+        list of IonChannel
+            The subset this neuron is responsible for stepping.
+        """
+        return [ch for ch in channels.values() if not isinstance(ch, IndependentIntegration)]
+
     @property
     def area(self):
         """Membrane area used to convert injected current into current density."""
@@ -206,9 +244,8 @@ class SingleCompartment(HHTypedNeuron):
         I_ext : float, optional
             External current input. Default is 0 nA/cm^2.
         """
-        for key, node in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
-            if not isinstance(node, IndependentIntegration):
-                node.pre_integral(self.V.value)
+        for ch in self._neuron_driven(self._ion_channels()):
+            ch.pre_integral(self.V.value)
 
     def compute_derivative(self, I_ext=0.0 * u.nA / u.cm**2):
         """
@@ -222,16 +259,16 @@ class SingleCompartment(HHTypedNeuron):
         I_ext : float, optional
             External current input. Supports either current density or total current.
         """
+        channels = self._ion_channels()
         I_ext = self.sum_current_inputs(I_ext, self.V.value)
-        for key, ch in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
+        for key, ch in channels.items():
             try:
                 I_ext = I_ext + ch.current(self.V.value)
             except (TypeError, ValueError, RuntimeError, ArithmeticError) as e:
                 raise ValueError(f"Error in computing current for ion channel '{key}': \n{ch}\nError: {e}") from e
         self.V.derivative = I_ext / self.C
-        for key, node in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
-            if not isinstance(node, IndependentIntegration):
-                node.compute_derivative(self.V.value)
+        for ch in self._neuron_driven(channels):
+            ch.compute_derivative(self.V.value)
 
     def post_integral(self, I_ext=0.0 * u.nA / u.cm**2):
         """
@@ -246,9 +283,8 @@ class SingleCompartment(HHTypedNeuron):
             External current input. Default is 0 nA/cm^2.
         """
         self.V.value = self.sum_delta_inputs(init=self.V.value)
-        for key, node in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
-            if not isinstance(node, IndependentIntegration):
-                node.post_integral(self.V.value)
+        for ch in self._neuron_driven(self._ion_channels()):
+            ch.post_integral(self.V.value)
 
     def update(self, I_ext=0.0 * u.nA / u.cm**2):
         """
@@ -267,9 +303,10 @@ class SingleCompartment(HHTypedNeuron):
         spike : array-like
             An array indicating whether a spike occurred (1) or not (0) for each neuron.
         """
-        # update nodes
-        for key, node in self.nodes(IonChannel, allowed_hierarchy=(1, 1)).items():
-            node.ind_update(self.V.value)
+        # Every channel, including the self-integrating ones that the three
+        # hook methods above skip.
+        for ch in self._ion_channels().values():
+            ch.ind_update(self.V.value)
 
         # numerical integration
         last_V = self.V.value

--- a/braincell/_single_compartment/base_test.py
+++ b/braincell/_single_compartment/base_test.py
@@ -46,7 +46,7 @@ from braincell.channel import (
     Na_HH1952,
 )
 from braincell.ion import PotassiumFixed, SodiumFixed
-from braincell import DiffEqSingleState, DiffEqState
+from braincell import DiffEqSingleState, DiffEqState, IndependentIntegration
 from braincell.quad import rk2_step, rk4_step
 
 
@@ -625,6 +625,94 @@ class SingleCompartmentUpdateTest(unittest.TestCase):
             sc.update(0.0 * u.nA / u.cm**2)
         v = sc.V.value.to_decimal(u.mV)
         self.assertTrue(bool(jnp.all(jnp.isfinite(v))))
+
+
+# ---------------------------------------------------------------------------
+# IndependentIntegration dispatch
+# ---------------------------------------------------------------------------
+
+
+class _SelfIntegratingChannel(Channel, IndependentIntegration):
+    """A channel that advances itself, recording which hooks reach it.
+
+    ``IndependentIntegration`` is a marker: a channel carrying it steps its
+    own state in ``ind_update`` and must therefore be skipped by the
+    neuron's ``pre_integral`` / ``compute_derivative`` / ``post_integral``
+    hooks, or it would be integrated twice per step.
+    """
+
+    root_type = HHTypedNeuron
+
+    def __init__(self, size, name=None):
+        super().__init__(size=size, name=name)
+        self.calls = []
+
+    def current(self, V):
+        return 0.0 * u.nA / u.cm**2
+
+    def init_state(self, V, batch_size=None):
+        pass
+
+    def reset_state(self, V, batch_size=None):
+        pass
+
+    def pre_integral(self, V):
+        self.calls.append("pre_integral")
+
+    def compute_derivative(self, V):
+        self.calls.append("compute_derivative")
+
+    def post_integral(self, V):
+        self.calls.append("post_integral")
+
+    def ind_update(self, V, *args):
+        self.calls.append("ind_update")
+
+
+class SingleCompartmentIndependentIntegrationTest(unittest.TestCase):
+    """The neuron must not step a channel that steps itself.
+
+    Pins both halves of the split: the three hook methods filter
+    ``IndependentIntegration`` channels out, and ``update`` drives every
+    channel's ``ind_update`` including those. Without this, the shared
+    predicate behind the filter is an untested invariant.
+    """
+
+    def _neuron(self):
+        brainstate.environ.set(dt=0.01 * u.ms)
+        channel = _SelfIntegratingChannel(size=(1,))
+        sc = SingleCompartment(size=(1,), self_int=channel)
+        sc.init_state()
+        channel.calls.clear()
+        return sc, channel
+
+    def test_hooks_skip_a_self_integrating_channel(self) -> None:
+        sc, channel = self._neuron()
+        sc.pre_integral(0.0 * u.nA / u.cm**2)
+        sc.compute_derivative(0.0 * u.nA / u.cm**2)
+        sc.post_integral(0.0 * u.nA / u.cm**2)
+        self.assertEqual(channel.calls, [])
+
+    def test_hooks_do_reach_an_ordinary_channel(self) -> None:
+        """The control: the same three hooks reach a channel without the mixin."""
+        brainstate.environ.set(dt=0.01 * u.ms)
+        leak = IL(size=(1,))
+        sc = SingleCompartment(size=(1,), leak=leak)
+        sc.init_state()
+        seen = []
+        leak.pre_integral = lambda V: seen.append("pre_integral")
+        leak.post_integral = lambda V: seen.append("post_integral")
+        sc.pre_integral(0.0 * u.nA / u.cm**2)
+        sc.post_integral(0.0 * u.nA / u.cm**2)
+        self.assertEqual(seen, ["pre_integral", "post_integral"])
+
+    def test_update_still_drives_ind_update(self) -> None:
+        sc, channel = self._neuron()
+        with brainstate.environ.context(t=0.0 * u.ms):
+            sc.update(0.0 * u.nA / u.cm**2)
+        self.assertIn("ind_update", channel.calls)
+        self.assertNotIn("pre_integral", channel.calls)
+        self.assertNotIn("post_integral", channel.calls)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/specs/2026-09-02-single-compartment-simplification.md
+++ b/docs/specs/2026-09-02-single-compartment-simplification.md
@@ -1,0 +1,181 @@
+# `braincell/_single_compartment` simplification
+
+Iteration 10 of the module-by-module simplification sweep. Written before
+any code changed; the Verification section at the end is filled in
+afterwards.
+
+## Baseline
+
+`braincell/_single_compartment` is the smallest package in the sweep. It
+holds one class, `SingleCompartment`, the point-neuron counterpart to
+`_multi_compartment.Cell`.
+
+| module | lines | role |
+| --- | --- | --- |
+| `base_test.py` | 709 | tests |
+| `base.py` | 284 | the `SingleCompartment` class |
+| `__init__.py` | 19 | export surface |
+
+Tests: `pytest braincell/_single_compartment -q` -> **48 passed, 22
+subtests passed in 12.80s**.
+
+## Findings
+
+Every claim below was verified against this worktree.
+
+### 1. The ion-channel graph walk is written four times and run seven times per step
+
+`self.nodes(IonChannel, allowed_hierarchy=(1, 1))` appears at `base.py`
+lines 209, 226, 232, 249 and 271 — four methods, and `compute_derivative`
+does it **twice** in a row over the same unchanged graph.
+
+One `update()` under the default rk2 solver evaluates
+`compute_derivative` twice, so the walk count per step is
+`1 (ind_update) + 2 x 2 (compute_derivative) + 1 (pre) + 1 (post)` = **7**,
+measured by instrumenting the call:
+
+```
+compute_derivative() evaluations per update(): 2  (rk2 has 2 stages)
+graph walks per update(): 7
+```
+
+Each walk costs, on a 3-channel 200-neuron `SingleCompartment`:
+
+```
+nodes(IonChannel, (1,1)) : 95.98 us/call  (3 top-level channels)
+```
+
+**This is not a runtime cost.** `update()` is meant to run inside
+`brainstate.transform.jit` / `for_loop`, which trace the Python body once,
+so the ~0.7 ms is paid per *trace*, not per step. Measured eagerly it is
+0.9% of a step, and eager stepping is not the supported way to drive the
+model. The finding is duplication, not speed — recorded here with the
+number so that nobody re-litigates it as an optimization.
+
+### 2. The `IndependentIntegration` predicate is written three times and explained zero times
+
+```python
+if not isinstance(node, IndependentIntegration):
+```
+
+appears verbatim in `pre_integral`, `compute_derivative` and
+`post_integral`, while `update` deliberately calls `ind_update` on *every*
+channel including those. That asymmetry is the whole contract of the mixin
+— a channel that integrates itself must not also be stepped by its
+neuron — and nothing in this module says so.
+
+The same predicate appears six more times in `_base_ion.py` and several
+more in `_multi_compartment/cell.py`. That is a package-wide concern, not a
+`_single_compartment` one; see the deferral below.
+
+### 3. `key` is bound and never used in three of the four loops
+
+`for key, node in ...` in `pre_integral`, `post_integral` and `update`
+never reads `key`. Only `compute_derivative` uses it, in its error message.
+
+### 4. A package rename corrupted the class docstring's central formula
+
+`base.py:51` reads
+
+```
+{braincell \over dt} = \phi_x {x_\infty (V) - x \over \tau_x(V)}
+```
+
+The numerator should be `d x` — the surrounding prose says "where
+:math:`x \in [M, N]`", and the next display renders the same law in
+alpha/beta form. A find-and-replace of the old package name rewrote the
+`dx`. `git grep` finds this as the only surviving instance in the
+repository, so it is a one-off, and it renders into the published API docs.
+
+### 5. Nothing tests the dispatch split that finding 2 describes
+
+`grep -c IndependentIntegration braincell/_single_compartment/base_test.py`
+-> **0**. The 48 tests cover defaults, geometry, lifecycle, spikes, solver
+resolution and state grouping, but no test asserts that an
+`IndependentIntegration` channel is skipped by the three hook methods and
+still driven by `update`. Refactoring that rule into a named helper without
+first pinning it would be moving an untested invariant.
+
+## Changes
+
+- Add `_ion_channels()` and `_neuron_driven()` to
+  `SingleCompartment`. The first is the one spelling of the graph walk; the
+  second applies the `IndependentIntegration` filter and carries the
+  docstring explaining why it exists. The four call sites use them.
+- `compute_derivative` walks once instead of twice, reusing the dict it
+  already has for its second loop. Seven walks per `update()` become five.
+- Drop the unused `key` binding from the three loops that ignore it.
+- Fix the corrupted `{braincell \over dt}` to `{d x \over dt}`.
+- Add `SingleCompartmentIndependentIntegrationTest`, pinning both halves of
+  the dispatch split, written before the refactor.
+
+## Breaking changes
+
+None. `_ion_channels` and `_neuron_driven` are new private helpers;
+no public name, signature or behaviour changes.
+
+## Considered and declined
+
+**Caching the channel walk on the instance.** It would turn five walks per
+`update()` into one, but `self.nodes(...)` must observe channels assigned as
+attributes after construction — `HHTypedNeuron.__init__` only records those
+passed as keyword arguments — so a cache would need an invalidation hook
+that does not exist today. At 96 us per trace the walk is not worth
+inventing one for.
+
+**Hoisting `_neuron_driven` onto `HHTypedNeuron`.** The right home
+for a predicate shared by `_single_compartment`, `_base_ion` and
+`_multi_compartment`, but moving it is a three-package change; see below.
+
+## Deferred to later iterations of the sweep
+
+- **Iteration 14 (whole package).** `not isinstance(node,
+  IndependentIntegration)` appears three times here, six times in
+  `_base_ion.py` (lines 275, 292, 309, 531, 538, 545) and repeatedly in
+  `_multi_compartment/cell.py` (1700, 1709, 1973, ...). One shared helper
+  on `HHTypedNeuron` or in `quad.protocol` should replace all of them, and
+  that decision spans the packages rather than belonging to any one of
+  them.
+
+## Verification
+
+Run from the worktree with `PYTHONPATH=$PWD JAX_PLATFORMS=cpu`.
+
+The three invariant tests were written first and pass against unmodified
+code — they document existing correct behaviour rather than reproduce a
+bug, which is the point: they had to exist before the predicate behind them
+could be moved.
+
+```
+$ pytest braincell/_single_compartment/base_test.py -q -k IndependentIntegration
+3 passed, 48 deselected in 5.41s
+```
+
+After the refactor:
+
+```
+$ pytest braincell/_single_compartment -q
+51 passed, 22 subtests passed in 10.13s
+
+$ pytest braincell/ -q
+2807 passed, 15 skipped, 408 warnings, 410 subtests passed in 213.99s
+```
+
+Baseline was 48; the delta is the three added tests.
+
+Structural check — the walk and the predicate now have one site each:
+
+```
+$ grep -c "self.nodes(IonChannel" braincell/_single_compartment/base.py
+1
+$ grep -c "isinstance(node, IndependentIntegration)" braincell/_single_compartment/base.py
+0
+```
+
+Walk count per `update()`, measured by instrumenting the call:
+
+```
+compute_derivative() evaluations per update(): 2  (rk2 has 2 stages)
+graph walks per update(), after : 5
+graph walks per update(), before: 7
+```


### PR DESCRIPTION
Iteration 10 of the module-by-module simplification sweep. Spec:
`docs/specs/2026-09-02-single-compartment-simplification.md`, written before
any code changed.

The smallest package in the sweep — one class, 284 lines — so this is a
focused cleanup rather than a structural change.

## What was duplicated

`self.nodes(IonChannel, allowed_hierarchy=(1, 1))` appeared in four methods,
and `compute_derivative` ran it **twice in a row** over an unchanged graph.
Under the default rk2 solver that is seven walks per `update()`:

```
compute_derivative() evaluations per update(): 2  (rk2 has 2 stages)
graph walks per update(), before: 7
graph walks per update(), after : 5
```

Alongside it, `if not isinstance(node, IndependentIntegration):` was written
verbatim three times and explained nowhere — even though the asymmetry it
encodes is the entire contract of the mixin: the three hook methods must
skip a channel that integrates itself, while `update` deliberately calls
`ind_update` on *every* channel including those. Stepping such a channel in
both places would integrate it twice per step.

Both now have one site: `_ion_channels()` and `_neuron_driven()`, the latter
carrying the docstring for the rule. The unused `key` binding is dropped
from the three loops that never read it.

## This is not an optimization, and is not claimed as one

Each walk costs ~96 µs on a 3-channel 200-neuron model, but `update()` is
meant to run inside `brainstate.transform.jit` / `for_loop`, which trace the
Python body once — so that cost is paid per *trace*, not per step. Measured
eagerly it is 0.9% of a step, and eager stepping is not the supported way to
drive the model. The number is in the spec so nobody re-litigates it.

## A docstring bug

`base.py:51` rendered the model's central equation as

```
{braincell \over dt} = \phi_x {x_\infty (V) - x \over \tau_x(V)}
```

A find-and-replace of the old package name had rewritten `d x`. The
surrounding prose says "where :math:`x \in [M, N]`" and the next display
gives the same law in alpha/beta form, so the intent is unambiguous.
`git grep` confirms it was the only surviving instance in the repository,
and it renders into the published API docs.

## Tests first

`grep -c IndependentIntegration braincell/_single_compartment/base_test.py`
returned **0** — the 48 existing tests covered defaults, geometry,
lifecycle, spikes, solver resolution and state grouping, but nothing pinned
the dispatch split. Moving an untested invariant into a helper is how it
gets quietly broken, so three tests were added first, covering both halves
plus a control that an ordinary channel *is* reached:

```
$ pytest braincell/_single_compartment/base_test.py -q -k IndependentIntegration
3 passed, 48 deselected in 5.41s
```

They pass against unmodified code — they document correct behaviour rather
than reproduce a bug, which is the point.

## Breaking changes

None. `_ion_channels` and `_neuron_driven` are new private helpers; no
public name, signature or behaviour changes.

## Verification

```
$ pytest braincell/_single_compartment -q
51 passed, 22 subtests passed in 10.13s

$ pytest braincell/ -q
2807 passed, 15 skipped, 408 warnings, 410 subtests passed in 213.99s (0:03:33)

$ grep -c "self.nodes(IonChannel" braincell/_single_compartment/base.py
1
$ grep -c "isinstance(node, IndependentIntegration)" braincell/_single_compartment/base.py
0
```

Baseline was 48 and 2804; the delta is the three added tests. All 12
pre-commit hooks pass.

## Deferred

The same predicate appears six more times in `_base_ion.py` and repeatedly
in `_multi_compartment/cell.py`. One shared helper on `HHTypedNeuron` or in
`quad.protocol` should replace all of them, but that spans three packages,
so it is recorded for iteration 14 rather than done here.

## Summary by Sourcery

Simplify SingleCompartment channel dispatch and document its IndependentIntegration contract without changing public behavior.

Bug Fixes:
- Correct the malformed differential-equation rendering in the SingleCompartment API documentation.

Enhancements:
- Centralize direct ion-channel discovery and IndependentIntegration dispatch in private SingleCompartment helpers while preserving existing integration behavior.
- Reuse a single channel discovery result during derivative computation, reducing duplicate graph walks without changing runtime semantics.

Documentation:
- Fix the central gating-variable equation displayed in the SingleCompartment class documentation.

Tests:
- Add coverage verifying that self-integrating channels are skipped by neuron-driven hooks, ordinary channels remain reachable, and all channels receive ind_update.