### PR TITLE
refactor(network): drop the lazy __init__, delete unreachable delivery branches, fix quadratic connection scans

### DIFF
--- a/braincell/_misc.py
+++ b/braincell/_misc.py
@@ -171,6 +171,43 @@ def concat_values(values):
     return u.math.concatenate(values, axis=0)
 
 
+def freeze_array(value):
+    """Return a read-only copy of a host array, leaving device arrays alone.
+
+    Every result object BrainCell hands back -- ``SampleBlock.values``,
+    ``EventSeries.time``, ``Population`` metadata, ``Network`` event rows --
+    is meant to be immutable. Three separate copies of this used to exist,
+    and only one of them handled :class:`brainunit.Quantity`, so attaching
+    units to population metadata silently made it writable again.
+
+    A device-backed array is returned unchanged: JAX arrays are already
+    immutable, and copying one to set a numpy flag would pull it to host.
+
+    Parameters
+    ----------
+    value : object
+        Array, quantity, or any other object.
+
+    Returns
+    -------
+    object
+        A read-only copy for host arrays and host-backed quantities; the
+        original object otherwise.
+    """
+    if isinstance(value, u.Quantity):
+        mantissa = value.mantissa
+        if isinstance(mantissa, np.ndarray):
+            mantissa = np.array(mantissa, copy=True)
+            mantissa.flags.writeable = False
+            return u.Quantity(mantissa, value.unit)
+        return value
+    if isinstance(value, np.ndarray):
+        result = np.array(value, copy=True)
+        result.flags.writeable = False
+        return result
+    return value
+
+
 def same_time_quantity(left, right) -> bool:
     """Return ``True`` when two optional time quantities agree to tolerance.
 

--- a/braincell/_multi_compartment/run.py
+++ b/braincell/_multi_compartment/run.py
@@ -35,7 +35,7 @@ from braincell._misc import (
     validate_time_quantity,
 )
 from braincell._multi_compartment import probes
-from braincell.network.recording import SampleBlock
+from braincell.network.recording import SampleBlock, concat_sample_blocks
 
 if TYPE_CHECKING:
     from .cell import Cell
@@ -96,7 +96,7 @@ class RunResult:
             for name in previous.samples:
                 if previous.samples[name].schema != current.samples[name].schema:
                     raise ValueError(f"Recording schema changed for {name!r}.")
-        samples = {name: _concat_sample_blocks(tuple(part.samples[name] for part in parts)) for name in first.samples}
+        samples = {name: concat_sample_blocks(tuple(part.samples[name] for part in parts)) for name in first.samples}
         common_traces = set(first.traces)
         for part in parts[1:]:
             common_traces.intersection_update(part.traces)
@@ -278,15 +278,3 @@ def _recording_time_mask(times, schema) -> np.ndarray:
     period_ms = float(np.asarray(schema.period.to_decimal(u.ms)).reshape(()))
     relative = (time_ms - start_ms) / period_ms
     return (time_ms >= start_ms - 1e-9) & np.isclose(relative, np.rint(relative), rtol=1e-6, atol=1e-6)
-
-
-def _concat_sample_blocks(blocks):
-    first = blocks[0]
-    first_time = next((block.first_time for block in blocks if block.first_time is not None), None)
-    return SampleBlock(
-        values=_concat_values(tuple(block.values for block in blocks)),
-        schema=first.schema,
-        segment_start=first.segment_start,
-        segment_stop=blocks[-1].segment_stop,
-        first_time=first_time,
-    )

--- a/braincell/network/__init__.py
+++ b/braincell/network/__init__.py
@@ -15,56 +15,34 @@
 
 """First-class population, connection, and runtime APIs.
 
-This module is deliberately cheap to import. :mod:`braincell.network.event`
-and :mod:`braincell.network.recording` are leaves that lower layers
-(:mod:`braincell._multi_compartment`) import directly, and Python runs a
-package's ``__init__`` before any of its submodules. Importing
-:mod:`.connection`, :mod:`.engine`, or :mod:`.lowering` here would
-therefore drag :mod:`braincell._multi_compartment` into the middle of its
-own initialization.
+This package is imported from the middle of
+:mod:`braincell._multi_compartment`'s own initialization:
+:mod:`braincell._multi_compartment.cell` imports
+:mod:`braincell.network.event` and :mod:`braincell.network.recording` at
+module scope, and Python runs a package's ``__init__`` before any of its
+submodules. So when this file runs, ``braincell._multi_compartment`` is
+present in :data:`sys.modules` but only partially executed.
 
-So only the leaf :mod:`.core` is imported eagerly; the three heavyweight
-public names resolve on first attribute access via :pep:`562`
-``__getattr__``. ``braincell.network.Network`` behaves exactly as before —
-the laziness is invisible from the outside, and
-``braincell/network/__init___test.py`` guards the invariant.
+Importing :mod:`.connection`, :mod:`.engine`, and :mod:`.pairing` here is
+still safe, because none of them import a *name* from that partially
+executed package root -- they import its submodules
+(:mod:`~braincell._multi_compartment.probes`,
+:mod:`~braincell._multi_compartment.run`,
+:mod:`~braincell._multi_compartment.synapses`), which Python resolves
+against a partial parent without complaint.
+
+That is the invariant this package depends on, and
+``braincell/network/__init___test.py`` checks it directly rather than
+maintaining a list of modules presumed dangerous.
 """
 
-from importlib import import_module
-from typing import TYPE_CHECKING
-
-from .core import NetworkResult, NetworkRunResult, Population
-
-if TYPE_CHECKING:  # pragma: no cover - import-time typing only
-    from .connection import NetworkConnections
-    from .engine import Network
-    from .lowering import ConnectionBlock
-
-_LAZY_ATTRS = {
-    "ConnectionBlock": ".lowering",
-    "Network": ".engine",
-    "NetworkConnections": ".connection",
-}
+from .connection import NetworkConnections
+from .core import NetworkResult, Population
+from .engine import Network
 
 __all__ = [
-    "ConnectionBlock",
     "Network",
     "NetworkConnections",
     "NetworkResult",
-    "NetworkRunResult",
     "Population",
 ]
-
-
-def __getattr__(name: str):
-    """Resolve the heavyweight public names on first access."""
-    module_name = _LAZY_ATTRS.get(name)
-    if module_name is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    value = getattr(import_module(module_name, __name__), name)
-    globals()[name] = value
-    return value
-
-
-def __dir__() -> list[str]:
-    return sorted({*globals(), *_LAZY_ATTRS})

--- a/braincell/network/__init___test.py
+++ b/braincell/network/__init___test.py
@@ -15,21 +15,26 @@
 
 """Package-scope guards for the :mod:`braincell.network` import graph.
 
-:mod:`braincell.network.event` and :mod:`braincell.network.recording` are
-leaves that lower layers import directly --
-:mod:`braincell._multi_compartment.cell` and
-:mod:`braincell._multi_compartment.run` at module scope, and
-:mod:`braincell._compute.layouts` for ``NetStim``. Python executes a
-package's ``__init__`` before any submodule, so if
-``braincell/network/__init__.py`` eagerly imported ``.connection``,
-``.engine``, or ``.lowering``, that would re-enter
-``braincell._multi_compartment`` in the middle of its own initialization and
-``import braincell`` would die with an ``ImportError``.
+This package is imported from the middle of
+:mod:`braincell._multi_compartment`'s initialization --
+:mod:`braincell._multi_compartment.cell` imports
+:mod:`braincell.network.event` and :mod:`braincell.network.recording` at
+module scope, and :mod:`braincell._compute.layouts` imports ``NetStim``.
+Python runs ``braincell/network/__init__.py`` before any of those
+submodules, so it executes while ``braincell._multi_compartment`` is in
+:data:`sys.modules` but only partially built.
 
