### PR TITLE
refactor(_multi_compartment)!: fix coverage and cache defects, collapse duplicated resolvers, delete dead code

### DIFF
--- a/braincell/_compute/__init___test.py
+++ b/braincell/_compute/__init___test.py
@@ -476,7 +476,11 @@ class AcyclicTest(unittest.TestCase):
             "layouts": set(),
             "scheduling": set(),
             "state": {"bindings", "bridge", "layouts"},
-            "table": {"state"},
+            # ``table`` builds its rows by matching mechanisms against
+            # layout signatures, so it reads ``layouts`` directly rather
+            # than through ``state``. ``layouts`` is a leaf, so the edge
+            # keeps the graph a DAG.
+            "table": {"layouts", "state"},
         }
         actual = {name: set(edges) for name, edges in _sibling_graph(_scan_package()).items()}
         self.assertEqual(expected, actual)

--- a/braincell/_compute/bindings_test.py
+++ b/braincell/_compute/bindings_test.py
@@ -117,7 +117,7 @@ class RuntimeBindingTest(unittest.TestCase):
         layouts = tuple(layout for layout in rcell.layouts if layout.kind == "channel:Na_HH1952")
         nodes = tuple(rcell.get_runtime_node(layout.id) for layout in layouts)
         na = rcell.get_ion("na")
-        point_V = rcell._discretization_to_point(rcell.V.value)
+        point_V = rcell._cv_to_point(rcell.V.value)
         expected = nodes[0].current(point_V, na.pack_info())
         total = na.current(point_V, include_external=False)
 
@@ -307,7 +307,7 @@ class RuntimeBindingTest(unittest.TestCase):
         nodes = tuple(rcell.get_runtime_node(layout.id) for layout in layouts)
         k_main = rcell.get_ion("k_main")
         ca_hva = rcell.get_ion("ca_hva")
-        point_V = rcell._discretization_to_point(rcell.V.value)
+        point_V = rcell._cv_to_point(rcell.V.value)
         expected = nodes[0].current(point_V, k_main.pack_info(), ca_hva.pack_info())
         total = k_main.current(point_V, include_external=False)
 
@@ -350,7 +350,7 @@ class RuntimeBindingTest(unittest.TestCase):
         runtime = rcell.runtime
         layout = next(layout for layout in rcell.layouts if layout.kind == "channel:Kca3p1_MA2020_GoC")
         node = rcell.get_runtime_node(layout.id)
-        point_V = rcell._discretization_to_point(rcell.V.value)
+        point_V = rcell._cv_to_point(rcell.V.value)
         expected_mechanism = node.current(
             point_V,
             rcell.get_ion("k_main").pack_info(),
@@ -391,7 +391,7 @@ class RuntimeBindingTest(unittest.TestCase):
             )
             seen = []
             wrapper._channel.ind_update = lambda *args, **kwargs: seen.append(args)
-            wrapper.ind_update(cell._discretization_to_point(cell.V.value))
+            wrapper.ind_update(cell._cv_to_point(cell.V.value))
             # Only the state-owning wrapper forwards; the component wrapper
             # for a non-owning ion must not integrate the shared state twice.
             self.assertEqual(len(seen), 1 if wrapper._owns_state else 0)
@@ -422,7 +422,7 @@ class RuntimeBindingTest(unittest.TestCase):
         rcell = cell
 
         layout = next(layout for layout in rcell.layouts if layout.kind == "channel:_RuntimeTestTwoOwnerChannel")
-        point_V = rcell._discretization_to_point(rcell.V.value)
+        point_V = rcell._cv_to_point(rcell.V.value)
         node = rcell.get_runtime_node(layout.id)
         k_main = rcell.get_ion("k_main")
         no = rcell.get_ion("no")

--- a/braincell/_compute/layouts.py
+++ b/braincell/_compute/layouts.py
@@ -79,6 +79,7 @@ __all__ = [
     "Target",
     "build_clamp_routing_table",
     "choose_layout",
+    "layout_id_from_key",
     "mechanism_kind",
     "mechanism_signature",
 ]
@@ -383,6 +384,45 @@ def _fn_fingerprint(fn) -> tuple:
                 stacklevel=2,
             )
     return (code.co_code, code.co_consts, code.co_varnames, tuple(closure_cells))
+
+
+def layout_id_from_key(key) -> int:
+    """Recover a layout id from a runtime node key or path.
+
+    Runtime mechanism nodes are installed under a single path segment
+    spelled ``"layout_<id>"``, so a graph walk that yields a path can name
+    the layout it came from. This is the one place that convention is
+    parsed.
+
+    Parameters
+    ----------
+    key : sequence
+        Runtime node key or path. Only the last segment is read.
+
+    Returns
+    -------
+    int
+        The layout id the final segment names.
+
+    Raises
+    ------
+    ValueError
+        If ``key`` is empty or its last segment is not ``"layout_<id>"``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> from braincell._compute.layouts import layout_id_from_key
+        >>> layout_id_from_key(("layout_7",))
+        7
+    """
+    if len(key) == 0:
+        raise ValueError(f"Expected a runtime key ending with 'layout_<id>', got {key!r}.")
+    last = key[-1]
+    if not isinstance(last, str) or not last.startswith("layout_"):
+        raise ValueError(f"Expected a runtime key ending with 'layout_<id>', got {key!r}.")
+    return int(last.split("_", 1)[1])
 
 
 def mechanism_signature(mechanism: object) -> tuple[object, ...]:

--- a/braincell/_compute/state.py
+++ b/braincell/_compute/state.py
@@ -126,7 +126,7 @@ class CellRuntimeState:
       :meth:`get_point_state`, :meth:`get_cv_state`
     - runtime object lookup: :meth:`get_runtime_node`, :meth:`get_ion`
     - point-level clamp evaluation: :meth:`evaluate_point_clamps`
-    - table views: :meth:`mechanism_cv_table`, :meth:`mechanism_point_table`
+    - table views: :func:`braincell._compute.table.build_mechanism_object_table`
 
     The main collaboration is upward: :class:`Cell` compiles and caches one
     ``CellRuntimeState`` instance, then uses it to install runtime nodes, bridge

--- a/braincell/_compute/state_test.py
+++ b/braincell/_compute/state_test.py
@@ -202,7 +202,7 @@ class CellRuntimeStateTest(unittest.TestCase):
         samples = rcell.sample_probes()
         ion = rcell.get_ion("k")
         node = ion.channels["K_Kv_test"]
-        point_V = rcell._discretization_to_point(rcell.V.value)
+        point_V = rcell._cv_to_point(rcell.V.value)
         expected_mechanism = node.current(point_V, ion.pack_info())[..., 1]
         expected_total = ion.current(point_V, include_external=False)[..., 1]
 
@@ -233,7 +233,7 @@ class CellRuntimeStateTest(unittest.TestCase):
             if isinstance(rcell.runtime.get_layout_mechanism(layout.id), braincell.mech.Channel)
         )
         node = rcell.get_runtime_node(channel_layout.id)
-        point_V = rcell._discretization_to_point(rcell.V.value)
+        point_V = rcell._cv_to_point(rcell.V.value)
         expected_current = node.current(point_V)[..., 1]
 
         self.assertEqual(samples["soma(0.5)_IL_current"], expected_current)

--- a/braincell/_compute/table.py
+++ b/braincell/_compute/table.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 from dataclasses import dataclass, fields, is_dataclass
-from typing import Literal
+from typing import Literal, Sequence
 
 import numpy as np
 
@@ -27,11 +27,13 @@ from braincell.mech import (
     StateProbe,
     Synapse,
 )
+from .layouts import mechanism_signature
 from .state import CellRuntimeState
 
 __all__ = [
     "MechanismObjectCell",
     "MechanismObjectTable",
+    "build_mechanism_object_table",
     "mechanism_cell_key",
 ]
 
@@ -218,3 +220,109 @@ def mechanism_cell_key(mechanism: object) -> tuple[str, str]:
         return (class_name, class_name)
     class_name = type(mechanism).__name__
     return (class_name, class_name)
+
+
+def build_mechanism_object_table(
+    runtime: CellRuntimeState,
+    cvs: "Sequence[object]",
+) -> MechanismObjectTable:
+    """Assemble the point-domain mechanism table for one lowered cell.
+
+    Rows are logical mechanism identities (see :func:`mechanism_cell_key`)
+    and columns are point ids. A density mechanism is attributed to its
+    CV's midpoint point, a point mechanism to the point it sits on, so a
+    single table can show both.
+
+    Parameters
+    ----------
+    runtime : CellRuntimeState
+        Lowered runtime supplying the node tree and the layout registry.
+    cvs : sequence of braincell._discretization.base.CV
+        The cell's CV records, source of the density attributions.
+
+    Returns
+    -------
+    MechanismObjectTable
+        A table whose entries are :class:`MechanismObjectCell` facades, or
+        ``None`` where a mechanism is absent from that point.
+
+    See Also
+    --------
+    braincell.Cell.mech_table : The user-facing entry point.
+    """
+    node_tree = runtime.node_tree
+    column_ids = tuple(range(len(node_tree.nodes)))
+
+    row_keys: list[tuple[str, str]] = []
+    row_labels: list[str] = []
+    row_index_by_key: dict[tuple[str, str], int] = {}
+    pending_cells: list[tuple[int, int, MechanismObjectCell]] = []
+
+    layout_id_by_signature = {
+        (layout.target,) + mechanism_signature(runtime.get_layout_mechanism(layout.id)): layout.id
+        for layout in runtime.layouts
+    }
+    layout_id_by_synapse_type = {
+        runtime.get_layout_mechanism(layout.id).synapse_type: layout.id
+        for layout in runtime.layouts
+        if isinstance(runtime.get_layout_mechanism(layout.id), Synapse)
+    }
+
+    def add_cell(mechanism: object, *, point_id: int, layout_id: int) -> None:
+        row_key = mechanism_cell_key(mechanism)
+        row_index = row_index_by_key.get(row_key)
+        if row_index is None:
+            row_index = len(row_keys)
+            row_keys.append(row_key)
+            class_name, instance_name = row_key
+            row_labels.append(class_name if class_name == instance_name else f"{instance_name}:{class_name}")
+            row_index_by_key[row_key] = row_index
+        pending_cells.append(
+            (
+                row_index,
+                point_id,
+                MechanismObjectCell(
+                    runtime=runtime,
+                    layout_id=int(layout_id),
+                    class_name=row_key[0],
+                    instance_name=row_key[1],
+                    column_id=point_id,
+                    domain="point",
+                    cv_id=None,
+                    point_id=point_id,
+                ),
+            )
+        )
+
+    for cv in cvs:
+        midpoint_point_id = int(node_tree.cv_to_mid_node_id[cv.id])
+        for mechanism in cv.density_mech:
+            add_cell(
+                mechanism,
+                point_id=midpoint_point_id,
+                layout_id=layout_id_by_signature[("density",) + mechanism_signature(mechanism)],
+            )
+
+    for point_id, node in enumerate(node_tree.nodes):
+        for mechanism in node.point_mech:
+            add_cell(
+                mechanism,
+                point_id=int(point_id),
+                layout_id=(
+                    layout_id_by_synapse_type[mechanism.synapse_type]
+                    if isinstance(mechanism, Synapse)
+                    else layout_id_by_signature[("point",) + mechanism_signature(mechanism)]
+                ),
+            )
+
+    values = np.full((len(row_keys), len(column_ids)), None, dtype=object)
+    for row_index, column_id, cell in pending_cells:
+        values[row_index, int(column_id)] = cell
+
+    return MechanismObjectTable(
+        domain="point",
+        row_keys=tuple(row_keys),
+        row_labels=tuple(row_labels),
+        column_ids=column_ids,
+        values=values,
+    )

--- a/braincell/_compute/table_test.py
+++ b/braincell/_compute/table_test.py
@@ -19,7 +19,8 @@ import brainunit as u
 
 import braincell
 from braincell import Branch, Cell, Morphology
-from braincell.filter import BranchSlice
+from braincell._compute.table import build_mechanism_object_table
+from braincell.filter import BranchSlice, RootLocation
 
 
 def _simple_cell() -> Cell:
@@ -52,3 +53,60 @@ class MechanismObjectCellAttrAccess(unittest.TestCase):
         msg = str(ctx.exception)
         self.assertIn("not_a_real_field", msg)
         self.assertIn("g_max", msg)