-``test_importing_braincell_succeeds`` is the empirical guard -- it fails
-outright if any of those three cycles returns. The AST checks that follow
-turn the same invariant into a targeted, readable failure so a future editor
-learns *why* rather than staring at a 30-frame traceback.
+``test_importing_braincell_succeeds`` is the empirical guard. The two AST
+checks that follow turn the same invariant into a targeted failure so a
+future editor learns *why* rather than staring at a 30-frame traceback:
+
+- ``PartialParentTest`` checks the property the eager ``__init__`` actually
+  depends on -- that no module here imports a *name* from the
+  ``braincell._multi_compartment`` package root, only from its submodules.
+  A submodule resolves against a partial parent; a name does not.
+- ``ImportGraphTest`` pins the intra-package edges so any new sibling
+  dependency surfaces in review, in the same idiom as
+  ``braincell/_compute/__init___test.py``.
 """
 
 import ast
@@ -42,62 +47,147 @@ import braincell.network
 _NETWORK_DIR = pathlib.Path(braincell.network.__file__).parent
 _MECH_DIR = pathlib.Path(braincell.mech.__file__).parent
 
-#: Submodules whose import pulls in ``braincell._multi_compartment``.
-_HEAVY_SUBMODULES = {".connection", ".engine", ".lowering"}
+#: Sibling modules each ``braincell.network`` module imports at load time.
+#:
+#: Layer order is ``{core, event, recording}`` -> ``{lowering, pairing}``
+#: -> ``{connection, delivery}`` -> ``engine`` -> ``__init__``. Every edge
+#: below respects it, which is what keeps the graph acyclic.
+_EXPECTED_GRAPH = {
+    "__init__": {"connection", "core", "engine"},
+    "_testing": set(),
+    # ``connection`` reads ``core`` to recognise a ``Population`` handed to
+    # ``connect()``; ``core`` is a leaf, so the edge keeps the graph a DAG.
+    "connection": {"core", "event", "pairing", "recording"},
+    "core": set(),
+    "delivery": {"lowering"},
+    "engine": {"connection", "core", "delivery", "lowering", "recording"},
+    "event": set(),
+    "lowering": {"core", "event"},
+    "pairing": {"event"},
+    "recording": set(),
+}
 
 
-def _module_level_statements(path: pathlib.Path):
-    """Yield top-level statements, descending into non-TYPE_CHECKING blocks."""
-    tree = ast.parse(path.read_text(encoding="utf-8"))
-    for node in tree.body:
-        if isinstance(node, ast.If) and "TYPE_CHECKING" in ast.dump(node.test):
+def _module_files():
+    """Yield ``(module_name, path)`` for every non-test module here."""
+    for path in sorted(_NETWORK_DIR.glob("*.py")):
+        if path.name.endswith("_test.py"):
             continue
-        yield node
+        yield path.stem, path
 
 
-class LazyInitTest(unittest.TestCase):
+def _load_time_nodes(path: pathlib.Path):
+    """Yield import nodes that run at module load.
+
+    Skips ``if TYPE_CHECKING:`` bodies and function bodies -- a deferred
+    import inside a function cannot participate in an import cycle.
+    """
+
+    def walk(body):
+        for node in body:
+            if isinstance(node, ast.If) and "TYPE_CHECKING" in ast.dump(node.test):
+                continue
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                yield node
+            elif isinstance(node, ast.ClassDef):
+                yield from walk(node.body)
+            elif isinstance(node, ast.If):
+                yield from walk(node.body)
+                yield from walk(node.orelse)
+            elif isinstance(node, ast.Try):
+                yield from walk(node.body)
+                yield from walk(node.orelse)
+                yield from walk(node.finalbody)
+                for handler in node.handlers:
+                    yield from walk(handler.body)
+
+    yield from walk(ast.parse(path.read_text(encoding="utf-8")).body)
+
+
+class ImportSucceedsTest(unittest.TestCase):
     def test_importing_braincell_succeeds(self) -> None:
-        """The empirical guard: all three known cycles are import-time fatal."""
+        """The empirical guard: an import cycle here is import-time fatal."""
         self.assertTrue(hasattr(braincell, "Network"))
-
-    def test_init_does_not_eagerly_import_the_heavy_submodules(self) -> None:
-        offenders = []
-        for node in _module_level_statements(_NETWORK_DIR / "__init__.py"):
-            if isinstance(node, ast.ImportFrom) and node.level == 1:
-                name = f".{node.module}" if node.module else "."
-                if name in _HEAVY_SUBMODULES:
-                    offenders.append(f"line {node.lineno}: from {name} import ...")
-        self.assertEqual(
-            offenders,
-            [],
-            "braincell/network/__init__.py must not import .connection/.engine/.lowering "
-            "at module scope -- doing so re-enters braincell._multi_compartment mid-import. "
-            "Add the name to _LAZY_ATTRS instead.",
-        )
-
-    def test_every_heavy_name_resolves_through_getattr(self) -> None:
-        self.assertIs(braincell.network.Network, braincell.network.engine.Network)
-        self.assertIs(
-            braincell.network.NetworkConnections,
-            braincell.network.connection.NetworkConnections,
-        )
-        self.assertIs(
-            braincell.network.ConnectionBlock,
-            braincell.network.lowering.ConnectionBlock,
-        )
 
     def test_every_exported_name_is_reachable(self) -> None:
         for name in braincell.network.__all__:
             self.assertTrue(hasattr(braincell.network, name), f"{name} is exported but unreachable")
 
-    def test_unknown_attribute_raises_attribute_error(self) -> None:
-        with self.assertRaisesRegex(AttributeError, "has no attribute 'NotAThing'"):
-            braincell.network.NotAThing
 
-    def test_dir_lists_the_lazy_names(self) -> None:
-        listed = dir(braincell.network)
-        for name in ("ConnectionBlock", "Network", "NetworkConnections"):
-            self.assertIn(name, listed)
+class PartialParentTest(unittest.TestCase):
+    """No module here may import a name from a partially built parent.
+
+    ``braincell/network/__init__.py`` runs while
+    ``braincell._multi_compartment`` is mid-initialization.
+    ``from braincell._multi_compartment.synapses import SynapseView`` is
+    fine -- Python imports the submodule against the partial parent. But
+    ``from braincell._multi_compartment import Cell`` would read an
+    attribute the parent has not bound yet and raise ``ImportError``.
+    """
+
+    def test_no_name_is_imported_from_the_multi_compartment_package_root(self) -> None:
+        offenders = []
+        for name, path in _module_files():
+            for node in _load_time_nodes(path):
+                if not isinstance(node, ast.ImportFrom) or node.level:
+                    continue
+                if node.module != "braincell._multi_compartment":
+                    continue
+                for alias in node.names:
+                    # ``from pkg import submodule`` is a submodule import and
+                    # is safe; a capitalised name is a class attribute and is
+                    # not. Resolve it rather than guessing.
+                    if not (_NETWORK_DIR.parent / "_multi_compartment" / f"{alias.name}.py").is_file():
+                        offenders.append(
+                            f"{name}.py:{node.lineno}: from braincell._multi_compartment import {alias.name}"
+                        )
+        self.assertEqual(
+            offenders,
+            [],
+            "braincell/network runs while braincell._multi_compartment is only partially "
+            "initialized, so it may import that package's submodules but not names bound "
+            "by its __init__. Import from the submodule directly.",
+        )
+
+
+class ImportGraphTest(unittest.TestCase):
+    """Pin the intra-package edges so a new one surfaces in review."""
+
+    @staticmethod
+    def _actual_graph() -> dict:
+        graph = {}
+        for name, path in _module_files():
+            siblings = set()
+            for node in _load_time_nodes(path):
+                if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module:
+                    siblings.add(node.module)
+                elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+                    if node.module.startswith("braincell.network."):
+                        siblings.add(node.module.split(".")[2])
+            graph[name] = siblings
+        return graph
+
+    def test_graph_matches_the_declared_layering(self) -> None:
+        self.assertEqual(self._actual_graph(), _EXPECTED_GRAPH)
+
+    def test_graph_is_acyclic(self) -> None:
+        graph = self._actual_graph()
+        visiting, done = set(), set()
+
+        def visit(node, trail):
+            if node in done:
+                return
+            self.assertNotIn(node, visiting, f"import cycle: {' -> '.join((*trail, node))}")
+            visiting.add(node)
+            for child in sorted(graph.get(node, ())):
+                visit(child, (*trail, node))
+            visiting.discard(node)
+            done.add(node)
+
+        for module in sorted(graph):
+            visit(module, ())
 
 
 class MechIsALeafTest(unittest.TestCase):

--- a/braincell/network/connection.py
+++ b/braincell/network/connection.py
@@ -44,7 +44,14 @@ from braincell.mech import (
     TriggerEventInput,
     get_registry,
 )
-from .event import EventSource, EventSourceView, round_half_up_steps_host as _round_half_up_steps
+from .core import Population
+from .event import (
+    EventSource,
+    EventSourceView,
+    _quantity_vector,
+    round_half_up_steps_host as _round_half_up_steps,
+)
+from .recording import _require_name
 
 __all__ = [
     "ConnectionView",
@@ -94,7 +101,7 @@ class _ConnectionStore:
         "target_index",
         "delay",
         "active",
-        "_row_by_id",
+        "_row_of_id",
         "_calls",
         "_call_by_id",
         "_call_by_name",
@@ -112,7 +119,7 @@ class _ConnectionStore:
         self.target_index = np.asarray([], dtype=np.int64)
         self.delay = np.asarray([], dtype=np.float64) * u.ms
         self.active = np.asarray([], dtype=bool)
-        self._row_by_id: dict[int, int] = {}
+        self._row_of_id = np.asarray([], dtype=np.int64)
         self._calls: list[_ConnectionCall] = []
         self._call_by_id: dict[int, _ConnectionCall] = {}
         self._call_by_name: dict[str, _ConnectionCall] = {}
@@ -148,7 +155,7 @@ class _ConnectionStore:
         self.target_index = np.concatenate((self.target_index, np.asarray(target_index, dtype=np.int64)))
         self.delay = _concat_quantities(self.delay, delay, unit=u.ms)
         self.active = np.concatenate((self.active, np.ones(count, dtype=bool)))
-        self._row_by_id.update((int(row_id), start + offset) for offset, row_id in enumerate(row_ids.tolist()))
+        self._row_of_id = np.concatenate((self._row_of_id, np.arange(start, start + count, dtype=np.int64)))
 
         call = _ConnectionCall(
             id=connect_id,
@@ -173,7 +180,7 @@ class _ConnectionStore:
         return row_ids
 
     def rows(self, ids) -> np.ndarray:
-        return np.asarray([self._row_by_id[int(value)] for value in np.asarray(ids).tolist()], dtype=np.int64)
+        return self._row_of_id[np.asarray(ids, dtype=np.int64)]
 
     def active_ids(self, ids=None) -> np.ndarray:
         ids = self.id if ids is None else np.asarray(ids, dtype=np.int64).reshape(-1)
@@ -193,29 +200,36 @@ class _ConnectionStore:
         ids = self.active_ids(ids)
         if ids.size == 0:
             raise ValueError("Cannot access weight on an empty ConnectionView.")
-        values = []
-        for row_id in ids.tolist():
-            row = self._row_by_id[int(row_id)]
-            call = self.call(int(self.connect_id[row]))
-            if call.weight is None:
-                values.append(None)
-                continue
-            local = int(np.flatnonzero(call.row_ids == int(row_id))[0])
-            values.append(call.weight[local])
-        if values[0] is None:
-            if any(value is not None for value in values):
+        calls = [self.call(int(value)) for value in self.connect_id[self.rows(ids)].tolist()]
+        if calls[0].weight is None:
+            if any(call.weight is not None for call in calls):
                 raise TypeError("ConnectionView mixes trigger-only and scalar-weight rows.")
             return None
-        return _stack_values(values)
+        if any(call.weight is None for call in calls):
+            raise TypeError("ConnectionView mixes trigger-only and scalar-weight rows.")
+        # ``add`` builds ``row_ids`` as one ``np.arange``, so a row's slot
+        # in its call's weight vector is its offset from that call's first
+        # row. Searching for it cost O(rows) per row.
+        return _stack_values(
+            [call.weight[int(row_id) - int(call.row_ids[0])] for row_id, call in zip(ids.tolist(), calls)]
+        )
 
     def set_weight(self, ids, values) -> None:
         ids = self.active_ids(ids)
         split = _split_values(values, len(ids))
-        for row_id, value in zip(ids.tolist(), split):
-            row = self._row_by_id[int(row_id)]
-            call = self.call(int(self.connect_id[row]))
-            local = int(np.flatnonzero(call.row_ids == int(row_id))[0])
-            call.weight = _set_quantity_or_array(call.weight, np.asarray([local]), _stack_values([value]))
+        connect_id = self.connect_id[self.rows(ids)]
+        # ``_set_quantity_or_array`` rebuilds the call's whole weight
+        # vector, so doing it once per row was quadratic in the rows of a
+        # single call. Group first, then assign each call's slots at once.
+        for call_id in np.unique(connect_id).tolist():
+            mask = connect_id == call_id
+            call = self.call(int(call_id))
+            selected = [value for value, keep in zip(split, mask.tolist()) if keep]
+            call.weight = _set_quantity_or_array(
+                call.weight,
+                ids[mask] - int(call.row_ids[0]),
+                _stack_values(selected),
+            )
 
 
 class ConnectionView:
@@ -353,7 +367,7 @@ class ConnectionView:
         return ConnectionView(self._store, np.asarray(selected, dtype=np.int64).reshape(-1))
 
     def by_connect_name(self, name: str) -> "ConnectionView":
-        _require_nonempty_string(name, "connection name")
+        _require_name(name, "connection name")
         return ConnectionView(self._store, self._active_ids[self.connect_name == name])
 
     def by_source(self, source: EventSource | EventSourceView) -> "ConnectionView":
@@ -367,19 +381,19 @@ class ConnectionView:
         return ConnectionView(self._store, self._active_ids[mask])
 
     def by_source_type(self, source_type: str) -> "ConnectionView":
-        _require_nonempty_string(source_type, "source_type")
+        _require_name(source_type, "source_type")
         return ConnectionView(self._store, self._active_ids[self.source_type == source_type])
 
     def by_source_name(self, source_name: str) -> "ConnectionView":
-        _require_nonempty_string(source_name, "source_name")
+        _require_name(source_name, "source_name")
         return ConnectionView(self._store, self._active_ids[self.source_name == source_name])
 
     def by_synapse_type(self, synapse_type: str) -> "ConnectionView":
-        _require_nonempty_string(synapse_type, "synapse_type")
+        _require_name(synapse_type, "synapse_type")
         return ConnectionView(self._store, self._active_ids[self.synapse_type == synapse_type])
 
     def by_synapse_name(self, synapse_name: str) -> "ConnectionView":
-        _require_nonempty_string(synapse_name, "synapse_name")
+        _require_name(synapse_name, "synapse_name")
         return ConnectionView(self._store, self._active_ids[self.synapse_name == synapse_name])
 
     def by_synapse_ids(self, synapse_ids) -> "ConnectionView":
@@ -413,14 +427,30 @@ class ConnectionView:
         self._store.active[self._store.rows(self._candidate_ids)] = False
 
     def _call_views(self, *, scheduled=None) -> tuple["ConnectionView", ...]:
+        """Split this view into one sub-view per originating ``connect()`` call.
+
+        Both ``_active_ids`` and ``connect_id`` are recomputed properties that
+        walk every row, so asking for them once per connect call made this
+        O(calls x rows) -- 20.7 s for 256 calls over 1600 rows against 9 ms
+        for the single grouping pass below. ``Network.run`` reaches here on
+        every call, as does ``Cell`` once per synapse layout.
+        """
+        ids = self._active_ids
+        if ids.size == 0:
+            return ()
+        connect_id = self._store.connect_id[self._store.rows(ids)]
+        call_ids, first_seen, inverse = np.unique(connect_id, return_index=True, return_inverse=True)
+        sorter = np.argsort(inverse, kind="stable")
+        starts = np.searchsorted(inverse[sorter], np.arange(call_ids.size))
+        grouped = np.split(ids[sorter], starts[1:])
         result = []
-        for connect_id in self._store.active_call_ids(self._candidate_ids):
-            call = self._store.call(connect_id)
+        # ``np.unique`` sorts; the previous ``dict.fromkeys`` shape yielded
+        # calls in first-appearance order, so restore that ordering.
+        for position in np.argsort(first_seen).tolist():
+            call = self._store.call(int(call_ids[position]))
             if scheduled is not None and bool(call.source.is_scheduled) != bool(scheduled):
                 continue
-            ids = self._active_ids[np.asarray(self.connect_id == connect_id)]
-            if ids.size:
-                result.append(ConnectionView(self._store, ids))
+            result.append(ConnectionView(self._store, grouped[position]))
         return tuple(result)
 
     def event_count(self, *, t, dt):
@@ -479,7 +509,8 @@ class ConnectionView:
         return output
 
     def _require_single_call(self, action: str) -> _ConnectionCall:
-        connect_ids = tuple(dict.fromkeys(int(item) for item in self.connect_id.tolist()))
+        # ``active_call_ids`` is this exact expression, one layer down.
+        connect_ids = self._store.active_call_ids(self._candidate_ids)
         if len(connect_ids) != 1:
             raise TypeError(f"Cannot {action}: ConnectionView contains {len(connect_ids)} connect calls.")
         return self._store.call(connect_ids[0])
@@ -656,7 +687,7 @@ def _connect_with_pairing_seed(
     pairing_seed_root,
     pairing_seed_path,
 ):
-    _require_nonempty_string(name, "connection name")
+    _require_name(name, "connection name")
     source_view = _as_source_view(source)
     if not isinstance(synapse, SynapseView):
         raise TypeError(f"connect synapse must be SynapseView, got {type(synapse).__name__!s}.")
@@ -700,10 +731,8 @@ def _connect_with_pairing_seed(
 
 
 def _as_source_view(source) -> EventSourceView:
-    # Population is imported structurally to keep the low-level connection
-    # module independent from the Network package.
-    event_outputs = getattr(source, "event_outputs", None)
-    if event_outputs is not None and hasattr(source, "model") and hasattr(source, "kind"):
+    if isinstance(source, Population):
+        event_outputs = source.event_outputs
         if len(event_outputs) != 1:
             raise ValueError(
                 "A Population can be passed to connect() only when it exposes exactly one event output; "
@@ -753,13 +782,8 @@ def _require_single_synapse_group(synapse: SynapseView) -> None:
         )
 
 
-def _require_nonempty_string(value, label: str) -> None:
-    if not isinstance(value, str) or not value:
-        raise ValueError(f"{label} must be a non-empty string.")
-
-
 def _normalize_delay(value, *, count: int):
-    result = _quantity_vector(value, unit=u.ms, count=count, name="Connection.delay")
+    result = _quantity_vector(value, unit=u.ms, size=count, name="Connection.delay")
     if np.any(np.asarray(result.to_decimal(u.ms)) < 0.0):
         raise ValueError("Connection.delay must be >= 0 ms.")
     return result
@@ -788,23 +812,7 @@ def _normalize_weight(synapse: SynapseView, value, *, count: int, omitted: bool 
         value = 1.0 * first.unit
     if value is None:
         raise TypeError("Scalar-event Connection weight cannot be None.")
-    return _quantity_vector(value, unit=first.unit, count=count, name="Connection.weight")
-
-
-def _quantity_vector(value, *, unit, count: int, name: str) -> u.Quantity:
-    if not isinstance(value, u.Quantity):
-        raise TypeError(f"{name} must be a quantity.")
-    try:
-        decimal = np.asarray(value.to_decimal(unit), dtype=np.float64)
-    except Exception as exc:
-        raise ValueError(f"{name} has an incompatible unit.") from exc
-    if decimal.ndim == 0:
-        decimal = np.broadcast_to(decimal, (count,))
-    elif decimal.shape != (count,):
-        raise ValueError(f"{name} must be scalar or have shape {(count,)!r}, got {decimal.shape!r}.")
-    if np.any(~np.isfinite(decimal)):
-        raise ValueError(f"{name} must contain finite values.")
-    return u.Quantity(np.array(decimal, copy=True), unit)
+    return _quantity_vector(value, unit=first.unit, size=count, name="Connection.weight")
 
 
 def _concat_quantities(left, right, *, unit):

--- a/braincell/network/connection_test.py
+++ b/braincell/network/connection_test.py
@@ -229,6 +229,31 @@ class ConnectionTest(unittest.TestCase):
         later = connect("later", source=NetStim(), synapse=cell.synapses[exp][0])
         np.testing.assert_array_equal(later.id, [3])
 
+    def test_multi_call_view_groups_calls_and_round_trips_weights(self) -> None:
+        # ``weight_for``/``set_weight`` index each call's weight vector by row
+        # offset and ``_call_views`` groups in one pass, so a view spanning
+        # several calls in shuffled order is the case that pins all three.
+        cell, exp = _population(6)
+        first = connect("a", source=NetStim(size=2), synapse=cell.synapses[exp][0:2], weight=[0.1, 0.2] * u.uS)
+        second = connect("b", source=NetStim(size=2), synapse=cell.synapses[exp][2:4], weight=[0.3, 0.4] * u.uS)
+        third = connect("c", source=NetStim(size=2), synapse=cell.synapses[exp][4:6], weight=[0.5, 0.6] * u.uS)
+        np.testing.assert_array_equal(first.id, [0, 1])
+        np.testing.assert_array_equal(second.id, [2, 3])
+        np.testing.assert_array_equal(third.id, [4, 5])
+
+        shuffled = cell.connections[[5, 0, 3, 2, 4, 1]]
+        np.testing.assert_allclose(shuffled.weight.to_decimal(u.uS), [0.6, 0.1, 0.4, 0.3, 0.5, 0.2])
+
+        views = shuffled._call_views()
+        # One view per call, in the order the calls first appear in ``shuffled``.
+        self.assertEqual([np.asarray(view.id).tolist() for view in views], [[5, 4], [0, 1], [3, 2]])
+
+        shuffled.set(weight=[-0.6, -0.1, -0.4, -0.3, -0.5, -0.2] * u.uS)
+        np.testing.assert_allclose(
+            cell.connections.weight.to_decimal(u.uS),
+            [-0.1, -0.2, -0.3, -0.4, -0.5, -0.6],
+        )
+
     def test_event_sequence_drives_connection_runtime(self) -> None:
         cell, exp = _population(2)
         sequence = EventSequence(

--- a/braincell/network/core.py
+++ b/braincell/network/core.py
@@ -23,7 +23,7 @@ from types import MappingProxyType
 import brainunit as u
 import numpy as np
 
-from braincell._misc import concat_values as _concat_values, same_time_quantity as _same_time
+from braincell._misc import concat_values as _concat_values, freeze_array, same_time_quantity as _same_time
 
 
 class Population:
@@ -65,14 +65,12 @@ class Population:
         if not isinstance(name, str) or not name:
             raise ValueError("Population name must be a non-empty string.")
         size, kind = _model_size_and_kind(model)
-        overlap = self._RESERVED_NAMES.intersection(metadata)
-        if overlap:
-            raise ValueError(f"Population metadata conflicts with reserved names: {sorted(overlap)!r}.")
+        # The reserved-name check lives in ``set``, which runs below.
         object.__setattr__(self, "name", name)
         object.__setattr__(self, "model", model)
         object.__setattr__(self, "kind", kind)
         object.__setattr__(self, "size", size)
-        object.__setattr__(self, "ids", _readonly_array(np.arange(size, dtype=np.int64)))
+        object.__setattr__(self, "ids", freeze_array(np.arange(size, dtype=np.int64)))
         object.__setattr__(self, "_metadata", {})
         object.__setattr__(self, "_event_outputs", {})
         self.set(**metadata)
@@ -257,20 +255,12 @@ def _population_metadata(value, size: int, *, name: str):
     if shape == ():
         if isinstance(value, u.Quantity):
             return u.math.broadcast_to(value, (size,))
-        return _readonly_array(np.full((size,), value))
+        return freeze_array(np.full((size,), value))
     if shape[0] != size:
         raise ValueError(
             f"Population metadata {name!r} must be scalar or have leading dimension {size}; got {shape!r}."
         )
-    if isinstance(value, np.ndarray):
-        return _readonly_array(value)
-    return value
-
-
-def _readonly_array(value) -> np.ndarray:
-    result = np.array(value, copy=True)
-    result.flags.writeable = False
-    return result
+    return freeze_array(value)
 
 
 @dataclass(frozen=True)
@@ -283,8 +273,18 @@ class NetworkResult:
         Step times spanning ``[start_t, start_t + duration)``.
     traces : dict
         ``population_name -> {probe_name: trace}`` mapping.
+    samples : dict
+        ``population_name -> {recording_name: SampleBlock}`` mapping. This
+        is what :meth:`braincell.network.Network.run` populates for every
+        :func:`braincell.observe` recording.
     events : dict
         ``population_name -> {port_name: EventSeries}`` mapping.
+    start_time : brainunit.Quantity or None
+        Inclusive start of the segment.
+    stop_time : brainunit.Quantity or None
+        Exclusive end of the segment.
+    dt : brainunit.Quantity or None
+        Fixed step the segment was run with. :meth:`concat` requires it.
     """
 
     time: object
@@ -314,7 +314,7 @@ class NetworkResult:
         NetworkResult
             Concatenated immutable result.
         """
-        from braincell._multi_compartment.run import RunResult
+        from .recording import concat_sample_blocks
 
         parts = tuple(parts)
         if not parts:
@@ -334,25 +334,23 @@ class NetworkResult:
             for population_name in previous.samples:
                 if tuple(previous.samples[population_name]) != tuple(current.samples[population_name]):
                     raise ValueError(f"Recording names changed for population {population_name!r}.")
+                # RunResult.concat used to raise this on our behalf, back when
+                # this method borrowed it by building throwaway RunResults.
+                for recording_name, block in previous.samples[population_name].items():
+                    if block.schema != current.samples[population_name][recording_name].schema:
+                        raise ValueError(f"Recording schema changed for {recording_name!r}.")
             for population_name in previous.events:
                 if tuple(previous.events[population_name]) != tuple(current.events[population_name]):
                     raise ValueError(f"Event ports changed for population {population_name!r}.")
-        samples = {}
-        for population_name in first.samples:
-            samples[population_name] = {}
-            for recording_name in first.samples[population_name]:
-                pseudo = tuple(
-                    RunResult(
-                        time=part.time,
-                        traces={recording_name: part.samples[population_name][recording_name].values},
-                        samples={recording_name: part.samples[population_name][recording_name]},
-                        start_time=part.start_time,
-                        stop_time=part.stop_time,
-                        dt=part.dt,
-                    )
-                    for part in parts
+        samples = {
+            population_name: {
+                recording_name: concat_sample_blocks(
+                    tuple(part.samples[population_name][recording_name] for part in parts)
                 )
-                samples[population_name][recording_name] = RunResult.concat(pseudo).samples[recording_name]
+                for recording_name in first.samples[population_name]
+            }
+            for population_name in first.samples
+        }
         traces = {
             population_name: {
                 name: _concat_values(tuple(part.traces[population_name][name] for part in parts))
@@ -378,10 +376,6 @@ class NetworkResult:
         )
 
 
-# Transitional public name retained for existing callers.
-NetworkRunResult = NetworkResult
-
-
 def _nested_mapping_proxy(value):
     return MappingProxyType(
         {key: MappingProxyType(dict(item)) if isinstance(item, dict) else item for key, item in dict(value).items()}
@@ -391,12 +385,8 @@ def _nested_mapping_proxy(value):
 def _concat_event_series(series):
     from .recording import EventSeries
 
-    unit = series[0].time.unit
     return EventSeries(
-        time=u.Quantity(
-            u.math.concatenate(tuple(item.time.to_decimal(unit) for item in series), axis=0),
-            unit,
-        ),
+        time=_concat_values(tuple(item.time for item in series)),
         source_id=np.concatenate(tuple(item.source_id for item in series)),
         count=np.concatenate(tuple(item.count for item in series)),
         metadata=series[0].metadata,

--- a/braincell/network/core_test.py
+++ b/braincell/network/core_test.py
@@ -140,6 +140,14 @@ class PopulationTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             population.metadata["layer"] = np.asarray([1, 2])
 
+    def test_metadata_is_frozen_for_plain_arrays_and_quantities(self) -> None:
+        population = braincell.network.Population("pc", _cell(2))
+        population.set(layer=np.asarray([1, 2]), depth=np.asarray([10.0, 20.0]) * u.um)
+
+        self.assertFalse(population.metadata["layer"].flags.writeable)
+        self.assertFalse(population.metadata["depth"].mantissa.flags.writeable)
+        self.assertFalse(population.ids.flags.writeable)
+
     def test_provider_is_eager_and_atomic(self) -> None:
         calls = []
         network = braincell.network.Network()

--- a/braincell/network/delivery.py
+++ b/braincell/network/delivery.py
@@ -52,12 +52,10 @@ class DeliveryBlock:
     delay_steps : int or ndarray of int
         One fixed delay for a grouped backend block, or one delay per contact
         for the canonical scatter representation.
-    pre_index, post_index : ndarray of int, shape ``(n_contact,)``
-        Presynaptic and postsynaptic population indices for this delay group.
-    synapse_index : ndarray of int, shape ``(n_contact,)``
-        Local target index in the postsynaptic synapse layout.
+    pre_index : ndarray of int, shape ``(n_contact,)``
+        Presynaptic population index for each contact in this delay group.
     flat_target_index : ndarray of int, shape ``(n_contact,)``
-        Flattened target index equal to ``post_index * n_active + synapse_index``.
+        Slot in the postsynaptic synapse layout for each contact.
     weight : object
         Per-contact event payload sliced from ``source.weight`` for this delay
         group. May be a :mod:`brainunit` quantity or an array-like object.
@@ -71,8 +69,6 @@ class DeliveryBlock:
     source: ConnectionBlock
     delay_steps: int | np.ndarray
     pre_index: np.ndarray
-    post_index: np.ndarray
-    synapse_index: np.ndarray
     flat_target_index: np.ndarray
     weight: object
 
@@ -105,43 +101,22 @@ class DeliveryState:
     queue_sources: tuple[ConnectionBlock, ...]
 
 
-def population_spike(spike) -> object:
-    """Return one spike value per population member.
+def route_source_event(block: DeliveryBlock) -> object:
+    """Read current event values for one live route.
 
     Parameters
     ----------
-    spike : array-like
-        Cell spike buffer. A one-dimensional array is returned unchanged. A
-        two-dimensional ``(pop_size, 1)`` buffer is squeezed on the trailing
-        singleton axis. Higher-dimensional cell buffers are reduced with a
-        logical ``any`` over all non-population axes.
+    block : DeliveryBlock
+        Delivery block whose lowered source names the live
+        :class:`~braincell.network.event.EventSource`.
 
     Returns
     -------
     object
-        Population-level spike vector with shape ``(pop_size,)``.
+        One event count per source-population member.
     """