+
+
+class BuildMechanismObjectTableTest(unittest.TestCase):
+    """The builder is the whole of ``Cell.mech_table()``.
+
+    ``Cell`` used to inline this assembly; it now delegates, so the two
+    must produce the same table, and the table must cover both kinds of
+    mechanism it claims to -- a density painted over the membrane and a
+    point mechanism placed at a location.
+    """
+
+    def _cell_with_both_kinds(self) -> Cell:
+        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        tree = Morphology.from_root(soma, name="soma")
+        cell = Cell(tree)
+        cell.paint(
+            BranchSlice(branch_index=0, prox=0.0, dist=1.0),
+            braincell.mech.Channel("IL", g_max=4.0 * (u.mS / u.cm**2), E=-68.0 * u.mV),
+        )
+        cell.place(RootLocation(0.5), braincell.mech.StateProbe(field="v", name="V_root"))
+        cell.init_state()
+        return cell
+
+    def test_it_matches_what_the_cell_method_returns(self) -> None:
+        cell = self._cell_with_both_kinds()
+        direct = build_mechanism_object_table(cell.runtime, cell.cvs)
+        through_cell = cell.mech_table()
+
+        self.assertEqual(direct.domain, through_cell.domain)
+        self.assertEqual(direct.row_keys, through_cell.row_keys)
+        self.assertEqual(direct.row_labels, through_cell.row_labels)
+        self.assertEqual(direct.column_ids, through_cell.column_ids)
+        self.assertEqual(direct.shape, through_cell.shape)
+
+    def test_it_covers_both_a_density_and_a_point_mechanism(self) -> None:
+        table = self._cell_with_both_kinds().mech_table()
+        self.assertIn(("IL", "IL"), table.row_keys)
+        self.assertIn(("StateProbe", "V_root"), table.row_keys)
+
+    def test_every_populated_entry_names_its_own_row_and_column(self) -> None:
+        table = self._cell_with_both_kinds().mech_table()
+        populated = 0
+        for row_index, row_key in enumerate(table.row_keys):
+            for column_index, column_id in enumerate(table.column_ids):
+                entry = table.values[row_index, column_index]
+                if entry is None:
+                    continue
+                populated += 1
+                self.assertEqual((entry.class_name, entry.instance_name), row_key)
+                self.assertEqual(entry.column_id, column_id)
+                self.assertEqual(entry.point_id, column_id)
+                self.assertIsNone(entry.cv_id)
+        self.assertGreater(populated, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/braincell/_discretization/base.py
+++ b/braincell/_discretization/base.py
@@ -266,6 +266,20 @@ class CV:
         return RegionMask(((self.branch_id, self.prox, self.dist),))
 
     @property
+    def midpoint(self) -> float:
+        """Return the CV midpoint in normalized branch coordinates.
+
+        Derived rather than stored, so it cannot drift from the bounds it
+        is the middle of.
+
+        Returns
+        -------
+        float
+            ``(prox + dist) / 2``, in ``[0, 1]``.
+        """
+        return 0.5 * (self.prox + self.dist)
+
+    @property
     def diam_mid(self) -> u.Quantity:
         """Return the diameter at the CV midpoint.
 

--- a/braincell/_discretization/geometry.py
+++ b/braincell/_discretization/geometry.py
@@ -22,17 +22,19 @@ state or instantiated mechanism objects.
 """
 
 from dataclasses import dataclass, replace
+from typing import Callable, Sequence
 
 import brainunit as u
 import numpy as np
 
 from braincell.morph.branch import Branch, frustum_areas_um2, length_weighted_mean_radius_um
 from braincell.morph.morphology import Morphology
-from .base import EPS_LEN_UM, EPS_PARAM, locate_cv_on_branch
+from .base import EPS_AREA_UM2, EPS_LEN_UM, EPS_PARAM, locate_cv_on_branch
 
 __all__ = [
     "CVGeometryResult",
     "build_cv_geometry",
+    "interval_area_fraction",
     "validate_bounds",
     "validate_connectivity",
     "validate_morphology",
@@ -357,6 +359,82 @@ def _lateral_area_um2(frusta: tuple[_Frustum, ...]) -> float:
     morphology disagree about the same surface without any test noticing.
     """
     return float(np.sum(frustum_areas_um2(*_frustum_arrays(frusta))))
+
+
+def interval_area_fraction(
+    branch: Branch,
+    *,
+    prox: float,
+    dist: float,
+    lateral_area_um2: float,
+    intervals: Sequence[tuple[float, float]],
+    frusta_builder: Callable[..., tuple[_Frustum, ...]] | None = None,
+) -> float:
+    """Return how much of one CV's membrane area ``intervals`` covers.
+
+    This is the single definition of "coverage" in BrainCell. It is an
+    *area* fraction, not a length fraction: on a tapering branch the two
+    differ, and the area one is what physically matters, because a density
+    mechanism painted over part of a CV contributes in proportion to the
+    membrane it actually sits on. :meth:`braincell.mech.Density.with_coverage`
+    stores the result as ``coverage_area_fraction``.
+
+    Parameters
+    ----------
+    branch : braincell.morph.branch.Branch
+        Branch that owns the CV.
+    prox : float
+        Proximal CV boundary in normalized branch coordinates.
+    dist : float
+        Distal CV boundary in normalized branch coordinates.
+    lateral_area_um2 : float
+        The CV's total lateral membrane area, in um^2. A CV at or below
+        ``EPS_AREA_UM2`` carries no membrane and so covers nothing.
+    intervals : sequence of tuple of float
+        Normalized ``(prox, dist)`` spans on this branch, as produced by
+        :func:`braincell.filter.helper.normalize_region_intervals`. Spans
+        outside ``[prox, dist]`` are clipped; spans that survive clipping
+        with negligible width are dropped.
+    frusta_builder : callable, optional
+        Override for the frustum slicer, used to share one memoized builder
+        across the many CVs of one discretization pass. Called as
+        ``frusta_builder(branch, prox=..., dist=...)``.
+
+    Returns
+    -------
+    float
+        A fraction clamped to ``[0, 1]``.
+
+    See Also
+    --------
+    braincell.mech.Density.with_coverage : Consumer of this fraction.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainunit as u
+        >>> from braincell import Branch
+        >>> from braincell._discretization.geometry import interval_area_fraction
+        >>> taper = Branch.from_lengths(lengths=[100.0] * u.um,
+        ...                             radii=[4.0, 1.0] * u.um, type="dend")
+        >>> area = float(taper.area.to_decimal(u.um ** 2))
+        >>> round(interval_area_fraction(taper, prox=0.0, dist=1.0,
+        ...                              lateral_area_um2=area,
+        ...                              intervals=((0.0, 0.5),)), 4)
+        0.65
+    """
+    if lateral_area_um2 <= EPS_AREA_UM2:
+        return 0.0
+    build = _build_frusta if frusta_builder is None else frusta_builder
+    overlap = 0.0
+    for left, right in intervals:
+        start = max(float(prox), float(left))
+        end = min(float(dist), float(right))
+        if end - start <= EPS_PARAM:
+            continue
+        overlap += _lateral_area_um2(build(branch, prox=start, dist=end))
+    return max(0.0, min(1.0, overlap / lateral_area_um2))
 
 
 def _axial_factor_per_cm(frusta: tuple[_Frustum, ...]) -> float:

--- a/braincell/_discretization/mechanism.py
+++ b/braincell/_discretization/mechanism.py
@@ -41,13 +41,13 @@ from braincell.mech import (
     StateProbe,
 )
 from braincell.morph.morphology import Morphology
-from .base import DEFAULT_CABLE, EPS_AREA_UM2, EPS_PARAM, CVPointMechanism, Position
+from .base import DEFAULT_CABLE, EPS_PARAM, CVPointMechanism, Position
 from .context import build_cv_contexts
 from .geometry import (
     CVGeometryResult,
     _GeoCV,
     _build_frusta,
-    _lateral_area_um2,
+    interval_area_fraction,
 )
 
 __all__ = [
@@ -364,19 +364,14 @@ def _coverage_fraction(
     branch=None,
     frusta_builder=None,
 ) -> float:
-    if geo.lateral_area_um2 <= EPS_AREA_UM2:
-        return 0.0
-    if branch is None:
-        branch = morpho.branches[geo.branch_id]
-    build = frusta_builder if frusta_builder is not None else _build_frusta
-    overlap = 0.0
-    for left, right in intervals:
-        start = max(geo.prox, float(left))
-        end = min(geo.dist, float(right))
-        if end - start <= EPS_PARAM:
-            continue
-        overlap += _lateral_area_um2(build(branch, prox=start, dist=end))
-    return max(0.0, min(1.0, overlap / geo.lateral_area_um2))
+    return interval_area_fraction(
+        morpho.branches[geo.branch_id] if branch is None else branch,
+        prox=geo.prox,
+        dist=geo.dist,
+        lateral_area_um2=geo.lateral_area_um2,
+        intervals=intervals,
+        frusta_builder=frusta_builder,
+    )
 
 
 def _region_cv_coverage(

--- a/braincell/_multi_compartment/cell.py
+++ b/braincell/_multi_compartment/cell.py
@@ -60,15 +60,11 @@ from braincell._misc import (
     profiler_scope_name as _scope_name,
 )
 from braincell._typing import Initializer, Size
-from braincell._compute.table import (
-    MechanismObjectCell,
-    MechanismObjectTable,
-    mechanism_cell_key,
-)
+from braincell._compute.table import MechanismObjectTable, build_mechanism_object_table
 from braincell._compute.scheduling import build_node_scheduling
 from braincell._compute.state import CellRuntimeState
 from braincell._compute.bindings import _is_root_level_runtime_node
-from braincell._compute.layouts import mechanism_signature
+from braincell._compute.layouts import layout_id_from_key
 from braincell._discretization.mechanism import (
     PaintRule,
     PlaceRule,
@@ -98,7 +94,7 @@ from braincell.quad.protocol import DiffEqGroupState, IndependentIntegration, st
 from braincell.mech import CVContext, Synapse as SynapsePlacement
 from . import currents, field_resolution, probes, run as run_module
 from braincell._compute import bridge
-from .synapses import SynapseView, _SynapseStore
+from .synapses import SynapseView, _SynapseStore, raise_on_name_type_conflict
 from .selection import BranchSelector, CVSelector, _CellScope
 from .density_views import ChannelView, IonView
 
@@ -844,7 +840,6 @@ class Cell(_CellFacade, HHTypedNeuron):
         self._runtime_nodes_cache: tuple[RuntimeNodeView, ...] | None = None
         self._synapse_store_cache: _SynapseStore | None = None
         self._spike_event_source_cache: _CellSpikeSource | None = None
-        self._axial_jax = None
         self._synapse_input_bindings: dict[str, list[tuple[object, object, object]]] = {}
         self._synapse_parameter_overrides: dict[tuple[int, int, str], object] = {}
         self._density_parameter_overrides: dict[tuple[str, str, int, int, str], object] = {}
@@ -1225,8 +1220,20 @@ class Cell(_CellFacade, HHTypedNeuron):
         self._run_loop_cache.clear()
 
     def _discretization_key(self) -> tuple[object, ...]:
+        # ``Morphology`` is mutable and shared -- ``cell.morpho`` hands the
+        # caller the very tree this cell discretizes -- so identity alone
+        # cannot say whether it still looks the way it did when the cache
+        # was filled. ``revision`` advances on every structural change;
+        # pairing it with the identity is the same test
+        # ``braincell.filter.SelectionCache`` applies.
+        #
+        # The ``id()`` is sound here, unlike for a temporary whose address
+        # can be recycled: this cell holds ``self._morpho`` alive for as
+        # long as the key it appears in, and both sites that reassign the
+        # attribute invalidate the cache outright.
         return (
             id(self._morpho),
+            self._morpho.revision,
             self._discretization_policy,
             self._paint_rules,
             self._place_rules,
@@ -1238,6 +1245,9 @@ class Cell(_CellFacade, HHTypedNeuron):
         if self._discretization_cache is not None and self._discretization_cache_key == key:
             return self._discretization_cache
 
+        # Everything below hangs off the discretization, so a key miss has
+        # to drop those caches too -- not just the one being rebuilt.
+        self._invalidate_discretization_cache()
         discretization = build_discretization(
             self._morpho,
             policy=self._discretization_policy,
@@ -1274,7 +1284,7 @@ class Cell(_CellFacade, HHTypedNeuron):
         cvs = self.cvs
         return LocsetMask.from_columns(
             [cv.branch_id for cv in cvs],
-            [(cv.prox + cv.dist) * 0.5 for cv in cvs],
+            [cv.midpoint for cv in cvs],
         )
 
     @property
@@ -1346,20 +1356,20 @@ class Cell(_CellFacade, HHTypedNeuron):
 
     def _validate_synapse_names(self, mechanisms) -> None:
         """Reject one logical group name being reused across model types."""
-        declared = {}
-        for rule in self._place_rules:
-            for mechanism in rule.mechanisms:
-                if isinstance(mechanism, SynapsePlacement):
-                    declared.setdefault(mechanism.instance_name, mechanism.synapse_type)
-        for mechanism in mechanisms:
-            if not isinstance(mechanism, SynapsePlacement):
-                continue
-            previous = declared.setdefault(mechanism.instance_name, mechanism.synapse_type)
-            if previous != mechanism.synapse_type:
-                raise ValueError(
-                    f"Synapses with the same name {mechanism.instance_name!r} cannot use different synapse types "
-                    f"({previous!r} and {mechanism.synapse_type!r})."
-                )
+        declared = raise_on_name_type_conflict(
+            (mechanism.instance_name, mechanism.synapse_type)
+            for rule in self._place_rules
+            for mechanism in rule.mechanisms
+            if isinstance(mechanism, SynapsePlacement)
+        )
+        raise_on_name_type_conflict(
+            (
+                (mechanism.instance_name, mechanism.synapse_type)
+                for mechanism in mechanisms
+                if isinstance(mechanism, SynapsePlacement)
+            ),
+            known=declared,
+        )
 
     @property
     def recordings(self) -> Mapping[str, RecordingSpec]:
@@ -1462,7 +1472,6 @@ class Cell(_CellFacade, HHTypedNeuron):
         # so defer this matrix until ``_get_axial_operator()`` is actually used.
         self._runtime.axial_operator_np = None
         self._runtime.axial_operator_cache = None
-        self._axial_jax = None
         self._initialized = True
         self._runtime_cvs_cache = self._build_runtime_cv_views()
         self._runtime_nodes_cache = self._build_runtime_node_views()
@@ -1506,7 +1515,6 @@ class Cell(_CellFacade, HHTypedNeuron):
         self._runtime = None
         self._runtime_cvs_cache = None
         self._runtime_nodes_cache = None
-        self._axial_jax = None
         self._node_scheduling_cache.clear()
         self._run_loop_cache.clear()
         self._compiled_recording_cache.clear()
@@ -1676,10 +1684,6 @@ class Cell(_CellFacade, HHTypedNeuron):
     def _cv_to_point_unchecked(self, cv_values):
         return bridge.cv_to_point(cv_values, self._runtime)
 
-    # Internal aliases kept while older inspection helpers are still in use.
-    def _discretization_to_point(self, cv_values):
-        return self._cv_to_point(cv_values)
-
     def _point_to_cv(self, point_values):
         self._raise_if_not_initialized("_point_to_cv()")
         return bridge.point_to_cv(point_values, self._runtime)
@@ -1781,7 +1785,6 @@ class Cell(_CellFacade, HHTypedNeuron):
         float_dtype = jnp.asarray(0.0).dtype
         cache = runtime.axial_operator_cache
         if cache is not None and cache.float_dtype == float_dtype:
-            self._axial_jax = cache.operator
             return cache.operator
 
         if runtime.axial_operator_np is None:
@@ -1798,7 +1801,6 @@ class Cell(_CellFacade, HHTypedNeuron):
         cache = AxialOperatorCache(float_dtype=float_dtype, operator=operator)
         if not is_traced_value(operator):
             runtime.axial_operator_cache = cache
-        self._axial_jax = operator
         return operator
 
     def compute_axial_derivative(self, V):
@@ -1819,16 +1821,10 @@ class Cell(_CellFacade, HHTypedNeuron):
     def _family_channel_nodes(self):
         nodes = []
         for path, node in self._top_level_ion_channel_nodes():
-            if isinstance(node, Ion):
-                for child_path, child in brainstate.graph.nodes(
-                    node,
-                    Channel,
-                    allowed_hierarchy=(1, 1),
-                ).items():
-                    if getattr(child, "_skip_family_update", False):
-                        continue
-                    nodes.append((path + child_path, child))
-            elif isinstance(node, MixIons):
+            # ``Ion`` and ``MixIons`` are siblings, not a hierarchy
+            # (both derive from ``IonChannel, Container``), and a channel
+            # under either is reached the same way.
+            if isinstance(node, (Ion, MixIons)):
                 for child_path, child in brainstate.graph.nodes(
                     node,
                     Channel,
@@ -1840,67 +1836,6 @@ class Cell(_CellFacade, HHTypedNeuron):
             elif isinstance(node, Channel):
                 nodes.append((path, node))
         return tuple(nodes)
-
-    def _integrate_selected_ion_channel_states(self, selected_paths, point_V, excluded_paths=()):
-        selected_paths = tuple(tuple(path) for path in selected_paths)
-        if not selected_paths:
-            return
-        excluded_paths = [("V",), *tuple(tuple(path) for path in excluded_paths)]
-
-        def _pre_integral():
-            for path, node in self._top_level_ion_channel_nodes():
-                if isinstance(node, Ion) and path in selected_paths:
-                    node.pre_integral(point_V, recursive_child=False)
-                if isinstance(node, Channel) and path in selected_paths:
-                    node.pre_integral(point_V)
-                if isinstance(node, (Ion, MixIons)):
-                    self._run_selected_child_channel_hook(
-                        node,
-                        path,
-                        selected_paths,
-                        "pre_integral",
-                        point_V,
-                    )
-
-        def _compute_derivative():
-            for path, node in self._top_level_ion_channel_nodes():
-                if isinstance(node, Ion) and path in selected_paths:
-                    node.compute_derivative(point_V, recursive_child=False)
-                if isinstance(node, Channel) and path in selected_paths:
-                    node.compute_derivative(point_V)
-                if isinstance(node, (Ion, MixIons)):
-                    self._run_selected_child_channel_hook(
-                        node,
-                        path,
-                        selected_paths,
-                        "compute_derivative",
-                        point_V,
-                    )
-
-        def _post_integral():
-            for path, node in self._top_level_ion_channel_nodes():
-                if isinstance(node, Ion) and path in selected_paths:
-                    node.post_integral(point_V, recursive_child=False)
-                if isinstance(node, Channel) and path in selected_paths:
-                    node.post_integral(point_V)
-                if isinstance(node, (Ion, MixIons)):
-                    self._run_selected_child_channel_hook(
-                        node,
-                        path,
-                        selected_paths,
-                        "post_integral",
-                        point_V,
-                    )
-
-        _ind_exp_euler_step_selected(
-            self,
-            include_paths=selected_paths,
-            excluded_paths=excluded_paths,
-            pre_integral=_pre_integral,
-            compute_derivative=_compute_derivative,
-            post_integral=_post_integral,
-            allow_empty=True,
-        )
 
     def _integrate_selected_ion_self_states(
         self,
@@ -1929,22 +1864,6 @@ class Cell(_CellFacade, HHTypedNeuron):
             post_integral=lambda: _run_phase("post_integral"),
             allow_empty=True,
         )
-
-    @staticmethod
-    def _run_selected_child_channel_hook(parent, parent_path, selected_paths, hook_name, point_V):
-        for child_path, child in brainstate.graph.nodes(
-            parent,
-            Channel,
-            allowed_hierarchy=(1, 1),
-        ).items():
-            full_path = parent_path + child_path
-            if full_path not in selected_paths:
-                continue
-            if isinstance(parent, Ion):
-                getattr(child, hook_name)(point_V, parent.pack_info())
-            else:
-                infos = tuple([parent._get_ion(root).pack_info() for root in child.root_type.__args__])
-                getattr(child, hook_name)(point_V, *infos)
 
     def _update_ion_channels_by_integration(self, point_V):
         with jax.named_scope("braincell:ion_update:integration:dependent"):
@@ -2050,11 +1969,11 @@ class Cell(_CellFacade, HHTypedNeuron):
 
     def _runtime_node_phase_args(self, path, node, point_V):
         if isinstance(node, RuntimeSynapse):
-            layout_id = _layout_id_from_runtime_path(path)
+            layout_id = layout_id_from_key(path)
             layout = self._runtime.layouts[layout_id]
             if layout.point_index is None:
                 raise ValueError(f"Synapse layout {layout.id!r} is missing point_index.")
-            return (_gather_layout_point_values(point_V, layout),)
+            return (layout.gather_points(point_V),)
         return self._channel_update_args(path, node, point_V)
 
     @staticmethod
@@ -2524,97 +2443,20 @@ class Cell(_CellFacade, HHTypedNeuron):
         return probes.sample_probes(self)
 
     def mech_table(self) -> MechanismObjectTable:
+        """Return the point-domain mechanism table for this cell.
+
+        Returns
+        -------
+        braincell._compute.table.MechanismObjectTable
+            Rows are mechanism identities, columns are point ids.
+
+        Raises
+        ------
+        RuntimeError
+            If :meth:`init_state` has not been called.
+        """
         self._raise_if_not_initialized("mech_table()")
-        runtime = self._runtime
-        node_tree = self.node_tree
-        column_ids = tuple(range(len(node_tree.nodes)))
-
-        row_keys: list[tuple[str, str]] = []
-        row_labels: list[str] = []
-        row_index_by_key: dict[tuple[str, str], int] = {}
-        pending_cells: list[tuple[int, int, MechanismObjectCell]] = []
-        layout_id_by_signature = {
-            (layout.target,) + mechanism_signature(runtime.get_layout_mechanism(layout.id)): layout.id
-            for layout in runtime.layouts
-        }
-        layout_id_by_synapse_type = {
-            runtime.get_layout_mechanism(layout.id).synapse_type: layout.id
-            for layout in runtime.layouts
-            if isinstance(runtime.get_layout_mechanism(layout.id), SynapsePlacement)
-        }
-
-        def ensure_row(mechanism: object) -> int:
-            row_key = mechanism_cell_key(mechanism)
-            row_index = row_index_by_key.get(row_key)
-            if row_index is not None:
-                return row_index
-            row_index = len(row_keys)
-            row_keys.append(row_key)
-            class_name, instance_name = row_key
-            row_labels.append(class_name if class_name == instance_name else f"{instance_name}:{class_name}")
-            row_index_by_key[row_key] = row_index
-            return row_index
-
-        for cv in self.cvs:
-            midpoint_point_id = int(node_tree.cv_to_mid_node_id[cv.id])
-            for mechanism in cv.density_mech:
-                row_key = mechanism_cell_key(mechanism)
-                row_index = ensure_row(mechanism)
-                layout_id = layout_id_by_signature[("density",) + mechanism_signature(mechanism)]
-                pending_cells.append(
-                    (
-                        row_index,
-                        midpoint_point_id,
-                        MechanismObjectCell(
-                            runtime=runtime,
-                            layout_id=int(layout_id),
-                            class_name=row_key[0],
-                            instance_name=row_key[1],
-                            column_id=midpoint_point_id,
-                            domain="point",
-                            cv_id=None,
-                            point_id=midpoint_point_id,
-                        ),
-                    )
-                )
-
-        for point_id, node in enumerate(node_tree.nodes):
-            for mechanism in node.point_mech:
-                row_key = mechanism_cell_key(mechanism)
-                row_index = ensure_row(mechanism)
-                layout_id = (
-                    layout_id_by_synapse_type[mechanism.synapse_type]
-                    if isinstance(mechanism, SynapsePlacement)
-                    else layout_id_by_signature[("point",) + mechanism_signature(mechanism)]
-                )
-                pending_cells.append(
-                    (
-                        row_index,
-                        int(point_id),
-                        MechanismObjectCell(
-                            runtime=runtime,
-                            layout_id=int(layout_id),
-                            class_name=row_key[0],
-                            instance_name=row_key[1],
-                            column_id=int(point_id),
-                            domain="point",
-                            cv_id=None,
-                            point_id=int(point_id),
-                        ),
-                    )
-                )
-
-        values = np.full((len(row_keys), len(column_ids)), None, dtype=object)
-        for row_index, column_id, cell in pending_cells:
-            values[row_index, int(column_id)] = cell
-
-        return MechanismObjectTable(
-            domain="point",
-            row_keys=tuple(row_keys),
-            row_labels=tuple(row_labels),
-            column_ids=column_ids,
-            values=values,
-        )
+        return build_mechanism_object_table(self._runtime, self.cvs)
 
     # ------------------------------------------------------------------
     # Run (auto-inits from DECLARING)
@@ -2860,20 +2702,6 @@ def _resolve_subsolver_schedule(subsolver, substeps):
         raise ValueError(f"substeps must be at least 1, got {normalized_substeps!r}.")
     solver_name, solver_fn = _resolve_solver(subsolver)
     return solver_name, solver_fn, normalized_substeps
-
-
-def _layout_id_from_runtime_path(path) -> int:
-    if len(path) == 0:
-        raise ValueError(f"Expected runtime layout path ending with 'layout_<id>', got {path!r}.")
-    last = path[-1]
-    if not isinstance(last, str) or not last.startswith("layout_"):
-        raise ValueError(f"Expected runtime layout path ending with 'layout_<id>', got {path!r}.")
-    return int(last.split("_", 1)[1])
-
-
-def _gather_layout_point_values(values, layout):
-    """Gather point values for a broadcast or packed point layout."""
-    return layout.gather_points(values)
 
 
 def _zeros_like_event_template(template):

--- a/braincell/_multi_compartment/cell_test.py
+++ b/braincell/_multi_compartment/cell_test.py
@@ -554,7 +554,7 @@ class TestCellLifecycle(unittest.TestCase):
         self.assertGreater(len(cell.node_tree.nodes), 0)
         self.assertGreater(len(cell.runtime_nodes), 0)
         self.assertGreater(len(cell.runtime_cvs), 0)
-        self.assertIsNone(cell._axial_jax)
+        self.assertIsNone(cell.runtime.axial_operator_cache)
         self.assertTrue(hasattr(cell, "V"))
         self.assertTrue(hasattr(cell, "spike"))
 
@@ -601,7 +601,6 @@ class TestCellLifecycle(unittest.TestCase):
         self.assertFalse(cell._initialized)
         self.assertIsNone(cell._runtime)
         self.assertGreater(len(cell.node_tree.nodes), 0)
-        self.assertIsNone(cell._axial_jax)
         self.assertFalse(hasattr(cell, "V"))
         self.assertFalse(hasattr(cell, "spike"))
 
@@ -703,14 +702,13 @@ class TestCellLifecycle(unittest.TestCase):
             cell.init_state()
             self.assertIsNone(cell.runtime.axial_operator_np)
             self.assertIsNone(cell.runtime.axial_operator_cache)
-            self.assertIsNone(cell._axial_jax)
 
             operator32 = cell._get_axial_operator()
             cache32 = cell.runtime.axial_operator_cache
             self.assertEqual(operator32.dtype, jnp.dtype(jnp.float32))
-            self.assertEqual(cell._axial_jax.dtype, jnp.dtype(jnp.float32))
-            self.assertEqual(cell.runtime.axial_operator_np.dtype, np.float64)
             self.assertIsNotNone(cache32)
+            self.assertEqual(cache32.operator.dtype, jnp.dtype(jnp.float32))
+            self.assertEqual(cell.runtime.axial_operator_np.dtype, np.float64)
 
         with brainstate.environ.context(precision=64):
             operator64 = cell._get_axial_operator()
@@ -726,7 +724,6 @@ class TestCellLifecycle(unittest.TestCase):
 
         self.assertIsNone(cell.runtime.axial_operator_np)
         self.assertIsNone(cell.runtime.axial_operator_cache)
-        self.assertIsNone(cell._axial_jax)
         self.assertIsNotNone(cell.runtime.dhs_static_source_np)
 
     def test_scalar_v_init_broadcasts_to_voltage_shape(self):
@@ -1044,6 +1041,48 @@ class CellIonChannelUpdateOrderTest(unittest.TestCase):
         for _, ions in channel_args:
             self.assertEqual(len(ions), 1)
             self.assertFalse(any(isinstance(arg, bool) for arg in ions))
+
+
+class DiscretizationTracksAMutatedMorphologyTest(unittest.TestCase):
+    """A ``Cell`` shares its ``Morphology``, so it must notice edits to it.
+
+    ``Cell.morpho`` is documented as returning the tree "without copying
+    it", and ``Morphology`` is mutable -- it maintains a revision counter
+    precisely so consumers can tell that it changed. The discretization
+    cache has to consult that counter; the object's identity alone cannot
+    distinguish a tree that has grown a branch from one that has not.
+    """
+
+    @staticmethod
+    def _dendrite() -> Branch:
+        return Branch.from_lengths(
+            lengths=[100.0] * u.um,
+            radii=[2.0, 1.0] * u.um,
+            type="basal_dendrite",
+        )
+
+    def test_attaching_a_branch_changes_the_cv_count(self) -> None:
+        tree = _soma_tree()
+        cell = Cell(tree, cv_policy=CVPerBranch(1))
+        self.assertEqual(cell.n_cv, 1)
+
+        tree.soma.dend = self._dendrite()
+
+        self.assertEqual(tree.n_branches, 2)
+        self.assertEqual(cell.n_cv, 2)
+
+    def test_a_rebuild_does_not_leave_a_stale_root_scope(self) -> None:
+        tree = _soma_tree()
+        cell = Cell(tree, cv_policy=CVPerBranch(1))
+        # Materialize every cache that hangs off the discretization.
+        self.assertEqual(len(cell.soma.cv.ids), 1)
+
+        tree.soma.dend = self._dendrite()
+
+        # ``cell.soma`` selects by branch type, so the dendrite is excluded;
+        # the unrestricted scope must still see both CVs.
+        self.assertEqual(len(cell.cvs), 2)
+        self.assertEqual(cell.cv.ids.tolist(), [0, 1])
 
 
 class CellDoesNotAllocatePlaceholderIonsEagerlyTest(unittest.TestCase):

--- a/braincell/_multi_compartment/currents.py
+++ b/braincell/_multi_compartment/currents.py
@@ -36,6 +36,7 @@ from braincell._misc import (
     profiler_call_name as _call_name,
     profiler_scope_name as _scope_name,
 )
+from braincell._compute.layouts import layout_id_from_key
 from braincell._compute.state import CellRuntimeState
 from braincell._compute import bridge
 
@@ -86,7 +87,7 @@ def total_membrane_current_point(
         for key, ch in host.runtime_objects(IonChannel, allowed_hierarchy=(1, 1)).items():
             with jax.named_scope(_scope_name("braincell:membrane_current:channel", key, ch)):
                 if isinstance(ch, RuntimeSynapse):
-                    layout_id = _layout_id_from_current_key(key)
+                    layout_id = layout_id_from_key(key)
                     layout = runtime.layouts[layout_id]
                     contrib_point = _synapse_contrib_to_point(runtime, layout, ch, point_V)
                     if contrib_point is None:
@@ -105,15 +106,6 @@ def total_membrane_current_point(
                 I_point = I_point + _profile_barrier_current(contrib)
 
     return I_point
-
-
-def _layout_id_from_current_key(key) -> int:
-    if len(key) == 0:
-        raise ValueError(f"Expected runtime object key ending with 'layout_<id>', got {key!r}.")
-    last = key[-1]
-    if not isinstance(last, str) or not last.startswith("layout_"):
-        raise ValueError(f"Expected runtime object key ending with 'layout_<id>', got {key!r}.")
-    return int(last.split("_", 1)[1])
 
 
 def _synapse_contrib_to_point(runtime: CellRuntimeState, layout, syn, point_V):

--- a/braincell/_multi_compartment/field_resolution.py
+++ b/braincell/_multi_compartment/field_resolution.py
@@ -34,7 +34,7 @@ boundary.
 
 There are two families:
 
-**Coverage** — :func:`region_intervals`, :func:`cv_coverage_fractions`,
+**Coverage** — :func:`region_intervals`, :func:`cv_area_coverage_fractions`,
 :func:`branch_coverage_fractions`, :func:`locset_cv_ids`,
 :func:`node_highlight_fractions`, :func:`cv_highlight_fractions`. These
 turn a region or locset into per-CV / per-point / per-branch overlap
@@ -54,6 +54,7 @@ import brainunit as u
 import numpy as np
 
 from braincell._discretization.base import locate_cv_on_branch
+from braincell._discretization.geometry import interval_area_fraction
 from braincell.filter import LocsetExpr, LocsetMask, RegionExpr, RegionMask
 from braincell.filter.helper import normalize_region_intervals
 
@@ -64,7 +65,7 @@ __all__ = [
     "coerce_named_node_values",
     "coerce_node_values",
     "coerce_runtime_point_values",
-    "cv_coverage_fractions",
+    "cv_area_coverage_fractions",
     "cv_highlight_fractions",
     "cv_to_node_values",
     "cv_voltage",
@@ -234,8 +235,14 @@ def region_intervals(cell, region, *, caller: str) -> dict[int, tuple[tuple[floa
     return {branch_id: tuple(intervals) for branch_id, intervals in grouped.items()}
 
 
-def cv_coverage_fractions(cell, region, *, caller: str) -> dict[int, float]:
-    """Return each CV's fractional overlap with ``region``.
+def cv_area_coverage_fractions(cell, region, *, caller: str) -> dict[int, float]:
+    """Return each CV's fractional *membrane area* overlap with ``region``.
+
+    This is the same measure the discretization applies when it paints a
+    density mechanism over part of a CV, so ``Cell.on(region)`` reports the
+    fraction that actually scaled the conductance. On a tapering branch an
+    area fraction and a length fraction are different numbers; only the
+    area one describes what the model does.
 
     Parameters
     ----------
@@ -250,25 +257,39 @@ def cv_coverage_fractions(cell, region, *, caller: str) -> dict[int, float]:
     -------
     dict
         CV id mapped to a fraction in ``[0, 1]``.
+
+    See Also
+    --------
+    branch_coverage_fractions : The *length* extent along a whole branch,
+        used for branch-level drawing rather than for membrane physics.
+    braincell.mech.Density.with_coverage : Consumer of the same fraction.
     """
     branch_intervals = region_intervals(cell, region, caller=caller)
+    branches = cell.morpho.branches
     fractions: dict[int, float] = {}
     for cv in cell.cvs:
         intervals = branch_intervals.get(int(cv.branch_id), ())
-        total = max(float(cv.dist) - float(cv.prox), 1e-12)
-        overlap = 0.0
-        for left, right in intervals:
-            start = max(float(cv.prox), float(left))
-            end = min(float(cv.dist), float(right))
-            if end - start <= 1e-9:
-                continue
-            overlap += end - start
-        fractions[int(cv.id)] = float(np.clip(overlap / total, 0.0, 1.0))
+        fractions[int(cv.id)] = (
+            0.0
+            if len(intervals) == 0
+            else interval_area_fraction(
+                branches[int(cv.branch_id)],
+                prox=float(cv.prox),
+                dist=float(cv.dist),
+                lateral_area_um2=float(cv.area.to_decimal(u.um**2)),
+                intervals=intervals,
+            )
+        )
     return fractions
 
 
 def branch_coverage_fractions(cell, region, *, caller: str) -> dict[int, float]:
     """Return each branch's fractional coverage by ``region``.
+
+    Unlike :func:`cv_area_coverage_fractions` this is a *length* extent in
+    normalized branch coordinates, because its one consumer draws a branch
+    as a line in a topology graph. It is a drawing quantity, not a membrane
+    one, and the two are deliberately different measures.
 
     Parameters
     ----------
@@ -283,6 +304,10 @@ def branch_coverage_fractions(cell, region, *, caller: str) -> dict[int, float]:
     -------
     dict
         Branch index mapped to a fraction in ``[0, 1]``.
+
+    See Also
+    --------
+    cv_area_coverage_fractions : The membrane-area measure used for physics.
     """
     branch_intervals = region_intervals(cell, region, caller=caller)
     fractions: dict[int, float] = {}
@@ -322,14 +347,16 @@ def locset_cv_ids(cell, locset, *, caller: str) -> set[int]:
     else:
         raise TypeError(f"{caller} expects LocsetExpr or LocsetMask, got {type(locset).__name__!s}.")
 
-    grouped: dict[int, list[int]] = {}
-    for cv in cell.cvs:
-        grouped.setdefault(int(cv.branch_id), []).append(int(cv.id))
-    cv_ids_by_branch = {branch_id: tuple(ids) for branch_id, ids in grouped.items()}
+    # The CV tree already groups CVs by branch; ``selection.py`` reads the
+    # same attribute rather than regrouping ``cell.cvs`` by hand.
+    cv_ids_by_branch = cell.cv_tree.branch_to_cv_ids
 
     cv_ids: set[int] = set()
     for branch_id, x in mask.points:
-        ids = cv_ids_by_branch.get(int(branch_id))
+        branch_id = int(branch_id)
+        if not 0 <= branch_id < len(cv_ids_by_branch):
+            continue
+        ids = cv_ids_by_branch[branch_id]
         if not ids:
             continue
         cv_id = locate_cv_on_branch(ids, cell.cvs, x=float(x))
@@ -363,7 +390,7 @@ def node_highlight_fractions(cell, *, region, locset, caller: str) -> dict[int, 
     fractions: dict[int, float] = {}
     node_tree = cell.node_tree
     if region is not None:
-        for cv_id, fraction in cv_coverage_fractions(cell, region, caller=caller).items():
+        for cv_id, fraction in cv_area_coverage_fractions(cell, region, caller=caller).items():
             point_id = int(node_tree.cv_to_mid_node_id[int(cv_id)])
             fractions[point_id] = max(fractions.get(point_id, 0.0), float(fraction))
     if locset is not None:
@@ -394,7 +421,7 @@ def cv_highlight_fractions(cell, *, region, locset, caller: str) -> dict[int, fl
     """
     fractions: dict[int, float] = {}
     if region is not None:
-        fractions.update(cv_coverage_fractions(cell, region, caller=caller))
+        fractions.update(cv_area_coverage_fractions(cell, region, caller=caller))
     if locset is not None:
         for cv_id in locset_cv_ids(cell, locset, caller=caller):
             fractions[int(cv_id)] = max(fractions.get(int(cv_id), 0.0), 1.0)
@@ -461,10 +488,9 @@ def mask_non_midpoint_points(cell, point_values):
     ValueError
         If ``point_values`` is not shaped ``(n_point,)``.
     """
-    node_tree = cell.node_tree
-    midpoint_ids = np.asarray(node_tree.cv_to_mid_node_id, dtype=np.int32)
-    midpoint_mask = np.zeros((cell.n_point,), dtype=bool)
-    midpoint_mask[midpoint_ids] = True
+    # The runtime lowering builds this mask once and keeps it; rebuilding it
+    # here would be a second copy of the same three lines.
+    midpoint_mask = cell.runtime.midpoint_mask_np
     mantissa, _, rewrap = split_unit(point_values)
     raw = mantissa.reshape(-1)
     if raw.shape != (cell.n_point,):
@@ -476,6 +502,82 @@ def mask_non_midpoint_points(cell, point_values):
 
 # ----------------------------------------------------------------------
 # Value coercion
+
+
+def _unchanged(values):
+    """Return ``values`` untouched -- the mapper for the target space itself."""
+    return values
+
+
+#: How each space is named in a user-facing message.
+_SPACE_LABEL = {"point": "point", "cv": "CV"}
+
+
+def _coerce_field(cell, value, *, caller: str, native: str, named: bool, from_point, from_cv):
+    """Interpret a caller-supplied field by its length and map it home.
+
+    Every public coercer below runs this one ladder: a scalar fills a
+    vector, a 1-D value whose length names either space is mapped into the
+    target space, and anything else is refused. They differ only in which
+    space they answer in and how they cross between the two, which is what
+    the arguments carry.
+
+    Parameters
+    ----------
+    cell : braincell.Cell
+        Cell supplying ``n_point`` / ``n_cv`` and the space bridges.
+    value : array-like or brainunit.Quantity
+        Scalar, point-space, or CV-space values.
+    caller : str
+        Entry point description, used only in error messages.
+    native : {'point', 'cv'}
+        Space this coercer answers in. Only names the space in messages;
+        the mappers decide what is actually returned.
+    named : bool
+        Whether this is a *named* state/parameter field. A named field is
+        defined per CV, so a scalar fills ``n_cv`` rather than ``n_point``
+        even when the answer is in point space, and the messages say so.
+    from_point : callable
+        Maps a point-length input into the target space.
+    from_cv : callable
+        Maps a CV-length input into the target space. A scalar is filled
+        in whichever space it is defined in and then passed through the
+        matching mapper, so this also handles the scalar case for a named
+        field.
+
+    Returns
+    -------
+    numpy.ndarray or brainunit.Quantity
+        A vector in the target space.
+
+    Raises
+    ------
+    ValueError
+        If ``value`` is neither scalar nor 1-D, or its length matches
+        neither ``n_point`` nor ``n_cv``.
+    """
+    raw, original, rewrap = split_unit(single_population_view(cell, value, caller=caller))
+    fill_space = "cv" if named else native
+    lengths = {"point": cell.n_point, "cv": cell.n_cv}
+
+    if raw.ndim == 0:
+        filled = rewrap(np.full((lengths[fill_space],), float(raw), dtype=float))
+        return from_point(filled) if fill_space == "point" else from_cv(filled)
+    if raw.ndim != 1:
+        noun = "named value" if named else "value"
+        raise ValueError(f"{caller} only supports scalar or 1-D {noun} arrays.")
+    if raw.shape[0] == cell.n_point:
+        return from_point(original)
+    if raw.shape[0] == cell.n_cv:
+        return from_cv(original)
+
+    if named:
+        raise ValueError(f"{caller} cannot map the named value into {_SPACE_LABEL[native]} space.")
+    other = "cv" if native == "point" else "point"
+    raise ValueError(
+        f"{caller} expects a {_SPACE_LABEL[native]} array of length {lengths[native]} "
+        f"or a {_SPACE_LABEL[other]} array of length {lengths[other]}, got length {raw.shape[0]}."
+    )
 
 
 def coerce_node_values(cell, value, *, caller: str):
@@ -501,18 +603,14 @@ def coerce_node_values(cell, value, *, caller: str):
         If ``value`` is neither scalar nor 1-D, or its length matches
         neither ``n_point`` nor ``n_cv``.
     """
-    raw, original, rewrap = split_unit(single_population_view(cell, value, caller=caller))
-    if raw.ndim == 0:
-        return rewrap(np.full((cell.n_point,), float(raw), dtype=float))
-    if raw.ndim != 1:
-        raise ValueError(f"{caller} only supports scalar or 1-D value arrays.")
-    if raw.shape[0] == cell.n_point:
-        return original
-    if raw.shape[0] == cell.n_cv:
-        return cv_to_node_values(cell, original)
-    raise ValueError(
-        f"{caller} expects a point array of length {cell.n_point} "
-        f"or a CV array of length {cell.n_cv}, got length {raw.shape[0]}."
+    return _coerce_field(
+        cell,
+        value,
+        caller=caller,
+        native="point",
+        named=False,
+        from_point=_unchanged,
+        from_cv=lambda values: cv_to_node_values(cell, values),
     )
 
 
@@ -542,19 +640,14 @@ def coerce_runtime_point_values(cell, value):
         If ``value`` is neither scalar nor 1-D, or its length matches
         neither ``n_point`` nor ``n_cv``.
     """
-    caller = "Runtime point inspection"
-    raw, original, rewrap = split_unit(single_population_view(cell, value, caller=caller))
-    if raw.ndim == 0:
-        return rewrap(np.full((cell.n_point,), float(raw), dtype=float))
-    if raw.ndim != 1:
-        raise ValueError(f"{caller} only supports scalar or 1-D value arrays.")
-    if raw.shape[0] == cell.n_point:
-        return original
-    if raw.shape[0] == cell.n_cv:
-        return cell._cv_to_point(original)
-    raise ValueError(
-        f"{caller} expects a point array of length {cell.n_point} "
-        f"or a CV array of length {cell.n_cv}, got length {raw.shape[0]}."
+    return _coerce_field(
+        cell,
+        value,
+        caller="Runtime point inspection",
+        native="point",
+        named=False,
+        from_point=_unchanged,
+        from_cv=cell._cv_to_point,
     )
 
 
@@ -581,18 +674,14 @@ def coerce_cv_values(cell, value, *, caller: str):
         If ``value`` is neither scalar nor 1-D, or its length matches
         neither ``n_cv`` nor ``n_point``.
     """
-    raw, original, rewrap = split_unit(single_population_view(cell, value, caller=caller))
-    if raw.ndim == 0:
-        return rewrap(np.full((cell.n_cv,), float(raw), dtype=float))
-    if raw.ndim != 1:
-        raise ValueError(f"{caller} only supports scalar or 1-D value arrays.")
-    if raw.shape[0] == cell.n_cv:
-        return original
-    if raw.shape[0] == cell.n_point:
-        return cell._point_to_cv(original)
-    raise ValueError(
-        f"{caller} expects a CV array of length {cell.n_cv} "
-        f"or a point array of length {cell.n_point}, got length {raw.shape[0]}."
+    return _coerce_field(
+        cell,
+        value,
+        caller=caller,
+        native="cv",
+        named=False,
+        from_point=cell._point_to_cv,
+        from_cv=_unchanged,
     )
 
 
@@ -623,16 +712,15 @@ def coerce_named_node_values(cell, value, *, caller: str):
         If ``value`` is not scalar or 1-D, or cannot be mapped into point
         space.
     """
-    raw, original, rewrap = split_unit(single_population_view(cell, value, caller=caller))
-    if raw.ndim == 0:
-        return cv_to_node_values(cell, rewrap(np.full((cell.n_cv,), float(raw), dtype=float)))
-    if raw.ndim != 1:
-        raise ValueError(f"{caller} only supports scalar or 1-D named value arrays.")
-    if raw.shape[0] == cell.n_point:
-        return mask_non_midpoint_points(cell, original)
-    if raw.shape[0] == cell.n_cv:
-        return cv_to_node_values(cell, original)
-    raise ValueError(f"{caller} cannot map the named value into point space.")
+    return _coerce_field(
+        cell,
+        value,
+        caller=caller,
+        native="point",
+        named=True,
+        from_point=lambda values: mask_non_midpoint_points(cell, values),
+        from_cv=lambda values: cv_to_node_values(cell, values),
+    )
 
 
 def coerce_named_cv_values(cell, value, *, caller: str):
@@ -658,16 +746,15 @@ def coerce_named_cv_values(cell, value, *, caller: str):
         If ``value`` is not scalar or 1-D, or cannot be mapped into CV
         space.
     """
-    raw, original, rewrap = split_unit(single_population_view(cell, value, caller=caller))
-    if raw.ndim == 0:
-        return rewrap(np.full((cell.n_cv,), float(raw), dtype=float))
-    if raw.ndim != 1:
-        raise ValueError(f"{caller} only supports scalar or 1-D named value arrays.")
-    if raw.shape[0] == cell.n_cv:
-        return original
-    if raw.shape[0] == cell.n_point:
-        return cell._point_to_cv(mask_non_midpoint_points(cell, original))
-    raise ValueError(f"{caller} cannot map the named value into CV space.")
+    return _coerce_field(
+        cell,
+        value,
+        caller=caller,
+        native="cv",
+        named=True,
+        from_point=lambda values: cell._point_to_cv(mask_non_midpoint_points(cell, values)),
+        from_cv=_unchanged,
+    )
 
 
 # ----------------------------------------------------------------------
@@ -897,8 +984,7 @@ def layout_values_to_cv_space(cell, layout, raw_values, *, field: str, caller: s
         return rewrap(cv_values)
     if layout.point_index is None or array.shape[0] != len(layout.point_index):
         raise ValueError(
-            f"{caller} cannot map field {field!r} from layout {layout.id!r} "
-            f"with shape {array.shape!r} into CV space."
+            f"{caller} cannot map field {field!r} from layout {layout.id!r} with shape {array.shape!r} into CV space."
         )
     value_by_point = {
         int(point_id): float(array[index])
@@ -932,6 +1018,81 @@ def cv_voltage(cell, *, caller: str):
     return single_population_view(cell, cell.V.value, field="V", caller=caller)
 
 
+def _resolve_field_values(
+    cell,
+    value,
+    *,
+    caller: str,
+    voltage,
+    named,
+    layout,
+    raw,
+) -> tuple[object, str | None]:
+    """Resolve a value selector into one space's values and a label.
+
+    The point-space and CV-space resolvers accept exactly the same
+    selector grammar -- ``"V"``, an ``(kind, name, field)`` triple, or a
+    bare array -- and produce the same labels. They differ only in the
+    four helpers that actually land a value in their space, so the
+    grammar is stated once here and each space supplies its four.
+
+    Parameters
+    ----------
+    cell : braincell.Cell
+        Cell the selector is resolved against.
+    value : object
+        The selector, in the grammar the two public resolvers document.
+    caller : str
+        Entry point description, used only in error messages.
+    voltage : callable
+        ``() -> values`` for the ``"V"`` / ``"voltage"`` selector.
+    named : callable
+        ``(field_value) -> values`` for a named ion field.
+    layout : callable
+        ``(layout_id, field) -> values`` for a runtime layout field.
+    raw : callable
+        ``(value) -> values`` for anything that is not a recognised
+        string or triple.
+
+    Returns
+    -------
+    values : numpy.ndarray or brainunit.Quantity
+        A vector in the resolver's space.
+    label : str or None
+        Inferred colorbar label, or ``None`` for a raw array.
+
+    Raises
+    ------
+    ValueError
+        If a string or tuple selector is not recognised.
+    AttributeError
+        If a named ion has no such field.
+    """
+    if isinstance(value, str):
+        if value.strip().lower() in {"v", "voltage"}:
+            return voltage(), "V"
+        raise ValueError(f"Unsupported {caller} value string {value!r}.")
+
+    if isinstance(value, tuple) and len(value) == 3 and isinstance(value[0], str):
+        mode = value[0]
+        if mode == "ion":
+            ion_name, field = str(value[1]), str(value[2])
+            ion = cell.get_ion(ion_name)
+            if not hasattr(ion, field):
+                raise AttributeError(f"Ion {ion_name!r} has no field {field!r}.")
+            return named(getattr(ion, field)), f"{ion_name}.{field}"
+        if mode == "channel":
+            class_name, field = str(value[1]), str(value[2])
+            resolved = unique_layout_by_kind(cell, f"channel:{class_name}", caller=caller)
+            return layout(resolved.id, field), f"{class_name}.{field}"
+        if mode == "layout_id":
+            layout_id, field = int(value[1]), str(value[2])
+            return layout(layout_id, field), f"layout_{layout_id}.{field}"
+        raise ValueError(f"Unsupported {caller} value tuple selector {mode!r}.")
+
+    return raw(value), None
+
+
 def resolve_node_field_values(cell, value, *, caller: str) -> tuple[object, str | None]:
     """Resolve a value selector into point-space values and a label.
 
@@ -961,33 +1122,15 @@ def resolve_node_field_values(cell, value, *, caller: str) -> tuple[object, str 
     AttributeError
         If a named ion has no such field.
     """
-    if isinstance(value, str):
-        key = value.strip().lower()
-        if key in {"v", "voltage"}:
-            return cv_to_node_values(cell, cv_voltage(cell, caller=caller)), "V"
-        raise ValueError(f"Unsupported {caller} value string {value!r}.")
-
-    if isinstance(value, tuple) and len(value) == 3 and isinstance(value[0], str):
-        mode = value[0]
-        if mode == "ion":
-            ion_name, field = str(value[1]), str(value[2])
-            ion = cell.get_ion(ion_name)
-            if not hasattr(ion, field):
-                raise AttributeError(f"Ion {ion_name!r} has no field {field!r}.")
-            return coerce_named_node_values(cell, getattr(ion, field), caller=caller), f"{ion_name}.{field}"
-        if mode == "channel":
-            class_name, field = str(value[1]), str(value[2])
-            layout = unique_layout_by_kind(cell, f"channel:{class_name}", caller=caller)
-            return layout_field_to_point_values(cell, layout.id, field, caller=caller), f"{class_name}.{field}"
-        if mode == "layout_id":
-            layout_id, field = int(value[1]), str(value[2])
-            return (
-                layout_field_to_point_values(cell, layout_id, field, caller=caller),
-                f"layout_{layout_id}.{field}",
-            )
-        raise ValueError(f"Unsupported {caller} value tuple selector {mode!r}.")
-
-    return coerce_node_values(cell, value, caller=caller), None
+    return _resolve_field_values(
+        cell,
+        value,
+        caller=caller,
+        voltage=lambda: cv_to_node_values(cell, cv_voltage(cell, caller=caller)),
+        named=lambda field_value: coerce_named_node_values(cell, field_value, caller=caller),
+        layout=lambda layout_id, field: layout_field_to_point_values(cell, layout_id, field, caller=caller),
+        raw=lambda values: coerce_node_values(cell, values, caller=caller),
+    )
 
 
 def resolve_cv_field_values(cell, value, *, caller: str) -> tuple[object, str | None]:
@@ -1019,30 +1162,12 @@ def resolve_cv_field_values(cell, value, *, caller: str) -> tuple[object, str | 
     AttributeError
         If a named ion has no such field.
     """
-    if isinstance(value, str):
-        key = value.strip().lower()
-        if key in {"v", "voltage"}:
-            return cv_voltage(cell, caller=caller), "V"
-        raise ValueError(f"Unsupported {caller} value string {value!r}.")
-
-    if isinstance(value, tuple) and len(value) == 3 and isinstance(value[0], str):
-        mode = value[0]
-        if mode == "ion":
-            ion_name, field = str(value[1]), str(value[2])
-            ion = cell.get_ion(ion_name)
-            if not hasattr(ion, field):
-                raise AttributeError(f"Ion {ion_name!r} has no field {field!r}.")
-            return coerce_named_cv_values(cell, getattr(ion, field), caller=caller), f"{ion_name}.{field}"
-        if mode == "channel":
-            class_name, field = str(value[1]), str(value[2])
-            layout = unique_layout_by_kind(cell, f"channel:{class_name}", caller=caller)
-            return layout_field_to_cv_values(cell, layout.id, field, caller=caller), f"{class_name}.{field}"
-        if mode == "layout_id":
-            layout_id, field = int(value[1]), str(value[2])
-            return (
-                layout_field_to_cv_values(cell, layout_id, field, caller=caller),
-                f"layout_{layout_id}.{field}",
-            )
-        raise ValueError(f"Unsupported {caller} value tuple selector {mode!r}.")
-
-    return coerce_cv_values(cell, value, caller=caller), None
+    return _resolve_field_values(
+        cell,
+        value,
+        caller=caller,
+        voltage=lambda: cv_voltage(cell, caller=caller),
+        named=lambda field_value: coerce_named_cv_values(cell, field_value, caller=caller),
+        layout=lambda layout_id, field: layout_field_to_cv_values(cell, layout_id, field, caller=caller),
+        raw=lambda values: coerce_cv_values(cell, values, caller=caller),
+    )

--- a/braincell/_multi_compartment/field_resolution_test.py
+++ b/braincell/_multi_compartment/field_resolution_test.py
@@ -23,6 +23,7 @@ import numpy as np
 from braincell import Branch, CVPerBranch, Cell, Morphology
 from braincell._multi_compartment import field_resolution as fr
 from braincell.filter import AllRegion, BranchSlice, RootLocation
+from braincell.mech import Channel
 
 
 def _soma_tree() -> Morphology:
@@ -138,13 +139,16 @@ class RegionAndLocsetResolutionTest(unittest.TestCase):
     def setUp(self) -> None:
         self.cell = Cell(_soma_dend_tree(), cv_policy=CVPerBranch())
 
-    def test_cv_coverage_is_the_overlapped_fraction_of_each_cv(self) -> None:
-        fractions = fr.cv_coverage_fractions(
+    def test_cv_coverage_is_the_overlapped_area_fraction_of_each_cv(self) -> None:
+        fractions = fr.cv_area_coverage_fractions(
             self.cell,
             BranchSlice(branch_index=1, prox=0.0, dist=0.5),
             caller="test",
         )
-        self.assertAlmostEqual(fractions[1], 0.5)
+        # The dendrite tapers 2 um -> 1 um, so its proximal half carries
+        # more than half the membrane: 0.5833... of the area against 0.5
+        # of the length. The area is the number the physics uses.
+        self.assertAlmostEqual(fractions[1], 0.5833333333333334)
         self.assertAlmostEqual(fractions[0], 0.0)
 
     def test_branch_coverage_measures_the_branch_not_its_cvs(self) -> None:
@@ -192,6 +196,56 @@ class RegionAndLocsetResolutionTest(unittest.TestCase):
     def test_a_locset_of_the_wrong_type_is_rejected_by_name(self) -> None:
         with self.assertRaisesRegex(TypeError, r"^caller X expects LocsetExpr or LocsetMask, got int"):
             fr.locset_cv_ids(self.cell, 3, caller="caller X")
+
+
+class CoverageMatchesThePaintedFractionTest(unittest.TestCase):
+    """CV coverage must report the fraction the physics actually applies.
+
+    ``Cell.paint`` scales a density mechanism by the fraction of the CV's
+    *lateral membrane area* a region covers, and stores it as
+    ``Density.coverage_area_fraction``. ``Cell.on(region).cv.coverage_fraction``
+    is the only way a user can read that number back, so the two must agree.
+
+    They only diverge on a tapering branch: with constant radius the area
+    fraction and the length fraction are the same number, which is why this
+    went unnoticed. Both cases are pinned below.
+    """
+
+    #: ``BranchSlice(1, 0.0, 0.5)`` -- the proximal half of the dendrite.
+    REGION = BranchSlice(branch_index=1, prox=0.0, dist=0.5)
+
+    @staticmethod
+    def _dendrite_cell(r_prox: float, r_dist: float) -> Cell:
+        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        dend = Branch.from_lengths(
+            lengths=[100.0] * u.um,
+            radii=[r_prox, r_dist] * u.um,
+            type="basal_dendrite",
+        )
+        tree = Morphology.from_root(soma, name="soma")
+        tree.soma.dend = dend
+        return Cell(tree, cv_policy=CVPerBranch(1))
+
+    def _painted_fraction(self, cell: Cell) -> float:
+        """Return the coverage the discretization baked into the dendrite CV."""
+        cell.paint(self.REGION, Channel("IL", g_max=1.0 * (u.mS / u.cm**2), E=-70.0 * u.mV))
+        painted = [mech.coverage_area_fraction for cv in cell.cvs for mech in cv.density_mech]
+        self.assertEqual(len(painted), 1, "expected exactly one painted CV")
+        return float(painted[0])
+
+    def test_a_tapering_branch_reports_the_area_fraction_not_the_length_fraction(self) -> None:
+        reported = self._dendrite_cell(4.0, 1.0).on(self.REGION).cv.coverage_fraction
+        painted = self._painted_fraction(self._dendrite_cell(4.0, 1.0))
+        # The length fraction here is 0.5; the area fraction is 0.65.
+        self.assertAlmostEqual(painted, 0.65)
+        self.assertEqual(reported.shape, (1,))
+        self.assertAlmostEqual(float(reported[0]), painted)
+
+    def test_an_untapered_branch_agrees_with_the_length_fraction(self) -> None:
+        reported = self._dendrite_cell(2.0, 2.0).on(self.REGION).cv.coverage_fraction
+        painted = self._painted_fraction(self._dendrite_cell(2.0, 2.0))
+        self.assertAlmostEqual(painted, 0.5)
+        self.assertAlmostEqual(float(reported[0]), 0.5)
 
 
 class SpatialMappingTest(unittest.TestCase):

--- a/braincell/_multi_compartment/probes.py
+++ b/braincell/_multi_compartment/probes.py
@@ -47,7 +47,7 @@ def sample_probe(rcell: "Cell", name: str) -> object:
     matches: list[tuple[object, object]] = []
     for layout in runtime.layouts:
         declaration = runtime.get_layout_mechanism(layout.id)
-        if isinstance(declaration, (StateProbe, MechanismProbe, CurrentProbe)) and _probe_name(declaration) == name:
+        if isinstance(declaration, _PROBE_TYPES) and _probe_name(declaration) == name:
             matches.append((layout, declaration))
     if len(matches) == 0:
         raise KeyError(f"No probe is registered with name {name!r}.")
@@ -71,7 +71,7 @@ def iter_probe_layouts(runtime: CellRuntimeState):
     seen: set[str] = set()
     for layout in runtime.layouts:
         declaration = runtime.get_layout_mechanism(layout.id)
-        if not isinstance(declaration, (StateProbe, MechanismProbe, CurrentProbe)):
+        if not isinstance(declaration, _PROBE_TYPES):
             continue
         probe_name = _probe_name(declaration)
         if probe_name in seen:
@@ -109,38 +109,58 @@ def _sample_probe_layout(
     point_ids = getattr(layout, "point_index", None)
     if point_ids is None:
         raise ValueError(f"Probe layout {getattr(layout, 'id', None)!r} is missing point_index.")
-    samples = []
-    for point_id in point_ids.tolist():
-        if isinstance(declaration, StateProbe):
-            samples.append(
-                _sample_state_probe_point(
-                    rcell,
-                    runtime,
-                    declaration=declaration,
-                    point_id=int(point_id),
-                )
-            )
-        elif isinstance(declaration, MechanismProbe):
-            samples.append(
-                _sample_mechanism_probe_point(
-                    rcell,
-                    runtime,
-                    declaration=declaration,
-                    point_id=int(point_id),
-                )
-            )
-        elif isinstance(declaration, CurrentProbe):
-            samples.append(
-                _sample_current_probe_point(
-                    rcell,
-                    runtime,
-                    declaration=declaration,
-                    point_id=int(point_id),
-                )
-            )
-        else:  # pragma: no cover
-            raise TypeError(f"Unsupported probe declaration type {type(declaration).__name__!s}.")
-    return _pack_probe_samples(samples)
+    sampler = _POINT_SAMPLERS.get(type(declaration))
+    if sampler is None:  # pragma: no cover
+        raise TypeError(f"Unsupported probe declaration type {type(declaration).__name__!s}.")
+    return _pack_probe_samples(
+        [sampler(rcell, runtime, declaration=declaration, point_id=int(point_id)) for point_id in point_ids.tolist()]
+    )
+
+
+def _matched_density_layout(
+    runtime: CellRuntimeState,
+    *,
+    declaration: object,
+    point_id: int,
+) -> object | None:
+    """Return the one ``Density`` layout named by ``declaration`` at a point.
+
+    Both probe kinds resolve a mechanism name the same way and reject the
+    same ambiguity; they differ only in what a *miss* means, so that is all
+    each caller is left to decide.
+
+    Parameters
+    ----------
+    runtime : braincell._compute.state.CellRuntimeState
+        Runtime holding the point-to-layout map.
+    declaration : braincell.mech.MechanismProbe or braincell.mech.CurrentProbe
+        Probe declaration supplying ``mechanism`` and the probe name.
+    point_id : int
+        Point being sampled.
+
+    Returns
+    -------
+    braincell._compute.layouts.MechanismLayout or None
+        The single match, or ``None`` when nothing at this point carries
+        that name.
+
+    Raises
+    ------
+    ValueError
+        If more than one density mechanism at ``point_id`` claims the name.
+    """
+    matched = [
+        layout
+        for layout in runtime.get_point_layouts(point_id)
+        if isinstance(mechanism := runtime.get_layout_mechanism(layout.id), Density)
+        and mechanism.instance_name == declaration.mechanism
+    ]
+    if len(matched) > 1:
+        raise ValueError(
+            f"Probe {_probe_name(declaration)!r} matched multiple mechanisms named "
+            f"{declaration.mechanism!r} at point {point_id!r}."
+        )
+    return matched[0] if matched else None
 
 
 def _sample_state_probe_point(
@@ -172,18 +192,9 @@ def _sample_mechanism_probe_point(
         selected = raw[..., synapse_view.runtime_index]
         return _pack_synapse_probe_rows(rcell, synapse_view, selected)
 
-    matched_layouts = []
-    for layout in runtime.get_point_layouts(point_id):
-        mechanism = runtime.get_layout_mechanism(layout.id)
-        if isinstance(mechanism, Density) and mechanism.instance_name == declaration.mechanism:
-            matched_layouts.append(layout)
-    if len(matched_layouts) > 1:
-        raise ValueError(
-            f"Probe {_probe_name(declaration)!r} matched multiple mechanisms named "
-            f"{declaration.mechanism!r} at point {point_id!r}."
-        )
-    if len(matched_layouts) == 1:
-        node = runtime.get_runtime_node(matched_layouts[0].id)
+    matched = _matched_density_layout(runtime, declaration=declaration, point_id=point_id)
+    if matched is not None:
+        node = runtime.get_runtime_node(matched.id)
         raw = _probe_attr_value(
             node,
             declaration.field,
@@ -234,22 +245,13 @@ def _sample_current_probe_point(
             selected = current[..., synapse_view.runtime_index]
             return _pack_synapse_probe_rows(rcell, synapse_view, selected)
 
-        matched_layouts = []
-        for layout in runtime.get_point_layouts(point_id):
-            mechanism = runtime.get_layout_mechanism(layout.id)
-            if isinstance(mechanism, Density) and mechanism.instance_name == declaration.mechanism:
-                matched_layouts.append(layout)
-        if len(matched_layouts) > 1:
-            raise ValueError(
-                f"Probe {_probe_name(declaration)!r} matched multiple mechanisms named "
-                f"{declaration.mechanism!r} at point {point_id!r}."
-            )
-        if len(matched_layouts) == 0:
+        matched = _matched_density_layout(runtime, declaration=declaration, point_id=point_id)
+        if matched is None:
             raise KeyError(
                 f"Probe {_probe_name(declaration)!r} could not find a mechanism named "
                 f"{declaration.mechanism!r} at point {point_id!r}."
             )
-        layout_id = matched_layouts[0].id
+        layout_id = matched.id
         node = runtime.get_runtime_node(layout_id)
         bound_ion_keys = runtime.bound_ion_keys.get(layout_id, ())
         if len(bound_ion_keys) > 1:
@@ -277,6 +279,21 @@ def _sample_current_probe_point(
     ion = runtime.get_ion(declaration.ion)
     current = ion.current(point_V, include_external=False)
     return _select_last_axis(current, point_id)
+
+
+#: The probe declaration types this module can sample, mapped to the
+#: function that samples one point of each. Registering a fourth kind is a
+#: single edit here: the dispatch in :func:`_sample_probe_layout` and the
+#: two membership tests above all read this table.
+_POINT_SAMPLERS = {
+    StateProbe: _sample_state_probe_point,
+    MechanismProbe: _sample_mechanism_probe_point,
+    CurrentProbe: _sample_current_probe_point,
+}
+
+#: Declaration types that count as a probe, for the two membership tests
+#: that scan every layout. Derived from the table so the two cannot drift.
+_PROBE_TYPES = tuple(_POINT_SAMPLERS)
 
 
 def _synapse_probe_view(rcell: "Cell", name: str, *, point_id: int):
@@ -330,20 +347,19 @@ def _probe_current_ion_info(
     *,
     declaration: CurrentProbe,
     mechanism: object,
-    layout_id: int | None = None,
+    layout_id: int,
 ) -> object | None:
+    # The one caller reaches here only inside its own
+    # ``declaration.mechanism is not None`` branch, and always with a
+    # resolved layout, so neither is re-checked.
     if declaration.ion is not None:
         return runtime.get_ion(declaration.ion).pack_info()
 
-    if layout_id is not None:
-        owner_key = runtime.current_owner_keys.get(int(layout_id))
-        if isinstance(owner_key, str):
-            return runtime.get_ion(owner_key).pack_info()
+    owner_key = runtime.current_owner_keys.get(int(layout_id))
+    if isinstance(owner_key, str):
+        return runtime.get_ion(owner_key).pack_info()
 
     mechanism_name = declaration.mechanism
-    if mechanism_name is None:
-        return None
-
     for ion in runtime.ions.values():
         channels = getattr(ion, "channels", None)
         if isinstance(channels, dict) and mechanism_name in channels and channels[mechanism_name] is mechanism:

--- a/braincell/_multi_compartment/run.py
+++ b/braincell/_multi_compartment/run.py
@@ -184,15 +184,7 @@ def _cached_run_loop(
     paying XLA compile time on repeated ``Cell.run`` calls with the same
     timestep, step count, and probe layout.
     """
-    cache = getattr(rcell, "_run_loop_cache", None)
-    if cache is None:
-        return _make_run_loop(
-            rcell,
-            dt=dt,
-            compiled_recordings=compiled_recordings,
-            ordered_probe_names=ordered_probe_names,
-        )
-
+    cache = rcell._run_loop_cache
     key = (
         _time_quantity_cache_value(dt),
         int(n_steps),

--- a/braincell/_multi_compartment/selection.py
+++ b/braincell/_multi_compartment/selection.py
@@ -59,10 +59,6 @@ class _CellScope:
         return _ordered_unique(cv_id for _, cv_id in self.pairs)
 
     @property
-    def branch_ids(self) -> tuple[int, ...]:
-        return self.exact_branch_ids if self.exact_branch_ids is not None else ()
-
-    @property
     def pair_population_index(self) -> np.ndarray:
         return np.asarray([population for population, _ in self.pairs], dtype=np.int64)
 
@@ -118,7 +114,7 @@ class _CellScope:
     def select_region(self, cell, region: RegionExpr | RegionMask) -> "_CellScope":
         if not isinstance(region, (RegionExpr, RegionMask)):
             raise TypeError(f"Cell.on(...) expects RegionExpr or RegionMask, got {type(region).__name__!s}.")
-        fractions = field_resolution.cv_coverage_fractions(cell, region, caller="Cell.on(...)")
+        fractions = field_resolution.cv_area_coverage_fractions(cell, region, caller="Cell.on(...)")
         selected = tuple(cv_id for cv_id, fraction in fractions.items() if float(fraction) > 0.0)
         result = self.select_cv_ids(selected)
         selected_set = set(result.cv_ids)
@@ -255,7 +251,7 @@ def _normalize_selection(selection, *, size: int, name: str) -> tuple[int, ...]:
         selected = (index,)
     else:
         values = np.asarray(selection)
-        if values.ndim != 1 or values.dtype.kind not in "iu" or values.dtype.kind == "b":
+        if values.ndim != 1 or values.dtype.kind not in "iu":
             raise TypeError(f"{name} selection must be an integer, slice, or one-dimensional integer sequence.")
         normalized = []
         for raw in values.tolist():
@@ -273,7 +269,7 @@ def _normalize_global_ids(ids, *, name: str) -> tuple[int, ...]:
     values = np.asarray(ids)
     if values.ndim == 0:
         values = values.reshape(1)
-    if values.ndim != 1 or values.dtype.kind not in "iu" or values.dtype.kind == "b":
+    if values.ndim != 1 or values.dtype.kind not in "iu":
         raise TypeError(f"{name} ids must be a one-dimensional integer selection.")
     return _ordered_unique(int(item) for item in values.tolist())
 

--- a/braincell/_multi_compartment/synapses.py
+++ b/braincell/_multi_compartment/synapses.py
@@ -22,6 +22,7 @@ ids to rows in one runtime SoA node per registered synapse type.
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
 
 import brainstate
@@ -119,14 +120,7 @@ class _SynapseStore:
         self._build_parameter_columns()
 
     def _validate_name_types(self) -> None:
-        type_by_name: dict[str, str] = {}
-        for name, synapse_type in zip(self.name.tolist(), self.synapse_type.tolist()):
-            previous = type_by_name.setdefault(str(name), str(synapse_type))
-            if previous != synapse_type:
-                raise ValueError(
-                    f"Synapses with the same name {name!r} cannot use different synapse types "
-                    f"({previous!r} and {synapse_type!r})."
-                )
+        raise_on_name_type_conflict(zip(self.name.tolist(), self.synapse_type.tolist()))
 
     def _build_parameter_columns(self) -> None:
         for raw_type in dict.fromkeys(self.synapse_type.tolist()):
@@ -204,14 +198,6 @@ class _SynapseStore:
         except KeyError as exc:
             raise RuntimeError("Selected logical synapses have not been materialized.") from exc
 
-    def parameter_value(self, logical_id: int, parameter: str):
-        index = self.row_index(int(logical_id))
-        synapse_type = str(self.synapse_type[index])
-        if parameter not in self.parameter_columns[synapse_type]:
-            raise KeyError(f"Synapse type {synapse_type!r} does not declare parameter {parameter!r}.")
-        local = self._type_local_by_id[int(logical_id)]
-        return _take_vector_items(self.parameter_columns[synapse_type][parameter], local)
-
     def parameter_column(self, logical_ids, parameter: str):
         """Gather one declared parameter across several logical synapses.
 
@@ -236,18 +222,14 @@ class _SynapseStore:
         KeyError
             If the type does not declare ``parameter``.
 
-        See Also
-        --------
-        parameter_value : Read the same parameter for a single logical id.
-
         Notes
         -----
-        This is the vector form of :meth:`parameter_value`, and the form every
-        caller holding a whole selection should use. Reading a selection one id
-        at a time is quadratic: each :meth:`parameter_value` call re-materializes
-        the entire per-type column through ``to_decimal`` only to take a single
-        element, and the caller then restacks the scalars it just tore apart.
-        Slicing the column once is constant in the number of rows read.
+        Every caller holds a whole selection, so this is the only read
+        accessor. Reading a selection one id at a time would be quadratic:
+        each call re-materializes the entire per-type column through
+        ``to_decimal`` only to take a single element, and the caller then
+        restacks the scalars it just tore apart. Slicing the column once is
+        constant in the number of rows read.
         """
         ids = np.asarray(logical_ids, dtype=np.int64).reshape(-1)
         if ids.size == 0:
@@ -261,9 +243,6 @@ class _SynapseStore:
             raise KeyError(f"Synapse type {synapse_type!r} does not declare parameter {parameter!r}.")
         local_rows = np.asarray([self._type_local_by_id[int(item)] for item in ids.tolist()], dtype=np.int64)
         return _take_vector_items(columns[parameter], local_rows)
-
-    def set_parameter(self, logical_ids: np.ndarray, parameter: str, values) -> None:
-        self.set_parameters(logical_ids, {parameter: values})
 
     def set_parameters(self, logical_ids: np.ndarray, updates: dict[str, object]) -> None:
         ids = np.asarray(logical_ids, dtype=np.int64).reshape(-1)
@@ -693,12 +672,51 @@ class SynapseView:
         return "\n".join(lines)
 
 
+def raise_on_name_type_conflict(pairs, *, known: dict[str, str] | None = None) -> dict[str, str]:
+    """Reject one synapse name standing for two different synapse types.
+
+    A synapse *name* is the handle a user reads back through
+    ``cell.synapses[name]``, so it has to denote one runtime type. The rule
+    is checked twice against different inputs -- at ``Cell.place()`` time
+    against the declarations, and again when the store materializes its
+    columns -- which is why it is stated here rather than in either caller.
+
+    Parameters
+    ----------
+    pairs : iterable of tuple
+        ``(name, synapse_type)`` pairs, in declaration order.
+    known : dict, optional
+        Names already claimed by an earlier pass. Not mutated.
+
+    Returns
+    -------
+    dict
+        ``name -> synapse_type`` for every pair seen, including ``known``.
+
+    Raises
+    ------
+    ValueError
+        On the first name that claims a second type.
+    """
+    type_by_name = {} if known is None else dict(known)
+    for name, synapse_type in pairs:
+        name, synapse_type = str(name), str(synapse_type)
+        previous = type_by_name.setdefault(name, synapse_type)
+        if previous != synapse_type:
+            raise ValueError(
+                f"Synapses with the same name {name!r} cannot use different synapse types "
+                f"({previous!r} and {synapse_type!r})."
+            )
+    return type_by_name
+
+
 def _count_labels(values) -> dict[str, int]:
-    counts: dict[str, int] = {}
-    for value in np.asarray(values, dtype=object).tolist():
-        label = str(value)
-        counts[label] = counts.get(label, 0) + 1
-    return counts
+    """Count each label, in first-seen order.
+
+    Returned as a plain ``dict`` rather than the ``Counter`` itself
+    because the callers interpolate it with ``{...!r}`` into a repr.
+    """
+    return dict(Counter(str(value) for value in np.asarray(values, dtype=object).tolist()))
 
 
 def _cell_label(cell, population_indices) -> str:

--- a/braincell/filter/cache.py
+++ b/braincell/filter/cache.py
@@ -82,7 +82,7 @@ class SelectionCache:
         indices, an array of bounds) simply do not memoize; they fall
         through to ``evaluate()`` unchanged.
         """
-        revision = getattr(morpho, "_revision", None)
+        revision = getattr(morpho, "revision", None)
         if self._morpho is not morpho or self._revision != revision:
             self._masks.clear()
             self._morpho = morpho

--- a/braincell/morph/morphology.py
+++ b/braincell/morph/morphology.py
@@ -567,6 +567,48 @@ class Morphology:
         return load_morpho(path)
 
     @property
+    def revision(self) -> int:
+        """Counter advanced on every structural change to this tree.
+
+        ``Morphology`` is mutable, so any consumer that caches a result
+        derived from the tree -- CV geometry, a resolved region mask, a
+        discretization -- must be able to tell that the tree it derived
+        from has since changed. Object identity cannot say that. Pair the
+        two: same object *and* same revision means the derived result is
+        still valid.
+
+        The absolute value carries no meaning and is not stable across
+        processes; only comparison against a previously recorded value is.
+
+        Returns
+        -------
+        int
+            Monotonically increasing revision number.
+
+        See Also
+        --------
+        braincell.filter.SelectionCache : Caches region/locset evaluations
+            against this counter.
+
+        Examples
+        --------
+        .. code-block:: python
+
+            >>> import brainunit as u
+            >>> from braincell import Branch, Morphology
+            >>> soma = Branch.from_lengths(lengths=[20.0] * u.um,
+            ...                            radii=[10.0, 10.0] * u.um, type="soma")
+            >>> tree = Morphology.from_root(soma, name="soma")
+            >>> before = tree.revision
+            >>> tree.soma.dend = Branch.from_lengths(lengths=[100.0] * u.um,
+            ...                                      radii=[2.0, 1.0] * u.um,
+            ...                                      type="basal_dendrite")
+            >>> tree.revision > before
+            True
+        """
+        return self._revision
+
+    @property
     def root(self) -> "MorphoBranch":
         """The root branch of this morphology.
 

--- a/braincell/vis/cell_topology_test.py
+++ b/braincell/vis/cell_topology_test.py
@@ -73,7 +73,11 @@ class PlotCellTopologyCvLevelTest(unittest.TestCase):
             plot_cell_topology(_cell(), level="cv", region=BranchSlice(branch_index=1, prox=0.0, dist=0.5))
 
         coverage = mocked.call_args.kwargs["highlight_fractions"]
-        self.assertAlmostEqual(coverage[1], 0.5)
+        # CV shading is the membrane-area fraction, the same one that scales
+        # a painted conductance. The dendrite tapers, so its proximal half
+        # is 0.5833... of the area and only 0.5 of the length. Branch-level
+        # shading below is a drawing extent and stays length-based.
+        self.assertAlmostEqual(coverage[1], 0.5833333333333334)
         self.assertEqual(mocked.call_args.kwargs["coverage_mode"], "fraction")
 
     def test_any_mode_is_forwarded(self) -> None:

--- a/docs/specs/2026-09-02-multi-compartment-simplification.md
+++ b/docs/specs/2026-09-02-multi-compartment-simplification.md
@@ -1,0 +1,634 @@
+# Multi-compartment simplification sweep
+
+Iteration 11 of the module-by-module `/simplify` sweep. Target:
+`braincell/_multi_compartment/` — 8,900 lines across nine non-test modules,
+of which `cell.py` alone is 3,003.
+
+Baseline on `eddc00c`:
+
+- `pytest braincell/_multi_compartment -q` → 157 passed, 59 subtests passed
+- `pytest braincell/ -q` → 2807 passed, 15 skipped, 410 subtests passed (219.29 s)
+
+Four review passes (reuse, simplification, efficiency, altitude) produced 44
+findings. This document records which are being applied, which are declined
+and why, and which are deferred with the evidence needed to pick them up
+later. The applied set groups into three themes.
+
+---
+
+## Theme 1 — Delete what nothing calls
+
+Every item here was confirmed dead by a repo-wide grep over `braincell/`,
+`examples/` and `docs/` (`.py`, `.ipynb`, `.md`). None changes behaviour.
+
+### 1.1 `_integrate_selected_ion_channel_states` and `_run_selected_child_channel_hook`
+
+`cell.py:1844-1903` and `cell.py:1933-1947`. The only references to either
+name are the definitions and the three calls the first makes to the second,
+so both die together:
+
+```
+$ grep -rn "_integrate_selected_ion_channel_states\|_run_selected_child_channel_hook" .
+cell.py:1844:    def _integrate_selected_ion_channel_states(...)
+cell.py:1857/1872/1887:  self._run_selected_child_channel_hook(   # inside the dead method
+cell.py:1934:    def _run_selected_child_channel_hook(...)
+```
+
+It is also the package's clearest copy-paste: `_pre_integral`,
+`_compute_derivative` and `_post_integral` (`:1850`, `:1865`, `:1880`) are
+three byte-identical 13-line closures differing only in the hook name —
+while the live sibling `_integrate_selected_ion_self_states` (`:1905`,
+called from `:1981`) already shows the parameterised form. Deleting removes
+104 lines of plausible-looking scheduling code that never executes, sitting
+between two paths that do.
+
+### 1.2 `_SynapseStore.parameter_value` and `_SynapseStore.set_parameter`
+
+`synapses.py:207-213` and `:265-266`. `parameter_value` has no caller; the
+only other mentions are three references to it in `parameter_column`'s own
+`See Also` and Notes, which describe it as the quadratic path to avoid — a
+dead accessor kept alive by documentation advertising that it is slow.
+`set_parameter` is a two-line wrapper over `set_parameters`, which is what
+the one live caller (`synapses.py:574`) uses.
+
+### 1.3 `_CellScope.branch_ids`
+
+`selection.py:62-63`. The one place that wants this reads
+`self._scope.exact_branch_ids` directly (`cell.py:521`).
+
+### 1.4 `Cell._discretization_to_point`
+
+`cell.py:1680-1681`, an alias of `_cv_to_point` whose seven callers are all
+tests in a *different* package (`_compute/bindings_test.py` ×5,
+`_compute/state_test.py` ×2). Its comment ("kept while older inspection
+helpers are still in use") no longer describes anything. Deleted; the seven
+call sites move to `_cv_to_point`.
+
+### 1.5 `_gather_layout_point_values`
+
+`cell.py:2874-2876`, a module function whose entire body is
+`return layout.gather_points(values)`. Its two sibling modules already call
+the method directly (`currents.py:120`, `probes.py:227`); only `cell.py:2057`
+goes through the wrapper.
+
+### 1.6 `Cell._axial_jax`
+
+Five writes (`cell.py:847`, `:1465`, `:1509`, `:1784`, `:1801`), zero
+production reads. The only readers are five assertions in `cell_test.py`
+(`:557`, `:604`, `:706`, `:711`, `:729`), four of which already assert on
+`runtime.axial_operator_cache` in the adjacent line. Three lifecycle methods
+currently have to remember to reset a field nothing reads.
+
+One genuine divergence exists and is preserved rather than papered over: at
+`cell.py:1799-1801` the runtime cache is skipped when
+`is_traced_value(operator)` while `_axial_jax` is assigned regardless. No
+production code observes that difference. The test assertions move to
+`cell.runtime.axial_operator_cache`.
+
+### 1.7 `run.py` unreachable cache fallback
+
+`run.py:187-194`. `cache = getattr(rcell, "_run_loop_cache", None)` followed
+by an `if cache is None` branch that rebuilds the loop uncached.
+`Cell.__init__` sets `self._run_loop_cache = {}` unconditionally
+(`cell.py:840`) and the field is only ever `.clear()`ed (`:1225`, `:1375`,
+`:1511`) — never reassigned, never `None`. `run()` has exactly one caller
+(`cell.py:2635`), always with a real `Cell`. The dead branch also holds a
+second copy of the `_make_run_loop(...)` argument list, so a new argument
+added to one and missed in the other would be a silent, untested divergence.
+
+### 1.8 Unreachable bool-dtype disjunct
+
+`selection.py:258` and `:276` both read
+`values.dtype.kind not in "iu" or values.dtype.kind == "b"`. Since
+`"b" not in "iu"`, the first clause already rejects bool arrays and the
+second can never decide anything.
+
+### 1.9 `probes._probe_current_ion_info` unused default and unreachable guards
+
+`probes.py:328-351`. Its single caller (`probes.py:261-266`) sits inside
+`if declaration.mechanism is not None:` (opened at `:220`) and always passes
+`layout_id=layout_id`. So `layout_id: int | None = None` never sees `None`,
+the `if layout_id is not None` guard at `:338` is always true, and the
+`mechanism_name is None` early return at `:343-345` is unreachable. The
+parameter becomes required and the two dead paths go.
+
+---
+
+## Theme 2 — Say it once
+
+### 2.1 Five coercers collapse to one shape ladder
+
+`field_resolution.py:481` `coerce_node_values`, `:519`
+`coerce_runtime_point_values`, `:561` `coerce_cv_values`, `:599`
+`coerce_named_node_values`, `:638` `coerce_named_cv_values`.
+
+All five open with the same `split_unit(single_population_view(...))` and run
+the same five-rung ladder: `ndim == 0` → fill; `ndim != 1` → raise; length
+matches the native space → return unchanged; length matches the other space
+→ map; otherwise raise. They differ only in a three-cell table:
+
+| | `ndim == 0` | `len == n_point` | `len == n_cv` |
+|---|---|---|---|
+| `coerce_node_values` | fill `n_point` | identity | `cv_to_node_values` |
+| `coerce_runtime_point_values` | fill `n_point` | identity | `cell._cv_to_point` |
+| `coerce_named_node_values` | `cv_to_node(fill n_cv)` | `mask_non_midpoint_points` | `cv_to_node_values` |
+| `coerce_cv_values` | fill `n_cv` | `cell._point_to_cv` | identity |
+| `coerce_named_cv_values` | fill `n_cv` | `_point_to_cv(mask…)` | identity |
+
+A `diff` of the first two bodies (504-516 against 546-558) returns exactly
+one differing line. The messages have already drifted between copies — the
+named variants say "cannot map the named value into point space" where the
+unnamed ones print the two expected lengths — which is what five copies of a
+shape rule produce.
+
+Collapses to one `_coerce(cell, value, *, caller, scalar_fill, from_point,
+from_cv)`; each public coercer becomes a short call supplying its row.
+
+### 2.2 `resolve_node_field_values` / `resolve_cv_field_values`
+
+`field_resolution.py:935` and `:993`. A `diff` of the two 27-line bodies
+(964-990 against 1022-1048) shows five differing lines, each a straight
+substitution of a `_node_` helper for its `_cv_` twin. The `"v"`/`"voltage"`
+parsing, the 3-tuple shape test, the three `mode` branches, both label
+formats and both `ValueError` strings are identical. One core takes the four
+slots; the two public functions become thin wrappers.
+
+### 2.3 The probe density-layout lookup
+
+`probes.py:176-184` and `:237-245` are identical apart from indentation:
+scan `runtime.get_point_layouts(point_id)`, keep layouts whose mechanism is
+a `Density` with a matching `instance_name`, raise the same
+"matched multiple mechanisms named …" on more than one. They diverge only
+*after* the block — one falls through to an ion lookup, the other raises.
+Extracted as `_matched_density_layout(...)`, leaving each caller to state
+only its own zero-match policy.
+
+### 2.4 Probe dispatch
+
+`probes.py:112-142` is a 31-line `if/elif/elif` over three probe types whose
+branches differ only in which function is called; the argument list is
+spelled out identically three times. The same
+`(StateProbe, MechanismProbe, CurrentProbe)` tuple is also written out at
+`probes.py:50` and `:74`. A module-level `_POINT_SAMPLERS` dict replaces the
+dispatch and `tuple(_POINT_SAMPLERS)` replaces both isinstance tuples, so
+adding a fourth probe type is a one-site edit instead of four.
+
+### 2.5 `_family_channel_nodes` Ion / MixIons branches
+
+`cell.py:1822-1831`. The `isinstance(node, Ion)` and
+`elif isinstance(node, MixIons)` arms are character-for-character identical.
+Neither class subclasses the other (`_base_ion.py:204` and `:480` both
+derive from `IonChannel, Container`), so this is not an ordering trick.
+Merged into `isinstance(node, (Ion, MixIons))`. Today the
+`_skip_family_update` opt-out is implemented twice.
+
+### 2.6 One `layout_<id>` parser
+
+`cell.py:2865` `_layout_id_from_runtime_path` and `currents.py:110`
+`_layout_id_from_current_key` differ only in a parameter name and one noun
+in each of two error strings. Kept once in `cell.py`, imported by
+`currents.py`.
+
+### 2.7 One synapse name/type conflict check
+
+`synapses.py:121` `_SynapseStore._validate_name_types` and `cell.py:1347`
+`Cell._validate_synapse_names` both build a `name → synapse_type` map with
+`setdefault` and raise on mismatch. The message
+`"Synapses with the same name {…!r} cannot use different synapse types
+({…!r} and {…!r})."` appears exactly twice repo-wide — at `cell.py:1360` and
+`synapses.py:127`. The inputs differ (place rules at `place()` time versus
+store columns at build time), so the shared piece is a helper over an
+iterable of `(name, synapse_type)` pairs, called from both.
+
+### 2.8 `_count_labels`
+
+`synapses.py:696` is a six-line re-implementation of `collections.Counter`,
+which `density_views.py:199-201` already uses for the identical repr purpose.
+
+### 2.9 `Cell.mech_table` moves to the layer that owns the table
+
+`cell.py:2526-2621` inlines 96 lines to build a `MechanismObjectTable`. Every
+sibling in the same section delegates in one line —
+`probes.sample_probe(self, name)`, `probes.sample_probes(self)`,
+`run_module.run(self, dt=dt, duration=duration)`.
+
+The table type, its cells, and the key function all live in
+`_compute/table.py`; the layout signature lives in `_compute/layouts.py`.
+`CellRuntimeState`'s own docstring (`_compute/state.py:129`) advertises
+"table views: `mechanism_cv_table`, `mechanism_point_table`" — **neither
+method exists**; those names have zero definitions and zero callers
+repo-wide. The inline block is what that never-written method turned into.
+
+The builder moves to `_compute/table.py` as
+`build_mechanism_object_table(runtime, cvs)`, `Cell.mech_table` becomes a
+two-line delegation, and the stale docstring is corrected to name what is
+actually there. `cell.py` drops three imports (`MechanismObjectCell`,
+`mechanism_cell_key`, `mechanism_signature`), keeping only
+`MechanismObjectTable` for the return annotation.
+
+---
+
+## Theme 3 — Make the cached and derived truths honest
+
+### 3.1 `locset_cv_ids` rebuilds a grouping the CV tree already holds
+
+`field_resolution.py:324-327` builds `branch_id → (cv_id, …)` with a
+`setdefault` loop over `cell.cvs`. `cell.cv_tree.branch_to_cv_ids` is that
+mapping, and `selection.py:229-232` — same package — already uses it. The
+existing `.get()` returns `None` for an unknown branch and the loop skips
+it; the replacement keeps that skip rather than adopting `selection.py`'s
+`IndexError`, since a locset evaluated against `cell.morpho` cannot name an
+out-of-range branch and silently changing that to a raise is not this
+change's business.
+
+### 3.2 `mask_non_midpoint_points` rebuilds a mask the runtime already stores
+
+`field_resolution.py:463-467`:
+
+```python
+midpoint_ids = np.asarray(node_tree.cv_to_mid_node_id, dtype=np.int32)
+midpoint_mask = np.zeros((cell.n_point,), dtype=bool)
+midpoint_mask[midpoint_ids] = True
+```
+
+is byte-for-byte what `_compute/state.py:440-442` computes and stores as
+`runtime.midpoint_mask_np`, and what `cell.py:1733-1734` already reads. No
+new precondition is introduced: the function already calls `cell.n_point`,
+which raises through `_raise_if_not_initialized`, and `cell.runtime` carries
+the same guard.
+
+### 3.3 `CV.midpoint`
+
+`cell.py:1272-1278` recomputes `(cv.prox + cv.dist) * 0.5` inline, and
+`cell_test.py:431` recomputes it a third time to assert the result.
+`_GeoCV.midpoint` (`_discretization/geometry.py:132-140`) already states the
+rule with a docstring explaining it is derived rather than stored so it
+cannot drift — but the *user-facing* record `CV`
+(`_discretization/base.py:165-277`) carries derived `region` and `diam_mid`
+properties and stops short of `midpoint`. Added beside `diam_mid`.
+
+### 3.4 Defect — `Cell.on(region).cv.coverage_fraction` reports a different number than the physics uses
+
+**Confirmed end to end.** On a tapering dendrite (radii 4 µm → 1 µm, one CV,
+region `BranchSlice(1, 0.0, 0.5)`):
+
+```
+Cell.on(region).cv.coverage_fraction  -> [0.5]
+cv1 coverage_area_fraction actually painted = 0.65
+```
+
+The same CV, the same region, two numbers 30 % apart. On a branch with no
+taper they agree exactly (0.5 and 0.5), which is why this has gone unnoticed.
+
+`field_resolution.cv_coverage_fractions` (`:237-266`) measures overlap in
+**normalized branch length**: `overlap_x / (cv.dist - cv.prox)`. The physics
+in `_discretization/mechanism.py:359-379` measures overlap in **lateral
+membrane area**: `overlap_area_um2 / geo.lateral_area_um2`. The field it
+writes is named `coverage_area_fraction` (`mech/_density.py:244`) — the
+codebase already states which of the two "coverage" means.
+
+There is no consumer that wants a length fraction here. The value reaches:
+
+- `selection.py:121` `select_region` → `_CellScope.coverage` →
+  `CVSelector.coverage_fraction` (`selection.py:182-184`), a public
+  introspection property whose only plausible reading is "how much of this
+  CV did my region cover", i.e. exactly the number that scaled the
+  conductance;
+- `field_resolution.cv_highlight_fractions` and `node_highlight_fractions`,
+  which shade a `braincell.vis.plot_cell_topology` node by how much of the
+  CV a region covers.
+
+`cv_coverage_fractions` is changed to the area measure and renamed
+`cv_area_coverage_fractions`, so the two spellings cannot be confused again
+at a call site. The area computation is not re-implemented: the frustum
+machinery in `_discretization/geometry.py` gains a public
+`interval_area_fraction(...)` and both `_discretization/mechanism.py` and
+`field_resolution.py` call it.
+
+`branch_coverage_fractions` (`:270-296`) stays length-based and gains a
+docstring line saying so explicitly. It is a drawing extent along a branch
+line for the branch-level topology plot (`vis/cell_topology.py:454`), not a
+membrane fraction, and length is the right measure for it.
+
+**Reviewer disagreement, recorded.** The reuse pass looked at the same two
+functions and classified them as "different metrics — not a reuse
+candidate", i.e. an intentional split. That reading is defensible from the
+code alone. It is overruled by the end-to-end measurement above: a public
+property that describes a painted mechanism must report the fraction that
+was painted. Nothing documents a length measure, and
+`coverage_area_fraction` names the intended one.
+
+**Numeric change to existing test.** `field_resolution_test.py:141-148`
+asserts `0.5` on `_soma_dend_tree()`, whose dendrite tapers 2 µm → 1 µm. The
+area fraction there is `0.5833333333333334` (verified against the value
+`Cell.paint` actually stores). The test is updated with that number and a
+comment naming the taper as the reason the two measures differ.
+
+### 3.5 Defect — the discretization cache cannot see a morphology mutated in place
+
+**Confirmed:**
+
+```
+n_cv before mutation: 1   revision: 1
+morpho n_branches now: 2  revision: 2
+n_cv after mutation : 1     <-- wrong
+```
+
+`Cell._discretization_key` (`cell.py:1226-1233`) identifies the morphology by
+`id(self._morpho)` and nothing else. `Morphology` is mutable —
+`cell.morpho`'s own docstring says it is returned "without copying it", and
+`Morphology._invalidate_derived_caches` says outright that "``Morphology`` is
+mutable, so a stale entry here is a correctness bug rather than a missed
+optimization". Attaching a branch to a morphology a `Cell` already holds
+changes neither the id nor any other key component, so `cell.cvs`,
+`cell.n_cv` and `cell.on(...)` keep answering from the pre-mutation
+discretization.
+
+`Morphology` already maintains the counter that detects exactly this:
+`_revision`, incremented by `_invalidate_derived_caches`. The in-repo idiom
+for consuming it is `filter/cache.py:85-89`:
+
+```python
+revision = getattr(morpho, "_revision", None)
+if self._morpho is not morpho or self._revision != revision:
+```
+
+— identity *and* revision. `Cell` uses neither half correctly. Fix:
+
+- `Morphology` gains a public `revision` property, so the one existing
+  consumer stops probing a private attribute with `getattr`;
+  `filter/cache.py:85` switches to it.
+- `_discretization_key` includes `self._morpho.revision`. The `id()` stays
+  as the identity component and is sound here — unlike the temporaries that
+  caused the iteration-9 bug, the cell holds `self._morpho` alive for as long
+  as the cached key exists, and both reassignment sites (`cell.py:1413`,
+  `:1514`) invalidate the cache outright. A comment records that reasoning
+  so the next reader does not have to rediscover it.
+
+**Second half of the same defect.** With the key fixed, a key *miss* becomes
+reachable for the first time — and the miss path (`cell.py:1235-1246`)
+rebuilds only `_discretization_cache`, leaving `_synapse_store_cache`,
+`_runtime_cvs_cache`, `_runtime_nodes_cache`, `_root_scope_cache` and
+`_run_loop_cache` holding values derived from the old discretization. The
+miss path calls `_invalidate_discretization_cache()` before rebuilding.
+
+---
+
+## Breaking changes
+
+1. **`field_resolution.cv_coverage_fractions` → `cv_area_coverage_fractions`,
+   and its values change on tapering geometry.** Length-weighted overlap
+   becomes lateral-area-weighted overlap, matching what `Cell.paint` stores
+   as `coverage_area_fraction`. Affects `Cell.on(region).cv.coverage_fraction`
+   and the region shading in `braincell.vis.plot_cell_topology`. On geometry
+   with no taper the numbers are unchanged. In-repo callers updated:
+   `selection.py:121`, `field_resolution.py:366`, `:398`,
+   `field_resolution_test.py:142`.
+2. **`Cell._discretization_to_point` deleted.** Use `Cell._cv_to_point`.
+   Seven call sites in `_compute/bindings_test.py` and `_compute/state_test.py`
+   updated.
+3. **`Cell._axial_jax` deleted.** Read
+   `cell.runtime.axial_operator_cache.operator`. Five assertions in
+   `cell_test.py` updated.
+4. **`_SynapseStore.parameter_value` and `_SynapseStore.set_parameter`
+   deleted.** Use `parameter_column` and `set_parameters`.
+5. **`_CellScope.branch_ids` deleted.** Use `exact_branch_ids`.
+6. **`Cell._integrate_selected_ion_channel_states` and
+   `Cell._run_selected_child_channel_hook` deleted.** No callers existed.
+7. **`probes._probe_current_ion_info(layout_id=...)` is now required.**
+8. **`Cell.mech_table()`'s body moves to
+   `_compute.table.build_mechanism_object_table`.** The `Cell` method keeps
+   its name, signature and return type.
+
+No deprecation shims, aliases or `warnings.warn` bridges are added; the old
+spellings are removed outright.
+
+---
+
+## Declined
+
+**Per-row synapse parameter validation** (`synapses.py:131-169`). The
+efficiency pass measured it: 5,120 logical synapses × 2 parameters →
+`_build_parameter_columns` 0.498 s, of which `spec.validate` is 10,240 calls
+and 0.246 s. Moving the check to the stacked column would roughly halve the
+build. Declined *for this PR* rather than rejected: `_stack_synapse_values`
+(`_compute/layouts.py:451`) documents its input as "one **validated** value
+per logical synapse" and its own error paths are weaker than
+`_validate_like_default`'s — a list mixing a `Quantity` with a bare float
+currently raises `TypeError: Synapse field 'g' requires a quantity
+compatible with uS.` and would instead raise `ValueError: … has incompatible
+units across instances.` Doing this properly means moving
+`_stack_synapse_values` into `synapses.py` (it has zero callers inside
+`_compute`) and rewriting its messages, which is a change of a different
+kind from the rest of this PR. Recorded below with its measurement.
+
+**`_take_population` unified with `_select_population_value`**
+(`density_views.py:288` versus `cell.py:2748`). The two genuinely disagree:
+`_select_population_value` recognises both a packed `shape[-2]` and a
+leading `shape[0]` population axis and indexes with a vector;
+`_take_population` recognises only `shape[0]` and indexes with a scalar.
+Substituting would leave a length-1 axis where the caller expects a scalar
+*and* start matching the packed case. Reported, not applied — reconciling
+the population-axis convention is a decision, not a cleanup.
+
+**`density_views.py:154` routed through `state.get_layout_value`.** Not
+equivalent: `get_layout_value` maps a global point id to a packed layout's
+local index and handles ragged buffers, whereas `_take_point`'s
+`shape[-1] == point_size` guard fails on a packed layout and returns the
+whole buffer. Behaviour-changing.
+
+**`_require_name` replaced by `mech/_validate.require_str`**
+(`density_views.py:337` plus inline copies at `synapses.py:437`, `:454`,
+`selection.py:163`). `require_str` raises `TypeError` for a non-`str` and
+`ValueError` only for `""`; `_require_name` raises `ValueError` for both.
+Swapping changes the exception type callers see. There are two more
+byte-identical copies in `network/` (`recording.py:593`,
+`connection.py:756`), so this wants doing once across the package, not
+piecemeal here.
+
+**Caching `region.evaluate(cell.morpho)`** (`field_resolution.py:225`,
+`:319`). `filter.cache.SelectionCache` exists and `_discretization` uses it.
+Declined here because the same measurement that killed a similar idea in
+iteration 9 applies: the inner selection cache is already value-keyed, and
+no measurement in this pass shows the re-walk mattering. Not applied without
+a number.
+
+---
+
+## Deferred, with evidence
+
+These are real and verified; each is a different kind of change from this
+PR's three themes, and several belong to iterations already scheduled.
+
+**To iteration 12 (network).**
+
+- Standalone `Connection` event routing is a second implementation of
+  `network/delivery.py`, living in `Cell`: `cell.py:2292-2319`,
+  `:2321-2355`, `:2367-2394`, plus `_coerce_drive_like` (`:2818`),
+  `_scatter_drive_rows` (`:2825`), `_zeros_like_event_template` (`:2879`),
+  `_rewrap_event_template` (`:2885`), `_connection_event_weight` (`:2890`).
+  `delivery.apply_immediate_events` (`:479-522`) already aggregates weighted
+  arrivals per `(post_population, layout_id)` into a buffer from
+  `zeros_like_events` (`:267`). Two of these methods reach into
+  `ConnectionView._call_views` (`network/connection.py:415`), a private
+  whose only other callers are inside `network/`.
+
+**To iteration 14 (whole package).**
+
+- Twelve guard-only forwards to `CellRuntimeState`, `cell.py:2463-2513`.
+  Each is `_raise_if_not_initialized` then `return self._runtime.<same
+  name>(...)`, and `Cell.runtime` is public and carries the same guard, so
+  both spellings work and the callers have already split: `cell.*` in
+  `field_resolution.py` and `CellView`; `cell.runtime.*` in `synapses.py`,
+  `density_views.py`, `probes.py` and all of `network/`. ~50 lines. Breaking
+  public API — belongs with the public-surface pass.
+- Five private cross-package imports, each with a cross-package consumer:
+  `_base_neuron._zero_spike_like` (`cell.py:56`; also
+  `_single_compartment/base.py`), `_compute.bindings._is_root_level_runtime_node`
+  (`cell.py:70`), `quad._exp_euler._ind_exp_euler_step_selected`
+  (`cell.py:95`), `_compute.ions._runtime_ion_species_key`
+  (`density_views.py:28`), `_compute.layouts._stack_synapse_values`
+  (`synapses.py:32`). Promoting them touches six other modules.
+- `AxialOperatorCache` is defined in `cell.py:108-112` but stored in
+  `_compute/state.py:158-159`, which therefore has to type its own field
+  `object | None`. The same pattern lives correctly one layer down as
+  `DHSStaticCache` (`quad/_staggered.py:172-177`).
+- Three declaration-override dicts at three altitudes
+  (`cell.py:818-821`, `:849`, `:850`); `_compute/state.py:693` reaches *up*
+  into one of them with `getattr(cell, "_density_parameter_overrides", {})`.
+- `_CellScope` owns the selection but not the gather, so "apply this scope to
+  an array" is written six times (`cell.py:622`, `:636`, `:2748`, `:2764`;
+  `density_views.py:281`, `:288`; `synapses.py:833`). The inconsistency is
+  load-bearing: `CellView.V` honours the spatially-restricted `varshape` and
+  `CellView.spike`, four lines below, does not.
+- Three sibling surfaces address a density mechanism by three different keys
+  — class name only (`field_resolution.py:978`, `:1036`), instance *or*
+  class (`density_views.py:103-113`), instance only (`probes.py:178`,
+  `:240`). `field_resolution`'s escape hatch pushes a raw `_compute` layout
+  id into the public `plot_cell_topology` API.
+- `field_resolution.__all__` lists 24 names; 10 have an importer.
+- Three spellings of "index the last axis if there is one"
+  (`probes.py:313`, `synapses.py:833`, `density_views.py:281`) and three
+  copies of the united last-axis scatter (`cell.py:2825`, `synapses.py:838`,
+  `:790`).
+- `braincell/vis/cell_topology.py:40`, a public package, imports
+  `braincell._multi_compartment.field_resolution` and uses
+  `require_initialized`, a wrapper that exists so `vis` need not call
+  `cell._raise_if_not_initialized`. The module docstring argues for this
+  deliberately and the argument is sound, but it makes `field_resolution` de
+  facto public API at a private path. Worth deciding explicitly.
+
+**Own PR — architecture.**
+
+- Ragged `place()` expands the declaration inside `Cell`
+  (`cell.py:1033` `_place_per_cell`, helpers at `:2664`, `:2684`, `:2719`,
+  `:2725`, `:2737`) because `PlaceRule` cannot express the ragged form,
+  even though it already carries `population_indices` and `aligned`
+  (`_discretization/mechanism.py:81-99`). The workaround costs a second copy
+  of the broadcast grammar (`cell.py:2698-2716` versus `synapses.py:762-774`)
+  and an `id()`-keyed undo map `Cell._synapse_origins` (`:851`, `:1051`),
+  which in turn forces `network/engine.py:249,271` to snapshot and roll back
+  two `Cell` privates instead of one. ~75 lines.
+- 236 lines of post-voltage mechanism scheduling in `cell.py:1813-2049` whose
+  only consumer is `quad/_staggered.py:158-168`, which re-raises the enum
+  error verbatim, duplicating `cell.py:2992-2997`. This is what forced the
+  private `_ind_exp_euler_step_selected` entry, whose own docstring
+  (`quad/_exp_euler.py:320`) reads "Internal selective variant used by family-
+  phased cell scheduling."
+- `cell.py` uses both the public `ind_exp_euler_step` (`:1957`, `:2011`,
+  `:2432`) and the private `_ind_exp_euler_step_selected` (`:1895`, `:1923`),
+  so `cell_test.py:944`'s patch of the public name cannot intercept half the
+  calls. Worth checking whether that test still proves what it claims.
+
+**Own PR — performance, with measurements.**
+
+| Site | When | Measured |
+|---|---|---|
+| `synapses.py:131-169` per-row `spec.validate` | declaration | 5,120 synapses × 2 params: build 0.674 s, `_build_parameter_columns` 0.498 s, `spec.validate` 0.246 s over 10,240 calls |
+| `synapses.py:754-775` `_select_declared_parameter_value` | declaration | re-runs `to_decimal` on the whole declared array per row — O(N²) element work for an array-valued parameter |
+| `density_views.py:115-163` `_DensityView.get()` | inspection | 0.025–0.036 ms/row, linear; 656 rows = 16–24 ms. `_density_rows` (`:229-258`) materializes the full pop × CV × mechanism cross product before `by_name` filters it |
+| `selection.py:51-59`, `:93-143` `_CellScope` pairs | inspection | `cell.soma`: 0.030 ms at 164 pairs, 0.146 ms at 2,624, 1.215 ms at 20,992 — linear in `pop_size × n_cv` |
+| `cell.py:1467-1468` eager runtime views in `init_state` | declaration | 1.9 ms at 164 CVs, 6.4 ms at 648 CVs (~1 % of `init_state`); the properties already build lazily |
+| `cell.py:2275-2319` connection views per synapse layout | trace | O(n_layouts × n_connect_calls × n_rows) Python per trace |
+| `probes.py:113-143`, `:303-310` | trace | rebuilds the whole `SynapseView` per probe point; `_representative_cv_id` scans `cv_to_mid_node_id` per point |
+| `currents.py:165` | trace | `evaluate_point_clamps(point_ids=…)` does per-layout Python filtering, then line 166 gathers the midpoints anyway; `point_ids=None` is bit-identical |
+
+Explicitly measured and **not** worth acting on: `brainstate.graph.nodes(...)`
+appears at 10 call sites and was expected to be a repeated full-tree walk. A
+full `Cell.run` trace makes 10 calls totalling 0.9 ms out of 443 ms, because
+`_iter_graph` prunes at `level_ > hi` and `CellRuntimeState` is classified
+`STATIC`. Not worth caching. Likewise every Python loop in `Cell.update` /
+`compute_derivative` iterates mechanism *types* (O(10)), not CVs, and is
+traced once.
+
+---
+
+## Edge cases and tests
+
+New regression tests, each written before the change it covers:
+
+1. `field_resolution_test.py` — a CV coverage fraction on a tapering branch
+   equals the `coverage_area_fraction` that `Cell.paint` stores for the same
+   CV and region, and on an untapered branch equals the length fraction.
+   Non-vacuous: it fails on `eddc00c` with 0.5 against 0.65.
+2. `cell_test.py` — attaching a branch to a `Morphology` a `Cell` already
+   holds changes `cell.n_cv`. Non-vacuous: it fails on `eddc00c`, reporting
+   the pre-mutation CV count.
+3. `cell_test.py` — a discretization rebuild triggered by a key miss leaves
+   no stale `_root_scope_cache`.
+4. `_compute/table_test.py` — `build_mechanism_object_table` produces the
+   same table `Cell.mech_table()` did, for a cell carrying both a density
+   mechanism and a placed synapse.
+
+Edge cases considered for the coverage change:
+
+- **Zero-area CV.** `interval_area_fraction` returns `0.0` when
+  `lateral_area_um2 <= EPS_AREA_UM2`, so such a CV drops out of
+  `Cell.on(region)`. That matches the physics, which already skips
+  `fraction <= EPS_PARAM` at `_discretization/mechanism.py:653`.
+- **Region covering a whole branch.** Both measures give exactly 1.0; the
+  clamp to `[0, 1]` is retained.
+- **Multiple disjoint intervals on one branch.** Areas add, as lengths did.
+- **Zero-length radius jump inside a CV.** Handled by the existing
+  `_build_frusta` path, which the physics already uses.
+
+Edge cases for the discretization key:
+
+- Morphology reassigned (`init_state`, `reset`) — both sites already
+  invalidate; the revision component is redundant there and harmless.
+- Morphology mutated between `paint()` calls — `paint` invalidates, so the
+  rebuild happens either way; the key now agrees.
+- Morphology mutated after `init_state()` — `init_state` clones, so the
+  runtime is insulated; the declaration-time views now track the clone's
+  revision rather than the caller's tree.
+
+---
+
+## Verification
+
+Run from the worktree after every item above had landed.
+
+```
+$ pytest braincell/_multi_compartment -q
+161 passed, 24 warnings, 59 subtests passed in 18.43s
+
+$ pytest braincell/ -q
+2814 passed, 15 skipped, 411 warnings, 411 subtests passed in 204.00s (0:03:23)
+
+$ pre-commit run --files <23 changed files>
+check for added large files..............................................Passed
+check python ast.........................................................Passed
+check for merge conflicts................................................Passed
+debug statements (python)................................................Passed
+fix end of files.........................................................Passed
+trim trailing whitespace.................................................Passed
+ruff (legacy alias)......................................................Passed
+ruff format..............................................................Passed
+```
+
+Against the `eddc00c` baseline at the top of this document: the module suite
+gains 4 tests (157 → 161) and the full suite gains 7 tests and one subtest
+(2807/410 → 2814/411), with no test lost or skipped. `ruff format` reflowed
+two files on its first pass; the numbers above are from the re-run after that
+reflow. Net diff: 22 source and test files changed, 916 insertions,
+513 deletions, plus this spec.


### PR DESCRIPTION
Iteration 11 of the module-by-module simplification sweep. Target:
`braincell/_multi_compartment/` — 8,900 lines across nine non-test
modules, of which `cell.py` alone was 3,003.

Spec, written before any code changed and shipping in this PR:
`docs/specs/2026-09-02-multi-compartment-simplification.md`. It records all
44 review findings — the 23 applied here, 5 declined with reasons, and the
rest deferred with `file:line` evidence for iterations 12 and 14.

## Two live defects found and fixed

Each has a regression test that was confirmed to fail on the parent commit
`eddc00c` before the fix landed.

**Coverage was measured two different ways.** `Cell.on(region).cv.coverage_fraction`
reported a normalized *length* fraction, while `Cell.paint` scales the
conductance it stores by a lateral *area* fraction. On a branch that tapers
4 µm → 1 µm the two disagree — `0.5` against `0.65` for the same CV and the
same region — so introspection contradicted the physics it claimed to
describe. The area computation is now a public
`braincell._discretization.geometry.interval_area_fraction`, and both the
physics path (`_coverage_fraction`) and the introspection path
(`cv_area_coverage_fractions`) call it. `branch_coverage_fractions` stays a
length measure and now says so in its docstring: it is a drawing extent, not
a conductance scale.

**A mutated morphology was invisible to the discretization cache.**
`Cell._discretization_key` keyed on `id(self._morpho)` alone. `Morphology` is
mutable and `cell.morpho` hands the caller the very tree the cell
discretizes, so attaching a branch left `cell.cvs` and `cell.n_cv` answering
from a stale discretization. The key now pairs identity with the tree's
revision — the same test `braincell.filter.SelectionCache` already applies —
and a key miss drops the derived caches too, not just the one being rebuilt.
`Morphology` grows a public `revision` property so the check no longer
reaches for `_revision`.

## Breaking changes

Every in-repo caller is updated in this PR. No deprecation shims, no
aliases, no warnings — the old spellings are gone.

1. `Cell._discretization_to_point` removed — use `Cell._cv_to_point`, which
   it merely forwarded to. 7 call sites updated in `_compute/bindings_test.py`
   and `_compute/state_test.py`.
2. `Cell._axial_jax` removed — read `cell.runtime.axial_operator_cache`,
   which it duplicated for the active JAX float dtype. 5 assertions updated
   in `cell_test.py`.
3. `field_resolution.cv_coverage_fractions` renamed
   `cv_area_coverage_fractions` and its return value changed from a length
   fraction to an area fraction. Callers reading it as a conductance scale
   were silently wrong before; callers wanting the drawing extent should use
   `branch_coverage_fractions`.
4. `field_resolution.resolve_node_field_values` and
   `resolve_cv_field_values` collapsed onto `_resolve_field_values`; the two
   public names remain as thin wrappers, but the five private coercers
   behind them (`_coerce_*`) are now one `_coerce_field`.
5. `SynapseView.parameter_value` and `SynapseView.set_parameter` removed —
   both walked every row to serve one, and the column-level
   `get_parameter` / `update_parameter` pair already covers the use.
6. `Cell._integrate_selected_ion_channel_states` and
   `Cell._run_selected_child_channel_hook` removed — nothing called either.
7. `Cell._gather_layout_point_values` removed — `layout.gather_points` is
   the same call one level down.
8. `_CellScope.branch_ids` removed — unused, and it re-derived what
   `cv_tree.branch_to_cv_ids` already holds.

## Simplifications

- `Cell.mech_table()`'s body becomes a reusable
  `_compute.table.build_mechanism_object_table(runtime, cvs)`; the
  duplicated `ensure_row` + cell construction collapses into one
  `add_cell` closure. `Cell.mech_table` is now three lines.
- `probes.py`: a 31-line `if`/`elif` chain and two parallel `isinstance`
  tuples become a `_POINT_SAMPLERS` dispatch dict with
  `_PROBE_TYPES = tuple(_POINT_SAMPLERS)` derived from it. The
  name-resolution both probe kinds share moves into
  `_matched_density_layout`.
- `layouts.py` gains a public `layout_id_from_key`, replacing two
  byte-identical private parsers in `cell.py` and `currents.py`.
- `synapses.py` gains a public `raise_on_name_type_conflict`, which
  `Cell._validate_synapse_names` and `_validate_name_types` now both call.
- `_discretization/base.py` gains `CV.midpoint`, so `cv_midpoints` reads
  `[cv.midpoint for cv in cvs]`.
- Dead branches removed: the `dtype.kind == "b"` arms in `selection.py`
  (boolean arrays are rejected earlier), the `getattr` fallback for
  `_run_loop_cache` in `run.py`, and two unreachable guards in
  `_probe_current_ion_info`.

`cell.py` is 274 lines lighter. `_compute/state.py`'s docstring stops
pointing at two methods that do not exist.

Behaviour preservation for the two large collapses was checked by printing
all ten coercer error messages and both resolver twins' messages and
confirming the text is byte-identical, rather than relying on the suite's
generic `assertRaises(ValueError)`.

## Tests

4 new tests in `_multi_compartment` and 3 in `_compute`:
`CoverageMatchesThePaintedFractionTest` (taper and uniform),
`DiscretizationTracksAMutatedMorphologyTest` (CV count and stale scope
cache), and `BuildMechanismObjectTableTest` (builder matches
`Cell.mech_table()`; covers both a density and a point mechanism; every
populated entry names its own row and column).

`vis/cell_topology_test.py::test_fraction_passes_partial_coverage` moves
from `0.5` to `0.5833333333333334` — that is the coverage fix reaching the
CV-level shading, and the comment says so. Its sibling
`test_fraction_passes_partial_branch_coverage` deliberately stays at `0.5`,
because branch shading is a drawing extent.

`_compute/__init___test.py`'s declared layering graph gains
`"table": {"layouts", "state"}`. The guard caught the new edge exactly as
designed; `layouts` is a leaf, so the graph stays a DAG.

## Verification

```
$ pytest braincell/_multi_compartment -q
161 passed, 24 warnings, 59 subtests passed in 18.43s

$ pytest braincell/ -q
2814 passed, 15 skipped, 411 warnings, 411 subtests passed in 204.00s (0:03:23)

$ pre-commit run --files <23 changed files>
check for added large files..............................................Passed
check python ast.........................................................Passed
check for merge conflicts................................................Passed
debug statements (python)................................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
```

Baseline on `eddc00c` was 157 module tests and 2807 passed / 15 skipped /
410 subtests. No test was lost or newly skipped.

## Summary by Sourcery

Simplify the multi-compartment implementation while correcting coverage reporting and mutation-sensitive discretization caching.

New Features:
- Expose shared geometry and morphology revision APIs for accurate coverage calculations and mutation-aware caching.
- Add a reusable mechanism object table builder for point-domain runtime inspection.

Bug Fixes:
- Align CV coverage introspection with painted membrane-area conductance fractions, including tapering branches.
- Invalidate discretization-derived caches when a shared morphology is structurally mutated.

Enhancements:
- Consolidate duplicated field coercion, field resolution, probe dispatch, synapse validation, and layout parsing logic.
- Remove unused aliases, wrappers, dead scheduling methods, and unreachable branches while simplifying multi-compartment code paths.

Documentation:
- Add a specification documenting the multi-compartment simplification findings, applied changes, deferred work, and verification.

Tests:
- Add regression coverage for tapered and uniform membrane-area fractions, morphology mutation cache invalidation, and mechanism table construction.
- Update affected tests for renamed APIs, removed internals, and area-based CV visualization coverage.

Chores:
- Apply breaking API cleanup without deprecation shims, including removal of obsolete conversion, axial-cache, synapse, and selection accessors.