-    if spike.ndim == 2 and spike.shape[-1] == 1:
-        return spike[..., 0]
-    if spike.ndim > 1:
-        return jnp.any(spike, axis=tuple(range(1, spike.ndim)))
-    return spike
-
-
-def source_spike(spike, source_cv_id: int) -> object:
-    """Return one spike per population member from a single source CV."""
-    if spike.ndim < 2:
-        return spike
-    return spike[..., int(source_cv_id)]
-
-
-def route_source_event(block: DeliveryBlock, *, populations: dict) -> object:
-    """Read current event values for one population or direct live route."""
-    if block.source.event_source is not None:
-        source = block.source.event_source
-        return source.current_event_count(np.arange(source.size, dtype=np.int32))
-    pre_cell = populations[block.source.pre_population].cell
-    return source_spike(pre_cell.spike.value, block.source.source_cv_id)
+    source = block.source.event_source
+    return source.current_event_count(np.arange(source.size, dtype=np.int32))
 
 
 def delivery_blocks(
@@ -156,6 +131,10 @@ def delivery_blocks(
     blocks : tuple of ConnectionBlock
         Lowered connection blocks. Each block may contain heterogeneous
         per-contact ``delay_steps``.
+    group_by_delay : bool, default True
+        Split each input block into one fixed-delay block per distinct
+        delay. The ``brainevent`` backend needs a scalar delay per block;
+        the scatter backend handles the per-contact vector directly.
 
     Returns
     -------
@@ -170,38 +149,26 @@ def delivery_blocks(
     """
     delivery = []
     for block in blocks:
+        delay_steps = np.asarray(block.delay_steps, dtype=np.int32)
         if not group_by_delay:
-            post_index = np.asarray(block.post_index, dtype=np.int32)
-            synapse_index = np.asarray(block.synapse_index, dtype=np.int32)
             delivery.append(
                 DeliveryBlock(
                     source=block,
-                    delay_steps=np.asarray(block.delay_steps, dtype=np.int32),
+                    delay_steps=delay_steps,
                     pre_index=np.asarray(block.pre_index, dtype=np.int32),
-                    post_index=post_index,
-                    synapse_index=synapse_index,
-                    flat_target_index=(
-                        synapse_index if block.packed else post_index * int(block.n_active) + synapse_index
-                    ).astype(np.int32, copy=False),
+                    flat_target_index=np.asarray(block.synapse_index, dtype=np.int32),
                     weight=block.weight,
                 )
             )
             continue
-        for delay_step in sorted(set(np.asarray(block.delay_steps, dtype=np.int32).tolist())):
-            mask = np.asarray(block.delay_steps, dtype=np.int32) == int(delay_step)
-            contact_indices = np.nonzero(mask)[0]
-            post_index = block.post_index[contact_indices]
-            synapse_index = block.synapse_index[contact_indices]
+        for delay_step in sorted(set(delay_steps.tolist())):
+            contact_indices = np.nonzero(delay_steps == int(delay_step))[0]
             delivery.append(
                 DeliveryBlock(
                     source=block,
                     delay_steps=int(delay_step),
                     pre_index=block.pre_index[contact_indices],
-                    post_index=post_index,
-                    synapse_index=synapse_index,
-                    flat_target_index=(
-                        synapse_index if block.packed else post_index * int(block.n_active) + synapse_index
-                    ).astype(np.int32, copy=False),
+                    flat_target_index=block.synapse_index[contact_indices].astype(np.int32, copy=False),
                     weight=slice_weight(block.weight, contact_indices),
                 )
             )
@@ -228,7 +195,7 @@ def slice_weight(weight, indices: np.ndarray):
     return np.asarray(weight)[indices]
 
 
-def zero_arrival(block: ConnectionBlock, *, post_size: int):
+def zero_arrival(block: ConnectionBlock):
     """Return a zero arrival buffer for one lowered connection block.
 
     Parameters
@@ -236,54 +203,43 @@ def zero_arrival(block: ConnectionBlock, *, post_size: int):
     block : ConnectionBlock
         Lowered block whose weight dtype/unit and synapse layout size define
         the arrival buffer.
-    post_size : int
-        Number of cells in the postsynaptic population.
 
     Returns
     -------
     object
-        Zero event matrix with shape ``(post_size, block.n_active)``.
+        Zero event vector with shape ``(block.n_active,)``.
     """
-    if block.packed:
-        return zeros_like_packed_events(block.weight, n_active=block.n_active)
-    return zeros_like_events(block.weight, post_size=post_size, n_active=block.n_active)
+    return zeros_like(block.weight, shape=(block.n_active,))
 
 
-def zero_shared_ring_buffer(source: ConnectionBlock, *, depth: int, post_size: int):
+def zero_shared_ring_buffer(source: ConnectionBlock, *, depth: int):
     """Return one target-layout queue shared by every incoming route block."""
-    shape = (depth, source.n_active) if source.packed else (depth, post_size, source.n_active)
-    if isinstance(source.weight, u.Quantity):
-        return u.math.zeros_like(source.weight, shape=shape)
-    return jnp.zeros(shape, dtype=jnp.asarray(source.weight).dtype)
+    return zeros_like(source.weight, shape=(depth, source.n_active))
 
 
-def zeros_like_packed_events(value, *, n_active: int):
-    """Return a zero event vector for packed point instances."""
-    if isinstance(value, u.Quantity):
-        return u.math.zeros_like(value, shape=(n_active,))
-    return jnp.zeros((n_active,), dtype=jnp.asarray(value).dtype)
+def zeros_like(value, *, shape: tuple[int, ...]):
+    """Return zeros of ``shape`` carrying ``value``'s dtype and unit.
 
-
-def zeros_like_events(value, *, post_size: int, n_active: int):
-    """Return a zero event buffer matching event payload dtype and unit.
+    Every buffer in this module -- arrival vectors, ring-buffer queues, and
+    the scatter accumulator inside a delivery op -- is shaped from an event
+    payload that may or may not be a :mod:`brainunit` quantity.
 
     Parameters
     ----------
     value : object
         Example event payload used to infer dtype and unit.
-    post_size : int
-        Number of cells in the postsynaptic population.
-    n_active : int
-        Number of active local targets in the target synapse layout.
+    shape : tuple of int
+        Shape of the returned buffer.
 
     Returns
     -------
     object
-        Zero event matrix with shape ``(post_size, n_active)``.
+        Zero buffer of ``shape``, a :class:`brainunit.Quantity` when
+        ``value`` is one.
     """
     if isinstance(value, u.Quantity):
-        return u.math.zeros_like(value, shape=(post_size, n_active))
-    return jnp.zeros((post_size, n_active), dtype=jnp.asarray(value).dtype)
+        return u.math.zeros_like(value, shape=shape)
+    return jnp.zeros(shape, dtype=jnp.asarray(value).dtype)
 
 
 def advance_ring_cursors(ring_buffers, ring_cursors) -> None:
@@ -303,7 +259,6 @@ def advance_ring_cursors(ring_buffers, ring_cursors) -> None:
 def create_delivery_state(
     blocks: tuple[DeliveryBlock, ...],
     *,
-    populations: dict,
     delivery_ops: tuple,
 ) -> DeliveryState:
     """Create persistent mutable state for network event delivery.
@@ -312,8 +267,6 @@ def create_delivery_state(
     ----------
     blocks : tuple of DeliveryBlock
         Static delivery blocks for the run setup.
-    populations : dict
-        ``population_name -> Population`` mapping used to size post buffers.
     delivery_ops : tuple
         Backend-specific event delivery callables, one per block.
 
@@ -352,13 +305,7 @@ def create_delivery_state(
             )
         block_queue_indices.append(queue_index)
     ring_buffers = tuple(
-        brainstate.ShortTermState(
-            zero_shared_ring_buffer(
-                source,
-                depth=queue_depths[index],
-                post_size=populations[source.post_population].size,
-            )
-        )
+        brainstate.ShortTermState(zero_shared_ring_buffer(source, depth=queue_depths[index]))
         for index, source in enumerate(queue_sources)
     )
     ring_cursors = tuple(brainstate.ShortTermState(jnp.asarray(0, dtype=jnp.int32)) for _ in queue_keys)
@@ -373,7 +320,6 @@ def create_delivery_state(
 
 
 def write_arrivals(
-    blocks: tuple[DeliveryBlock, ...],
     state: DeliveryState,
     *,
     populations: dict,
@@ -382,10 +328,10 @@ def write_arrivals(
 
     Parameters
     ----------
-    blocks : tuple of DeliveryBlock
-        Static delivery blocks for the current run setup.
     state : DeliveryState
-        Mutable ring buffers and cursors for the current run.
+        Mutable ring buffers and cursors for the current run. The queues,
+        not the delivery blocks, are what this walks -- several blocks may
+        share one queue.
     populations : dict
         ``population_name -> Population`` mapping used to locate target cells.
 
@@ -400,14 +346,7 @@ def write_arrivals(
         cursor = state.ring_cursors[index].value
         arrival = state.ring_buffers[index].value[cursor]
         state.ring_buffers[index].value = (
-            state.ring_buffers[index]
-            .value.at[cursor]
-            .set(
-                zero_arrival(
-                    state.queue_sources[index],
-                    post_size=populations[key[0]].size,
-                )
-            )
+            state.ring_buffers[index].value.at[cursor].set(zero_arrival(state.queue_sources[index]))
         )
         post_population, layout_id = key
         cell = populations[post_population].cell
@@ -417,8 +356,6 @@ def write_arrivals(
 def enqueue_future_events(
     blocks: tuple[DeliveryBlock, ...],
     state: DeliveryState,
-    *,
-    populations: dict,
 ) -> None:
     """Project current spikes into future ring-buffer slots.
 
@@ -428,19 +365,15 @@ def enqueue_future_events(
         Static delivery blocks for the current run setup.
     state : DeliveryState
         Mutable ring buffers, cursors, and backend operators.
-    populations : dict
-        ``population_name -> Population`` mapping used to read presynaptic
-        spikes and size postsynaptic event matrices.
 
     Notes
     -----
-    Each block reads population-level presynaptic spikes, applies its backend
-    operator, reshapes the flattened event vector to ``(n_active,)`` for
-    packed layouts or ``(post_size, n_active)`` for broadcast layouts, and
-    adds it to the ring-buffer slot ``current_cursor + delay_steps``.
+    Each block reads its source's current events, applies its backend
+    operator, and adds the resulting ``(n_active,)`` event vector to the
+    ring-buffer slot ``current_cursor + delay_steps``.
     """
     for index, block in enumerate(blocks):
-        pre_spike = route_source_event(block, populations=populations)
+        pre_spike = route_source_event(block)
         queue_index = state.block_queue_indices[index]
         delay_steps = np.asarray(block.delay_steps, dtype=np.int32)
         if delay_steps.ndim == 0:
@@ -451,15 +384,7 @@ def enqueue_future_events(
                 queue_index
             ].value.shape[0]
             state.ring_buffers[queue_index].value = (
-                state.ring_buffers[queue_index]
-                .value.at[target_cursor]
-                .add(
-                    event.reshape(
-                        (block.source.n_active,)
-                        if block.source.packed
-                        else (populations[block.source.post_population].size, block.source.n_active)
-                    )
-                )
+                state.ring_buffers[queue_index].value.at[target_cursor].add(event.reshape((block.source.n_active,)))
             )
             continue
 
@@ -486,36 +411,20 @@ def apply_immediate_events(
     """Apply zero-delay population events at their detection boundary."""
     grouped = {}
     for index, block in enumerate(blocks):
-        pre_spike = route_source_event(block, populations=populations)
+        pre_spike = route_source_event(block)
         delay_steps = np.asarray(block.delay_steps, dtype=np.int32)
+        n_active = int(block.source.n_active)
         if delay_steps.ndim == 0:
             if int(delay_steps) != 0:
                 continue
-            event = state.delivery_ops[index](pre_spike).reshape(
-                (block.source.n_active,)
-                if block.source.packed
-                else (populations[block.source.post_population].size, block.source.n_active)
-            )
+            event = state.delivery_ops[index](pre_spike).reshape((n_active,))
         else:
             immediate = delay_steps == 0
             if not np.any(immediate):
                 continue
             contact_event = pre_spike[jnp.asarray(block.pre_index)] * block.weight
-            target_size = (
-                int(block.source.n_active)
-                if block.source.packed
-                else populations[block.source.post_population].size * int(block.source.n_active)
-            )
-            if isinstance(contact_event, u.Quantity):
-                event = u.math.zeros_like(contact_event, shape=(target_size,))
-            else:
-                event = jnp.zeros((target_size,), dtype=jnp.asarray(contact_event).dtype)
+            event = zeros_like(contact_event, shape=(n_active,))
             event = event.at[jnp.asarray(block.flat_target_index[immediate])].add(contact_event[immediate])
-            event = event.reshape(
-                (block.source.n_active,)
-                if block.source.packed
-                else (populations[block.source.post_population].size, block.source.n_active)
-            )
         key = (block.source.post_population, int(block.source.layout_id))
         grouped[key] = event if key not in grouped else grouped[key] + event
     for (post_population, layout_id), event in grouped.items():
@@ -599,7 +508,6 @@ def make_delivery_op(
     block: DeliveryBlock,
     *,
     pre_size: int,
-    post_size: int,
     backend: str,
     brainevent_backend: str | None = "jax_raw",
 ):
@@ -609,8 +517,8 @@ def make_delivery_op(
     ----------
     block : DeliveryBlock
         Static sparse delivery block produced during network setup.
-    pre_size, post_size : int
-        Presynaptic and postsynaptic population sizes.
+    pre_size : int
+        Presynaptic population size.
     backend : {"scatter", "brainevent"}
         Delivery backend selected for this run setup.
     brainevent_backend : str or None, optional
@@ -629,7 +537,7 @@ def make_delivery_op(
     into ``flat_target_index``. The ``brainevent`` path uses ``brainevent.coomv``
     with the same sparse topology.
     """
-    target_size = int(block.source.n_active) if block.source.packed else int(post_size) * int(block.source.n_active)
+    target_size = int(block.source.n_active)
     pre_index = jnp.asarray(block.pre_index, dtype=jnp.int32)
     flat_target_index = jnp.asarray(block.flat_target_index, dtype=jnp.int32)
     if backend == "brainevent":
@@ -654,12 +562,8 @@ def make_delivery_op(
         return _op
 
     def _op(pre_spike):
-        pre_values = pre_spike[pre_index]
-        contact_event = pre_values * block.weight
-        if isinstance(contact_event, u.Quantity):
-            out = u.math.zeros_like(contact_event, shape=(target_size,))
-        else:
-            out = jnp.zeros((target_size,), dtype=jnp.asarray(contact_event).dtype)
+        contact_event = pre_spike[pre_index] * block.weight
+        out = zeros_like(contact_event, shape=(target_size,))
         return out.at[flat_target_index].add(contact_event)
 
     return _op

--- a/braincell/network/delivery_test.py
+++ b/braincell/network/delivery_test.py
@@ -15,25 +15,44 @@
 
 """Tests for :mod:`braincell.network.delivery`.
 
-Only the two behaviours this module exposes directly are covered here; the
+Only the behaviours this module exposes directly are covered here; the
 ring-buffer arrival machinery is exercised end-to-end from ``engine_test.py``
 via :meth:`Network.run`."""
 
 import unittest
 
+import brainunit as u
 import numpy as np
 
-import braincell
+
+class ZerosLikeTest(unittest.TestCase):
+    """The one shape helper every buffer in the module goes through.
+
+    Arrival vectors, ring-buffer queues, and the scatter accumulator inside
+    a delivery op each used to inline this ``isinstance`` fork; the unit
+    branch is the half that a plain ``jnp.zeros`` would silently drop.
+    """
+
+    def test_a_quantity_payload_keeps_its_unit(self) -> None:
+        from braincell.network.delivery import zeros_like
+
+        result = zeros_like(np.asarray([1.0, 2.0]) * u.uS, shape=(3, 4))
+
+        self.assertEqual(result.shape, (3, 4))
+        self.assertEqual(u.get_unit(result), u.uS)
+        np.testing.assert_array_equal(np.asarray(result.mantissa), np.zeros((3, 4)))
+
+    def test_a_plain_payload_keeps_its_dtype(self) -> None:
+        from braincell.network.delivery import zeros_like
+
+        result = zeros_like(np.asarray([1.0, 2.0], dtype=np.float32), shape=(2,))
+
+        self.assertEqual(result.shape, (2,))
+        self.assertEqual(result.dtype, np.float32)
+        self.assertNotIsInstance(result, u.Quantity)
 
 
 class DeliveryTest(unittest.TestCase):
-    def test_population_spike_reduces_multicompartment_spike_to_cell_level_events(self) -> None:
-        spike = np.asarray([[False, True, False], [False, False, False]])
-
-        reduced = braincell.network.delivery.population_spike(spike)
-
-        np.testing.assert_array_equal(np.asarray(reduced), [True, False])
-
     def test_event_backend_brainevent_requires_coomv(self) -> None:
         import braincell.network.delivery as delivery
 

--- a/braincell/network/engine.py
+++ b/braincell/network/engine.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from dataclasses import dataclass
 
 import brainstate
@@ -24,14 +25,14 @@ import brainunit as u
 import jax
 import numpy as np
 
-from braincell._misc import validate_time_quantity
+from braincell._misc import freeze_array, validate_time_quantity
 from braincell._multi_compartment import probes as _probes
 from braincell._multi_compartment.run import _duration_steps, _recording_time_mask
 from braincell._multi_compartment.synapses import SynapseView
 from .connection import NetworkConnections, PairingSpec, _UNSET, _connect_with_pairing_seed
 from .recording import EventSeries, SampleBlock
 
-from .core import NetworkRunResult, Population
+from .core import NetworkResult, Population
 from .delivery import (
     DeliveryBlock,
     advance_delivery_state,
@@ -53,7 +54,6 @@ class _RunSetup:
     """Reusable topology/backend data for one ``Network.run`` configuration."""
 
     delivery_blocks: tuple[DeliveryBlock, ...]
-    delivery_backend: str
     delivery_ops: tuple
     ordered_population_names: tuple[str, ...]
     probe_names: dict[str, tuple[str, ...]]
@@ -96,6 +96,22 @@ class Network:
     def _raise_if_initialized(self, action: str) -> None:
         if self._initialized:
             raise RuntimeError(f"Cannot {action} after Network initialization.")
+
+    @contextlib.contextmanager
+    def _cell_lifecycle(self):
+        """Mark the network as driving its cells' init/reset transitions.
+
+        ``Cell`` consults ``_cell_lifecycle_active`` to tell a network-driven
+        transition from a user calling ``cell.init_state()`` directly
+        (``_multi_compartment/cell.py:862``, ``:888``). Both
+        :meth:`init_state` and :meth:`reset_state` need the flag cleared even
+        when a cell raises, so the ``try``/``finally`` lives here once.
+        """
+        self._cell_lifecycle_active = True
+        try:
+            yield
+        finally:
+            self._cell_lifecycle_active = False
 
     def _mark_topology_changed(self) -> None:
         self._topology_version += 1
@@ -295,20 +311,14 @@ class Network:
         cells are left unchanged because ``Cell.init_state`` itself is a
         one-shot declaration-to-runtime transition.
         """
-        if batch_size is not None:
-            raise NotImplementedError(
-                "Network batch execution is not implemented yet; use Cell batch execution for same-topology batches."
-            )
-        self._validate_direct_source_ownership()
+        _reject_batch_size(batch_size)
         if self._initialized:
             return self
-        self._cell_lifecycle_active = True
-        try:
+        self._validate_direct_source_ownership()
+        with self._cell_lifecycle():
             for population in self._cell_populations().values():
                 if not getattr(population.cell, "_initialized", False):
-                    population.cell.init_state(batch_size=batch_size)
-        finally:
-            self._cell_lifecycle_active = False
+                    population.cell.init_state()
         self._initialized = True
         return self
 
@@ -332,10 +342,7 @@ class Network:
         ``Cell.reset()``, which would tear down runtime objects and return the
         cell to the declaration phase.
         """
-        if batch_size is not None:
-            raise NotImplementedError(
-                "Network batch execution is not implemented yet; use Cell batch execution for same-topology batches."
-            )
+        _reject_batch_size(batch_size)
         uninitialized = [
             name
             for name, population in self._cell_populations().items()
@@ -346,12 +353,9 @@ class Network:
                 "Network.reset_state() requires initialized population Cells; "
                 f"call Network.init_state() or Network.run() first (uninitialized={uninitialized!r})."
             )
-        self._cell_lifecycle_active = True
-        try:
+        with self._cell_lifecycle():
             for population in self._cell_populations().values():
-                population.cell.reset_state(batch_size=batch_size)
-        finally:
-            self._cell_lifecycle_active = False
+                population.cell.reset_state()
         for state in self._delivery_state_cache.values():
             _reset_delivery_state(state)
         self._source_current_time = 0.0 * u.ms
@@ -365,7 +369,7 @@ class Network:
         delay_quantization: str = "nearest",
         event_backend: str = "auto",
         brainevent_backend: str | None = "jax_raw",
-    ) -> NetworkRunResult:
+    ) -> NetworkResult:
         """Run the network for ``duration`` at fixed step ``dt``."""
         validate_time_quantity(dt, name="dt", prefix="Network.run(...)")
         validate_time_quantity(duration, name="duration", prefix="Network.run(...)")
@@ -399,7 +403,6 @@ class Network:
         start_t = self._common_start_time(ordered_population_names)
         n_steps = _duration_steps(duration, dt)
         relative_times = u.math.arange(n_steps) * dt
-        times = start_t + relative_times
         probe_names = setup.probe_names
         n_trace = setup.n_trace
         n_recording = setup.n_recording
@@ -454,7 +457,7 @@ class Network:
             event_values=event_values,
         )
         self._source_current_time = stop_t
-        return NetworkRunResult(
+        return NetworkResult(
             time=times,
             traces=traces,
             samples=samples,
@@ -488,19 +491,27 @@ class Network:
             delay_quantization=delay_quantization,
         )
         delivery_backend = resolve_event_backend(event_backend)
-        delivery_blocks = build_delivery_blocks(
-            blocks,
-            group_by_delay=delivery_backend == "brainevent",
-        )
-        delivery_ops = tuple(
-            make_delivery_op(
-                block,
-                pre_size=self.populations[block.source.pre_population].size,
-                post_size=self.populations[block.source.post_population].size,
-                backend=delivery_backend,
-                brainevent_backend=brainevent_backend,
+        grouped_by_delay = delivery_backend == "brainevent"
+        delivery_blocks = build_delivery_blocks(blocks, group_by_delay=grouped_by_delay)
+        # A delivery op is only ever indexed for a block with a scalar delay,
+        # which is exactly what grouping by delay produces. Without grouping
+        # every block carries a per-contact delay vector and the vector path
+        # in enqueue_future_events/apply_immediate_events runs instead -- so
+        # building the ops there would materialize two device index arrays per
+        # block, and close over the block, for something never called. The two
+        # cannot disagree: both read grouped_by_delay.
+        delivery_ops = (
+            tuple(
+                make_delivery_op(
+                    block,
+                    pre_size=self.populations[block.source.pre_population].size,
+                    backend=delivery_backend,
+                    brainevent_backend=brainevent_backend,
+                )
+                for block in delivery_blocks
             )
-            for block in delivery_blocks
+            if grouped_by_delay
+            else (None,) * len(delivery_blocks)
         )
         ordered_population_names = tuple(self._cell_populations())
         # Read the probe keys without evaluating the probes: sample_probes()
@@ -518,7 +529,6 @@ class Network:
         }
         setup = _RunSetup(
             delivery_blocks=delivery_blocks,
-            delivery_backend=delivery_backend,
             delivery_ops=delivery_ops,
             ordered_population_names=ordered_population_names,
             probe_names=probe_names,
@@ -572,7 +582,6 @@ class Network:
             if delivery_state is None:
                 delivery_state = create_delivery_state(
                     setup.delivery_blocks,
-                    populations=self.populations,
                     delivery_ops=setup.delivery_ops,
                 )
                 self._delivery_state_cache[setup_key] = delivery_state
@@ -614,11 +623,7 @@ class Network:
                                 for compiled in compiled_recordings[name]
                             )
                         with jax.named_scope("braincell:network_run:write_arrivals"):
-                            write_arrivals(
-                                delivery_blocks,
-                                delivery_state,
-                                populations=self.populations,
-                            )
+                            write_arrivals(delivery_state, populations=self.populations)
                         with jax.named_scope("braincell:network_run:prepare_inputs"):
                             for name in ordered_population_names:
                                 self.populations[name].cell._prepare_next_synapse_inputs()
@@ -646,11 +651,7 @@ class Network:
                                 for _, view in event_sources[name]
                             )
                         with jax.named_scope("braincell:network_run:enqueue_events"):
-                            enqueue_future_events(
-                                delivery_blocks,
-                                delivery_state,
-                                populations=self.populations,
-                            )
+                            enqueue_future_events(delivery_blocks, delivery_state)
                         with jax.named_scope("braincell:network_run:advance_delivery"):
                             advance_delivery_state(delivery_state)
                         with jax.named_scope("braincell:network_run:pack_traces"):
@@ -804,7 +805,7 @@ class Network:
                 )
         return events
 
-    def _run_scheduled_sources_only(self, *, dt, duration) -> NetworkRunResult:
+    def _run_scheduled_sources_only(self, *, dt, duration) -> NetworkResult:
         dt_ms = float(np.asarray(dt.to_decimal(u.ms), dtype=float).reshape(()))
         if self._scheduled_dt_ms is None:
             self._scheduled_dt_ms = dt_ms
@@ -822,7 +823,7 @@ class Network:
             event_values=(),
         )
         self._source_current_time = stop_t
-        return NetworkRunResult(
+        return NetworkResult(
             time=times,
             traces={},
             samples={},
@@ -830,6 +831,14 @@ class Network:
             start_time=start_t,
             stop_time=stop_t,
             dt=dt,
+        )
+
+
+def _reject_batch_size(batch_size) -> None:
+    """Reject the batch argument both lifecycle entry points still accept."""
+    if batch_size is not None:
+        raise NotImplementedError(
+            "Network batch execution is not implemented yet; use Cell batch execution for same-topology batches."
         )
 
 
@@ -847,9 +856,7 @@ def _event_source_metadata(population: str, port: str, view) -> dict:
             array = np.broadcast_to(array, (owner.size,))
         if array.shape[0] != owner.size:
             continue
-        selected = np.array(array[source_ids], copy=True)
-        selected.flags.writeable = False
-        metadata[name] = selected
+        metadata[name] = freeze_array(array[source_ids])
     return metadata
 
 

--- a/braincell/network/event.py
+++ b/braincell/network/event.py
@@ -132,11 +132,6 @@ class EventSourceView:
         """Return selected stable source-local IDs."""
         return np.array(self._source_ids, copy=True)
 
-    @property
-    def ids(self) -> np.ndarray:
-        """Alias for :attr:`source_id`."""
-        return self.source_id
-
     def __len__(self) -> int:
         return int(self._source_ids.size)
 

--- a/braincell/network/event_test.py
+++ b/braincell/network/event_test.py
@@ -20,8 +20,8 @@ import brainunit as u
 import numpy as np
 
 from braincell import Branch, CVPerBranch, Cell, EventSequence, EventTable, Morphology, NetStim
-from braincell.network.event import EventSourceView, VoltageCrossingSource
-from braincell.filter import at
+from braincell.network.event import EventSourceView, VoltageCrossingSource, _resolve_cell_location_cv
+from braincell.filter import RootLocation, at
 
 
 def _two_cv_population(size=2):
@@ -259,6 +259,35 @@ class EventSourceTest(unittest.TestCase):
         np.testing.assert_array_equal(source.source_id, [1])
         with self.assertRaisesRegex(RuntimeError, "init_state"):
             source.owner.current_event_count(source.source_id)
+
+
+class ResolveCellLocationCvTest(unittest.TestCase):
+    """The one place a presynaptic location becomes a CV id.
+
+    ``braincell.network.lowering`` used to carry a second copy of this,
+    ``resolve_source_cv``, which had no production caller -- only its own
+    test. These assertions came from there.
+    """
+
+    def _named_dend_cell(self) -> Cell:
+        soma = Branch.from_lengths(lengths=[20.0] * u.um, radii=[10.0, 10.0] * u.um, type="soma")
+        morpho = Morphology.from_root(soma, name="soma")
+        morpho.soma.dend = Branch.from_lengths(
+            lengths=[100.0] * u.um,
+            radii=[2.0, 1.0] * u.um,
+            type="dendrite",
+        )
+        return Cell(morpho, cv_policy=CVPerBranch(), pop_size=(2,))
+
+    def test_a_single_location_resolves_to_its_owning_cv(self) -> None:
+        cell = self._named_dend_cell()
+        self.assertEqual(_resolve_cell_location_cv(cell, RootLocation(0.5)), 0)
+        self.assertEqual(_resolve_cell_location_cv(cell, at("dend", 0.5)), 1)
+
+    def test_a_multi_point_locset_is_rejected(self) -> None:
+        cell = self._named_dend_cell()
+        with self.assertRaisesRegex(ValueError, "resolve to one point"):
+            _resolve_cell_location_cv(cell, at("soma", 0.5) | at("dend", 0.5))
 
 
 if __name__ == "__main__":

--- a/braincell/network/lowering.py
+++ b/braincell/network/lowering.py
@@ -22,9 +22,7 @@ from dataclasses import dataclass
 import brainunit as u
 import numpy as np
 
-from braincell._discretization.base import locate_cv_on_branch
 from braincell._misc import validate_time_quantity
-from braincell.filter import LocsetExpr
 
 from .core import Population
 from .event import round_half_up_steps_host as _round_half_up_steps
@@ -44,10 +42,7 @@ class ConnectionBlock:
     synapse_index: np.ndarray
     weight: object
     delay_steps: np.ndarray
-    buffer_size: int
-    source_cv_id: int
-    packed: bool = False
-    event_source: object | None = None
+    event_source: object
 
 
 def lower_direct_connections(
@@ -98,34 +93,10 @@ def lower_direct_connections(
                     synapse_index=synapse_index,
                     weight=connection.weight,
                     delay_steps=delay_steps,
-                    buffer_size=int(np.max(delay_steps, initial=1)) + 1,
-                    # Live EventSource routes read their own endpoint mapping;
-                    # this legacy scalar is only used by raw Cell spike blocks.
-                    source_cv_id=0,
-                    packed=True,
                     event_source=source,
                 )
             )
     return tuple(blocks)
-
-
-def resolve_source_cv(cell, source: LocsetExpr) -> int:
-    """Resolve a single continuous presynaptic location to its owning CV."""
-    if not isinstance(source, LocsetExpr):
-        raise TypeError(
-            f"Connection source must be a LocsetExpr resolving to one location, got {type(source).__name__!s}."
-        )
-    mask = source.evaluate(cell.morpho)
-    if len(mask) != 1:
-        raise ValueError(f"Connection source must resolve to exactly one presynaptic location; got {len(mask)!r}.")
-    branch_id = int(mask.branch_id[0])
-    branch_x = float(mask.branch_x[0])
-    ids = cell.cv_tree.branch_to_cv_ids[int(branch_id)]
-    return locate_cv_on_branch(
-        ids,
-        cell.cvs,
-        x=float(branch_x),
-    )
 
 
 def _expand_delay_steps(delay, *, dt, n_contact: int, quantization: str = "nearest") -> np.ndarray:

--- a/braincell/network/lowering_test.py
+++ b/braincell/network/lowering_test.py
@@ -17,44 +17,8 @@ import unittest
 
 import brainunit as u
 
-import braincell
-from braincell.filter import RootLocation, at
 from braincell._misc import validate_time_quantity
-from braincell.network.lowering import lower_direct_connections, resolve_source_cv
-
-
-def _two_branch_tree() -> braincell.Morphology:
-    """A soma with one section explicitly named ``dend``.
-
-    :func:`braincell.network._testing.make_two_point_tree` builds the same
-    shape but types the dendrite ``basal_dendrite``; these tests select by
-    section name, so the fixture is kept local rather than shared.
-    """
-    soma = braincell.Branch.from_lengths(
-        lengths=[20.0] * u.um,
-        radii=[10.0, 10.0] * u.um,
-        type="soma",
-    )
-    morphology = braincell.Morphology.from_root(soma, name="soma")
-    morphology.soma.dend = braincell.Branch.from_lengths(
-        lengths=[100.0] * u.um,
-        radii=[2.0, 1.0] * u.um,
-        type="dendrite",
-    )
-    return morphology
-
-
-class LoweringTest(unittest.TestCase):
-    def test_source_location_resolves_to_canonical_cv(self) -> None:
-        cell = braincell.Cell(
-            _two_branch_tree(),
-            cv_policy=braincell.CVPerBranch(),
-            pop_size=(2,),
-        )
-        self.assertEqual(resolve_source_cv(cell, RootLocation(0.5)), 0)
-        self.assertEqual(resolve_source_cv(cell, at("dend", 0.5)), 1)
-        with self.assertRaisesRegex(ValueError, "exactly one"):
-            resolve_source_cv(cell, at("soma", 0.5) | at("dend", 0.5))
+from braincell.network.lowering import lower_direct_connections
 
 
 class TimeQuantityValidationTest(unittest.TestCase):

--- a/braincell/network/pairing.py
+++ b/braincell/network/pairing.py
@@ -604,8 +604,10 @@ def _materialize_group(spec, source_data, synapse_data, sources, synapses, group
         source_weight = _score(spec.source_score, source_ctx, (1, len(sources)), side="source", positions=sources)
         synapse_weight = _score(spec.synapse_score, source_ctx, (1, len(synapses)), side="synapse", positions=synapses)
         return _EndpointPairs(
-            _sample(sources, source_weight[0], count, spec.source_replace, _derived_seed(seed, "source")),
-            _sample(synapses, synapse_weight[0], count, spec.synapse_replace, _derived_seed(seed, "synapse")),
+            _sample(sources, _score_row(source_weight, 0), count, spec.source_replace, _derived_seed(seed, "source")),
+            _sample(
+                synapses, _score_row(synapse_weight, 0), count, spec.synapse_replace, _derived_seed(seed, "synapse")
+            ),
         )
     if isinstance(spec, _First):
         count = _group_number(spec.number, group_index, n_groups)
@@ -614,7 +616,9 @@ def _materialize_group(spec, source_data, synapse_data, sources, synapses, group
         ctx = _context(source_data, synapse_data, sources, synapses, group)
         if spec.side == "source":
             first_weight = _score(spec.source_score, ctx, (1, len(sources)), side="source", positions=sources)
-            first = _sample(sources, first_weight[0], count, spec.first_replace, _derived_seed(seed, "first"))
+            first = _sample(
+                sources, _score_row(first_weight, 0), count, spec.first_replace, _derived_seed(seed, "first")
+            )
             second = _conditional_sample(
                 fixed_side="source",
                 fixed=first,
@@ -628,7 +632,7 @@ def _materialize_group(spec, source_data, synapse_data, sources, synapses, group
             )
             return _EndpointPairs(first, second)
         first_weight = _score(spec.synapse_score, ctx, (1, len(synapses)), side="synapse", positions=synapses)
-        first = _sample(synapses, first_weight[0], count, spec.first_replace, _derived_seed(seed, "first"))
+        first = _sample(synapses, _score_row(first_weight, 0), count, spec.first_replace, _derived_seed(seed, "first"))
         second = _conditional_sample(
             fixed_side="synapse",
             fixed=first,
@@ -743,7 +747,7 @@ def _conditional_sample(
         sampled_by_fixed.append(
             _sample(
                 candidates,
-                weights[row],
+                _score_row(weights, row),
                 count,
                 replace,
                 _derived_seed(seed, fixed_side, int(endpoint_id)),
@@ -758,8 +762,20 @@ def _conditional_sample(
 
 
 def _score(score, ctx, shape, *, side, positions):
+    """Resolve one score declaration to a weight matrix, or ``None`` if uniform.
+
+    ``None`` stands for the all-ones matrix of ``shape``. Returning the
+    sentinel instead of materializing it bounds peak memory in
+    :func:`_conditional_sample`, whose shape is
+    ``(n_distinct_fixed_endpoints, n_candidates)`` and so grows with the
+    product of the two population sizes: a 1000-source by 5000-synapse
+    ``by_source`` pairing peaked at 39 MiB of ones and now peaks at 1.5 MiB.
+    Sampling time is unchanged, and so are the draws -- :func:`_sample`
+    rebuilds the one uniform row it needs, and ``1.0 / n`` is bit-identical
+    to ``1.0 / sum(ones(n))``.
+    """
     if score is None:
-        result = np.ones(shape, dtype=float)
+        result = None
     else:
         value = score(ctx) if callable(score) else score
         if isinstance(value, u.Quantity):
@@ -775,11 +791,19 @@ def _score(score, ctx, shape, *, side, positions):
             result = np.asarray(np.broadcast_to(values, shape), dtype=float)
         except ValueError as exc:
             raise ValueError(f"{side}_score must broadcast to {shape!r}, got {values.shape!r}.") from exc
-    if np.any(~np.isfinite(result)) or np.any(result < 0.0):
-        raise ValueError(f"{side}_score must contain finite non-negative values.")
-    if np.any(np.sum(result, axis=1) <= 0.0):
+        if np.any(~np.isfinite(result)) or np.any(result < 0.0):
+            raise ValueError(f"{side}_score must contain finite non-negative values.")
+    # Row sums of the implied all-ones matrix are ``shape[-1]``, so the uniform
+    # case fails this exactly when there is a row and no candidate in it.
+    empty = (shape[0] > 0 and shape[-1] == 0) if result is None else bool(np.any(np.sum(result, axis=1) <= 0.0))
+    if empty:
         raise ValueError(f"{side}_score must have positive support in every normalization row.")
     return result
+
+
+def _score_row(weights, row: int):
+    """Return one normalization row of a :func:`_score` result, ``None`` if uniform."""
+    return None if weights is None else weights[row]
 
 
 def _sample(candidates, weights, count, replace, seed):
@@ -790,11 +814,17 @@ def _sample(candidates, weights, count, replace, seed):
         replace = bool(replace)
     if not isinstance(replace, bool):
         raise TypeError("replace flags must be bool values.")
-    support = int(np.count_nonzero(weights > 0.0))
+    support = len(candidates) if weights is None else int(np.count_nonzero(weights > 0.0))
     if not replace and count > support:
         raise ValueError(f"Sampling without replacement requires at least {count} positive candidates; got {support}.")
     rng = brainstate.random.RandomState(seed)
-    probabilities = np.asarray(weights, dtype=float) / float(np.sum(weights))
+    # A uniform ``p`` is passed rather than ``None`` on purpose: it draws the
+    # same values a materialized all-ones row would have, and brainstate's
+    # ``p=None`` path is the slower one for ``replace=False``.
+    if weights is None:
+        probabilities = np.full(len(candidates), 1.0 / len(candidates), dtype=float)
+    else:
+        probabilities = np.asarray(weights, dtype=float) / float(np.sum(weights))
     return np.asarray(rng.choice(candidates, size=count, replace=replace, p=probabilities), dtype=np.int64)
 
 

--- a/braincell/network/pairing_test.py
+++ b/braincell/network/pairing_test.py
@@ -258,6 +258,25 @@ class ConnectionSamplingTest(unittest.TestCase):
             )
         self.assertEqual(len(cell.connections), 0)
 
+    def test_omitted_score_draws_exactly_like_an_explicit_uniform_score(self):
+        # _score returns None instead of a dense ones matrix for the default
+        # case, so the two spellings must remain indistinguishable.
+        def rows(score):
+            cell, exp = _population(6)
+            result = connect(
+                "drive",
+                source=NetStim(size=4, start=1.0 * u.ms),
+                synapse=cell.synapses[exp],
+                pairing=braincell.network.connection.by_source(3, seed=5, synapse_score=score),
+            )
+            return np.asarray(result.source_index), np.asarray(result.target_index)
+
+        default_source, default_target = rows(None)
+        uniform_source, uniform_target = rows(np.ones(6))
+
+        np.testing.assert_array_equal(default_source, uniform_source)
+        np.testing.assert_array_equal(default_target, uniform_target)
+
     def test_context_exposes_geometry_and_synapse_parameters(self):
         cell, exp = _population(2)
         source = NetStim(size=2, start=[1.0, 2.0] * u.ms)

--- a/braincell/network/recording.py
+++ b/braincell/network/recording.py
@@ -17,7 +17,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import Mapping
 
@@ -26,12 +26,15 @@ import brainunit as u
 import jax.numpy as jnp
 import numpy as np
 
+from braincell._misc import concat_values as _concat_values, freeze_array as _freeze_array
+
 __all__ = [
     "EventSeries",
     "RecordingRow",
     "RecordingSchema",
     "RecordingSpec",
     "SampleBlock",
+    "concat_sample_blocks",
     "observe",
 ]
 
@@ -140,7 +143,6 @@ class RecordingSpec:
     period: object | None = None
     frequency: object | None = None
     start: object = field(default_factory=lambda: 0.0 * u.ms)
-    legacy: bool = False
 
     def __post_init__(self) -> None:
         _require_name(self.name, "recording name")
@@ -212,6 +214,40 @@ class SampleBlock:
         return self.first_time + np.arange(count) * self.schema.period
 
 
+def concat_sample_blocks(blocks):
+    """Join contiguous sample blocks of one recording into a single block.
+
+    Both run drivers need this: :meth:`braincell.RunResult.concat` for one
+    cell and :meth:`braincell.network.NetworkResult.concat` for a network.
+    It lives beside :class:`SampleBlock` so neither has to reach into the
+    other's module for it.
+
+    The caller is responsible for checking that the blocks are contiguous
+    and share a schema; this only joins them.
+
+    Parameters
+    ----------
+    blocks : sequence of SampleBlock
+        Ordered contiguous segments of one recording. Must be non-empty.
+
+    Returns
+    -------
+    SampleBlock
+        One block spanning ``blocks[0].segment_start`` to
+        ``blocks[-1].segment_stop``. ``first_time`` is taken from the first
+        segment that actually sampled, since a leading segment may span an
+        interval in which the recording never fired.
+    """
+    first = blocks[0]
+    return SampleBlock(
+        values=_concat_values(tuple(block.values for block in blocks)),
+        schema=first.schema,
+        segment_start=first.segment_start,
+        segment_stop=blocks[-1].segment_stop,
+        first_time=next((block.first_time for block in blocks if block.first_time is not None), None),
+    )
+
+
 @dataclass(frozen=True)
 class EventSeries:
     """Immutable sparse event rows."""
@@ -251,7 +287,7 @@ def compile_recording(cell, spec: RecordingSpec, *, dt):
             f"Recording {spec.name!r} sampler returned {values.shape[-1]!r} rows for schema size {len(rows)!r}."
         )
     unit = values.unit if isinstance(values, u.Quantity) else None
-    rows = tuple(RecordingRow(**{**row.__dict__, "unit": unit}) if row.unit is None else row for row in rows)
+    rows = tuple(replace(row, unit=unit) if row.unit is None else row for row in rows)
     schema = RecordingSchema(
         name=spec.name,
         rows=rows,
@@ -266,14 +302,6 @@ class _CompiledRecording:
     spec: RecordingSpec
     schema: RecordingSchema
     sample: object = field(compare=False, repr=False)
-
-    def is_scheduled(self, t, dt):
-        t_ms = t.to_decimal(u.ms)
-        start_ms = self.schema.schedule_start.to_decimal(u.ms)
-        period_ms = self.schema.period.to_decimal(u.ms)
-        step = np.rint((t_ms - start_ms) / dt.to_decimal(u.ms))
-        period_steps = np.rint(period_ms / dt.to_decimal(u.ms))
-        return (t_ms >= start_ms) & (np.mod(step, period_steps) == 0)
 
 
 def _observable_rows_and_sampler(cell, spec: RecordingSpec):
@@ -519,13 +547,11 @@ def _spatial_row(cell, pair, *, field: str, contributor_ids=()) -> RecordingRow:
 
 def _density_recording_row(cell, row, *, field: str) -> RecordingRow:
     spatial = _spatial_row(cell, (row.population_index, row.cv_id), field=field)
-    return RecordingRow(
-        **{
-            **spatial.__dict__,
-            "mechanism_category": row.category,
-            "mechanism_type": row.mechanism_type,
-            "mechanism_name": row.name,
-        }
+    return replace(
+        spatial,
+        mechanism_category=row.category,
+        mechanism_type=row.mechanism_type,
+        mechanism_name=row.name,
     )
 
 
@@ -533,15 +559,13 @@ def _synapse_recording_row(cell, view, index: int, field: str) -> RecordingRow:
     logical_id = int(view.id[index])
     cv_id = int(view.cv_id[index])
     spatial = _spatial_row(cell, (int(view.population_index[index]), cv_id), field=field)
-    return RecordingRow(
-        **{
-            **spatial.__dict__,
-            "point_id": int(view.point_id[index]),
-            "mechanism_category": "synapse",
-            "mechanism_type": str(view.synapse_type[index]),
-            "mechanism_name": str(view.name[index]),
-            "synapse_id": logical_id,
-        }
+    return replace(
+        spatial,
+        point_id=int(view.point_id[index]),
+        mechanism_category="synapse",
+        mechanism_type=str(view.synapse_type[index]),
+        mechanism_name=str(view.name[index]),
+        synapse_id=logical_id,
     )
 
 
@@ -595,19 +619,3 @@ def _nonnegative_quantity(value, unit, name: str) -> None:
 def _require_name(value, label: str) -> None:
     if not isinstance(value, str) or not value:
         raise ValueError(f"{label} must be a non-empty string.")
-
-
-def _freeze_array(value):
-    """Make host-backed result arrays read-only without copying device arrays."""
-    if isinstance(value, u.Quantity):
-        mantissa = value.mantissa
-        if isinstance(mantissa, np.ndarray):
-            mantissa = np.array(mantissa, copy=True)
-            mantissa.flags.writeable = False
-            return u.Quantity(mantissa, value.unit)
-        return value
-    if isinstance(value, np.ndarray):
-        result = np.array(value, copy=True)
-        result.flags.writeable = False
-        return result
-    return value

--- a/docs/design/network/module-layout.md
+++ b/docs/design/network/module-layout.md
@@ -47,31 +47,41 @@ runtime event buffer）和 `network.connection`（校验 `connect()` 的 payload
 两者都是纯声明、无 runtime state，放在 `mech` 使 `mech` 成为一个真正的 leaf，
 栈上任何一层都可以安全依赖它。
 
-## `network/__init__.py` 必须保持轻
+## `network/__init__.py` 与部分初始化的父包
 
 `_multi_compartment.cell`、`_multi_compartment.run` 和 `_compute.layouts` 在
 **模块顶层** import `braincell.network.event` / `braincell.network.recording`。
-Python 在导入任何子模块前先执行包的 `__init__`，因此：
+Python 在导入任何子模块前先执行包的 `__init__`，所以 `network/__init__.py`
+是在 `braincell._multi_compartment` 尚未执行完时被拉起来的。
 
-> `network/__init__.py` 一旦在模块作用域 import `.connection`、`.engine` 或
-> `.lowering`，就会在 `braincell._multi_compartment` 初始化过程中重新进入它，
-> `import braincell` 直接失败。
+真正的不变式不是「`__init__` 必须保持轻」，而是：
 
-所以 `__init__.py` 只 eager import leaf 的 `.core`，三个重名字
-（`Network`、`NetworkConnections`、`ConnectionBlock`）通过 PEP 562
-`__getattr__` 延迟解析。对外行为完全不变：`braincell.network.Network` 照常可用，
-`__all__` 未变，只是解析时机推后到首次属性访问。
+> 从 `network` 包 eager 可达的任何模块，都不能从**部分初始化**的
+> `braincell._multi_compartment` 包根 import 一个*名字*。
 
-`braincell/network/__init___test.py` 守住这条不变式：一个 AST 检查禁止
-`__init__.py` 在模块作用域 import 那三个模块，另一个 AST 检查禁止
-`braincell/mech/` 下任何模块 import 其它 `braincell` 包。`import braincell`
-本身是经验性守卫——上述任一环回归都会让它直接崩溃。
+`connection.py`、`pairing.py`、`engine.py` 确实会回指 `_multi_compartment`，
+但它们 import 的是*子模块*（`.synapses`、`.probes`、`.run`、`.cell`）——
+Python 对部分初始化的父包一样解析得了子模块。真正会炸的写法是
+`from braincell._multi_compartment import Cell`。
+
+因此 `__init__.py` 是全 eager 的：`Network`、`NetworkConnections`、
+`NetworkResult`、`Population` 都在模块作用域直接绑定，没有 PEP 562
+`__getattr__`，也没有 `TYPE_CHECKING` 分支。此前那套延迟解析装置守的是一个
+已经不存在的环：把 `__init__.py` 改成全 eager 后 `import braincell` 正常，
+整个测试套件也全绿。
+
+`braincell/network/__init___test.py` 守住这条不变式：`PartialParentTest`
+用 AST 检查禁止 eager 可达的模块从 `braincell._multi_compartment` 包根
+import 名字；`ImportGraphTest` 把包内 import DAG 钉成一张显式的表并断言它
+无环；`MechIsALeafTest` 禁止 `braincell/mech/` 下任何模块 import 其它
+`braincell` 包。`import braincell` 本身是经验性守卫——上述任一环回归都会让
+它直接崩溃。
 
 ## 命名
 
 | 模块 | 职责 |
 |---|---|
-| `network/core.py` | `Population`、`NetworkResult`、`NetworkRunResult` |
+| `network/core.py` | `Population`、`NetworkResult` |
 | `network/event.py` | 事件*源*：`EventSource`、`EventTable`、`EventSequence`、`NetStim`、`VoltageCrossingSource` |
 | `network/recording.py` | `RecordingSpec`、`RecordingSchema`、`SampleBlock`、`EventSeries`、`observe` |
 | `network/connection.py` | `connect()`、`ConnectionView`、`NetworkConnections` |

--- a/docs/specs/2026-09-02-network-simplification.md
+++ b/docs/specs/2026-09-02-network-simplification.md
@@ -1,0 +1,815 @@
+# Network simplification sweep
+
+Iteration 12 of the module-by-module `/simplify` sweep. Target:
+`braincell/network/` — 5,102 lines across ten non-test modules, plus 1,802
+lines of co-located tests.
+
+| Module | Lines | Role |
+| --- | --- | --- |
+| `__init__.py` | 70 | Package surface, lazy via PEP 562 `__getattr__` |
+| `core.py` | 403 | `Population`, `NetworkResult` — the leaf both layers share |
+| `event.py` | 775 | `EventSource`, `NetStim`, `EventSequence`, spike plumbing |
+| `recording.py` | 613 | `RecordingSpec`, `EventSeries`, `observe` |
+| `lowering.py` | 189 | `ConnectionBlock`, delay quantization |
+| `delivery.py` | 665 | Ring buffers, arrival writes, backend selection |
+| `pairing.py` | 872 | `PairingSpec` grammar and its materialization |
+| `connection.py` | 842 | `_ConnectionStore`, `ConnectionView`, `connect()` |
+| `engine.py` | 872 | `Network` — populations, run loop, results |
+| `_testing.py` | 206 | Shared test doubles |
+
+Baseline on `4fdfd98`:
+
+- `pytest braincell/network -q` → 113 passed, 2 subtests passed (31.38 s)
+- `pytest braincell/ -q` → 2814 passed, 15 skipped, 411 subtests passed (219.63 s)
+
+Four review passes (reuse, simplification, efficiency, altitude) produced 61
+findings. This document records which are applied, which are declined and
+why, and which are deferred with the evidence needed to pick them up later.
+The applied set groups into five themes.
+
+## Constraints this package carries
+
+The package is a documented public surface: `docs/design/network/api.md`
+(36 KB) spells out the `connect()` and pairing grammar, and
+`examples/multi_compartment/connection.ipynb`,
+`examples/multi_compartment/network.ipynb`, and
+`examples/profiling/connection_sampling_benchmark.py` call it. Any rename
+lands in all four in this PR.
+
+`braincell.mech` must stay a leaf — it owns the declaration contracts that
+`network.connection`, `_base_channel`, and `_compute.state` all depend on.
+`braincell/network/__init___test.py::MechIsALeafTest` guards that, and this
+sweep does not touch it.
+
+---
+
+## Theme 1 — The lazy `__init__` guards a cycle that no longer exists
+
+`braincell/network/__init__.py` resolves `Network`, `NetworkConnections`,
+and `ConnectionBlock` through a PEP 562 `__getattr__` rather than importing
+them. Its docstring (`__init__.py:16-31`) and the guard test that enforces
+it (`__init___test.py:16-33`) both assert that an eager import would
+"re-enter `braincell._multi_compartment` in the middle of its own
+initialization" and that `import braincell` "would die with an
+`ImportError`".
+
+**That is measurably false as of `4fdfd98`, and the guard that enforces it
+names the wrong modules.**
+
+### 1.1 The claim does not reproduce
+
+`dev/eager_probe.py` adds one eager submodule import to
+`braincell/network/__init__.py` at a time and runs `python -c "import
+braincell"` in a fresh subprocess:
+
+```
+connection  import braincell OK
+delivery    import braincell OK
+engine      import braincell OK
+lowering    import braincell OK
+pairing     import braincell OK
+recording   import braincell OK
+```
+
+`dev/eager_init.py` goes further and replaces the whole file with a fully
+eager version — four plain `from .x import Y` lines and an `__all__`, no
+`__getattr__`, no `_LAZY_ATTRS`, no `__dir__`:
+
+```
+2807 passed, 15 skipped, 411 warnings, 411 subtests passed in 194.78s
+```
+
+2807 is the full suite minus exactly the 7 tests in
+`braincell/network/__init___test.py`, which the probe excludes because they
+assert the lazy mechanism itself.
+
+The reason is visible in `braincell/__init__.py`: line 57 imports
+`._multi_compartment`, whose `cell.py:87` imports `braincell.network.event`
+and so runs `network/__init__.py` — and none of `engine`, `connection`, or
+`pairing` import a *name* from the partially-executed
+`braincell/_multi_compartment/__init__.py`. They import its *submodules*
+(`.probes`, `.run`, `.synapses`), which Python resolves against a partial
+parent without complaint.
+
+The laziness also buys no deferral, because `braincell/__init__.py:66` and
+`:70-79` import `Network`, `NetworkConnections`, `ConnectionView`,
+`EventSource`, and `observe` thirteen lines later regardless. Every module
+the `__getattr__` defers is loaded during `import braincell` anyway.
+
+**Applied:** `braincell/network/__init__.py` becomes three eager import
+lines binding four names. `_LAZY_ATTRS`, `__getattr__`, `__dir__`, and the
+`TYPE_CHECKING` block go, and the module docstring now states the invariant
+that holds instead of the cycle that does not.
+
+### 1.2 `_HEAVY_SUBMODULES` names the wrong three modules
+
+`__init___test.py:46` hardcodes `{".connection", ".engine", ".lowering"}`.
+`dev/closure.py` walks each submodule's load-time import closure (skipping
+`TYPE_CHECKING` and function bodies) and asks which actually reach
+`braincell._multi_compartment`:
+
+```
+connection  REACHES  ['braincell._multi_compartment.synapses']
+core        clean
+delivery    clean
+engine      REACHES  ['braincell._multi_compartment', ...cell]
+event       clean
+lowering    clean
+pairing     REACHES  ['braincell._multi_compartment.synapses']
+recording   clean
+```
+
+The set is wrong in both directions: it misses `.pairing`, which does reach
+`_multi_compartment`, and it lists `.lowering`, which does not. A
+demonstration that the guard is not merely imprecise but inert — adding
+`from .pairing import degree` to `__init__.py` and running the guard:
+
+```
+$ python -m pytest braincell/network/__init___test.py -q -k eagerly
+1 passed
+```
+
+**Applied:** the hardcoded set goes. `LazyInitTest` is replaced by
+`ImportGraphTest`, which (a) keeps the empirical
+`test_importing_braincell_succeeds`, (b) pins the intra-package import DAG
+in the `braincell/_compute/__init___test.py` idiom so any new sibling edge
+surfaces in review, and (c) asserts the invariant that actually holds —
+that no `braincell/network` module imports a name from
+`braincell._multi_compartment`'s package root, only from its submodules.
+That is the property the eager import depends on, and it is checkable.
+
+### 1.3 `ConnectionBlock` is not public
+
+No importer outside `braincell/network/` — only prose in
+`docs/design/network/*.md`. It is a lowering intermediate consumed solely
+by `delivery.py`. **Applied:** dropped from `__all__`.
+`docs/design/network/module-layout.md` is updated for 1.1–1.3.
+
+---
+
+## Theme 2 — Delete what nothing reaches
+
+### 2.1 `ConnectionBlock` carries three structurally constant fields
+
+`lowering.py:89-108` is the only construction site in the repository, and
+it hardcodes `packed=True`, `source_cv_id=0`, `event_source=source`. Every
+downstream branch on those values is therefore unreachable:
+
+| dead | site |
+| --- | --- |
+| `route_source_event`'s `else` | `delivery.py:143-144` |
+| `source_spike` (only caller is that `else`) | `delivery.py:131-135` |
+| `population_spike` (test-only) | `delivery.py:108-128` |
+| `zeros_like_events` (reachable only via `zero_arrival`'s dead leg) | `delivery.py:267-286` |
+| `zero_arrival`'s fork and its `post_size=` parameter | `delivery.py:231-249` |
+| `synapse_index if packed else post_index * n_active + synapse_index`, ×2 | `delivery.py:183-185`, `202-204` |
+| `(n_active,) if packed else (post_size, n_active)`, ×4 | `delivery.py:457-462`, `494-498`, `504-508`, `514-518` |
+| `post_size` parameters threaded to reach those forks | `delivery.py:252`, `303`, `598` |
+
+**Applied:** `packed`, `source_cv_id`, and `buffer_size` (written at
+`lowering.py:101`, never read) are deleted; `event_source` becomes
+non-optional; every `X if packed else Y` becomes `X`.
+
+### 2.2 `DeliveryBlock.post_index` and `.synapse_index` are write-only
+
+Set at `delivery.py:181-182` and `200-201`. Every read in the module
+(`:174`, `:175`, `:193`, `:194`) is on the *source* `ConnectionBlock`, never
+on a `DeliveryBlock`. `flat_target_index` is the field the runtime actually
+uses. **Applied:** both fields deleted.
+
+### 2.3 `write_arrivals(blocks, ...)` never touches `blocks`
+
+`delivery.py:375-414` iterates `state.queue_keys`. Confirmed by
+`ruff check --select ARG`. **Applied:** parameter and its docstring entry
+removed; the sole call site at `engine.py:617-621` updated.
+
+### 2.4 `lowering.resolve_source_cv` has no production caller
+
+Only `lowering_test.py:23,54,55,57`. It duplicates
+`event._resolve_cell_location_cv` (`event.py:632-636`), differing only in
+rejecting an already-resolved `LocsetMask`. **Applied:** deleted, along
+with the `LocsetExpr` and `locate_cv_on_branch` imports it alone needed;
+the three test assertions move to `event_test.py` against
+`_resolve_cell_location_cv`.
+
+### 2.5 Members with no reader
+
+Each verified by grep over `braincell/`, `examples/`, `docs/` (`.py`,
+`.ipynb`, `.md`). **Applied:**
+
+- `EventSourceView.ids` (`event.py:135-138`), an alias for `source_id`.
+- `_CompiledRecording.is_scheduled` (`recording.py:270-276`) — every
+  `.is_scheduled` hit in the repo is `EventSource.is_scheduled`.
+- `RecordingSpec.legacy` (`recording.py:143`) — never passed, never read.
+- `_RunSetup.delivery_backend` (`engine.py:56`) — written at `:521`; the
+  three reads at `:490`, `:493`, `:500` are all of the local variable.
+- `times = start_t + relative_times` (`engine.py:402`) — overwritten at
+  `:413` before any read.
+
+Four more that the review pass reported as dead survived a second look and
+are **declined**; see the Declined section for `ConnectionView.root` /
+`EventSourceView.root`, `GroupContext.size` / `.n_groups`, and the
+`Score` / `Degree` aliases. "No in-repo reader" is necessary but not
+sufficient for deletion on a public surface.
+
+### 2.6 `Population.__init__` re-runs the check `set()` makes three lines later
+
+`core.py:68-70` and `core.py:130-132` are the same three lines with the same
+message, and nothing between them consumes `metadata`. **Applied:** the
+first copy deleted.
+
+---
+
+## Theme 3 — Stop rescanning every row
+
+Every item here is measured, and every measurement is **runtime**, not
+trace time. Scripts are in the gitignored `dev/`; sizes are stated with
+each number.
+
+### 3.1 `Network.run()` re-validates the whole topology on every call
+
+`engine.py:302` calls `self._validate_direct_source_ownership()` *above*
+the `if self._initialized: return self` guard at `:303`. That validation
+walks `_call_views()` (3.2), so a cached-loop 20-step `run()` of a
+64-call / 25,600-row network costs **270 ms, ~90% of it in `_call_views`**
+(profile: 0.405 s cumulative of 0.449 s). Chunked-run loops pay it per
+chunk. **Applied:** the `_initialized` early return moves above the
+validation.
+
+### 3.2 `ConnectionView._call_views()` is O(calls × rows)
+
+`connection.py:415` recomputes `self._active_ids` and `self.connect_id` per
+connect call, each walking every row through `_ConnectionStore.rows()`
+(`connection.py:175`, a Python dict comprehension).
+
+| rows | current | single pass |
+| --- | --- | --- |
+| 64 calls × 400 | 240 ms | 0.6 ms |
+| 256 × 400 | 4.45 s | 3.0 ms |
+| 256 × 1600 | **20.7 s** | **9.1 ms** |
+
+Three hot callers: `engine.py:750` (every `run()`), `lowering.py:66`, and
+`_multi_compartment/cell.py:2221` — the last once per synapse layout.
+**Applied:** `_ConnectionStore.rows()` gets an `int64` id→row lookup array
+instead of the dict comprehension, and `_call_views` groups by the already
+non-decreasing `connect_id` with one `np.searchsorted` pass.
+
+### 3.3 `_ConnectionStore.weight_for` scans for every row
+
+`connection.py:192` runs `np.flatnonzero(call.row_ids == row_id)` per row
+and builds one `Quantity` per row. `view.weight` at 16,000 rows: **191 ms**
+(~142 ms Python/`Quantity` churn, ~50 ms quadratic scan). In a real
+trace-and-compile profile at 32 calls × 200 rows it is **0.202 s of a
+1.11 s network setup — 18%**. `call.row_ids` is a contiguous `np.arange`,
+so the row's position is `row_id - call.row_ids[0]`. **Applied:** one
+grouped gather per call, concatenated once.
+
+### 3.4 `_ConnectionStore.set_weight` copies the whole array per row
+
+`connection.py:211` → `_set_quantity_or_array` (`:817`) rebuilds the entire
+weight array on each iteration. `ConnectionView.set(weight=...)`: 8,000
+rows 293 ms, 16,000 rows 661 ms, 32,000 rows **1.63 s** — 36.6 → 51.1 µs
+per row, superlinear. **Applied:** one grouped assignment per call, using
+the same offset arithmetic as 3.3.
+
+### 3.5 `pairing._score` allocates a dense matrix for the uniform case
+
+`pairing.py:761` builds `np.ones((n_unique, n_candidates))` even when
+`score is None`, and `_sample` then rescans it row by row. The shape in
+`_conditional_sample` is the product of two population sizes, so it grows
+quadratically.
+
+**Applied:** `_score` returns `None` for the uniform case and `_score_row`
+carries the sentinel to `_sample`. Measured on a `by_source(6)` connect
+over 1000 sources × 5000 synapses (`tracemalloc` around `connect()`):
+
+| | peak allocation | `connect()` |
+| --- | --- | --- |
+| before | 39.1 MiB | 784 ms |
+| after | **1.5 MiB** | 789 ms |
+
+This is a memory result, not a speed one — `rng.choice` dominates the
+loop, so wall time is unchanged within noise. It is worth taking anyway
+because the 39.1 MiB scales with `n_sources × n_synapses`.
+
+`_sample` passes an explicitly materialized uniform `p` rather than
+`p=None`. Two reasons, both measured. `p=None` and `p=uniform` **do not
+draw the same values for the same seed** — so `p=None` would silently
+change the connectivity of every default-pairing network, which the
+"Declined: unify the two seed schemes" entry below rejects for the same
+reason. And `p=None` is not even faster: for `replace=False` at
+200 × 5000 it took 414 ms against 206 ms for the weighted path.
+`np.full(n, 1.0 / n)` is bit-identical to `np.ones(n) / n.sum()`, verified
+across nine sizes, so draws are preserved exactly.
+
+### 3.6 `make_delivery_op` builds operators the default backend never calls
+
+Instrumented run (`dev/bench_delivery.py`): `delivery ops built=1, invoked
+during trace=0`. On the scatter path `delivery_blocks(group_by_delay=False)`
+always produces per-contact `delay_steps` arrays, so
+`enqueue_future_events` and `apply_immediate_events` take the vector branch
+and never index `state.delivery_ops`. Each unused op still materializes two
+device arrays (800 KB per 100k-contact block), closes over the whole
+`DeliveryBlock`, and is retained in `_RunSetup` inside `_run_setup_cache`
+for the network's lifetime. **Applied:** ops are built only when
+`delivery_backend == "brainevent"`.
+
+---
+
+## Theme 4 — Say it once
+
+### 4.1 `NetworkResult.concat` builds throwaway `RunResult`s to reach one combiner
+
+`core.py:340-355` constructs a full `RunResult` per part per recording —
+with a `traces=` dict that is immediately discarded — to call
+`RunResult.concat(...).samples[name]`, re-running the entire
+contiguity/schema validation loop that `NetworkResult.concat` already ran
+at `:325-339`. The primitive wanted is `_concat_sample_blocks`
+(`_multi_compartment/run.py:283`), a pure function over `SampleBlock`s.
+
+**Applied:** `_concat_sample_blocks` is promoted to public
+`concat_sample_blocks` in `network/recording.py`, next to the `SampleBlock`
+it operates on; `RunResult.concat` and `NetworkResult.concat` both call it.
+This also removes `core.py`'s deferred `_multi_compartment.run` import,
+making `core.py` a leaf with no cross-package dependency at all.
+
+`RunResult.concat` also raised `"Recording schema changed for {name!r}."`
+on a schema mismatch, which `NetworkResult.concat`'s own loop did not
+check. That check is lifted into `core.py` so the diagnostic is not lost.
+
+### 4.2 `_quantity_vector` exists twice, byte-identical
+
+`connection.py:794-807` and `event.py:712-722`, same four error messages,
+differing only in the keyword name (`count=` vs `size=`). `connection.py`
+already imports from `.event`. **Applied:** the `connection.py` copy is
+deleted and the `event.py` one imported.
+
+### 4.3 Three "make this read-only" helpers, diverged on `Quantity`
+
+`core.py:270-273` (`_readonly_array`, ndarray only),
+`recording.py:600-613` (`_freeze_array`, also handles `u.Quantity`), and
+`engine.py:850-851` (inline, ndarray only). The divergence is visible:
+`Population.set(...)` freezes numpy metadata but returns `Quantity`
+metadata unfrozen, because `_readonly_array` has no `Quantity` branch.
+**Applied:** `_freeze_array` moves to `braincell/_misc.py` as
+`freeze_array` — which already hosts `concat_values` and
+`same_time_quantity` — and all three sites call it.
+
+### 4.4 `_concat_event_series` re-inlines the `concat_values` its own file imports
+
+`core.py:396-399` spells out `u.Quantity(u.math.concatenate(tuple(
+item.time.to_decimal(unit) ...), unit)`, which is `_misc.concat_values`
+character for character — imported at `core.py:26` and used two lines away.
+**Applied.**
+
+### 4.5 Two different `_stack_values` in sibling modules
+
+`connection.py:828-833` (`np.asarray([...])`, no empty guard) and
+`recording.py:548-555` (`u.math.stack(..., axis=-1)`, empty guard). Same
+name, same package. The review pass called them "interchangeable in
+practice". **Declined** — see the Declined section; they are not, and the
+substitution would silently downcast every public `ConnectionView.weight`.
+
+### 4.6 `_require_nonempty_string` written twice
+
+`connection.py:756-758` and `recording.py:595-597` are identical.
+**Applied:** one copy, `recording._require_name`, imported by
+`connection.py` at its nine call sites.
+
+### 4.7 `ConnectionView._require_single_call` recomputes the store's own answer
+
+`connection.py:481-485` spells out
+`tuple(dict.fromkeys(int(i) for i in self.connect_id.tolist()))`, which is
+the body of `_ConnectionStore.active_call_ids` (`:188-190`). **Applied:**
+it calls the store. This also removes one of the `connect_id`
+materializations 3.2 is about.
+
+### 4.8 `_as_source_view` duck-types a class it is allowed to name
+
+`connection.py:702-717` probes `hasattr(source, "model")` and
+`hasattr(source, "kind")` under a comment claiming `Population` is imported
+"structurally to keep the low-level connection module independent from the
+Network package". `connection.py` *is* in the network package, and
+`core.py` is a graph leaf that `lowering.py:29` already imports.
+**Applied:** `from .core import Population` and `isinstance`. The
+`connection → core` edge keeps the package graph a DAG.
+
+### 4.9 `Network.init_state` and `reset_state` duplicate their guard and lifecycle
+
+`engine.py:298-313` and `:335-358`: the `batch_size is not None`
+`NotImplementedError` block is character-for-character identical, and both
+wrap their loop in the same `_cell_lifecycle_active = True / try /
+finally = False`. **Applied:** a module-level `_reject_batch_size` and a
+`_cell_lifecycle` context manager.
+
+### 4.10 `RecordingRow(**{**row.__dict__, ...})` at three sites
+
+`recording.py:254`, `:522-529`, `:536-545`. `__dict__` ordering on a frozen
+dataclass is an implementation detail; `dataclasses.replace` is the API.
+**Applied.**
+
+---
+
+## Theme 5 — Docstrings that describe the branch that cannot run
+
+All are consequences of Theme 2 and land with it:
+
+- `delivery.py:59-61` documents `flat_target_index` as
+  `post_index * n_active + synapse_index`. That is the dead branch; it
+  always equals `synapse_index`.
+- `delivery.py:245-249` says `zero_arrival` returns shape
+  `(post_size, n_active)`. It always returns `(n_active,)`.
+- `delivery.py:384-386` documents `write_arrivals`'s `blocks` parameter
+  (2.3).
+- `delivery.py:437-441` describes the packed/broadcast fork that never
+  forks.
+- `delivery.py:152-170` omits `group_by_delay` from `Parameters` while
+  documenting it under `Returns`. NumPy-doc requires the entry, and unlike
+  the rest of this list `group_by_delay` is genuinely live —
+  `engine.py:493` passes both values.
+- `lowering.py:102-103` comments that `source_cv_id` is "only used by raw
+  Cell spike blocks", a block kind that no longer exists.
+- `core.py:279-288` lists three of `NetworkResult`'s seven fields, omitting
+  `samples` — the one `Network.run` actually populates.
+
+---
+
+## Breaking changes
+
+Every in-repo caller is updated in this PR. No deprecation shims, no
+aliases, no warnings.
+
+1. **`braincell.network.NetworkRunResult` removed.** It was a bare
+   `NetworkRunResult = NetworkResult` alias whose comment claimed it was
+   "retained for existing callers"; there are none in the repository, and
+   `engine.py` imported the alias rather than the real name. Use
+   `braincell.network.NetworkResult`.
+2. **`braincell.network.ConnectionBlock` removed from the package
+   `__all__`.** Still importable from `braincell.network.lowering`; it is a
+   lowering intermediate with no external importer.
+3. **`ConnectionBlock.packed`, `.source_cv_id`, and `.buffer_size` removed;
+   `.event_source` is now required.** All three were constant at the single
+   construction site.
+4. **`DeliveryBlock.post_index` and `.synapse_index` removed.** Write-only;
+   `flat_target_index` is what the runtime reads.
+5. **`delivery.population_spike`, `delivery.source_spike`,
+   `delivery.zeros_like_events` removed**, and `delivery.zero_arrival` lost
+   its `post_size` keyword. All were reachable only through `packed=False`.
+6. **`delivery.write_arrivals` lost its `blocks` parameter.**
+7. **`lowering.resolve_source_cv` removed.** Use
+   `braincell.network.event._resolve_cell_location_cv`, which it
+   duplicated.
+8. **`EventSourceView.ids`, `RecordingSpec.legacy`,
+   `_CompiledRecording.is_scheduled`, and `_RunSetup.delivery_backend`
+   removed.** No reader in the repository. `EventSourceView.ids` was a bare
+   alias for `.source_id`, which stays.
+9. **`connection._quantity_vector` and `connection._require_nonempty_string`
+   removed** in favour of the `event._quantity_vector` and
+   `recording._require_name` copies they duplicated.
+10. **`braincell._multi_compartment.run._concat_sample_blocks` moved and
+    renamed** to `braincell.network.recording.concat_sample_blocks`.
+11. **`braincell/network/__init__.py` no longer defines `__getattr__` or
+    `__dir__`.** The three names it resolved lazily are now imported
+    eagerly; attribute access is unchanged.
+
+---
+
+## Declined
+
+Five of these overrule a review finding. Each is recorded with the check
+that overturned it, because "no in-repo reader" and "identical in practice"
+are both cheap to assert and expensive to get wrong.
+
+- **Replace `connection._stack_values` with `recording._stack_values`
+  (4.5).** They are not interchangeable. Measured on the same input:
+
+  ```
+  connection._stack_values -> ndarray   float64
+  recording._stack_values  -> ArrayImpl float32
+  ```
+
+  `recording`'s goes through `u.math.stack`, which lands on JAX and so
+  inherits `jax_enable_x64=False`. `connection._stack_values` is what
+  `weight_for` returns, i.e. what `ConnectionView.weight` hands the user.
+  Substituting would silently downcast every published weight from float64
+  to float32 and change its type. The duplicate name is a real smell; the
+  fix is to rename one, not to merge them, and that belongs with the naming
+  pass deferred below.
+- **Delete `ConnectionView.root` and `EventSourceView.root`.** They have no
+  in-repo reader, but they are one instance of a view-family convention:
+  `CellView.root` and `IonView.root` are the same accessor on the same kind
+  of object and *are* tested (`_multi_compartment/cell_test.py:219`, `:296`,
+  `:380`). Deleting two members of a four-member convention makes the API
+  less predictable, not smaller.
+- **Delete `GroupContext.size` and `.n_groups`.** Nothing inside `pairing.py`
+  reads them, which is the point: `GroupContext` is handed to *user* score
+  and degree callables as `ctx.group`. "No reader in this repository" does
+  not apply to a field whose only intended readers are out of tree.
+- **Delete the `Score` and `Degree` type aliases** (`pairing.py:33-34`).
+  They are documentary — they name the two callable protocols the pairing
+  grammar accepts, and `docs/design/network/api.md` uses that vocabulary.
+  AGENTS.md does say shared type expressions belong in `_typing.py`, but
+  these are used in one module; moving them there is iteration 14's call.
+- **Adopt `mech._validate.require_str` for the network's nine inline
+  non-empty-string checks.** `require_str` raises `TypeError` for a
+  non-`str`; every network copy raises `ValueError`, and
+  `connection_test.py` / `core_test.py` assert `ValueError`. Changing the
+  exception type is a breaking change with no benefit beyond the
+  deduplication 4.6 already gets within the package.
+- **Unify the two deterministic seed schemes** (`pairing._derived_seed`,
+  blake2b/`\x1f`/4 bytes; `NetStim._bind_network_seed`, blake2b/`\0`/8
+  bytes masked to 31 bits). They answer the same question with different
+  bit widths, but merging them changes which random streams existing
+  networks draw — silently different connectivity for the same seed. Worth
+  doing deliberately, with a note in the changelog, not as a side effect of
+  a cleanup sweep.
+- **Route `recording._positive_quantity` / `_nonnegative_quantity` through
+  `_misc.validate_time_quantity`.** It hardcodes `to_decimal(u.ms)` and the
+  `frequency` call site (`recording.py:152`) is in `u.Hz`; the local copies
+  also check `np.isfinite`, which the shared helper does not. The honest
+  fix adds `unit=` and `require_finite=` parameters to `_misc.py`, which is
+  iteration 13's target — deferred there rather than half-done here.
+- **Collapse `pairing._materialize_group`'s `_First` arms.** The mirror is
+  real and the seed labels match, so RNG streams would be preserved — but
+  the adjacent `_ByEndpoint` and `_MatchDegrees` arms look identically
+  mirrored and are not: the synapse side passes `positions=synapses` to
+  `_group_degree` (`:663`, `:682`) and the source side does not. Collapsing
+  one pair of four while its neighbours stay expanded makes the asymmetry
+  harder to see, not easier.
+- **Drop `EventSource(ABC)`** (ruff `B024` — it declares no abstract
+  members, and `event.py:97` duck-types `current_event_count` via
+  `getattr`). The `ABC` base and the `NotImplementedError` at `:98-99` are
+  the documented extension contract for third-party sources; removing them
+  is an API decision, not a cleanup. Folded into the two-ABC deferral
+  below.
+- **Split `_CONNECT_CALL_WARNING_THRESHOLD`** (`connection.py:66`) into a
+  warning threshold and a repr limit. Two policies on one constant is a
+  real smell, but both are 256 and the constant is package-private; the
+  change is cosmetic and would need a judgement call on the new repr limit
+  that belongs with the repr work deferred below.
+
+---
+
+## Deferred, with evidence
+
+### Own PR — architecture
+
+- **`recording.py` is declared a leaf but half of it is a
+  `_multi_compartment` module.** `compile_recording` (`:241`) and eight
+  helpers below it resolve a live `Cell` against its runtime, staying
+  "leaf" only by deferring imports into function bodies (`:321`, `:383`,
+  `:421`, `:441`, `:442`). Meanwhile `_multi_compartment/cell.py:88`
+  imports `compile_recording` at module scope. Split at the
+  declaration/resolution seam: `observe`, `RecordingSpec`, `RecordingRow`,
+  `RecordingSchema`, `SampleBlock`, `EventSeries` stay; everything from
+  `compile_recording` down moves to `_multi_compartment/`. ~370 lines
+  moved plus a test-file split.
+- **`event.py` has the same shape.** `VoltageCrossingSource` (`:409`),
+  `_CellSpikeSource` (`:559`), `EventOutputCollection` (`:604`), and the
+  two `_resolve_cell_location_cv*` helpers (`:632`, `:639`) know
+  `cell.morpho`, `cell.cv_tree`, `cell.V_th`, `cell.spike`,
+  `cell._event_previous_V` (`:542`), and `cell._raise_if_not_initialized`
+  (`:530`, `:596`), and defer `braincell.filter` and
+  `braincell._discretization.base` imports. `_multi_compartment/cell.py:87`
+  then imports two of them back out — one underscore-private, and neither
+  in `event.__all__`. Should land with or after the `recording.py` split;
+  same seam.
+- **Two independent delayed-event queues.** `ConnectionView`'s
+  `prepare_runtime` / `_prepare_live_runtime` / `reset_runtime` /
+  `clear_runtime` / `_live_event_count` (`connection.py:433-479`) plus the
+  three `_ConnectionCall` slots (`:80-82`) and
+  `Cell._apply_direct_live_connection_events`
+  (`_multi_compartment/cell.py:2240-2274`) are a second implementation of
+  what `DeliveryState` already does (`delivery.py:80-105`, `289-533`). They
+  are mutually exclusive at runtime — `prepare_runtime` is called only from
+  `_multi_compartment/run.py:123`, so `live_history` stays `None` in
+  network mode. They have diverged three ways: the standalone path
+  hardwires nearest-step quantization (`connection.py:450`) where lowering
+  offers four policies (`lowering.py:170-182`); it uses a shift register
+  (`connection.py:478`) where delivery uses a ring and a modular cursor
+  (`delivery.py:450-452`); and a delayed event lands *after*
+  `_update_dynamics` in standalone (`run.py:224-226`) but *before*
+  `_begin_step` in network mode (`engine.py:616-627`). ~90 lines
+  duplicated. Unifying is semantics-visible, not a cleanup.
+
+  Note for whoever takes it: the reuse pass's original lead named three
+  `Cell` methods here. Two were refuted —
+  `_apply_synapse_layout_event_drive` is the *shared sink*
+  (`delivery.py:522` calls it), and `_evaluate_contact_inputs` handles
+  *scheduled* sources, which `lower_direct_connections` explicitly excludes
+  (`lowering.py:66` passes `scheduled=False`). Only the live-delay queue is
+  genuinely duplicated.
+
+- **Naming pass.** "target" means the post-population name
+  (`connection.py:536`), a `Population`-or-`CellView` (`engine.py:186`), a
+  position in the originally-passed `SynapseView` (`connection.py:306`),
+  and a slot in a synapse layout (`delivery.py:76`). `DeliveryBlock.source`
+  is a `ConnectionBlock`, not an event source, while
+  `ConnectionBlock.event_source` is the actual `EventSource` — hence
+  `block.source.event_source` at `delivery.py:140`. Renames across five
+  modules, and `target_index` is asserted in `connection_test.py:351,368,370`
+  and `pairing_test.py:55,331,338`.
+- **Two `EventSource` ABCs.** `is_scheduled` (`event.py:72-74`) is doing
+  subclass dispatch by hand: scheduled sources override `event_count` and
+  expose `.events`; live sources implement `current_event_count`, which the
+  base reaches by `getattr`. A `ScheduledEventSource` / `LiveEventSource`
+  split makes `is_scheduled` a class fact and turns `connection.py:419`'s
+  filter into a type filter. Carries the `execution_owner`-returns-`None`
+  ternary at `connection.py:591`, `engine.py:705`, `engine.py:752` and the
+  `port = "spike" if kind == "netstim" else "event"` rule written twice
+  (`core.py:100`, `engine.py:782`).
+- **Retire `Population.kind`.** A stringly-typed enum switched on at
+  `core.py:83,94,100,106,113,162`, `connection.py:541,570`,
+  `engine.py:172,685,689,716,739,774`, `lowering.py:62` — a hand-rolled
+  type test over the `EventSource`/`Cell` polymorphism that already exists.
+
+### Own PR — performance, measured
+
+| site | cost | size |
+| --- | --- | --- |
+| `event.py:346`, `:697` scheduled `event_count` rebuilds the full `(rows, events)` arrival matrix **inside the compiled step** | NetStim 4000 events / 4000 rows: **4.25 s / 500 steps** (8.49 ms per step); EventSequence 20,000 events: **16.8 s** (33.5 ms per step). The lowered live path over the same sizes is flat at 94–104 ms. | `arrival_step` has no `t` dependence — quantize on the host once and index a per-step count table, or route scheduled sources through the same ring buffer |
+| `pairing.py:740` `_conditional_sample` makes one `RandomState` + `rng.choice` per unique endpoint | `by_source(deg=5)`, 800×1600: **1.26 s of a 1.28 s `connect()`**; ~870–1010 µs per endpoint, linear, so 10k sources ≈ 9 s | one batched draw per group; changes RNG streams, so it needs the same deliberate call as the seed unification |
+| `pairing.py:312` `_synapse_geometry` rebuilds `MorphologySpatialGeometry` per `connect()` | `build(CA1.swc)` is uncached at **15.4 ms**; the row loop is **196 ms for 2,000 synapses** (98 µs/row). 100 geometry-scored connects on one cell repeat ~20 s | cache on the morphology keyed by `Morphology.revision` (the idiom `filter/cache.py` and `Cell._discretization_key` already use); group rows by `branch_id` |
+| `delivery.py:442` blocks sharing one queue run sequentially | same 6400 rows, 200 steps: 1 block 121 ms, 8 blocks 164 ms, 32 blocks 318 ms, 64 blocks **547 ms** — ~33 µs/step per extra block | concatenate blocks sharing `(event source, post_population, layout_id)` in `delivery_blocks()` |
+| `connection.py:497`, `:573`, `engine.py:118` repr paths rescan every row per connect name | `repr(ConnectionView)` at 20,000 rows / 400 connects: **1.10 s**; `str(Network)` at 128 connects / 6400 rows: **173 ms** | index a `connect_id → name` array; one grouping pass instead of one scan per name |
+| `connection.py:143` `_ConnectionStore.add` re-concatenates seven SoA columns per call | 16,000 rows in 1,600 calls **65.0 ms** vs in 10 calls **4.0 ms** | accumulate in lists, materialize on first read |
+| `pairing.py:752` per-row Python scatter in `_conditional_sample` | 30.6 ms at 100,000 rows | `np.argsort(inverse, kind="stable")` + one scatter |
+| `delivery.py:190` re-derives `np.asarray(block.delay_steps)` inside the delay-group loop | 30.6 ms at 100,000 contacts × 1,000 delays; only reachable on the `brainevent` backend | hoist the `asarray`; group with one `argsort`+`split` |
+
+### Iteration 13 (root modules)
+
+- `_misc.validate_time_quantity` needs `unit=` and `require_finite=` before
+  `recording.py`'s two local copies can go (see Declined).
+- Nine copies of `float(np.asarray(x.to_decimal(u.ms), dtype=float).reshape(()))`
+  — `engine.py:542,770,771,808`, `connection.py:439`, `lowering.py:162`,
+  `recording.py:571` (×2), plus `run.py:266-267,277-278`. One
+  `_misc.to_ms_scalar` covers all nine.
+
+### Iteration 14 (whole package)
+
+- **`braincell/network/` imports no alias from `_typing.py`** — zero hits
+  across all ten modules, where AGENTS.md makes them mandatory. `T` and
+  `DT` cover every `dt`/`duration`/`delay` parameter
+  (`engine.py:360-368`, `lowering.py:53`, `:131`).
+- **Cross-package private imports**, each a missing public API:
+  `connection.py:28` (`_multi_compartment.synapses._cell_label`),
+  `engine.py:29` (`run._duration_steps`, `run._recording_time_mask`),
+  `recording.py:442` (`density_views._runtime_layout`), `pairing.py:31`
+  (`morph._spatial.MorphologySpatialGeometry`, `interpolate_branch` — that
+  module declares `__all__` for exactly these two and three packages import
+  them, so they should be re-exported from `braincell.morph`). And in
+  reverse: `_multi_compartment/cell.py:87` imports `_CellSpikeSource`, and
+  `:1352` imports `connection._ConnectionStore`.
+- **`Network.run` re-implements `Cell.run`'s sample assembly.**
+  `engine.py:423-448` is structurally `run.py:146-159`, and
+  `engine._normalize_scan_samples` (`:856`) is `run._normalize_run_traces`
+  (`:247`) with different error text. The shared home is
+  `network/recording.py`, which already owns `SampleBlock` and
+  `RecordingSchema`. Held back from this sweep because 4.1 already moves
+  one combiner across that boundary and two moves in one PR would make the
+  `_multi_compartment`/`network` seam hard to review.
+- **`engine._event_source_metadata` (`:841`) hardcodes the union of every
+  source type's attributes** — it probes `("population_index",
+  "location_index", "cv_id")` by `getattr` and silently skips misses
+  (`:849`). Wants `EventSource.row_metadata(source_ids) -> dict`.
+- **`connect()` / `_connect_with_pairing_seed`** (`connection.py:602`,
+  `:648`): the public wrapper always passes `pairing_seed_root=0,
+  pairing_seed_path=()`, and the only caller passing anything else is
+  `Network.connect` (`engine.py:227-236`) — which at its second call site
+  (`:266-267`) computes a seed and discards it. `engine.py:31` imports both
+  `_UNSET` and `_connect_with_pairing_seed` by their underscore names.
+  Resolving the seed in `Network.connect` via
+  `dataclasses.replace(pairing, seed=...)` collapses this to one public
+  signature. Deferred because it interacts with the seed-unification
+  decision above.
+- **`Network._run_scheduled_sources_only` (`engine.py:807`) is a second
+  `run()`** with its own dt-freeze field (`_scheduled_dt_ms`, `:91`)
+  parallel to `_runtime_config` (`:90`), its own time bookkeeping, and its
+  own result construction. `_source_current_time` (`:94`) is written by the
+  main path at `:456` and read only here (`:814`).
+- **`Population._RESERVED_NAMES` (`core.py:47-62`) is a hand-maintained
+  frozenset of the class's own attribute and method names** — it will drift
+  the first time someone adds a property. Derive it from the class
+  namespace.
+- **`core_test.py:23` and `recording_test.py:22` import `_cell` from
+  `braincell._multi_compartment.selection_test`** — a helper taken from
+  another package's *test* module, against the `_testing.py` rule in
+  AGENTS.md. `braincell/network/_testing.py` is the right home.
+- **`engine.py:163`**: `if callable(model) and not isinstance(model,
+  EventSource) and not hasattr(model, "pop_size")` — a three-clause
+  structural probe with one concrete-type `isinstance` inside otherwise
+  duck-typed code, to decide "is this a factory".
+- **`pairing._synapse_geometry` (`:312-345`) is the third builder of the
+  same six morphology fields**, alongside `filter/_sampling.py:234-260`
+  (`_context` → `SamplingContext`) and `_discretization/context.py:75-108`
+  (`CVContext`). All three call `MorphologySpatialGeometry.build`; two call
+  `interpolate_branch`.
+
+---
+
+## Edge cases and tests
+
+New regression tests:
+
+1. `__init___test.py` — the import DAG is pinned as a dict literal, and a
+   new test asserts that no `braincell/network` module imports a name from
+   `braincell._multi_compartment`'s package root. That is the property the
+   now-eager `__init__.py` depends on, replacing a `_HEAVY_SUBMODULES` set
+   that was wrong in both directions.
+2. `connection_test.py::test_multi_call_view_groups_calls_and_round_trips_weights`
+   — a view spanning three connect calls in shuffled order. It asserts
+   `.weight` per row, that `_call_views()` splits into one view per call in
+   first-appearance order with the right IDs, and that a shuffled
+   `set(weight=...)` round-trips. This is the case the three rewrites in
+   3.2–3.4 share: the offset arithmetic assumes `call.row_ids` is a
+   contiguous `arange`, and the grouping assumes `np.unique`'s sorted order
+   is re-sorted back to first-appearance order. Existing tests only covered
+   single-call views, where both are invisible. It is an equivalence pin,
+   not a bug reproducer — it passes against the old implementation too.
+3. `pairing_test.py::test_omitted_score_draws_exactly_like_an_explicit_uniform_score`
+   — the default `score=None` and an explicit `np.ones(n)` produce identical
+   `source_index`/`target_index`. This is the guard on 3.5's sentinel: the
+   whole point is that the optimization is not observable.
+4. `core_test.py::test_metadata_is_frozen_for_plain_arrays_and_quantities`
+   — `Population.set` freezes plain arrays *and* host-backed `Quantity`
+   metadata. Non-vacuous, demonstrated by running the pre-change tail
+   directly:
+
+   ```
+   old path froze Quantity metadata? False
+   mutated through the returned metadata -> [999.  20.]
+   ```
+
+`concat_sample_blocks` (4.1) needed no new test: it is already driven from
+both sides, by `recording_test.py:62` (`braincell.RunResult.concat`) and
+`core_test.py:206`/`:412` (`NetworkResult.concat`), which is exactly the
+"shared by both concats" property.
+
+Edge cases considered:
+
+- **Empty connection store.** `_call_views` on a store with zero rows must
+  return `()`, not a one-element group. Handled by the explicit
+  `if ids.size == 0: return ()` guard before the grouping pass, because
+  `np.split` on an empty array would otherwise yield one empty group.
+- **All rows of a call removed.** `active_ids` filters first, so a call can
+  disappear entirely from the grouping; the existing `ConnectionView.remove`
+  tests cover it.
+- **Row IDs must stay dense.** `_ConnectionStore.rows` is now an array index
+  (`_row_of_id[ids]`) rather than a dict lookup, which requires IDs to be a
+  gapless `0..n-1` over every row ever added. `add` builds them as one
+  `np.arange` from a monotonic `_next_row_id` and `remove` only clears
+  `active`, so removed rows keep their slot — pinned by the existing
+  `test_connection_view_set_remove_and_nonreused_ids`. A negative index
+  cannot reach it: `ConnectionView.__getitem__` selects positionally into
+  `_active_ids`, so only real IDs are ever passed down.
+- **Single connect call.** The common case, and the one where an off-by-one
+  in the boundary computation is invisible in aggregate assertions.
+- **`packed=False` removal.** No production constructor ever set it, but
+  `delivery_test.py:30` exercised `population_spike` directly. That test is
+  deleted with the function rather than rewritten — there is nothing left
+  for it to assert.
+- **`score=None` in `_score` (3.5).** The obvious spelling — pass
+  `p=None` to `rng.choice` — fails this edge case: `p=None` and
+  `p=uniform` draw *different* values from the same seed, so it would
+  change existing connectivity. `_sample` materializes the uniform row
+  instead. End-to-end check on the 1000 × 5000 `by_source` benchmark:
+  `identical connectivity for the same seed: True`.
+- **An empty candidate pool under a uniform score.** `_score`'s
+  `positive support` error had to be preserved for the sentinel branch,
+  where there is no matrix to sum. Row sums of the implied all-ones matrix
+  are `shape[-1]`, so the equivalent condition is
+  `shape[0] > 0 and shape[-1] == 0`. Unreachable through the public API —
+  `connect()` rejects an empty source or synapse view first — so it is kept
+  for branch symmetry rather than tested.
+- **`make_delivery_op` (3.6).** The `brainevent` backend is unavailable in
+  this environment (`resolve_event_backend` falls back to `scatter`), so
+  the ops path is exercised only by `delivery_test.py`. The guard keys on
+  the same `delivery_backend` string that already selects
+  `group_by_delay`, so the two cannot disagree.
+
+---
+
+## Verification
+
+```
+$ pytest braincell/network -q
+117 passed, 5 warnings, 2 subtests passed in 25.01s
+
+$ pytest braincell/ -q
+2818 passed, 15 skipped, 411 warnings, 411 subtests passed in 179.27s (0:02:59)
+
+$ pre-commit run --files <18 changed .py files + 2 .md>
+check for added large files..............................................Passed
+check python ast.........................................................Passed
+check for merge conflicts................................................Passed
+debug statements (python)................................................Passed
+fix end of files.........................................................Passed
+trim trailing whitespace.................................................Passed
+ruff (legacy alias)......................................................Passed
+ruff format..............................................................Passed
+```
+
+Baseline was 113 network tests and 2814 in the full suite. The network
+package nets +4: three new regression tests (Edge cases and tests, above)
+plus the `__init___test.py` rewrite, which replaces two lazy-import guards
+with three that check the invariant that actually holds.


### PR DESCRIPTION
Iteration 12 of the module-by-module simplification sweep. Full spec, with every declined and deferred finding and its evidence: `docs/specs/2026-09-02-network-simplification.md`.

Four review passes over `braincell/network/` produced 61 findings. ~25 are applied here in five themes; the rest are declined with a reason or deferred with file:line evidence and measurements.

## The lazy `__init__` guarded a cycle that no longer exists

`braincell/network/__init__.py` resolved `Network`, `NetworkConnections`, and `ConnectionBlock` through PEP 562 `__getattr__`, on the documented grounds that an eager import would re-enter `braincell._multi_compartment` mid-initialization and kill `import braincell`. Three probes say otherwise: adding each submodule eagerly one at a time (all six fine), replacing the whole file with a fully eager version and running the suite (2807 passed — the full suite minus exactly the 7 tests that assert the lazy mechanism), and an AST walk of each module's load-time import closure.

The real invariant is narrower: none of the eagerly reachable modules import a *name* from the partially executed `_multi_compartment` package root — they import its *submodules*, which Python resolves against a partial parent. The laziness also deferred nothing, since `braincell/__init__.py` imports all of those names thirteen lines later anyway.

The old guard was also inert and wrong in both directions: `_HEAVY_SUBMODULES` missed `.pairing` (which does reach `_multi_compartment`) and listed `.lowering` (which does not), and adding a `.pairing` import left it passing. It is replaced by `ImportGraphTest`, which pins the intra-package import DAG as a dict literal, asserts it is acyclic, and checks the partial-parent invariant directly.

## Delete what nothing reaches

`ConnectionBlock`'s only construction site hardcodes `packed=True` and `source_cv_id=0`, so every `X if packed else Y` in `delivery.py` and the four functions reachable only through the `else` legs were dead — about 200 lines. Plus two write-only `DeliveryBlock` fields, a `write_arrivals` parameter it never touched (confirmed by `ruff --select ARG`), and five members with no reader.

## Stop rescanning every row

Every number below is runtime, not trace time.

| site | before | after |
| --- | --- | --- |
| `Network.run()` re-validating topology above the `_initialized` guard | 270 ms per cached run (64 calls × 25,600 rows), ~90% in `_call_views` | skipped |
| `_call_views` at 256 calls × 1600 rows | 20.7 s | 9.1 ms |
| `weight_for` at 16,000 rows | 191 ms | one grouped gather |
| `set_weight` at 32,000 rows | 1.63 s | one grouped assignment |
| `pairing._score` peak allocation, 1000 × 5000 `by_source` | 39.1 MiB | **1.5 MiB** |
| `make_delivery_op` on the default backend | built, never invoked | not built |

The `_score` change is a memory result, not a speed one — `rng.choice` dominates, so `connect()` wall time is unchanged (784 → 789 ms). It is worth taking because the 39.1 MiB grows with `n_sources × n_synapses`.

Note on that one: the obvious spelling is to pass `p=None` to `rng.choice`. Measured, `p=None` and `p=uniform` **draw different values from the same seed**, so that would silently change every default-pairing network's connectivity — and it is 2× *slower* for `replace=False`. `_sample` materializes the uniform row instead; `np.full(n, 1/n)` is bit-identical to `np.ones(n)/n.sum()`, and the end-to-end check on the benchmark network reports identical connectivity.

## Say it once

Deduplicated `_quantity_vector`, `_require_nonempty_string`, and the sample-block concatenator (which `NetworkResult.concat` had been reaching by building throwaway `RunResult`s). Also three diverged "make this read-only" helpers, one of which was a real defect: `Population.set()` froze numpy metadata but returned `Quantity` metadata still writable, because `core._readonly_array` had no `Quantity` branch. Now one `_misc.freeze_array`.

## Breaking changes

Every in-repo caller is updated in this PR. No deprecation shims, no aliases, no warnings.

1. **`braincell.network.NetworkRunResult` removed** — a bare alias for `NetworkResult` with no caller in the repository.
2. **`braincell.network.ConnectionBlock` removed from the package `__all__`** — still importable from `braincell.network.lowering`; it is a lowering intermediate with no external importer.
3. **`ConnectionBlock.packed`, `.source_cv_id`, `.buffer_size` removed; `.event_source` is now required.**
4. **`DeliveryBlock.post_index` and `.synapse_index` removed** — write-only; `flat_target_index` is what the runtime reads.
5. **`delivery.population_spike`, `delivery.source_spike`, `delivery.zeros_like_events` removed**, and `delivery.zero_arrival` lost its `post_size` keyword. All reachable only through `packed=False`.
6. **`delivery.write_arrivals` lost its `blocks` parameter.**
7. **`lowering.resolve_source_cv` removed** — use `event._resolve_cell_location_cv`, which it duplicated.
8. **`EventSourceView.ids`, `RecordingSpec.legacy`, `_CompiledRecording.is_scheduled`, `_RunSetup.delivery_backend` removed** — no reader.
9. **`connection._quantity_vector` and `connection._require_nonempty_string` removed** in favour of the `event.py` / `recording.py` copies they duplicated.
10. **`_multi_compartment.run._concat_sample_blocks` moved and renamed** to `braincell.network.recording.concat_sample_blocks`.
11. **`braincell/network/__init__.py` no longer defines `__getattr__` or `__dir__`.** Attribute access is unchanged.

`Network.init_state()` no longer re-validates direct-source ownership when the network is already initialized. That is the point of the 270 ms item, but it does mean a validation error surfaces on the first `init_state()` rather than on every one.

## Declined, with the check that overturned the finding

- **Replacing `connection._stack_values` with `recording._stack_values`.** Reported as "interchangeable in practice". They are not: `connection`'s returns `ndarray float64`, `recording`'s goes through `u.math.stack` onto JAX and returns `ArrayImpl float32`. `connection._stack_values` is what `ConnectionView.weight` hands the user — substituting would silently downcast every published weight.
- **`ConnectionView.root` / `EventSourceView.root`.** No in-repo reader, but they are two members of a four-member view-family convention whose other two (`CellView.root`, `IonView.root`) are tested.
- **`GroupContext.size` / `.n_groups`.** Nothing in `pairing.py` reads them because their intended readers are *user* score and degree callables receiving `ctx.group`.
- **The `Score` / `Degree` aliases.** Documentary; they name the protocols `docs/design/network/api.md` describes.
- Plus `mech._validate.require_str` adoption (would change `ValueError` → `TypeError`), unifying the two seed schemes (changes RNG streams), and routing `recording`'s quantity validators through `_misc` (needs `unit=` / `require_finite=` parameters, which is iteration 13's file).

## Tests

```
$ pytest braincell/network -q
117 passed, 5 warnings, 2 subtests passed in 25.01s

$ pytest braincell/ -q
2818 passed, 15 skipped, 411 warnings, 411 subtests passed in 179.27s (0:02:59)

$ pre-commit run --files <18 changed .py files + 2 .md>
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
[all other hooks Passed or Skipped]
```

Baseline was 113 network / 2814 full. Three new regression tests: multi-call `ConnectionView` weight round-trip and `_call_views` grouping order (the case the three hot-path rewrites share, invisible in the single-call tests that existed); `score=None` drawing identically to an explicit uniform score; and `Population.set` freezing `Quantity` metadata, which is non-vacuous — running the pre-change code path directly mutates the returned metadata through to `[999. 20.]`.

## Summary by Sourcery

Simplify the network package by removing obsolete paths and APIs, optimizing connection and pairing hot paths, and consolidating shared utilities while preserving runtime behavior.

Bug Fixes:
- Prevent repeated topology and connection-row scans from causing quadratic runtime in network execution and connection weight access.
- Preserve immutability for quantity-backed population metadata.

Enhancements:
- Replace lazy network package exports with eager imports guarded by explicit import-graph and partial-parent checks.
- Remove unreachable delivery paths, unused data fields, and unreferenced compatibility aliases and helpers.
- Reduce default pairing memory usage without changing seeded connectivity results.
- Consolidate shared validation, array-freezing, and sample-concatenation utilities.

Documentation:
- Update network module-layout documentation and add the network simplification specification.

Tests:
- Add regression coverage for import-graph invariants, multi-call connection grouping and weight round trips, uniform pairing reproducibility, and immutable quantity metadata.

Chores:
- Apply the associated public API removals and update in-repository callers.